### PR TITLE
Use markdown headers in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,16 @@
-__Ultimate problem:__
+## Ultimate problem:
 
 
-
-__How it was fixed:__
-
+## How it was fixed:
 
 
-__Testing suggestions:__
+## Testing suggestions:
 
 
-
-__Potential areas of regression:__
+## Potential areas of regression:
 
 
 
 ---
-
 
 > __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf


### PR DESCRIPTION
## Ultimate problem:
PR template was not using headers. The sections don't have enough visual weight.

## How it was fixed:
Use headers instead of bold text.

## Testing suggestions:
Verify this PR Looks good.

## Potential areas of regression:
PR template.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
