### PR TITLE
UIP-1639 Update formatting guidelines WRT dartfmt and trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,17 +495,50 @@ as shown in the examples above.
 
 ## Component Formatting
 
-> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it
-> _greatly_ decreases the readability of components built using
-> [OverReact's fluent-style](#fluent-style-component-consumption).
->
-> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our
-> fluent-style to remain readable even after the formatter executes._
+#### dart_style
+Currently, [dart_style (dartfmt)](https://github.com/dart-lang/dart_style) decreases the readability of components
+built using [OverReact's fluent-style](#fluent-style-component-consumption).
+See https://github.com/dart-lang/dart_style/issues/549 for more info.
 
-Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that
-we _strongly recommended_ when building components using the `over_react` library.
+We're exploring some different ideas to improve automated formatting, but for the time being, we __do not recommend__ using dart_style with OverReact.
 
-&nbsp;
+However, if you do choose to use dart_style, you can greatly improve its output by using trailing commas in children argument lists:
+
+* dart_style formatting:
+```dart
+return (Button()
+  ..id = 'flip'
+  ..skin =
+      ButtonSkin.vanilla)((Dom.span()
+  ..className = 'flip-container')((Dom.span()..className = 'flipper')(
+    (Dom.span()
+      ..className =
+          'front-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)()),
+    (Dom.span()
+      ..className =
+          'back-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)()))));
+```
+* dart_style formatting, when trailing commas are used:
+```dart
+return (Button()
+  ..id = 'flip'
+  ..skin = ButtonSkin.vanilla)(
+  (Dom.span()..className = 'flip-container')(
+    (Dom.span()..className = 'flipper')(
+      (Dom.span()..className = 'front-side')(
+        (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)(),
+      ),
+      (Dom.span()..className = 'back-side')(
+        (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)(),
+      ),
+    ),
+  ),
+);
+```
+
+### Guidelines
+
+To help ensure your OverReact code is readable and consistent, we've arrived at the following formatting rules.
 
 * __ALWAYS__ place the closing builder parent on a new line.
 
@@ -524,38 +557,78 @@ we _strongly recommended_ when building components using the `over_react` librar
       ..isDisabled = true)('Submit')
     ```
 
-&nbsp;
-
-* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__
-  indentation.
+* __ALWAYS__ pass component children on a new line with trailing commas and 2 space indentation.
 
   _Good:_
     ```dart
     Dom.div()(
       Dom.span()('nested component'),
-      Dom.span()('nested component')
+    )
+    ```
+
+    ```dart
+    Dom.div()(
+      Dom.span()('nested component A'),
+      Dom.span()('nested component B'),
     )
     ```
 
   _Bad:_
     ```dart
-    // Nested component is not on a new line
-    Dom.div()(Dom.span()('nested component'))
-
-    // Nested component has a continuation indent
-    Dom.div()(
-        Dom.span()('nested component'),
-    )
-
-    // Nested components are within a list instead of
-    // being passed in as variadic children.
-    Dom.div()([
-      Dom.span()('nested component'),
-      Dom.span()('nested component')
-    ])
+    // Children are not on a new line; in most cases,
+    // this makes it difficult to quickly determine nesting.
+    Dom.div()(Dom.span()('nested component'), Dom.span()('nested component'))
     ```
 
-&nbsp;
+    ```dart
+    // With nested hierarchies, continuation indents can quickly result
+    // in a "pyramid of Doom"
+    Dom.div()(
+        Dom.ul()(
+            Dom.li()(
+                Dom.a()('A link!')
+            )
+        )
+    )
+    ```
+
+    ```dart
+    // Omitting trailing commas makes it a pain to rearrange lines
+    Dom.div()(
+      Dom.span()('nested component A'),
+      Dom.span()('nested component B')
+    )
+    Dom.div()(
+      Dom.span()('nested component B') // ugh, need to add a comma here...
+      Dom.span()('nested component A'),
+    )
+    ```
+
+* __AVOID__ passing children within lists; lists should only be used when the number/order of the children are dynamic.
+
+  _Good:_
+    ```dart
+    Dom.div()(
+      Dom.span()('nested component'),
+      Dom.span()('nested component'),
+    )
+    ```
+
+    ```dart
+    var children = [
+      Dom.div()('List of Items:'),
+    ]..addAll(props.items.map(renderItem));
+
+    return Dom.div()(children)
+    ```
+
+  _Bad:_
+    ```dart
+    Dom.div()([
+      (Dom.span()..key = 'span1')('nested component'),
+      (Dom.span()..key = 'span2')('nested component'),
+    ])
+    ```
 
 * __AVOID__ specifying more than one cascading prop setter on the same line.
 
@@ -571,10 +644,6 @@ we _strongly recommended_ when building components using the `over_react` librar
     ```dart
     (Dom.div()..id = 'my_div'..className = 'my-class')()
     ```
-
-&nbsp;
-&nbsp;
-
 
 
 ## Building custom components

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 
 * __[Using it in your project](#using-it-in-your-project)__
-    * [Running tests in your project](#running-tests-in-your-project) 
+    * [Running tests in your project](#running-tests-in-your-project)
 * __[Anatomy of an OverReact component](#anatomy-of-an-overreact-component)__
     * [UiFactory](#uifactory)
     * [UiProps](#uiprops)
@@ -32,31 +32,31 @@
 ## Using it in your project
 
 > __If you are not familiar with React JS__
-> 
-> Since OverReact is built atop React JS, we strongly encourage you to gain 
-> familiarity with it by reading this [React JS tutorial][react-js-tutorial] first. 
+>
+> Since OverReact is built atop React JS, we strongly encourage you to gain
+> familiarity with it by reading this [React JS tutorial][react-js-tutorial] first.
 
 1. Add the `over_react` package as a dependency in your `pubspec.yaml`.
-    
+
     ```yaml
     dependencies:
       over_react: "^1.3.0"
     ```
-  
+
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.
-    
+
     ```yaml
     transformers:
       - over_react
       # Reminder: dart2js should come after any other transformers that touch Dart code
       - $dart2js
     ```
-  
-    _Our transformer uses code generation to wire up the different pieces of your 
+
+    _Our transformer uses code generation to wire up the different pieces of your
     component declarations - and to create typed getters/setters for `props` and `state`._
 
-3. Include the native JavaScript `react` and `react_dom` libraries in your app’s `index.html` file, 
-and add an HTML element with a unique identifier where you’ll mount your OverReact UI component(s). 
+3. Include the native JavaScript `react` and `react_dom` libraries in your app’s `index.html` file,
+and add an HTML element with a unique identifier where you’ll mount your OverReact UI component(s).
 
     ```html
     <html>
@@ -67,7 +67,7 @@ and add an HTML element with a unique identifier where you’ll mount your OverR
         <div id="react_mount_point">
           // OverReact component render() output will show up here.
         </div>
-     
+
         <script src="packages/react/react.js"></script>
         <script src="packages/react/react_dom.js"></script>
         <script type="application/dart" src="your_app_name.dart"></script>
@@ -75,14 +75,14 @@ and add an HTML element with a unique identifier where you’ll mount your OverR
       </body>
     </html>
     ```
-    
-    > __Note:__ When serving your application in production, use `packages/react/react_with_react_dom_prod.js` 
+
+    > __Note:__ When serving your application in production, use `packages/react/react_with_react_dom_prod.js`
     file instead of the un-minified `react.js` / `react_dom.js` files shown in the example above.  
-    
-4. Import the `over_react` library _(and associated react libraries)_ into `your_app_name.dart`, and initialize 
-React within your Dart application. Then [build a custom component](#building-custom-components) and 
+
+4. Import the `over_react` library _(and associated react libraries)_ into `your_app_name.dart`, and initialize
+React within your Dart application. Then [build a custom component](#building-custom-components) and
 mount / render it into the HTML element you created in step 3.
-    
+
     ```dart
     import 'dart:html';
     import 'package:react/react.dart' as react;
@@ -93,8 +93,8 @@ mount / render it into the HTML element you created in step 3.
     main() {
       // Initialize React within our Dart app
       react_client.setClientConfiguration();
-      
-      // Mount / render your component. 
+
+      // Mount / render your component.
       react_dom.render(Foo()(), querySelector('#react_mount_point'));
     }    
     ```
@@ -105,7 +105,7 @@ mount / render it into the HTML element you created in step 3.
 
 ### Running tests in your project
 
-When running tests on code that uses our [transformer] _(or any code that imports `over_react`)_, 
+When running tests on code that uses our [transformer] _(or any code that imports `over_react`)_,
 __you must run your tests using Pub__.
 
 1. Add the `test/pub_serve` transformer to your `pubspec.yaml` _after_ the `over_react` transformer.
@@ -121,9 +121,9 @@ __you must run your tests using Pub__.
 2. Use [the `--pub-serve` option](https://github.com/dart-lang/test#testing-with-barback) when running your tests:
 
     ```bash
-    $ pub run test --pub-serve=8081 test/your_test_file.dart 
+    $ pub run test --pub-serve=8081 test/your_test_file.dart
     ```
-    
+
     > __Note:__ `8081` is the default port used, but your project may use something different.  Be sure to take note
      of the output when running `pub serve` to ensure you are using the correct port.
 
@@ -135,14 +135,14 @@ __you must run your tests using Pub__.
 ## Anatomy of an OverReact component
 
 > __If you are not familiar with React JS__
-> 
-> Since OverReact is built atop React JS, we strongly encourage you to gain 
+>
+> Since OverReact is built atop React JS, we strongly encourage you to gain
 > familiarity with it by reading this [React JS tutorial][react-js-tutorial] first.
 
-The `over_react` library functions as an additional "layer" atop the [Dart react package][react-dart] 
+The `over_react` library functions as an additional "layer" atop the [Dart react package][react-dart]
 which handles the underlying JS interop that wraps around [React JS][react-js].
 
-The library strives to maintain a 1:1 relationship with the React JS component class and API. 
+The library strives to maintain a 1:1 relationship with the React JS component class and API.
 To do that, an OverReact component is comprised of four core pieces that are each wired up to our
 Pub transformer using an analogous [annotation].
 
@@ -155,7 +155,7 @@ Pub transformer using an analogous [annotation].
 
 ### UiFactory
 
-__`UiFactory` is a function__ that returns a new instance of a 
+__`UiFactory` is a function__ that returns a new instance of a
 [`UiComponent`](#uicomponent)’s [`UiProps`](#uiprops) class.
 
 ```dart
@@ -164,14 +164,14 @@ UiFactory<FooProps> Foo;
 ```
 
 * This factory is __the entry-point__ to consuming every OverReact component.
-* The `UiProps` instance it returns can be used [as a component builder](#uiprops-as-a-builder), 
+* The `UiProps` instance it returns can be used [as a component builder](#uiprops-as-a-builder),
 or [as a typed view into an existing props map](#uiprops-as-a-map).
 
 &nbsp;
 
 ### UiProps
 
-__`UiProps` is a Map class__ that adds statically-typed getters and setters for each React component prop. 
+__`UiProps` is a Map class__ that adds statically-typed getters and setters for each React component prop.
 It can also be invoked as a function, serving as a builder for its analogous component.
 
 ```dart
@@ -179,7 +179,7 @@ It can also be invoked as a function, serving as a builder for its analogous com
 class FooProps extends UiProps {
   // ...
 }
-``` 
+```
 
 &nbsp;
 
@@ -208,13 +208,13 @@ void bar() {
   print(props);       // {FooProps.color: #66cc00}
 }
 
-/// You can use the factory to create a UiProps instance 
+/// You can use the factory to create a UiProps instance
 /// backed by an existing Map.
 void baz() {
   Map existingMap = {'FooProps.color': '#0094ff'};
-  
+
   FooProps props = Foo(existingMap);
-  
+
   print(props.color); // #0094ff
 }
 ```
@@ -241,7 +241,7 @@ class FooComponent extends UiComponent<FooProps> {
     // Add props
     builder.id = 'the_best_foo';
     builder.color = '#ee2724';
-  
+
     // Invoke as a function with the desired children
     // to return a new instance of the component.
     return builder('child1', 'child2');
@@ -253,7 +253,7 @@ class FooComponent extends UiComponent<FooProps> {
       ..id = 'the_best_foo'
       ..color = 'red'
     )(
-      'child1', 
+      'child1',
       'child2'
     );
   }
@@ -266,7 +266,7 @@ class FooComponent extends UiComponent<FooProps> {
 
 ### UiState
 
-__`UiState` is a Map class__ _(just like `UiProps`)_ that adds statically-typed getters and setters 
+__`UiState` is a Map class__ _(just like `UiProps`)_ that adds statically-typed getters and setters
 for each React component state property.
 
 ```dart
@@ -282,7 +282,7 @@ class FooState extends UiState {
 
 ### UiComponent
 
-__`UiComponent` is a subclass of [`react.Component`][react.component]__, containing lifecycle methods 
+__`UiComponent` is a subclass of [`react.Component`][react.component]__, containing lifecycle methods
 and rendering logic for components.
 
 ```dart
@@ -292,18 +292,18 @@ class FooComponent extends UiComponent<FooProps> {
 }
 ```
 
-* This component provides statically-typed props via [`UiProps`](#uiprops), as well as utilities for 
+* This component provides statically-typed props via [`UiProps`](#uiprops), as well as utilities for
 prop forwarding and CSS class merging.
-* The `UiStatefulComponent` flavor augments `UiComponent` behavior with statically-typed state via 
+* The `UiStatefulComponent` flavor augments `UiComponent` behavior with statically-typed state via
 [`UiState`](#uistate).
 
 &nbsp;
 
 #### Accessing and manipulating props / state within UiComponent
 
-* Within the `UiComponent` class, `props` and `state` are not just `Map`s. 
+* Within the `UiComponent` class, `props` and `state` are not just `Map`s.
 They are instances of `UiProps` and `UiState`, __which means you don’t need String keys to access them!__
-* `newProps()` and `newState()` are also exposed to conveniently create empty instances of `UiProps` and 
+* `newProps()` and `newState()` are also exposed to conveniently create empty instances of `UiProps` and
 `UiState` as needed.
 * `typedPropsFactory()` and `typedStateFactory()` are also exposed to conveniently create typed `props` / `state` objects out of any provided backing map.
 
@@ -314,7 +314,7 @@ class FooComponent extends UiStatefulComponent<FooProps, FooState> {
   getDefaultProps() => (newProps()
     ..color = '#66cc00'
   );
-    
+
   @override
   getInitialState() => (newState()
     ..isActive = false
@@ -326,10 +326,10 @@ class FooComponent extends UiStatefulComponent<FooProps, FooState> {
     var tNewProps = typedPropsFactory(newProps);
 
     var becameActive = !state.isActive && tNewState.isActive;
-    
+
     // Do something here!
   }
-  
+
   @override
   render() {
     return (Dom.div()
@@ -342,11 +342,11 @@ class FooComponent extends UiStatefulComponent<FooProps, FooState> {
       props.children
     );
   }
-  
+
   void _handleButtonClick(SyntheticMouseEvent event) {
     _toggleActive();
   }
-  
+
   void _toggleActive() {
     setState(newState()
       ..isActive = !state.isActive
@@ -362,14 +362,14 @@ class FooComponent extends UiStatefulComponent<FooProps, FooState> {
 
 ## Fluent-style component consumption
 
-In OverReact, components are consumed by invoking a `UiFactory` to return a new `UiProps` builder, which is then 
+In OverReact, components are consumed by invoking a `UiFactory` to return a new `UiProps` builder, which is then
 modified and invoked to build a `ReactElement`.
 
-This is done to make ["fluent-style"](#fluent-style-component-consumption) component consumption possible, so that 
-the OverReact consumer experience is very similar to the [React JS][react-js] / "vanilla" [react-dart] 
+This is done to make ["fluent-style"](#fluent-style-component-consumption) component consumption possible, so that
+the OverReact consumer experience is very similar to the [React JS][react-js] / "vanilla" [react-dart]
 experience.
 
-To demonstrate the similarities, the example below shows a render method for JS, JSX, react-dart, 
+To demonstrate the similarities, the example below shows a render method for JS, JSX, react-dart,
 and over_react that will have the exact same HTML markup result.
 
 * __React JS__:
@@ -385,7 +385,7 @@ and over_react that will have the exact same HTML markup result.
     );
   }
   ```
-  
+
 * __React JS__ (JSX):
 
   ```jsx
@@ -404,7 +404,7 @@ and over_react that will have the exact same HTML markup result.
 
   ```dart
   render() {
-    return react.div({'className': 'container'}, 
+    return react.div({'className': 'container'},
       react.h1({}, 'Click the button!'),
       react.button({
         'id': 'main_button',
@@ -429,18 +429,18 @@ and over_react that will have the exact same HTML markup result.
   ```
 
   Let’s break down the OverReact fluent-style shown above
-    
+
   ```dart
   render() {
     // Create a builder for a <div>,
     // add a CSS class name by cascading a typed setter,
     // and invoke the builder with the HTML DOM <h1> and <button> children.
     return (Dom.div()..className = 'container')(
-  
+
       // Create a builder for an <h1> and invoke it with children.
       // No need for wrapping parentheses, since no props are added.
       Dom.h1()('Click the button!'),
-    
+
       // Create a builder for a <button>,
       (Dom.button()
         // add a ubiquitous DOM prop exposed on all components,
@@ -461,8 +461,8 @@ and over_react that will have the exact same HTML markup result.
 
 ## DOM components and props
 
-All [react-dart][react-dart] DOM components _(`react.div`, `react.a`, etc.)_ have a 
-corresponding `Dom` method _(`Dom.div()`, `Dom.a()`, etc.)_ in OverReact. 
+All [react-dart][react-dart] DOM components _(`react.div`, `react.a`, etc.)_ have a
+corresponding `Dom` method _(`Dom.div()`, `Dom.a()`, etc.)_ in OverReact.
 
 ```dart
 ReactElement renderLink() {
@@ -480,12 +480,12 @@ ReactElement renderResizeHandle() {
 }
 ```
 
-* OverReact DOM components return a new `DomProps` builder, which can be used 
-to render them via our [fluent interface](#fluent-style-component-consumption) 
+* OverReact DOM components return a new `DomProps` builder, which can be used
+to render them via our [fluent interface](#fluent-style-component-consumption)
 as shown in the examples above.
 * `DomProps` has statically-typed getters and setters for all "ubiquitous" HTML attribute props.
-  * The `domProps()` function is also available to create a new typed Map or a typed view into an 
-  existing Map. Useful for manipulating DOM props and adding DOM props to components that don’t 
+  * The `domProps()` function is also available to create a new typed Map or a typed view into an
+  existing Map. Useful for manipulating DOM props and adding DOM props to components that don’t
   forward them directly.
 
 &nbsp;
@@ -495,14 +495,14 @@ as shown in the examples above.
 
 ## Component Formatting
 
-> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it 
-> _greatly_ decreases the readability of components built using 
+> NOTE: At this time, we __do not recommend using [`dartfmt`](https://github.com/dart-lang/dart_style)__, as it
+> _greatly_ decreases the readability of components built using
 > [OverReact's fluent-style](#fluent-style-component-consumption).
-> 
-> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our 
+>
+> _We have a long-term goal of writing our own formatter that extends from `dartfmt` to make it possible for our
 > fluent-style to remain readable even after the formatter executes._
 
-Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that 
+Since using `dartfmt` results in unreadable code, we have documented the following formatting best-practices that
 we _strongly recommended_ when building components using the `over_react` library.
 
 &nbsp;
@@ -526,7 +526,7 @@ we _strongly recommended_ when building components using the `over_react` librar
 
 &nbsp;
 
-* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__ 
+* __ALWAYS__ pass nested components as variadic children when keys are not specified, on a new line with a __2 space__
   indentation.
 
   _Good:_
@@ -579,8 +579,8 @@ we _strongly recommended_ when building components using the `over_react` librar
 
 ## Building custom components
 
-Now that we’ve gone over how to [use the `over_react` package in your project](#using-it-in-your-project), 
-the [anatomy of a component](#anatomy-of-an-overreact-component) and the [DOM components](#dom-components-and-props) 
+Now that we’ve gone over how to [use the `over_react` package in your project](#using-it-in-your-project),
+the [anatomy of a component](#anatomy-of-an-overreact-component) and the [DOM components](#dom-components-and-props)
 that you get for free from OverReact, you're ready to start building your own custom React UI components.
 
 1. Start with one of the [component boilerplate templates](#component-boilerplate-templates) below.
@@ -597,8 +597,8 @@ that you get for free from OverReact, you're ready to start building your own cu
     ```
 
     _That’s it! Code will be automatically generated on the fly by Pub!_
-    
-    
+
+
 > __Check out some custom [component demos] to get a feel for what’s possible!__
 
 &nbsp;
@@ -613,17 +613,17 @@ that you get for free from OverReact, you're ready to start building your own cu
     import 'package:react/react_dom.dart' as react_dom;
     import 'package:react/react_client.dart';
     import 'package:over_react/over_react.dart';
-    
+
     @Factory()
     UiFactory<FooProps> Foo;
-    
+
     @Props()
     class FooProps extends UiProps {
       // Props go here, declared as fields:
       bool isDisabled;
       Iterable<String> items;
     }
-    
+
     @Component()
     class FooComponent extends UiComponent<FooProps> {
       @override
@@ -632,7 +632,7 @@ that you get for free from OverReact, you're ready to start building your own cu
         ..isDisabled = false
         ..items = []
       );
-    
+
       @override
       render() {
         // Return the rendered component contents here.
@@ -640,7 +640,7 @@ that you get for free from OverReact, you're ready to start building your own cu
       }
     }
     ```
-    
+
 * #### Stateful Component Boilerplate
 
     ```dart
@@ -649,23 +649,23 @@ that you get for free from OverReact, you're ready to start building your own cu
     import 'package:react/react_dom.dart' as react_dom;
     import 'package:react/react_client.dart';
     import 'package:over_react/over_react.dart';
-    
+
     @Factory()
     UiFactory<BarProps> Bar;
-    
+
     @Props()
     class BarProps extends UiProps {
       // Props go here, declared as fields:
       bool isDisabled;
       Iterable<String> items;
     }
-  
+
     @State()
     class BarState extends UiState {
       // State goes here, declared as fields:
       bool isShown;
     }
-    
+
     @Component()
     class BarComponent extends UiStatefulComponent<BarProps, BarState> {
       @override
@@ -674,13 +674,13 @@ that you get for free from OverReact, you're ready to start building your own cu
         ..isDisabled = false
         ..items = []
       );
-    
+
       @override
       Map getInitialState() => (newState()
         // Cascade initial state here
         ..isShown = true
       );
-    
+
       @override
       render() {
         // Return the rendered component contents here.
@@ -688,31 +688,31 @@ that you get for free from OverReact, you're ready to start building your own cu
       }
     }
     ```
-    
+
 * #### Flux Component Boilerplate
-    
+
     ```dart
     import 'dart:html';
     import 'package:react/react.dart' as react;
     import 'package:react/react_dom.dart' as react_dom;
     import 'package:react/react_client.dart';
     import 'package:over_react/over_react.dart';
-    
+
     @Factory()
     UiFactory<BazProps> Baz;
-    
+
     @Props()
     class BazProps extends FluxUiProps<BazActions, BazStore> {
       // Props go here, declared as fields.
       // `actions` and `store` are already defined for you!
     }
-    
+
     @Component()
     class BazComponent extends FluxUiComponent<BazProps> {
       getDefaultProps() => (newProps()
         // Cascade default props here
       );
-    
+
       @override
       render() {
         // Return the rendered component contents here.
@@ -721,41 +721,41 @@ that you get for free from OverReact, you're ready to start building your own cu
       }
     }
     ```
-    
+
 * #### Stateful Flux Component Boilerplate
-    
+
     ```dart
     import 'dart:html';
     import 'package:react/react.dart' as react;
     import 'package:react/react_dom.dart' as react_dom;
     import 'package:react/react_client.dart';
     import 'package:over_react/over_react.dart';
-    
+
     @Factory()
     UiFactory<BazProps> Baz;
-    
+
     @Props()
     class BazProps extends FluxUiProps<BazActions, BazStore> {
       // Props go here, declared as fields.
       // `actions` and `store` are already defined for you!
     }
-  
+
     @State()
     class BazState extends UiState {
       // State goes here, declared as fields.
     }
-    
+
     @Component()
     class BazComponent extends FluxUiStatefulComponent<BazProps, BazState> {
       getDefaultProps() => (newProps()
         // Cascade default props here
       );
-    
+
       @override
       Map getInitialState() => (newState()
         // Cascade initial state here
       );
-    
+
       @override
       render() {
         // Return the rendered component contents here.
@@ -770,8 +770,8 @@ that you get for free from OverReact, you're ready to start building your own cu
 ### Component Best Practices
 
 
-* __ALWAYS__ write informative comments for your component factories. 
-Include what the component relates to, relies on, or if it extends 
+* __ALWAYS__ write informative comments for your component factories.
+Include what the component relates to, relies on, or if it extends
 another component.
 
   _Good:_
@@ -797,27 +797,27 @@ another component.
 
 &nbsp;
 
-* __ALWAYS__ set a default / initial value for `props` / `state` fields, 
+* __ALWAYS__ set a default / initial value for `props` / `state` fields,
 and document that value in a comment.
 
-  _Why?_ Without default prop values for bool fields, they could be 
-  `null` - which is extremely confusing and can lead to a lot of 
-  unnecessary null-checking in your business logic. 
+  _Why?_ Without default prop values for bool fields, they could be
+  `null` - which is extremely confusing and can lead to a lot of
+  unnecessary null-checking in your business logic.
 
   _Good:_
     ```dart
     @Props()
     DropdownButtonProps extends UiProps {
       /// Whether the [DropdownButton] appears disabled.
-      /// 
+      ///
       /// Default: `false`
       bool isDisabled;
 
       /// Whether the [DropdownButton]'s child [DropdownMenu] is open
       /// when the component is first mounted.
-      /// 
+      ///
       /// Determines the initial value of [DropdownButtonState.isOpen].
-      /// 
+      ///
       /// Default: `false`
       bool initiallyOpen;
     }
@@ -825,13 +825,13 @@ and document that value in a comment.
     @State()
     DropdownButtonState extends UiState {
       /// Whether the [DropdownButton]'s child [DropdownMenu] is open.
-      /// 
+      ///
       /// Initial: [DropdownButtonProps.initiallyOpen]
       bool isOpen;
     }
 
     @Component()
-    DropdownButtonComponent 
+    DropdownButtonComponent
         extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
       @override
       Map getDefaultProps() => (newProps()
@@ -860,16 +860,16 @@ and document that value in a comment.
     }
 
     @Component()
-    DropdownButtonComponent 
+    DropdownButtonComponent
         extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
-      // Confusing stuff is gonna happen in here with 
+      // Confusing stuff is gonna happen in here with
       // bool props that could be null.
     }
     ```
 
 &nbsp;
 
-* __AVOID__ adding `props` or `state` fields that don't have 
+* __AVOID__ adding `props` or `state` fields that don't have
 an informative comment.
 
   _Good:_
@@ -877,15 +877,15 @@ an informative comment.
     @Props()
     DropdownButtonProps extends UiProps {
       /// Whether the [DropdownButton] appears disabled.
-      /// 
+      ///
       /// Default: `false`
       bool isDisabled;
 
       /// Whether the [DropdownButton]'s child [DropdownMenu] is open
       /// when the component is first mounted.
-      /// 
+      ///
       /// Determines the initial value of [DropdownButtonState.isOpen].
-      /// 
+      ///
       /// Default: `false`
       bool initiallyOpen;
     }
@@ -893,7 +893,7 @@ an informative comment.
     @State()
     DropdownButtonState extends UiState {
       /// Whether the [DropdownButton]'s child [DropdownMenu] is open.
-      /// 
+      ///
       /// Initial: [DropdownButtonProps.initiallyOpen]
       bool isOpen;
     }
@@ -918,7 +918,7 @@ an informative comment.
 ### Common Pitfalls
 
 Below you’ll find some common errors / issues that new consumers run into when building custom components.
- 
+
 > Don’t see the issue you're having? [Tell us about it.][new-issue]
 
 ---
@@ -929,7 +929,7 @@ Below you’ll find some common errors / issues that new consumers run into when
 ⓧ Exception: The null object does not have a method 'call'.
 ```
 
-This error is thrown when you call a `@Factory()` function that has not been initialized due to 
+This error is thrown when you call a `@Factory()` function that has not been initialized due to
 the `over_react` [transformer] not running, you’ll get this error.
 
 __Make sure you’ve followed the [setup instructions](#using-it-in-your-project).__
@@ -943,7 +943,7 @@ __Make sure you’ve followed the [setup instructions](#using-it-in-your-project
 ⓧ An error occurred loading file: http://localhost:8080/src/your_component.dart
 ```
 
-When the `over_react` [transformer] finds something wrong with your file, it logs an error in Pub and causes the 
+When the `over_react` [transformer] finds something wrong with your file, it logs an error in Pub and causes the
 invalid file to 404. This ensures that when the transformer breaks, `pub build` will break, and you’ll know about it.
 
 __Check your `pub serve` output for errors.__
@@ -967,7 +967,7 @@ Yes please! ([__Please read our contributor guidelines first__][contributing-doc
 The `over_react` library adheres to [Semantic Versioning](http://semver.org/):
 
 * Any API changes that are not backwards compatible will __bump the major version__ _(and reset the minor / patch)_.
-* Any new functionality that is added in a backwards-compatible manner will __bump the minor version__ 
+* Any new functionality that is added in a backwards-compatible manner will __bump the minor version__
   _(and reset the patch)_.
 * Any backwards-compatible bug fixes that are added will __bump the patch version__.
 

--- a/README.md
+++ b/README.md
@@ -494,47 +494,47 @@ as shown in the examples above.
 
 
 ## Component Formatting
-
-#### dart_style
-Currently, [dart_style (dartfmt)](https://github.com/dart-lang/dart_style) decreases the readability of components
-built using [OverReact's fluent-style](#fluent-style-component-consumption).
-See https://github.com/dart-lang/dart_style/issues/549 for more info.
-
-We're exploring some different ideas to improve automated formatting, but for the time being, we __do not recommend__ using dart_style with OverReact.
-
-However, if you do choose to use dart_style, you can greatly improve its output by using trailing commas in children argument lists:
-
-* dart_style formatting:
-```dart
-return (Button()
-  ..id = 'flip'
-  ..skin =
-      ButtonSkin.vanilla)((Dom.span()
-  ..className = 'flip-container')((Dom.span()..className = 'flipper')(
-    (Dom.span()
-      ..className =
-          'front-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)()),
-    (Dom.span()
-      ..className =
-          'back-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)()))));
-```
-* dart_style formatting, when trailing commas are used:
-```dart
-return (Button()
-  ..id = 'flip'
-  ..skin = ButtonSkin.vanilla)(
-  (Dom.span()..className = 'flip-container')(
-    (Dom.span()..className = 'flipper')(
-      (Dom.span()..className = 'front-side')(
-        (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)(),
-      ),
-      (Dom.span()..className = 'back-side')(
-        (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)(),
-      ),
-    ),
-  ),
-);
-```
+> __A note on dart_style:__
+> 
+> Currently, [dart_style (dartfmt)](https://github.com/dart-lang/dart_style) decreases the readability of components
+> built using [OverReact's fluent-style](#fluent-style-component-consumption).
+> See https://github.com/dart-lang/dart_style/issues/549 for more info.
+> 
+> We're exploring some different ideas to improve automated formatting, but for the time being, we __do not recommend__ using dart_style with OverReact.
+> 
+> However, if you do choose to use dart_style, you can greatly improve its output by using trailing commas in children argument lists:
+> 
+> * dart_style formatting:
+> ```dart
+> return (Button()
+>   ..id = 'flip'
+>   ..skin =
+>       ButtonSkin.vanilla)((Dom.span()
+>   ..className = 'flip-container')((Dom.span()..className = 'flipper')(
+>     (Dom.span()
+>       ..className =
+>           'front-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)()),
+>     (Dom.span()
+>       ..className =
+>           'back-side')((Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)()))));
+> ```
+> * dart_style formatting, when trailing commas are used:
+> ```dart
+> return (Button()
+>   ..id = 'flip'
+>   ..skin = ButtonSkin.vanilla)(
+>   (Dom.span()..className = 'flip-container')(
+>     (Dom.span()..className = 'flipper')(
+>       (Dom.span()..className = 'front-side')(
+>         (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_RIGHT)(),
+>       ),
+>       (Dom.span()..className = 'back-side')(
+>         (Icon()..glyph = IconGlyph.CHEVRON_DOUBLE_LEFT)(),
+>       ),
+>     ),
+>   ),
+> );
+> ```
 
 ### Guidelines
 


### PR DESCRIPTION
## Ultimate problem:
Formatting guidelines were outdated when it came to trailing commas. (#25)

## How it was fixed:
Update them.

## Testing suggestions:
* Verify that the new guidelines are correct and makes sense.

## Potential areas of regression:
* README formatting

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
