### PR TITLE
Corrected a mistake in ReadMe.md "Using it in your project" 4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ mount / render it into the HTML element you created in step 3.
     import 'dart:html';
     import 'package:react/react.dart' as react;
     import 'package:react/react_dom.dart' as react_dom;
-    import 'package:react/react_client.dart';
+    import 'package:react/react_client.dart' as react_client;
     import 'package:over_react/over_react.dart';
 
     main() {


### PR DESCRIPTION
__Ultimate problem:__

Just a small mistake in the code proposed as an entry point to the over_react library.
At the fouth point in "Using it in your project" the import "react/react_client.dart"was missing the name re-definition "as react_client".
And the top-level function called in this import could not be called in the main.

__How it was fixed:__

Changed :
     ```import 'package:react/react_client.dart'```
To :
    ```import 'package:react/react_client.dart' as react_client;```

__Testing suggestions:__

N/A

__Potential areas of regression:__

N/A

---


> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf

