### PR TITLE
changed react_dom.render(FooComponent()() to react_dom.render(Foo()()

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ mount / render it into the HTML element you created in step 3.
       react_client.setClientConfiguration();
       
       // Mount / render your component. 
-      react_dom.render(FooComponent()(), querySelector('#react_mount_point'));
+      react_dom.render(Foo()(), querySelector('#react_mount_point'));
     }    
     ```
 


### PR DESCRIPTION
The example code always uses:

``` dart
@Factory()
UiFactory<FooProps> Foo;
```

So shouldn't Foo also be used in the initial render call? FooComponent is a bit misleading.
