### PR TITLE
Add map_util method newStyleFromProps

### DIFF
--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -64,7 +64,7 @@ Map getPropsToForward(Map props, {bool omitReactProps: true, bool onlyCopyDomPro
 /// Returns a copy of the style map found in [props].
 ///
 /// Returns an empty map if [props] or its style map are null.
-Map newStyleFromProps(Map props) {
+Map<String, dynamic> newStyleFromProps(Map props) {
   if (props == null) return {};
 
   var existingStyle = domProps(props).style;

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -16,8 +16,9 @@ library over_react.map_util;
 
 import 'dart:collection';
 
-import 'package:over_react/src/component/prop_mixins.dart';
 import 'package:over_react/src/component_declaration/transformer_helpers.dart';
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/prop_mixins.dart';
 
 /// Returns a copy of the specified props map, omitting reserved React props by default,
 /// in addition to any specified keys.
@@ -58,6 +59,16 @@ Map getPropsToForward(Map props, {bool omitReactProps: true, bool onlyCopyDomPro
   }
 
   return propsToForward;
+}
+
+/// Returns a copy of the style map found in [props].
+///
+/// Returns an empty map if [props] or its style map are null.
+Map newStyleFromProps(Map props) {
+  if (props == null) return {};
+
+  var existingStyle = domProps(props).style;
+  return existingStyle == null ? {} : new Map.from(existingStyle);
 }
 
 SplayTreeSet _validDomProps = new SplayTreeSet()

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -121,5 +121,23 @@ main() {
         expect(actual, equals(expected));
       });
     });
+
+    group('newStyleFromProps() returns', () {
+      test('a copy of the style map found in the specified props', () {
+        var styles = {'color': 'red', 'width': '10rem'};
+        var props = domProps()
+          ..style = styles;
+
+        expect(newStyleFromProps(props), equals(styles));
+      });
+
+      test('an empty map when the specified props are null', () {
+        expect(newStyleFromProps(null), equals({}));
+      });
+
+      test('an empty map when the specified props have a null style map', () {
+        expect(newStyleFromProps(domProps()), equals({}));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Ultimate problem:

We frequently run into an `over_react` use case where we have a computed inline style we'd like to merge into an existing props map that may or may not be defined.

## How it was fixed:

Add a new method to `map_util`, `newStyleFromProps`.

## Testing suggestions:

* All tests should pass

## Potential areas of regression:

None.

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @joelleibow-wf

