### PR TITLE
UIP-1903 Run unit tests in dart2js on CI

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -6,6 +6,7 @@ runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173
 
 script:
   - pub get
+  - ./tool/smithy_dart2js_tests.sh
 
 artifacts:
   build:

--- a/test/over_react/component/dom_components_test.dart
+++ b/test/over_react/component/dom_components_test.dart
@@ -17,7 +17,7 @@ library dom_components_test;
 // Tell dart2js that this library only needs to reflect the specified types.
 // This speeds up compilation and makes JS output much smaller.
 @MirrorsUsed(targets: const [
-  'over_react.Dom'
+  'over_react.dom_components.Dom'
 ])
 import 'dart:mirrors';
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -30,7 +30,11 @@ main(List<String> args) async {
     ..pubServe = true
     ..platforms = [
       'vm',
-      'content-shell'
+      'content-shell',
+      // Can't run tests in dart2js on Travis since the suite takes too long to load and times out.
+      // Run on Smithy instead.
+      // See https://github.com/Workiva/over_react/issues/36
+      // 'chrome',
     ]
     // Prevent test load timeouts on Smithy.
     ..concurrency = 1

--- a/tool/smithy_dart2js_tests.sh
+++ b/tool/smithy_dart2js_tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Can't run tests in dart2js on Travis since the suite takes too long to load and times out.
+# Run on Smithy instead.
+# See https://github.com/Workiva/over_react/issues/36
+
+set -e
+
+# Trick the test package into using Chromium instead of Chrome
+TMP_BIN=$(mktemp -d)
+ln -s "$(which chromium-browser)" "$TMP_BIN/google-chrome"
+export PATH="$PATH:$TMP_BIN"
+
+# Run the tests
+DART_FLAGS=--checked  xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test -p chrome
+
+# Be sneaky and clean up our tricks
+rm -rf "$TMP_BIN"


### PR DESCRIPTION
## Ultimate problem:
dart2js-compiled code that deals with JS interop doesn't always behave the same as native Dart code.

We should be running unit tests in dart2js.

## How it was fixed:
* Fix `MirrorsUsed` typo in test, for proper dart2js compilation
* ~~Run dart2js tests on Travis~~
    * Travis is too slow and the suite times out; see #36
* ~~Run dart2js tests on Smithy in Firefox~~
    * Focus-related tests fail in Firefox on CI. Attempts to tweak xvfb config or set the `focusmanager.testmode` user preference proved fruitless
* ~~Run dart2js tests on Smithy in Chrome~~
    * Chrome wouldn't install properly in the Docker build, and debugging that wasn't going anywhere...
* Run dart2js tests on Smithy using Chromium (already installed) 
    * Have to spoof the `google-chrome` executable that the `test` package uses to run the `chrome` platform, since running in Chromium isn't yet supported (see https://github.com/dart-lang/test/issues/391)
    * ...Finally!

## Testing suggestions:
* Verify that Smithy build succeeds, and that tests are run in dart2js

## Potential areas of regression:
Smithy build

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf

