### PR TITLE
Fix react_client reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ mount / render it into the HTML element you created in step 3.
     import 'dart:html';
     import 'package:react/react.dart' as react;
     import 'package:react/react_dom.dart' as react_dom;
-    import 'package:react/react_client.dart';
+    import 'package:react/react_client.dart' as react_client;
     import 'package:over_react/over_react.dart';
 
     main() {


### PR DESCRIPTION
**Ultimate problem:**

The README code does not run.

**How it was fixed:**

Named the import `react_client` so the example code runs.

**Testing suggestions:**

Paste code and verify it runs.

**Potential areas of regression:**

None.
---

> **FYA:** @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf

The README code does not compile because it looks for `react_client`.
# 16 is needed to make the code actually run as well.
