### PR TITLE
UIP-1392 Make props methods work conditionally

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -282,7 +282,8 @@ abstract class UiProps
     props[propKey] = value;
   }
 
-  /// Adds a Map of arbitrary props if [shouldAdd] is true, otherwise, does nothing.
+  /// Adds a Map of arbitrary props if [shouldAdd] is true and [propMap] is not null.
+  ///
   /// [props] may be null.
   void addProps(Map propMap, [bool shouldAdd = true]) {
     if (!shouldAdd || propMap == null) return;
@@ -290,7 +291,7 @@ abstract class UiProps
     props.addAll(propMap);
   }
 
-  /// Allows [modifier] to alter this instance of props if [shouldModify] is true, otherwise, does nothing.
+  /// Allows [modifier] to alter this instance of props if [shouldModify] is true and [modifier] is not null.
   void modifyProps(PropsModifier modifier, [bool shouldModify = true]){
     if (!shouldModify || modifier == null) return;
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -283,8 +283,6 @@ abstract class UiProps
   }
 
   /// Adds a Map of arbitrary props if [shouldAdd] is true and [propMap] is not null.
-  ///
-  /// [props] may be null.
   void addProps(Map propMap, [bool shouldAdd = true]) {
     if (!shouldAdd || propMap == null) return;
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -275,25 +275,22 @@ typedef PropsModifier(Map props);
 abstract class UiProps
     extends Object with MapViewMixin, PropsMapViewMixin, ReactPropsMixin, UbiquitousDomPropsMixin, CssClassPropsMixin
     implements Map {
-
-  /// Adds an arbitrary prop key-value pair.
-  /// IF [shouldAdd] is true, otherwise, does nothing.
+  /// Adds an arbitrary prop key-value pair if [shouldAdd] is true, otherwise, does nothing.
   void addProp(propKey, value, [bool shouldAdd = true]) {
     if (!shouldAdd) return;
 
     props[propKey] = value;
   }
 
-  /// Adds a Map of arbitrary props. [props] may be null.
-  /// IF [shouldAdd] is true, otherwise, does nothing.
+  /// Adds a Map of arbitrary props if [shouldAdd] is true, otherwise, does nothing.
+  /// [props] may be null.
   void addProps(Map propMap, [bool shouldAdd = true]) {
     if (!shouldAdd || propMap == null) return;
 
     props.addAll(propMap);
   }
 
-  /// Allows [modifier] to alter this instance of props.
-  /// IF [shouldModify] is true, otherwise, do nothing.
+  /// Allows [modifier] to alter this instance of props if [shouldModify] is true, otherwise, does nothing.
   void modifyProps(PropsModifier modifier, [bool shouldModify = true]){
     if (!shouldModify || modifier == null) return;
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -275,23 +275,27 @@ typedef PropsModifier(Map props);
 abstract class UiProps
     extends Object with MapViewMixin, PropsMapViewMixin, ReactPropsMixin, UbiquitousDomPropsMixin, CssClassPropsMixin
     implements Map {
+
   /// Adds an arbitrary prop key-value pair.
-  void addProp(propKey, value) {
+  /// IF [shouldAdd] is true, otherwise, does nothing.
+  void addProp(propKey, value, [bool shouldAdd = true]) {
+    if (!shouldAdd) return;
+
     props[propKey] = value;
   }
 
   /// Adds a Map of arbitrary props. [props] may be null.
-  void addProps(Map propMap) {
-    if (propMap == null) {
-      return;
-    }
+  /// IF [shouldAdd] is true, otherwise, does nothing.
+  void addProps(Map propMap, [bool shouldAdd = true]) {
+    if (!shouldAdd || propMap == null) return;
 
     props.addAll(propMap);
   }
 
   /// Allows [modifier] to alter this instance of props.
-  void modifyProps(PropsModifier modifier){
-    if (modifier == null) return;
+  /// IF [shouldModify] is true, otherwise, do nothing.
+  void modifyProps(PropsModifier modifier, [bool shouldModify = true]){
+    if (!shouldModify || modifier == null) return;
 
     modifier(this);
   }

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -260,10 +260,19 @@ main() {
         mapProxyTests((Map backingMap) => new TestComponentProps(backingMap));
       });
 
-      test('addProp() adds the given key-value pair', () {
-        var props = new TestComponentProps();
-        props.addProp('key', 'value');
-        expect(props, equals({'key': 'value'}));
+      group('addProp()', () {
+        test('adds the given key-value pair', () {
+          var props = new TestComponentProps();
+          props.addProp('key', 'value');
+          expect(props, equals({'key': 'value'}));
+        });
+
+        test('does nothing when shouldAdd is false', () {
+          var props = new TestComponentProps();
+          props.addProp('key', 'value', false);
+
+          expect(props, equals({}));
+        });
       });
 
       group('addProps()', () {
@@ -290,11 +299,18 @@ main() {
 
           expect(props, equals({'key': 'value'}));
         });
+
+        test('does nothing when shouldAdd is false', () {
+          var props = new TestComponentProps();
+          props.addProps({'newKey1': 'newValue1'}, false);
+
+          expect(props, equals({}));
+        });
       });
 
       group('modifyProps()', () {
         test('passes the provided modifier itself', () {
-          modifier(Map props) {
+          modifier(UiProps props) {
             props['className'] = 'modified-class-name';
           }
 
@@ -322,6 +338,23 @@ main() {
           expect(() => props.modifyProps(null), returnsNormally);
 
           expect(props, equals({'className': 'original-class-name'}));
+        });
+
+        test('does nothing when shouldModify is false', () {
+          modifier(UiProps props) {
+            props['className'] = 'modified-class-name';
+          }
+
+          var props = new TestComponentProps()
+            ..['className'] = 'original-class-name'
+            ..['id'] = 'original-id';
+
+          props.modifyProps(modifier, false);
+
+          expect(props, equals({
+            'className': 'original-class-name',
+            'id': 'original-id'
+          }));
         });
       });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -310,7 +310,7 @@ main() {
 
       group('modifyProps()', () {
         test('passes the provided modifier itself', () {
-          modifier(UiProps props) {
+          modifier(Map props) {
             props['className'] = 'modified-class-name';
           }
 
@@ -341,7 +341,7 @@ main() {
         });
 
         test('does nothing when shouldModify is false', () {
-          modifier(UiProps props) {
+          modifier(Map props) {
             props['className'] = 'modified-class-name';
           }
 


### PR DESCRIPTION
## Ultimate problem:
`UiProps.addProp`, `UiProps.addProps` and `UiProps.modifyProps` should have a second optional parameter that will allow the consumer to conditionally add or modify props. Similar to ClassnameBuilder.add.

## How it was fixed:
- Added boolean parameters to the `addProp`, `addProps`, and `modifyProps` methods.
- Wrote tests for these three methods.

## Testing suggestions:
- Verify that the tests pass.

## Potential areas of regression:
- N/A


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
