### PR TITLE
Add stateful component demo

### DIFF
--- a/web/demos/demos.dart
+++ b/web/demos/demos.dart
@@ -28,3 +28,6 @@ part 'progress/progress-animated-stripes.dart';
 part 'tag/tag-basic.dart';
 part 'tag/tag-contextual.dart';
 part 'tag/tag-pills.dart';
+
+part 'toggle-button/toggle-button-checkbox.dart';
+part 'toggle-button/toggle-button-radio.dart';

--- a/web/demos/toggle-button/toggle-button-checkbox.dart
+++ b/web/demos/toggle-button/toggle-button-checkbox.dart
@@ -1,0 +1,17 @@
+part of over_react.web.demos;
+
+ReactElement checkboxToggleButtonDemo() =>
+  (ToggleButtonGroup()
+    ..toggleType = ToggleBehaviorType.CHECKBOX
+  )(
+    (ToggleButton()
+      ..value = '1'
+    )('Checkbox 1'),
+    (ToggleButton()
+      ..value = '2'
+      ..defaultChecked = true
+    )('Checkbox 2'),
+    (ToggleButton()
+      ..value = '3'
+    )('Checkbox 3')
+  );

--- a/web/demos/toggle-button/toggle-button-radio.dart
+++ b/web/demos/toggle-button/toggle-button-radio.dart
@@ -1,0 +1,17 @@
+part of over_react.web.demos;
+
+ReactElement radioToggleButtonDemo() =>
+  (ToggleButtonGroup()
+    ..toggleType = ToggleBehaviorType.RADIO
+  )(
+    (ToggleButton()
+      ..value = '1'
+    )('Radio 1'),
+    (ToggleButton()
+      ..value = '2'
+      ..defaultChecked = true
+    )('Radio 2'),
+    (ToggleButton()
+      ..value = '3'
+    )('Radio 3')
+  );

