### PR TITLE
added missing dependency browser_detect

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   source_span: "^1.2.0"
   transformer_utils: "^0.1.1"
   w_flux: "^2.5.0"
+  browser_detect: "^1.0.4"
 dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"


### PR DESCRIPTION
Added browser_detect to dependencies because it is imported in over_react but only included via dart_dev in dev_dependencies. Deploying an application without it fails, because browser_detect.dart returns with a 404.
