### PR TITLE
Add contributor docs / guides, add pr + issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,7 +16,8 @@ Looking to contribute something to the over_react library? __Here's how you can 
 
 ## Coding standards
 
-A lot can be gained by writing code in a consistent way.  Moreover, always remember that code is written and maintained by _people_. Ensure your code is descriptive, well commented, and approachable by others.
+A lot can be gained by writing code in a consistent way.  Moreover, always remember that code is written and 
+maintained by _people_. Ensure your code is descriptive, well commented, and approachable by others.
 
 __ALWAYS__ adhere to the [Dart Style Guide].  _Please take the time to read it if you have never done so._
 
@@ -36,7 +37,8 @@ __ALWAYS__ adhere to the [Dart Style Guide].  _Please take the time to read it i
 
 ## Using the issue tracker
 
-The issue tracker is the preferred channel for [bug reports](#bug-reports) and [feature requests](#feature-requests), but __please follow the guidelines:__
+The issue tracker is the preferred channel for [bug reports](#bug-reports) and [feature requests](#feature-requests), 
+but __please follow the guidelines:__
 
   + __Fill out the template we've provided.__
 
@@ -57,14 +59,17 @@ _Good bug reports are extremely helpful - thank you!__
 
 __Guidelines for bug reports:__
 
-1. __Search for existing issues.__ Duplicate issues can become cumbersome, and you'd help us out a lot by first checking if someone else has reported the same issue. Moreover, the issue may have already been resolved with a fix available.
+1. __Search for existing issues.__ Duplicate issues can become cumbersome, and you'd help us out a lot by first 
+   checking if someone else has reported the same issue. Moreover, the issue may have already been resolved with a 
+   fix available.
 
 2. __Record a screencast of yourself reproducing the issue__. 
   1. Be sure the problem exists in over_react's code by building a 
      reduced test case that one of the reviewers can pull locally 
      and test out.
 
-3. __Share as much information as possible.__ Include operating system and version, browser and version, version of `over_react`, etc. where appropriate. 
+3. __Share as much information as possible.__ Include operating system and version, browser and version, version of 
+   `over_react`, etc. where appropriate. 
 
 Always include steps to reproduce the bug.
 
@@ -91,16 +96,21 @@ __Example Bug Report:__
 
 ### Feature requests
 
-Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the `over_react` team of the merits of this feature. Please provide as much detail and context as possible.
+Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the 
+project. It's up to *you* to make a strong case to convince the `over_react` team of the merits of this feature. 
+Please provide as much detail and context as possible.
 
 &nbsp;
 
 
 ### Pull requests
 
-Good pull requests - patches, improvements, new features - are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
+Good pull requests - patches, improvements, new features - are a fantastic help. They should remain focused in scope 
+and avoid containing unrelated commits.
 
-__Please ask first__ before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's lead developers might not want to merge into the project.
+__Please ask first__ before embarking on any significant pull request (e.g. implementing features, refactoring code, 
+porting to a different language), otherwise you risk spending a lot of time working on something that the project's 
+lead developers might not want to merge into the project.
 
 Please adhere to the [Dart Style Guide] for all changes contained in your pull requests.
 
@@ -133,7 +143,10 @@ Adhering to the following process is the best way to get your work included in t
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](#git-commit-message-standards) or your code is unlikely be merged into the master branch. Optionally, you can use Git's [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
+4. Commit your changes in logical chunks. Please adhere to these 
+   [git commit message guidelines](#git-commit-message-standards) or your code is unlikely be merged into the master 
+   branch. Optionally, you can use Git's [interactive rebase](https://help.github.com/articles/interactive-rebase) 
+   feature to tidy up your commits before making them public.
 
 5. Write tests for your changes.  
   1. There are no exceptions.  
@@ -161,7 +174,8 @@ Adhering to the following process is the best way to get your work included in t
 
 ## Git Commit Message Standards
 
-Below you will find an example commit message that follows the guidelines we would like all over_react contributors to follow.
+Below you will find an example commit message that follows the guidelines we would like all over_react contributors 
+to follow.
 
 ```
 Capitalized, short (50 chars or less) summary
@@ -180,11 +194,13 @@ followed by a single space, with blank lines in between, but
 conventions vary here
 ```
 
-Write your commit message in the imperative: "Fix bug" and not "Fixed bug" or "Fixes bug."  This convention matches up with commit messages generated by commands like git merge and git revert.
+Write your commit message in the imperative: "Fix bug" and not "Fixed bug" or "Fixes bug."  This convention matches up 
+with commit messages generated by commands like git merge and git revert.
 
 Further paragraphs come after blank lines.
 
-> [Read this](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for more information on why standardized commit message format is important.
+> [Read this](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for more information on why a
+> standardized commit message format is important.
 
 &nbsp;
 &nbsp;

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Good pull requests - patches, improvements, new features - are a fantastic help.
 
 __Please ask first__ before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's lead developers might not want to merge into the project.
 
-Please adhere to the [Dart Style Guide][dart-style-guide] for all changes contained in your pull requests.
+Please adhere to the [Dart Style Guide] for all changes contained in your pull requests.
 
 Adhering to the following process is the best way to get your work included in the project:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -137,8 +137,7 @@ Adhering to the following process is the best way to get your work included in t
 
 5. Write tests for your changes.  
   1. There are no exceptions.  
-  2. If your PR doesn't have accompanying test coverage - your code 
-     will not get merged.
+  2. If you're having trouble, reach out in your PR about how to best go about testing your changes.
 
 6. Locally merge the upstream master branch into your topic branch:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -152,7 +152,7 @@ Adhering to the following process is the best way to get your work included in t
   1. There are no exceptions.  
   2. If you're having trouble, reach out in your PR about how to best go about testing your changes.
 
-6. Locally merge the upstream master branch into your topic branch:
+6. If you have merge conflicts, locally merge the upstream master branch into your topic branch:
 
    ```bash
    git pull upstream master
@@ -211,14 +211,16 @@ Further paragraphs come after blank lines.
 
 The `over_react` developer workflow couldn't be any more simple!
 
+To serve the demos within `web/`, or start the transformer, run:
+
 ```bash
 pub serve
 ```
 
-When you're ready to run the tests... in a separate terminal:
+When you're ready to run the tests... run:
 
 ```bash
-pub run test -p content-shell --pub-serve=8081 test/over_react_test.dart
+pub run dart_dev test
 ```
 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,210 @@
+# Contributing to OverReact
+
+Looking to contribute something to the over_react library? __Here's how you can help.__
+
++ __[Coding Standards](#coding-standards)__
+  + [General Formatting Guidelines](#general-formatting-guidelines)
++ __[Using the Issue Tracker](#using-the-issue-tracker)__
+  + [Reporting Bugs](#bug-reports)
+  + [Feature Requests](#feature-requests)
+  + [Submitting Pull Requests](#pull-requests)
++ __[Commit Message Standards](#git-commit-message-standards)__
++ __[Developer Workflow](#developer-workflow)__
+
+
+
+
+## Coding standards
+
+A lot can be gained by writing code in a consistent way.  Moreover, always remember that code is written and maintained by _people_. Ensure your code is descriptive, well commented, and approachable by others.
+
+__ALWAYS__ adhere to the [Dart Style Guide].  _Please take the time to read it if you have never done so._
+
+&nbsp;
+
+
+### General formatting guidelines
+
++ __AVOID__ lines longer than 120 characters.
++ __AVOID__ using `dartfmt` as an excuse to ignore good judgement about
+  whether your code is readable and approachable by others.
+
+&nbsp;
+&nbsp;
+
+
+
+## Using the issue tracker
+
+The issue tracker is the preferred channel for [bug reports](#bug-reports) and [feature requests](#feature-requests), but __please follow the guidelines:__
+
+  + __Fill out the template we've provided.__
+
+  + __Be Professional__
+    + Please __do not__ derail or troll issues. Keep the discussion on topic and respect the opinions of others.
+
+  + __Not that Professional__
+    + Feel free to include _relevant_ animated gifs to drive home your message / request.
+
+&nbsp;
+
+
+### Bug reports
+
+A bug is a _demonstrable problem_ that is caused by the code in the repository.
+
+_Good bug reports are extremely helpful - thank you!__
+
+__Guidelines for bug reports:__
+
+1. __Search for existing issues.__ Duplicate issues can become cumbersome, and you'd help us out a lot by first checking if someone else has reported the same issue. Moreover, the issue may have already been resolved with a fix available.
+
+2. __Record a screencast of yourself reproducing the issue__. 
+  1. Be sure the problem exists in over_react's code by building a 
+     reduced test case that one of the reviewers can pull locally 
+     and test out.
+
+3. __Share as much information as possible.__ Include operating system and version, browser and version, version of `over_react`, etc. where appropriate. 
+
+Always include steps to reproduce the bug.
+
+__Example Bug Report:__
+
+> Short and descriptive example bug report title
+>
+> A summary of the issue and the browser/OS environment in which it occurs. If
+> suitable, include the steps required to reproduce the bug.
+>
+> 1. This is the first step
+> 2. This is the second step
+> 3. Further steps, etc.
+>
+> `<url>` - a link to branch with the reduced test case
+>
+> Any other information you want to share that is relevant to the issue being
+> reported. This might include the lines of code that you have identified as
+> causing the bug, and potential solutions (and your opinions on their
+> merits).
+
+&nbsp;
+
+
+### Feature requests
+
+Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the `over_react` team of the merits of this feature. Please provide as much detail and context as possible.
+
+&nbsp;
+
+
+### Pull requests
+
+Good pull requests - patches, improvements, new features - are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
+
+__Please ask first__ before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's lead developers might not want to merge into the project.
+
+Please adhere to the [Dart Style Guide][dart-style-guide] for all changes contained in your pull requests.
+
+Adhering to the following process is the best way to get your work included in the project:
+
+1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+   and configure the remotes:
+
+   ```bash
+   # Navigate to the directory where you store repos locally
+   cd ~/your-local-git-repo-spot
+   # Clone your fork of the repo into the current directory
+   git clone git@github.com:<your-username>/over_react
+   # Navigate to the newly cloned directory
+   cd ~/your-local-git-repo-spot/over_react
+   # Assign the repo you forked from to a remote called "upstream"
+   git remote add upstream git@github.com:Workiva/over_react
+   ```
+
+2. If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout master
+   git pull upstream master
+   ```
+
+3. Create a new topic branch that will contain your feature, change, or fix:
+
+   ```bash
+   git checkout -b <topic-branch-name>
+   ```
+
+4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](#git-commit-message-standards) or your code is unlikely be merged into the master branch. Optionally, you can use Git's [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
+
+5. Write tests for your changes.  
+  1. There are no exceptions.  
+  2. If your PR doesn't have accompanying test coverage - your code 
+     will not get merged.
+
+6. Locally merge the upstream master branch into your topic branch:
+
+   ```bash
+   git pull upstream master
+   ```
+
+7. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin <topic-branch-name>
+   ```
+
+8. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+    with a clear title and description - following all the [issue guidelines](#using-the-issue-tracker) listed above.
+
+&nbsp;
+&nbsp;
+
+
+
+## Git Commit Message Standards
+
+Below you will find an example commit message that follows the guidelines we would like all over_react contributors to follow.
+
+```
+Capitalized, short (50 chars or less) summary
+
+More detailed explanatory text, if necessary.  Wrap it to about 72
+characters or so.  In some contexts, the first line is treated as the
+subject of an email and the rest of the text as the body.  The blank
+line separating the summary from the body is critical (unless you omit
+the body entirely); tools like rebase can get confused if you run the
+two together.
+
++ Bullet points are okay, too
+
++ Typically a hyphen, asterisk or plus-symbol is used for the bullet, 
+followed by a single space, with blank lines in between, but 
+conventions vary here
+```
+
+Write your commit message in the imperative: "Fix bug" and not "Fixed bug" or "Fixes bug."  This convention matches up with commit messages generated by commands like git merge and git revert.
+
+Further paragraphs come after blank lines.
+
+> [Read this](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for more information on why standardized commit message format is important.
+
+&nbsp;
+&nbsp;
+
+
+
+## Developer Workflow
+
+The `over_react` developer workflow couldn't be any more simple!
+
+```bash
+pub serve
+```
+
+When you're ready to run the tests... in a separate terminal:
+
+```bash
+pub run test -p content-shell --pub-serve=8081 test/over_react_test.dart
+```
+
+
+[Dart Style Guide]: https://www.dartlang.org/guides/language/effective-dart/style

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+> * Issue Type: [BUG, FEATURE REQUEST, etc.]
+> * `over_react` Version(s): `x.x.x`
+
+
+Describe your issue here... _If it is a bug - PLEASE follow our [bug submission guidelines](https://github.com/Workiva/over_react/blob/master/.github/CONTRIBUTING.md#bug-reports)._
+
+
+---
+
+
+> __FYI:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+__ULTIMATE PROBLEM:__
+
+
+
+__HOW IT WAS FIXED:__
+
+
+
+__TESTING SUGGESTIONS:__
+
+
+
+__POTENTIAL AREAS OF REGRESSION:__
+
+
+
+---
+
+
+> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,16 @@
-__ULTIMATE PROBLEM:__
+__Ultimate problem:__
 
 
 
-__HOW IT WAS FIXED:__
+__How it was fixed:__
 
 
 
-__TESTING SUGGESTIONS:__
+__Testing suggestions:__
 
 
 
-__POTENTIAL AREAS OF REGRESSION:__
+__Potential areas of regression:__
 
 
 

--- a/README.md
+++ b/README.md
@@ -662,6 +662,23 @@ Since using `dartfmt` results in unreadable code, we have documented the followi
 
 &nbsp;
 
+* __AVOID__ specifying more than one cascading prop setter on the same line.
+
+  _Good:_
+    ```dart
+    (Dom.div()
+      ..id = 'my_div'
+      ..className = 'my-class'
+    )()
+    ```
+
+  _Bad:_
+    ```dart
+    (Dom.div()..id = 'my_div'..className = 'my-class')()
+    ```
+
+&nbsp;
+
 * __ALWAYS__ write informative comments for your component factories. 
 Include what the component relates to, relies on, or if it extends 
 another component.
@@ -689,15 +706,12 @@ another component.
 
 &nbsp;
 
-* __ALWAYS__ set a default / intial value for `props` / `state` fields, 
+* __ALWAYS__ set a default / initial value for `props` / `state` fields, 
 and document that value in a comment.
 
   _Why?_ Without default prop values for bool fields, they could be 
   `null` - which is extremely confusing and can lead to a lot of 
   unnecessary null-checking in your business logic. 
-
-  Also, if you fail to provide an initial value for all the fields in 
-  `state`, your component will fail to build at run-time.
 
   _Good:_
     ```dart
@@ -757,8 +771,8 @@ and document that value in a comment.
     @Component()
     DropdownButtonComponent 
         extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
-      // Confusing stuff is gonna happen in here with bool props that could
-      // be null, and un-initialized state keys.
+      // Confusing stuff is gonna happen in here with 
+      // bool props that could be null.
     }
     ```
 
@@ -806,23 +820,6 @@ an informative comment.
     DropdownButtonState extends UiState {
       bool isOpen;
     }
-    ```
-
-&nbsp;
-
-* __AVOID__ specifying more than one cascading prop setter on the same line.
-
-  _Good:_
-    ```dart
-    (Dom.div()
-      ..id = 'my_div'
-      ..className = 'my-class'
-    )()
-    ```
-
-  _Bad:_
-    ```dart
-    (Dom.div()..id = 'my_div'..className = 'my-class')()
     ```
 
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
     * [UiComponent](#uicomponent)
 * __[Fluent-style component consumption](#fluent-style-component-consumption)__
 * __[DOM components and props](#dom-components-and-props)__
+* __[Component Formatting](#component-formatting)__
 * __[Building custom components](#building-custom-components)__
     * __[Component Boilerplates](#component-boilerplate-templates)__
-    * __[Component Formatting](#component-formatting)__
+    * __[Component Best Practices](#component-best-practices)__
     * __[Common Pitfalls](#common-pitfalls)__
 * __[Contributing](#contributing)__
 
@@ -491,6 +492,90 @@ as shown in the examples above.
 
 
 
+## Component Formatting
+
+> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it 
+> _greatly_ decreases the readability of components built using 
+> [OverReact's fluent-style](#fluent-style-component-consumption).
+> 
+> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our 
+> fluent-style to remain readable even after the formatter executes._
+
+Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that 
+we _strongly recommended_ when building components using the `over_react` library.
+
+&nbsp;
+
+* __ALWAYS__ place the closing builder parent on a new line.
+
+  _Good:_
+    ```dart
+    (Button()
+      ..skin = ButtonSkin.SUCCESS
+      ..isDisabled = true
+    )('Submit')
+    ```
+
+  _Bad:_
+    ```dart
+    (Button()
+      ..skin = ButtonSkin.SUCCESS
+      ..isDisabled = true)('Submit')
+    ```
+
+&nbsp;
+
+* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__ 
+  indentation.
+
+  _Good:_
+    ```dart
+    Dom.div()(
+      Dom.span()('nested component'),
+      Dom.span()('nested component')
+    )
+    ```
+
+  _Bad:_
+    ```dart
+    // Nested component is not on a new line
+    Dom.div()(Dom.span()('nested component'))
+
+    // Nested component has a continuation indent
+    Dom.div()(
+        Dom.span()('nested component'),
+    )
+
+    // Nested components are within a list instead of
+    // being passed in as variadic children.
+    Dom.div()([
+      Dom.span()('nested component'),
+      Dom.span()('nested component')
+    ])
+    ```
+
+&nbsp;
+
+* __AVOID__ specifying more than one cascading prop setter on the same line.
+
+  _Good:_
+    ```dart
+    (Dom.div()
+      ..id = 'my_div'
+      ..className = 'my-class'
+    )()
+    ```
+
+  _Bad:_
+    ```dart
+    (Dom.div()..id = 'my_div'..className = 'my-class')()
+    ```
+
+&nbsp;
+&nbsp;
+
+
+
 ## Building custom components
 
 Now that we’ve gone over how to [use the `over_react` package in your project](#using-it-in-your-project), 
@@ -603,81 +688,8 @@ that you get for free from OverReact, you're ready to start building your own cu
 
 &nbsp;
 
-### Component Formatting
+### Component Best Practices
 
-> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it _greatly_ decreases the readability of components built using [OverReact's fluent-style](#fluent-style-component-consumption).
-> 
-> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our fluent-style to remain readable even after the formatter executes._
-
-Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that we _strongly recommended_ when building components using the `over_react` library.
-
-&nbsp;
-
-* __ALWAYS__ place the closing builder parent on a new line.
-
-  _Good:_
-    ```dart
-    (Button()
-      ..skin = ButtonSkin.SUCCESS
-      ..isDisabled = true
-    )('Submit')
-    ```
-
-  _Bad:_
-    ```dart
-    (Button()
-      ..skin = ButtonSkin.SUCCESS
-      ..isDisabled = true)('Submit')
-    ```
-
-&nbsp;
-
-* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__ indentation.
-
-  _Good:_
-    ```dart
-    Dom.div()(
-      Dom.span()('nested component'),
-      Dom.span()('nested component')
-    )
-    ```
-
-  _Bad:_
-    ```dart
-    // Nested component is not on a new line
-    Dom.div()(Dom.span()('nested component'))
-
-    // Nested component has a continuation indent
-    Dom.div()(
-        Dom.span()('nested component'),
-    )
-
-    // Nested components are within a list instead of
-    // being passed in as variadic children.
-    Dom.div()([
-      Dom.span()('nested component'),
-      Dom.span()('nested component')
-    ])
-    ```
-
-&nbsp;
-
-* __AVOID__ specifying more than one cascading prop setter on the same line.
-
-  _Good:_
-    ```dart
-    (Dom.div()
-      ..id = 'my_div'
-      ..className = 'my-class'
-    )()
-    ```
-
-  _Bad:_
-    ```dart
-    (Dom.div()..id = 'my_div'..className = 'my-class')()
-    ```
-
-&nbsp;
 
 * __ALWAYS__ write informative comments for your component factories. 
 Include what the component relates to, relies on, or if it extends 
@@ -876,7 +888,8 @@ Yes please! ([__Please read our contributor guidelines first__][contributing-doc
 The `over_react` library adheres to [Semantic Versioning](http://semver.org/):
 
 * Any API changes that are not backwards compatible will __bump the major version__ _(and reset the minor / patch)_.
-* Any new functionality that is added in a backwards-compatible manner will __bump the minor version__ _(and reset the patch)_.
+* Any new functionality that is added in a backwards-compatible manner will __bump the minor version__ 
+  _(and reset the patch)_.
 * Any backwards-compatible bug fixes that are added will __bump the patch version__.
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 * __[DOM components and props](#dom-components-and-props)__
 * __[Building custom components](#building-custom-components)__
     * __[Component Boilerplates](#component-boilerplate-templates)__
+    * __[Component Formatting](#component-formatting)__
     * __[Common Pitfalls](#common-pitfalls)__
+* __[Contributing](#contributing)__
 
 [](#__START_EMBEDDED_README__)
 
@@ -97,6 +99,7 @@ mount / render it into the HTML element you created in step 3.
 
 5. Run `pub serve` in the root of your Dart project.
 
+&nbsp;
 
 ### Running tests in your project
 
@@ -146,6 +149,7 @@ Pub transformer using an analogous [annotation].
 3. _[UiState](#uistate) (optional)_
 4. [UiComponent](#uicomponent)
 
+&nbsp;
 
 ### UiFactory
 
@@ -161,6 +165,7 @@ UiFactory<FooProps> Foo;
 * The `UiProps` instance it returns can be used [as a component builder](#uiprops-as-a-builder), 
 or [as a typed view into an existing props map](#uiprops-as-a-map).
 
+&nbsp;
 
 ### UiProps
 
@@ -173,6 +178,8 @@ class FooProps extends UiProps {
   // ...
 }
 ``` 
+
+&nbsp;
 
 #### UiProps as a Map
 
@@ -209,6 +216,8 @@ void baz() {
   print(props.color); // #0094ff
 }
 ```
+
+&nbsp;
 
 #### UiProps as a builder
 
@@ -251,6 +260,7 @@ class FooComponent extends UiComponent<FooProps> {
 
 > See [_fluent-style component consumption_](#fluent-style-component-consumption) for more examples on builder usage.
 
+&nbsp;
 
 ### UiState
 
@@ -266,6 +276,7 @@ class FooState extends UiState {
 
 > UiState is optional, and won’t be used for every component.
 
+&nbsp;
 
 ### UiComponent
 
@@ -283,6 +294,8 @@ class FooComponent extends UiComponent<FooProps> {
 prop forwarding and CSS class merging.
 * The `UiStatefulComponent` flavor augments `UiComponent` behavior with statically-typed state via 
 [`UiState`](#uistate).
+
+&nbsp;
 
 #### Accessing and manipulating props / state within UiComponent
 
@@ -500,6 +513,7 @@ that you get for free from OverReact, you're ready to start building your own cu
     
 > __Check out some custom [component demos] to get a feel for what’s possible!__
 
+&nbsp;
 
 ### Component Boilerplate Templates
 
@@ -587,6 +601,231 @@ that you get for free from OverReact, you're ready to start building your own cu
     }
     ```
 
+&nbsp;
+
+### Component Formatting
+
+> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it _greatly_ decreases the readability of components built using [OverReact's fluent-style](#fluent-style-component-consumption).
+> 
+> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our fluent-style to remain readable even after the formatter executes._
+
+Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that we _strongly recommended_ when building components using the `over_react` library.
+
+&nbsp;
+
+* __ALWAYS__ place the closing builder parent on a new line.
+
+  _Good:_
+    ```dart
+    (Button()
+      ..skin = ButtonSkin.SUCCESS
+      ..isDisabled = true
+    )('Submit')
+    ```
+
+  _Bad:_
+    ```dart
+    (Button()
+      ..skin = ButtonSkin.SUCCESS
+      ..isDisabled = true)('Submit')
+    ```
+
+&nbsp;
+
+* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__ indentation.
+
+  _Good:_
+    ```dart
+    Dom.div()(
+      Dom.span()('nested component'),
+      Dom.span()('nested component')
+    )
+    ```
+
+  _Bad:_
+    ```dart
+    // Nested component is not on a new line
+    Dom.div()(Dom.span()('nested component'))
+
+    // Nested component has a continuation indent
+    Dom.div()(
+        Dom.span()('nested component'),
+    )
+
+    // Nested components are within a list instead of
+    // being passed in as variadic children.
+    Dom.div()([
+      Dom.span()('nested component'),
+      Dom.span()('nested component')
+    ])
+    ```
+
+&nbsp;
+
+* __ALWAYS__ write informative comments for your component factories. 
+Include what the component relates to, relies on, or if it extends 
+another component.
+
+  _Good:_
+    ```dart
+    /// Use the `DropdownButton` component to render a button
+    /// that controls the visibility of a child [DropdownMenu].
+    ///
+    /// * Related to [Button].
+    /// * Extends [DropdownTrigger].
+    /// * Similar to [SplitButton].
+    ///
+    /// See: <https://link-to-any-relevant-documentation>.
+    @Factory()
+    UiFactory<DropdownButtonProps> DropdownButton;
+    ```
+
+  _Bad:_
+    ```dart
+    /// Component Factory for a dropdown button component.
+    @Factory()
+    UiFactory<DropdownButtonProps> DropdownButton;
+    ```
+
+&nbsp;
+
+* __ALWAYS__ set a default / intial value for `props` / `state` fields, 
+and document that value in a comment.
+
+  _Why?_ Without default prop values for bool fields, they could be 
+  `null` - which is extremely confusing and can lead to a lot of 
+  unnecessary null-checking in your business logic. 
+
+  Also, if you fail to provide an initial value for all the fields in 
+  `state`, your component will fail to build at run-time.
+
+  _Good:_
+    ```dart
+    @Props()
+    DropdownButtonProps extends UiProps {
+      /// Whether the [DropdownButton] appears disabled.
+      /// 
+      /// Default: `false`
+      bool isDisabled;
+
+      /// Whether the [DropdownButton]'s child [DropdownMenu] is open
+      /// when the component is first mounted.
+      /// 
+      /// Determines the initial value of [DropdownButtonState.isOpen].
+      /// 
+      /// Default: `false`
+      bool initiallyOpen;
+    }
+
+    @State()
+    DropdownButtonState extends UiState {
+      /// Whether the [DropdownButton]'s child [DropdownMenu] is open.
+      /// 
+      /// Initial: [DropdownButtonProps.initiallyOpen]
+      bool isOpen;
+    }
+
+    @Component()
+    DropdownButtonComponent 
+        extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
+      @override
+      Map getDefaultProps() => (newProps()
+        ..isDisabled = false
+        ..initiallyOpen = false
+      );
+
+      @override
+      Map getInitialState() => (newState()
+        ..isOpen = props.initiallyOpen
+      );
+    }
+    ```
+
+  _Bad:_
+    ```dart
+    @Props()
+    DropdownButtonProps extends UiProps {
+      bool isDisabled;
+      bool initiallyOpen;
+    }
+
+    @State()
+    DropdownButtonState extends UiState {
+      bool isOpen;
+    }
+
+    @Component()
+    DropdownButtonComponent 
+        extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
+      // Confusing stuff is gonna happen in here with bool props that could
+      // be null, and un-initialized state keys.
+    }
+    ```
+
+&nbsp;
+
+* __AVOID__ adding `props` or `state` fields that don't have 
+an informative comment.
+
+  _Good:_
+    ```dart
+    @Props()
+    DropdownButtonProps extends UiProps {
+      /// Whether the [DropdownButton] appears disabled.
+      /// 
+      /// Default: `false`
+      bool isDisabled;
+
+      /// Whether the [DropdownButton]'s child [DropdownMenu] is open
+      /// when the component is first mounted.
+      /// 
+      /// Determines the initial value of [DropdownButtonState.isOpen].
+      /// 
+      /// Default: `false`
+      bool initiallyOpen;
+    }
+
+    @State()
+    DropdownButtonState extends UiState {
+      /// Whether the [DropdownButton]'s child [DropdownMenu] is open.
+      /// 
+      /// Initial: [DropdownButtonProps.initiallyOpen]
+      bool isOpen;
+    }
+    ```
+
+  _Bad:_
+    ```dart
+    @Props()
+    DropdownButtonProps extends UiProps {
+      bool isDisabled;
+      bool initiallyOpen;
+    }
+
+    @State()
+    DropdownButtonState extends UiState {
+      bool isOpen;
+    }
+    ```
+
+&nbsp;
+
+* __AVOID__ specifying more than one cascading prop setter on the same line.
+
+  _Good:_
+    ```dart
+    (Dom.div()
+      ..id = 'my_div'
+      ..className = 'my-class'
+    )()
+    ```
+
+  _Bad:_
+    ```dart
+    (Dom.div()..id = 'my_div'..className = 'my-class')()
+    ```
+
+&nbsp;
 
 ### Common Pitfalls
 
@@ -621,10 +860,33 @@ invalid file to 404. This ensures that when the transformer breaks, `pub build` 
 
 __Check your `pub serve` output for errors.__
 
+&nbsp;
+&nbsp;
+
+
+
+## Contributing
+
+Yes please! ([__Please read our contributor guidelines first__][contributing-docs])
+
+&nbsp;
+&nbsp;
+
+
+
+## Versioning
+
+The `over_react` library adheres to [Semantic Versioning](http://semver.org/):
+
+* Any API changes that are not backwards compatible will __bump the major version__ _(and reset the minor / patch)_.
+* Any new functionality that is added in a backwards-compatible manner will __bump the minor version__ _(and reset the patch)_.
+* Any backwards-compatible bug fixes that are added will __bump the patch version__.
+
 
 
 [component demos]: https://workiva.github.io/over_react/demos
 
+[contributing-docs]: https://github.com/Workiva/over_react/blob/master/.github/CONTRIBUTING.md
 [transformer]: https://github.com/Workiva/over_react/blob/master/lib/src/transformer/README.md
 [annotations]: https://github.com/Workiva/over_react/blob/master/lib/src/component_declaration/annotations.dart
 [annotation]: https://github.com/Workiva/over_react/blob/master/lib/src/component_declaration/annotations.dart


### PR DESCRIPTION
Pretty self-explanatory...

I added `CONTRIBUTING.md`, along with a PR / ISSUE template, and an update to the main readme with a word about our friend `dartfmt`, and our versioning scheme.

__FYA:__ @jacehensley-wf @clairesarsam-wf @greglittlefield-wf @joelleibow-wf 