--- a/web/index.dart
+++ b/web/index.dart
@@ -19,4 +19,10 @@ void main() {
 
   react_dom.render(
     tagBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--tag'));
+
+  react_dom.render(
+    checkboxToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--checkbox-toggle'));
+
+  react_dom.render(
+    radioToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--radio-toggle'));
 }

--- a/web/index.html
+++ b/web/index.html
@@ -43,6 +43,18 @@
                     around with the component rendered below.</p>
                 <div class="component-demo__mount--tag"></div>
             </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>ToggleButton (Checkbox)</h2>
+                <p>Modify the source of <code>/web/demos/toggle-button/toggle-button-checkbox.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--checkbox-toggle"></div>
+            </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>ToggleButton (Radio)</h2>
+                <p>Modify the source of <code>/web/demos/toggle-button/toggle-button-radio.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--radio-toggle"></div>
+            </div>
         </div>
     </div>
 

--- a/web/src/demo_components.dart
+++ b/web/src/demo_components.dart
@@ -12,7 +12,10 @@ import 'package:over_react/over_react.dart';
 part 'demo_components/shared.dart';
 
 part 'demo_components/button.dart';
+part 'demo_components/button_group.dart';
 part 'demo_components/list_group.dart';
 part 'demo_components/list_group_item.dart';
 part 'demo_components/progress.dart';
 part 'demo_components/tag.dart';
+part 'demo_components/toggle_button_group.dart';
+part 'demo_components/toggle_button.dart';

--- a/web/src/demo_components/button.dart
+++ b/web/src/demo_components/button.dart
@@ -71,8 +71,11 @@ class ButtonProps extends UiProps {
   ButtonType type;
 }
 
+@State()
+class ButtonState extends UiState {}
+
 @Component()
-class ButtonComponent extends UiComponent<ButtonProps> {
+class ButtonComponent<T extends ButtonProps, S extends ButtonState> extends UiStatefulComponent<T, S> {
   @override
   Map getDefaultProps() => (newProps()
     ..skin = ButtonSkin.PRIMARY
@@ -85,26 +88,30 @@ class ButtonComponent extends UiComponent<ButtonProps> {
 
   @override
   render() {
+    return renderButton(props.children);
+  }
+
+  ReactElement renderButton(dynamic children) {
     BuilderOnlyUiFactory<DomProps> factory = _buttonDomNodeFactory;
 
     return (factory()
       ..addProps(copyUnconsumedDomProps())
-      ..className = _getButtonClasses().toClassName()
+      ..className = getButtonClasses().toClassName()
       ..href = props.href
       ..target = props.target
-      ..type = _isAnchorLink ? null : props.type.typeName
+      ..type = _type
       ..disabled = _isAnchorLink ? null : props.isDisabled
       ..addProps(ariaProps()
         ..disabled = _isAnchorLink ? props.isDisabled : null
       )
-    )(props.children);
+    )(children);
   }
 
-  ClassNameBuilder _getButtonClasses() {
+  ClassNameBuilder getButtonClasses() {
     return forwardingClassNameBuilder()
       ..add('btn')
       ..add('btn-block', props.isBlock)
-      ..add('active', props.isActive)
+      ..add('active', _isActive)
       ..add('disabled', props.isDisabled)
       ..add(props.skin.className)
       ..add(props.size.className);
@@ -113,6 +120,10 @@ class ButtonComponent extends UiComponent<ButtonProps> {
   BuilderOnlyUiFactory<DomProps> get _buttonDomNodeFactory => _isAnchorLink ? Dom.a : Dom.button;
 
   bool get _isAnchorLink => props.href != null;
+
+  bool get _isActive => props.isActive;
+
+  String get _type => _isAnchorLink ? null : props.type.typeName;
 }
 
 /// Contextual skin options for a [Button] component.

--- a/web/src/demo_components/button_group.dart
+++ b/web/src/demo_components/button_group.dart
@@ -1,4 +1,4 @@
- part of over_react.web.demo_components;
+part of over_react.web.demo_components;
 
 /// Groups a series of [Button]s together on a single line.
 ///

--- a/web/src/demo_components/button_group.dart
+++ b/web/src/demo_components/button_group.dart
@@ -1,0 +1,94 @@
+ part of over_react.web.demo_components;
+
+/// Groups a series of [Button]s together on a single line.
+///
+/// See: <http://v4-alpha.getbootstrap.com/components/button-group/>.
+@Factory()
+UiFactory<ButtonGroupProps> ButtonGroup;
+
+@Props()
+class ButtonGroupProps extends UiProps {
+  /// Apply a button size variation universally to every [Button] within the [ButtonGroup].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#sizing>.
+  ///
+  /// Default: [ButtonGroupSize.DEFAULT]
+  ButtonGroupSize size;
+
+  /// Make the [Button]s within a [ButtonGroup] stack vertically.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.
+  ///
+  /// Default: false
+  bool isVertical;
+}
+
+@State()
+class ButtonGroupState extends UiState {}
+
+@Component()
+class ButtonGroupComponent<T extends ButtonGroupProps, S extends ButtonGroupState>
+    extends UiStatefulComponent<T, S> {
+  @override
+  Map getDefaultProps() => (newProps()
+    ..size = ButtonGroupSize.DEFAULT
+    ..isVertical = false
+  );
+
+  @override
+  render() {
+    return renderButtonGroup(props.children);
+  }
+
+  ReactElement renderButtonGroup(dynamic children) {
+    var componentBuilder = Dom.div();
+
+    if (children.length > 1) {
+      componentBuilder.role = Role.group;
+    }
+
+    return (componentBuilder
+      ..addProps(copyUnconsumedDomProps())
+      ..className = getButtonGroupClasses().toClassName())(children);
+  }
+
+  ClassNameBuilder getButtonGroupClasses() {
+    return forwardingClassNameBuilder()
+      ..add('btn-group', !props.isVertical)
+      ..add('btn-group-vertical', props.isVertical)
+      ..add(props.size.className);
+  }
+}
+
+/// Size options for a [ButtonGroup]s, with corresponding [className] values.
+class ButtonGroupSize extends ClassNameConstant {
+  const ButtonGroupSize._(String name, String className) : super(name, className);
+
+  /// [className] value: 'btn-group-sm'
+  static const ButtonGroupSize SMALL   = const ButtonGroupSize._('SMALL', 'btn-group-sm');
+
+  /// [className] value: ''
+  static const ButtonGroupSize DEFAULT = const ButtonGroupSize._('DEFAULT', '');
+
+  /// [className] value: 'btn-group-lg'
+  static const ButtonGroupSize LARGE   = const ButtonGroupSize._('LARGE', 'btn-group-lg');
+}
+
+/// Mapping from [ButtonSize] values to their analogous [ButtonGroupSize] values.
+///
+/// __Example:__
+///
+///     @Props()
+///     class MyProps extends UiProps {
+///       ButtonSize size;
+///     }
+///
+///     @Component()
+///     class MyComponent extends UiComponent<MyProps> {
+///       ButtonGroupSize matchingButtonGroupSize = buttonToButtonGroupSize[props.size];
+///     }
+final Map<ButtonSize, ButtonGroupSize> buttonToButtonGroupSize = const <ButtonSize, ButtonGroupSize>{
+  ButtonSize.SMALL:   ButtonGroupSize.SMALL,
+  ButtonSize.DEFAULT: ButtonGroupSize.DEFAULT,
+  ButtonSize.LARGE:   ButtonGroupSize.LARGE,
+};

--- a/web/src/demo_components/button_group.dart
+++ b/web/src/demo_components/button_group.dart
@@ -15,6 +15,9 @@ class ButtonGroupProps extends UiProps {
   /// Default: [ButtonGroupSize.DEFAULT]
   ButtonGroupSize size;
 
+  /// The [ButtonSkin] variation applied to every [Button] within the [ButtonGroup].
+  ButtonSkin skin;
+
   /// Make the [Button]s within a [ButtonGroup] stack vertically.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.
@@ -37,7 +40,7 @@ class ButtonGroupComponent<T extends ButtonGroupProps, S extends ButtonGroupStat
 
   @override
   render() {
-    return renderButtonGroup(props.children);
+    return renderButtonGroup(renderButtons());
   }
 
   ReactElement renderButtonGroup(dynamic children) {
@@ -58,6 +61,63 @@ class ButtonGroupComponent<T extends ButtonGroupProps, S extends ButtonGroupStat
       ..add('btn-group-vertical', props.isVertical)
       ..add(props.size.className);
   }
+
+  /// Renders a list of [Button]s using [renderButton].
+  List<ReactElement> renderButtons() {
+    var buttons = [];
+
+    for (int index = 0; index < props.children.length; index++) {
+      buttons.add(renderButton(props.children[index], index));
+    }
+
+    return buttons;
+  }
+
+  /// Clones the provided [child] with the props specified in [buttonPropsToAdd].
+  ReactElement renderButton(dynamic child, int index) {
+    if (isValidButtonChild(child)) {
+      return cloneElement(child, buttonPropsToAdd(child, index));
+    }
+
+    print('invalid child');
+    return child;
+  }
+
+  /// The props that should be added when we clone the given [child] using
+  /// [cloneElement] via [renderButton].
+  ButtonProps buttonPropsToAdd(dynamic child, int index) {
+    var childProps = childFactory(getProps(child));
+    var childKey = getInstanceKey(child);
+
+    return childFactory()
+      ..skin = props.skin ?? childProps.skin
+      ..key = childKey ?? index;
+  }
+
+  /// Returns whether the provided [child] can be cloned using [cloneElement].
+  bool isValidButtonChild(dynamic child) {
+    var isCloneable = false;
+    if (isValidElement(child)) {
+      if (!isComponentOfType(child, childFactory)) {
+        assert(ValidationUtil.warn(
+            'An unexpected child type was found within this component.'
+        ));
+      }
+
+      isCloneable = true;
+    } else if (child != null) {
+      assert(ValidationUtil.warn(
+          'You are not using a valid ReactElement.'
+      ));
+    }
+
+    return isCloneable;
+  }
+
+  /// The factory expected for each child of [ButtonGroup].
+  ///
+  /// _The factory accept [ButtonProps] as its generic parameter._
+  UiFactory<ButtonProps> get childFactory => Button;
 }
 
 /// Size options for a [ButtonGroup]s, with corresponding [className] values.

--- a/web/src/demo_components/shared.dart
+++ b/web/src/demo_components/shared.dart
@@ -19,3 +19,77 @@ class ButtonType extends DebugFriendlyConstant {
   @override
   String get debugDescription => 'typeName: $typeName';
 }
+
+/// Toggle button behavior options for the children of a [ToggleButtonGroup].
+class ToggleBehaviorType extends DebugFriendlyConstant {
+  /// The HTML `type` attribute value that should be placed on the HTML `<input>` element rendered
+  /// by a [ToggleButton].
+  final String typeName;
+
+  const ToggleBehaviorType._(String name, this.typeName) : super(name);
+
+  /// [typeName] value: 'radio'
+  static const ToggleBehaviorType RADIO = const ToggleBehaviorType._('RADIO', 'radio');
+
+  /// [typeName] value: 'checkbox'
+  static const ToggleBehaviorType CHECKBOX = const ToggleBehaviorType._('CHECKBOX', 'checkbox');
+
+  @override
+  String get debugDescription => 'typeName: $typeName';
+}
+
+@PropsMixin()
+abstract class AbstractInputPropsMixin {
+  Map get props;
+
+  /// The id for the input.
+  ///
+  /// If unspecified, [AbstractInputStateMixin.id] will be generated.
+  ///
+  /// _Proxies [DomProps.id]._
+  String get id;
+
+  /// The HTML `name` attribute to be applied to `<input>`.
+  ///
+  /// If unspecified, [AbstractInputStateMixin.name] will be generated.
+  ///
+  /// _Proxies [DomProps.name]._
+  @Accessor(keyNamespace: '')
+  String name;
+
+  /// The value of the input. Setting this will make the input's value _controlled_; it will not update automatically in
+  /// response to user input, but instead will always render the value of this prop.
+  ///
+  /// See: [React Controlled Components](https://facebook.github.io/react/docs/forms.html#controlled-components)
+  ///
+  /// _Proxies [DomProps.value]._
+  @Accessor(keyNamespace: '')
+  dynamic value;
+
+  /// The type of "toggle" behavior an HTML `<input>` should exhibit:
+  ///
+  /// * [ToggleBehaviorType.CHECKBOX] - More than one can be active at once.
+  /// * [ToggleBehaviorType.RADIO] - Only one can be active at once.
+  ///
+  /// Default: [ToggleBehaviorType.CHECKBOX]
+  ToggleBehaviorType toggleType;
+}
+
+@StateMixin()
+abstract class AbstractInputStateMixin {
+  Map get state;
+
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML ids are needed in inputs for proper label linking and accessibility support,
+  /// so this state value ensures there's always a valid ID value to use.
+  String id;
+
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.name] is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML names must be the same for anything that renders an HTML `<input type="radio">` element
+  /// so that only one can be selected at a time.
+  String name;
+}

--- a/web/src/demo_components/toggle_button.dart
+++ b/web/src/demo_components/toggle_button.dart
@@ -1,0 +1,209 @@
+part of over_react.web.demo_components;
+
+/// Use [ToggleButton]s in order to render functional `<input type="checkbox">`
+/// or `<input type="radio">` elements that look like a [Button].
+///
+/// See: <http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons>
+@Factory()
+UiFactory<ToggleButtonProps> ToggleButton;
+
+@Props()
+class ToggleButtonProps extends ButtonProps with AbstractInputPropsMixin {
+  /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
+  ///
+  /// _Proxies [DomProps.autoFocus]._
+  ///
+  /// Default: `false`
+  @Accessor(keyNamespace: '')
+  bool autoFocus;
+
+  /// Whether the [ToggleButton] is checked by default.
+  ///
+  /// Setting this without the setting the [checked] prop to will make the
+  /// [ToggleButton] _uncontrolled_; it will initially render checked or unchecked
+  /// depending on the value of this prop, and then update itself automatically
+  /// in response to user input, like a normal HTML input.
+  ///
+  /// Related: [checked]
+  ///
+  /// _Proxies [DomProps.defaultChecked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#uncontrolled-components>.
+  @Accessor(keyNamespace: '')
+  bool defaultChecked;
+
+  /// Whether the [ToggleButton] is checked.
+  ///
+  /// Setting this will make the [ToggleButton] _controlled_; it will not update
+  /// automatically in response to user input, but instead will always render
+  /// checked or unchecked depending on the value of this prop.
+  ///
+  /// Related: [defaultChecked]
+  ///
+  /// _Proxies [DomProps.checked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#controlled-components>.
+  @Accessor(keyNamespace: '')
+  bool checked;
+}
+
+@State()
+class ToggleButtonState extends ButtonState with AbstractInputStateMixin {
+  /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
+  /// class.
+  ///
+  /// Initial: [ToggleButtonProps.autoFocus]
+  bool isFocused;
+
+  /// Tracks if the [ToggleButton] input is `checked`. Determines whether to render with the `active` CSS class.
+  ///
+  /// Initial: [ToggleButtonProps.checked] `??` [ToggleButtonProps.defaultChecked] `?? false`
+  bool isChecked;
+}
+
+@Component(subtypeOf: ButtonComponent)
+class ToggleButtonComponent extends ButtonComponent<ToggleButtonProps, ToggleButtonState> {
+  // Refs
+
+  /// A reference to the [Dom.input] rendered via [renderInput] within the [ToggleButton].
+  InputElement inputRef;
+
+  @override
+  Map getDefaultProps() => (newProps()
+    ..addProps(super.getDefaultProps())
+    ..toggleType = ToggleBehaviorType.CHECKBOX
+  );
+
+  @override
+  Map getInitialState() => (newState()
+    ..id = 'toggle_button_' + generateGuid()
+    ..isFocused = props.autoFocus
+    ..isChecked = props.checked ?? props.defaultChecked ?? false
+  );
+
+  @override
+  get consumedProps => const [
+    const $Props(ToggleButtonProps),
+    const $Props(ButtonProps),
+    const $Props(AbstractInputPropsMixin),
+  ];
+
+  @override
+  void componentWillMount() {
+    super.componentWillMount();
+
+    _validateProps(props);
+  }
+
+  @override
+  void componentWillReceiveProps(Map newProps) {
+    super.componentWillReceiveProps(newProps);
+    var tNewProps = typedPropsFactory(newProps);
+
+    _validateProps(tNewProps);
+
+    if (tNewProps.checked != null && props.checked != tNewProps.checked) {
+      setState(newState()..isChecked = tNewProps.checked);
+    }
+  }
+
+  @override
+  render() {
+    return renderButton(
+      [
+        renderInput(),
+        props.children
+      ]
+    );
+  }
+
+  ReactElement renderInput() {
+    var builder = Dom.input()
+      ..type = props.toggleType.typeName
+      ..id = id
+      ..key = 'input'
+      ..name = props.name
+      ..tabIndex = props.tabIndex
+      ..disabled = props.isDisabled
+      ..autoFocus = props.autoFocus
+      ..onChange = props.onChange
+      ..onClick = props.onClick
+      ..style = makeInputNodeInvisible
+      ..ref = (ref) { inputRef = ref; };
+
+    // ********************************************************
+    //
+    //  React JS 15.0 Workarounds
+    //
+    //  [1] Starting from React 15.0, the checked/defaultChecked
+    //      props should not be set with a cascading setter
+    //      because it will recognize the null as a "clear input"
+    //      rather than a request to make the input controlled
+    //      vs uncontrolled.
+    //
+    //  [2] React 15.0 introduced a bug that warns when setting
+    //      value to null on an input even if that input is of
+    //      type radio or checkbox. This comes from treating
+    //      setting value as a controlled input even when it
+    //      should not.
+    //
+    //      See: https://github.com/facebook/react/issues/6779
+    //
+    // ********************************************************
+
+    if (props.defaultChecked != null) builder.defaultChecked = state.isChecked; // [1]
+    if (props.checked != null) builder.checked = state.isChecked; // [1]
+    if (props.value != null) builder.value = props.value; // [2]
+
+    return builder();
+  }
+
+  /// Returns a map of inline CSS styles to be applied to the HTML `<input>` node.
+  ///
+  /// These styles are a workaround to hide the input in an a11y-friendly manner since
+  /// the bootstrap styles we are using for the demo components uses an HTML attribute
+  /// CSS selector that we do not want to use since we're demoing how to build a stateful
+  /// toggle button with OverReact, not with Bootstrap's jQuery plugin data-api hook.
+  ///
+  /// In an actual implementation, you would want to add a unique class to the root of this
+  /// component, and add these styles in your app / component library stylesheet.
+  Map get makeInputNodeInvisible => {
+    'position': 'absolute',
+    'clip': 'rect(0,0,0,0)',
+    'pointerEvents': 'none'
+  };
+
+  /// Checks the `<input>` element to ensure that [ToggleButtonState.isChecked]
+  /// matches the value of the [InputElement.checked] attribute.
+  ///
+  /// Does not refresh the state if [ToggleButtonProps.checked] is not null
+  /// (the component is a "controlled" component).
+  void _refreshState() {
+    if (!_isControlled) setState(newState()..isChecked = inputRef.checked);
+  }
+
+  void _validateProps(ToggleButtonProps props) {
+    assert(
+        (props.toggleType == ToggleBehaviorType.RADIO && props.name != null) ||
+        props.toggleType == ToggleBehaviorType.CHECKBOX
+    );
+  }
+
+  /// Used to check if the `input` element is controlled or not.
+  bool get _isControlled => props.checked != null;
+
+  @override
+  bool get _isActive => state.isChecked;
+
+  @override
+  String get _type => null;
+
+  @override
+  BuilderOnlyUiFactory<DomProps> get _buttonDomNodeFactory => Dom.label;
+
+  /// The id to use for a [ToggleButton].
+  ///
+  /// Attempts to use [AbstractInputPropsMixin.id] _(specified by the consumer)_, falling back to
+  /// [AbstractInputStateMixin.id] _(auto-generated)_.
+  String get id => props.id ?? state.id;
+}

--- a/web/src/demo_components/toggle_button.dart
+++ b/web/src/demo_components/toggle_button.dart
@@ -121,7 +121,6 @@ class ToggleButtonComponent extends ButtonComponent<ToggleButtonProps, ToggleBut
     var builder = Dom.input()
       ..type = props.toggleType.typeName
       ..id = id
-      ..key = 'input'
       ..name = props.name
       ..tabIndex = props.tabIndex
       ..disabled = props.isDisabled
@@ -129,7 +128,8 @@ class ToggleButtonComponent extends ButtonComponent<ToggleButtonProps, ToggleBut
       ..onChange = props.onChange
       ..onClick = props.onClick
       ..style = makeInputNodeInvisible
-      ..ref = (ref) { inputRef = ref; };
+      ..ref = (ref) { inputRef = ref; }
+      ..key = 'input';
 
     // ********************************************************
     //

--- a/web/src/demo_components/toggle_button_group.dart
+++ b/web/src/demo_components/toggle_button_group.dart
@@ -1,0 +1,122 @@
+part of over_react.web.demo_components;
+
+/// A specialized [ButtonGroup] component that will surround one or more child
+/// [ToggleButton] components so that a single shared [ToggleButtonGroupProps.name]
+/// value can be applied to the aforementioned children via [cloneElement].
+///
+/// __Renders HTML Markup:__
+///
+///     <div class="form-group {props.size.class} {props.formGroupProps.className}">
+///       <label class="control-label {props.groupLabelWidth.class}" for="{state.name}">
+///         {props.groupLabel}
+///       </label>
+///       <div class="{props.wrapperClassName} {props.groupControlsWidth.class}">
+///         <div class="btn-group {props.buttonSize.class}" data-toggle="buttons" role="group">
+///           {props.children}
+///         </div>
+///       </div>
+///     </div>
+///
+/// See: <http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons>
+@Factory()
+UiFactory <ToggleButtonGroupProps> ToggleButtonGroup;
+
+@Props()
+class ToggleButtonGroupProps extends ButtonGroupProps with AbstractInputPropsMixin {}
+
+@State()
+class ToggleButtonGroupState extends ButtonGroupState with AbstractInputStateMixin {}
+
+@Component(subtypeOf: ButtonGroupComponent)
+class ToggleButtonGroupComponent extends ButtonGroupComponent<ToggleButtonGroupProps, ToggleButtonGroupState> {
+  // Refs
+
+  Map<int, dynamic> _toggleButtonRefs = <int, dynamic>{};
+
+  /// The name to use for all children of a [ToggleButtonGroup].
+  ///
+  /// Attempts to use [ToggleButtonGroupProps.name] _(specified by the consumer)_, falling back to
+  /// [ToggleButtonGroupState.name] _(auto-generated)_.
+  String get name => props.name ?? state.name;
+
+  @override
+  Map getDefaultProps() => (newProps()
+    ..addProps(super.getDefaultProps())
+    ..toggleType = ToggleBehaviorType.CHECKBOX
+  );
+
+  @override
+  Map getInitialState() => (newState()
+    ..addAll(super.getInitialState())
+    ..name = 'toggle_button_group_' + generateGuid()
+  );
+
+  @override
+  get consumedProps => const [
+    const $Props(ToggleButtonGroupProps),
+  ];
+
+  @override
+  render() {
+    var toggleButtons = [];
+
+    for (int index = 0; index < props.children.length; index++) {
+      toggleButtons.add(renderToggleButton(props.children[index], index));
+    }
+
+    return renderButtonGroup(toggleButtons);
+  }
+
+  /// Render an individual child [ToggleButton], cloned to apply the shared [name] value.
+  renderToggleButton(child, int index) {
+    if (_isValidToggleButtonChild(child)) {
+      var childProps = ToggleButton(getProps(child));
+      var childKey = getInstanceKey(child);
+
+      var propsToAdd = ToggleButton()
+        ..name = name
+        ..toggleType = props.toggleType
+        ..skin = props.skin ?? childProps.skin
+        ..onChange = formEventCallbacks.chain(props.onChange, _handleOnChange)
+        ..value = childProps.value ?? index
+        ..key = childKey ?? index
+        ..ref = chainRef(child, (ref) { _toggleButtonRefs[index] = ref; });
+
+      return cloneElement(child, propsToAdd);
+    }
+
+    return child;
+  }
+
+  @override
+  ClassNameBuilder getButtonGroupClasses() {
+    return super.getButtonGroupClasses()
+      ..add('btn-toggle-group');
+  }
+
+  /// The handler for when one of the children of the [ToggleButtonGroup] is changed or unchecked
+  void _handleOnChange(_) {
+    _toggleButtonRefs.values.forEach((childComponent) {
+      if (childComponent is ToggleButtonComponent) childComponent._refreshState();
+    });
+  }
+
+  bool _isValidToggleButtonChild(child) {
+    var isCloneable = false;
+    if (isValidElement(child)) {
+      if (!isComponentOfType(child, ToggleButton)) {
+        assert(ValidationUtil.warn(
+            'Children of ToggleButtonGroup should be ToggleButton instances.'
+        ));
+      }
+
+      isCloneable = true;
+    } else if (child != null) {
+      assert(ValidationUtil.warn(
+          'You are not using a valid ReactElement.'
+      ));
+    }
+
+    return isCloneable;
+  }
+}

--- a/web/src/demo_components/toggle_button_group.dart
+++ b/web/src/demo_components/toggle_button_group.dart
@@ -56,36 +56,22 @@ class ToggleButtonGroupComponent extends ButtonGroupComponent<ToggleButtonGroupP
     const $Props(ToggleButtonGroupProps),
   ];
 
+  /// The props that should be added when we clone the given [child] using
+  /// [cloneElement] via [renderButton].
   @override
-  render() {
-    var toggleButtons = [];
+  ToggleButtonProps buttonPropsToAdd(dynamic child, int index) {
+    var childProps = childFactory(getProps(child));
+    var childKey = getInstanceKey(child);
 
-    for (int index = 0; index < props.children.length; index++) {
-      toggleButtons.add(renderToggleButton(props.children[index], index));
-    }
+    ButtonProps superPropsToAdd = super.buttonPropsToAdd(child, index);
 
-    return renderButtonGroup(toggleButtons);
-  }
-
-  /// Render an individual child [ToggleButton], cloned to apply the shared [name] value.
-  renderToggleButton(child, int index) {
-    if (_isValidToggleButtonChild(child)) {
-      var childProps = ToggleButton(getProps(child));
-      var childKey = getInstanceKey(child);
-
-      var propsToAdd = ToggleButton()
-        ..name = name
-        ..toggleType = props.toggleType
-        ..skin = props.skin ?? childProps.skin
-        ..onChange = formEventCallbacks.chain(props.onChange, _handleOnChange)
-        ..value = childProps.value ?? index
-        ..key = childKey ?? index
-        ..ref = chainRef(child, (ref) { _toggleButtonRefs[index] = ref; });
-
-      return cloneElement(child, propsToAdd);
-    }
-
-    return child;
+    return childFactory()
+      ..addProps(superPropsToAdd)
+      ..name = name
+      ..toggleType = props.toggleType
+      ..onChange = formEventCallbacks.chain(props.onChange, _handleOnChange)
+      ..value = childProps.value ?? index
+      ..ref = chainRef(child, (ref) { _toggleButtonRefs[index] = ref; });
   }
 
   @override
@@ -101,22 +87,7 @@ class ToggleButtonGroupComponent extends ButtonGroupComponent<ToggleButtonGroupP
     });
   }
 
-  bool _isValidToggleButtonChild(child) {
-    var isCloneable = false;
-    if (isValidElement(child)) {
-      if (!isComponentOfType(child, ToggleButton)) {
-        assert(ValidationUtil.warn(
-            'Children of ToggleButtonGroup should be ToggleButton instances.'
-        ));
-      }
-
-      isCloneable = true;
-    } else if (child != null) {
-      assert(ValidationUtil.warn(
-          'You are not using a valid ReactElement.'
-      ));
-    }
-
-    return isCloneable;
-  }
+  /// The factory expected for each child of [ToggleButtonGroup].
+  @override
+  UiFactory<ToggleButtonProps> get childFactory => ToggleButton;
 }


### PR DESCRIPTION
All of our component demos thus-far have been props-only.

This new demo component constructs a bootstrap "toggle button", and is fully-functional without the use of the jQuery bootstrap "button" plugin.

---

__FYA__ @greglittlefield-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf 