### PR TITLE
Bump minimum sdk version from 1.17.1 to 1.19.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - "1.17.1"
+  - "1.19.1"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/integrate/pubspec.yaml
+++ b/integrate/pubspec.yaml
@@ -2,7 +2,7 @@ name: import_web_skin_dart_test
 version: 0.0.1
 description: Test importing web_skin_dart
 environment:
-  sdk: ">=1.12.1"
+  sdk: ">=1.19.1"
 dependencies:
   browser: ">=0.10.0 <0.11.0"
   crypto: "0.9.2+1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.17.1"
+  sdk: ">=1.19.1"
 dependencies:
   analyzer: ">=0.26.1+3 <0.28.0"
   barback: "^0.15.0"


### PR DESCRIPTION
## Ultimate problem:
Dart SDK version 1.19.1 introduces the ability to have trailing commas in argument lists, which will make re-ordering components in our fluent style much less error-prone for consumers.

It also removes the need for a couple of gross type casts we were doing in #15.

## How it was fixed:
Updated the sdk constraint in `pubspec.yaml`, `integrate/pubspec.yaml`, and in the Travis CI configuration.

## Testing suggestions:
Verify that all tests pass.

## Potential areas of regression:
None expected.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf