### PR TITLE
Consume smithy-runner 3.5.5

### DIFF
--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,5 +1,6 @@
 project: dart
 language: dart
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner:112206
 
 # dart 1.19.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
 runner_image: drydock-prod.workiva.org/workiva/smithy-runner-dart:74173


### PR DESCRIPTION
In order to keep builds deterministic, and reduce the risk of future build failure, please pin your smithy runner to the currently defaulted runner.
For more information please see the email 'Smithy Runner Recommendation' or reach out to Travis Reed in hipchat.


Requested by: @travisreed-wf

@travisreed-wf