### PR TITLE
Try to fix failing travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - ./tool/setup_dartium.sh
   - export PATH=$PATH":$PWD"
   - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev analyze
   - pub run dart_dev test


### PR DESCRIPTION
Travis will frequently fail on dart_dev test, because Content Shell exits with 1.

This is an attempt to fix that, the idea was taken from https://github.com/dart-lang/test/issues/449#issuecomment-243527617.