### PR TITLE
Declare quiver as a direct dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   transformer_utils: "^0.1.1"
   w_flux: "^2.5.0"
   platform_detect: "^1.1.1"
-  quiver: "^0.21.4"
+  quiver: ">=0.21.4 <0.25.0"
 dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   transformer_utils: "^0.1.1"
   w_flux: "^2.5.0"
   platform_detect: "^1.1.1"
+  quiver: "^0.21.4"
 dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"


### PR DESCRIPTION
## Ultimate problem:
`quiver` only a transitive dev dependency but it is used within `lib/`.

## How it was fixed:
- Declare `quiver` as a direct dependency.

## Testing suggestions:
N/A

## Potential areas of regression:
N/A

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
