### PR TITLE
UIP-1590: Deprecate the Required annotation (Includes UIP-1835)

### DIFF
--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -186,6 +186,9 @@ class StateMixin implements TypedMap {
 
 /// Marks a `prop` as required to be set.
 ///
+/// Validation occurs in `UiComponent.validateRequiredProps` which requires super calls into `componentWillMount` and
+/// `componentWillReceiveProps`.
+///
 ///     @Props()
 ///     abstract class FooProps {
 ///       @requiredProp
@@ -194,6 +197,9 @@ class StateMixin implements TypedMap {
 const Accessor requiredProp = const Accessor(isRequired: true);
 
 /// Marks a `prop` as required to be set, but allowed to be set explicitly to `null`.
+///
+/// Validation occurs in `UiComponent.validateRequiredProps` which requires super calls into `componentWillMount` and
+/// `componentWillReceiveProps`.
 ///
 ///     @Props()
 ///     abstract class FooProps {

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -184,13 +184,42 @@ class StateMixin implements TypedMap {
   const StateMixin({this.keyNamespace: null});
 }
 
+/// Marks a `prop` as required to be set.
+///
+///     @Props()
+///     abstract class FooProps {
+///       @requiredProp
+///       String requiredProp;
+///     }
+const Accessor requiredProp = const Accessor(isRequired: true);
+
+/// Marks a `prop` as required to be set, but allowed to be set explicitly to `null`.
+///
+///     @Props()
+///     abstract class FooProps {
+///       @nullableRequiredProp
+///       String nullableRequiredProp;
+///     }
+const Accessor nullableRequiredProp = const Accessor(isRequired: true, isNullable: true);
+
 /// Annotation used with the `over_react` transformer to customize individual accessors (props/state fields).
+///
+/// Validation occurs in `UiComponent.validateRequiredProps` which requires super calls into `componentWillMount` and
+/// `componentWillReceiveProps`.
 ///
 ///     @Props()
 ///     abstract class FooProps {
 ///       @Accessor(keyNamespace: '', key: 'custom_key')
 ///       String bar;
+///
+///       @Accessor(isRequired: true)
+///       String requiredProp;
+///
+///       @Accessor(isRequired: true, isNullable: true)
+///       String nullableRequiredProp;
 ///     }
+///
+/// Related: [requiredProp], [nullableRequiredProp].
 class Accessor {
   /// A key for the annotated accessor, overriding the default of the accessor's name.
   final String key;
@@ -199,22 +228,26 @@ class Accessor {
   /// overriding the default of `'${enclosingClassName}.'`.
   final String keyNamespace;
 
+  /// Whether the accessor is required to be set.
+  final bool isRequired;
+
+  /// Whether setting a prop to null is allowed.
+  final bool isNullable;
+
+  /// The erro message displayed when the accessor is not set.
+  final String requiredErrorMessage;
+
   const Accessor({
-    this.key: null,
-    this.keyNamespace: null
+    this.key,
+    this.keyNamespace,
+    this.isRequired = false,
+    this.isNullable = false,
+    this.requiredErrorMessage,
   });
 }
 
-/// Annotation used with the `over_react` transformer to express a specific prop is required to be set.
-///
-/// This is validated in `UiComponent.validateRequiredProps` which requires super calls into `componentWillMount` and
-/// `componentWillReceiveProps`.
-///
-///     @Props()
-///     abstract class FooProps {
-///       @Required()
-///       String bar;
-///     }
+/// Deprecated use [Accessor], [requiredProp], or [nullableRequiredProp] instead.
+@Deprecated('2.0.0')
 class Required {
   /// Whether setting a prop to null is allowed.
   final bool isNullable;

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -234,7 +234,7 @@ class Accessor {
   /// Whether setting a prop to null is allowed.
   final bool isNullable;
 
-  /// The erro message displayed when the accessor is not set.
+  /// The error message displayed when the accessor is not set.
   final String requiredErrorMessage;
 
   const Accessor({
@@ -246,7 +246,9 @@ class Accessor {
   });
 }
 
-/// Deprecated use [Accessor], [requiredProp], or [nullableRequiredProp] instead.
+/// Deprecated.
+///
+/// Use [Accessor], [requiredProp], or [nullableRequiredProp] instead.
 @Deprecated('2.0.0')
 class Required {
   /// Whether setting a prop to null is allowed.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -14,6 +14,7 @@
 
 library over_react.component_declaration.component_base;
 
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart' show
     ClassNameBuilder,
     CssClassPropsMixin,
@@ -143,11 +144,13 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
   }
 
   @override
+  @mustCallSuper
   void componentWillReceiveProps(Map newProps) {
     validateRequiredProps(newProps);
   }
 
   @override
+  @mustCallSuper
   void componentWillMount() {
     validateRequiredProps(props);
   }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -399,7 +399,13 @@ class ImplGenerator {
 
             String accessorName = variable.name.name;
 
+            T getConstantAnnotation<T>(AnnotatedNode member, String name, T value) {
+              return member.metadata.any((annotation) => annotation.name?.name == name) ? value : null;
+            }
+
             annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
+            annotations.Accessor requiredProp = getConstantAnnotation(field, 'requiredProp', annotations.requiredProp);
+            annotations.Accessor nullableRequiredProp = getConstantAnnotation(field, 'nullableRequiredProp', annotations.nullableRequiredProp);
             annotations.Required requiredMeta = instantiateAnnotation(field, annotations.Required);
 
             String individualKeyNamespace = accessorMeta?.keyNamespace ?? keyNamespace;
@@ -411,15 +417,23 @@ class ImplGenerator {
             String constantName = '${generatedPrefix}prop__$accessorName';
             String constantValue = 'const $constConstructorName($keyConstantName';
 
-            if (accessorMeta != null && accessorMeta.isRequired) {
-              constantValue += ', isRequired: true';
+            var annotationCount = 0;
 
-              if (accessorMeta.isNullable) constantValue += ', isNullable: true';
+            if (accessorMeta != null) {
+              annotationCount++;
 
-              if (accessorMeta.requiredErrorMessage != null && accessorMeta.requiredErrorMessage.isNotEmpty) {
-                constantValue += ', errorMessage: ${stringLiteral(accessorMeta.requiredErrorMessage)}';
+              if (accessorMeta.isRequired) {
+                constantValue += ', isRequired: true';
+
+                if (accessorMeta.isNullable) constantValue += ', isNullable: true';
+
+                if (accessorMeta.requiredErrorMessage != null && accessorMeta.requiredErrorMessage.isNotEmpty) {
+                  constantValue += ', errorMessage: ${stringLiteral(accessorMeta.requiredErrorMessage)}';
+                }
               }
-            } else if (requiredMeta != null) {
+            }
+
+            if (requiredMeta != null) {
               constantValue += ', isRequired: true';
 
               if (requiredMeta.isNullable) constantValue += ', isNullable: true';
@@ -427,6 +441,20 @@ class ImplGenerator {
               if (requiredMeta.message != null && requiredMeta.message.isNotEmpty) {
                 constantValue += ', errorMessage: ${stringLiteral(requiredMeta.message)}';
               }
+            }
+
+            if (requiredProp != null) {
+              annotationCount++;
+              constantValue += ', isRequired: true';
+            }
+
+            if (nullableRequiredProp != null) {
+              annotationCount++;
+              constantValue += ', isRequired: true, isNullable: true';
+            }
+
+            if (annotationCount > 1) {
+              logger.error('At most only a single annotation can be applied to an accessor.', span: getSpan(sourceFile, field));
             }
 
             constantValue += ')';

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -402,10 +402,6 @@ class ImplGenerator {
             annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
             annotations.Required requiredMeta = instantiateAnnotation(field, annotations.Required);
 
-            bool isRequired = requiredMeta != null;
-            bool isNullable = isRequired && requiredMeta.isNullable;
-            bool hasErrorMessage = isRequired && requiredMeta.message != null && requiredMeta.message.isNotEmpty;
-
             String individualKeyNamespace = accessorMeta?.keyNamespace ?? keyNamespace;
             String individualKey = accessorMeta?.key ?? accessorName;
 
@@ -415,11 +411,22 @@ class ImplGenerator {
             String constantName = '${generatedPrefix}prop__$accessorName';
             String constantValue = 'const $constConstructorName($keyConstantName';
 
-            if (isRequired) {
+            if (accessorMeta != null && accessorMeta.isRequired) {
               constantValue += ', isRequired: true';
 
-              if (isNullable) constantValue += ', isNullable: true';
-              if (hasErrorMessage) constantValue += ', errorMessage: ${stringLiteral(requiredMeta.message)}';
+              if (accessorMeta.isNullable) constantValue += ', isNullable: true';
+
+              if (accessorMeta.requiredErrorMessage != null && accessorMeta.requiredErrorMessage.isNotEmpty) {
+                constantValue += ', errorMessage: ${stringLiteral(accessorMeta.requiredErrorMessage)}';
+              }
+            } else if (requiredMeta != null) {
+              constantValue += ', isRequired: true';
+
+              if (requiredMeta.isNullable) constantValue += ', isNullable: true';
+
+              if (requiredMeta.message != null && requiredMeta.message.isNotEmpty) {
+                constantValue += ', errorMessage: ${stringLiteral(requiredMeta.message)}';
+              }
             }
 
             constantValue += ')';

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -454,7 +454,11 @@ class ImplGenerator {
             }
 
             if (annotationCount > 1) {
-              logger.error('At most only a single annotation can be applied to an accessor.', span: getSpan(sourceFile, field));
+              logger.error(
+                  '@requiredProp/@nullableProp/@Accessor cannot be used together.\n'
+                  'You can use `@Accessor(required: true)` or `isNullable: true` instead of the shorthand versions.',
+                  span: getSpan(sourceFile, field)
+              );
             }
 
             constantValue += ')';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   analyzer: ">=0.26.1+3 <0.30.0"
   barback: "^0.15.0"
+  meta: "^1.0.4"
   react: "^3.1.0"
   source_span: "^1.2.0"
   transformer_utils: "^0.1.1"

--- a/test/over_react/component_declaration/transformer_integration_tests/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/constant_required_accessor_integration_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library over_react.component_declaration.transformer_integration_tests.required_prop_integration;
+library over_react.component_declaration.transformer_integration_tests.constant_required_accessor_integration;
 
 import 'dart:html';
 
@@ -22,12 +22,12 @@ import 'package:test/test.dart';
 
 import '../../../test_util/test_util.dart';
 
-void requiredPropsIntegrationTest() {
+void main() {
   group('properly identifies required props by', () {
     group('throwing when a prop is required and not set', () {
       test('on mount', () {
         expect(() => render(ComponentTest()..nullable = true),
-            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
+            throwsPropError_Required('ComponentTestProps.required')
         );
       });
 
@@ -39,7 +39,7 @@ void requiredPropsIntegrationTest() {
         )(), mountNode);
 
         expect(() => react_dom.render((ComponentTest()..nullable = true)(), mountNode),
-            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
+            throwsPropError_Required('ComponentTestProps.required')
         );
       });
     });
@@ -64,7 +64,7 @@ void requiredPropsIntegrationTest() {
               ..required = null
               ..nullable = true
             )(), mountNode),
-            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
+            throwsPropError_Required('ComponentTestProps.required')
         );
       });
     });
@@ -83,7 +83,7 @@ void requiredPropsIntegrationTest() {
         )(), mountNode);
 
         expect(() => react_dom.render((ComponentTest()..required = true)(), mountNode),
-            throwsPropError_Required('ComponentTestProps.nullable', 'This prop can be set to null!')
+            throwsPropError_Required('ComponentTestProps.nullable')
         );
       });
     });
@@ -139,12 +139,10 @@ UiFactory<ComponentTestProps> ComponentTest;
 
 @Props()
 class ComponentTestProps extends UiProps {
-  // ignore: deprecated_member_use
-  @Required(message: 'This Prop is Required for testing purposes.')
+  @requiredProp
   var required;
 
-  // ignore: deprecated_member_use
-  @Required(isNullable: true, message: 'This prop can be set to null!')
+  @nullableRequiredProp
   var nullable;
 }
 

--- a/test/over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library over_react.component_declaration.transformer_integration_tests.required_prop_integration;
+library over_react.component_declaration.transformer_integration_tests.required_accessor_integration;
 
 import 'dart:html';
 
@@ -22,7 +22,7 @@ import 'package:test/test.dart';
 
 import '../../../test_util/test_util.dart';
 
-void requiredPropsIntegrationTest() {
+void main() {
   group('properly identifies required props by', () {
     group('throwing when a prop is required and not set', () {
       test('on mount', () {
@@ -132,6 +132,14 @@ void requiredPropsIntegrationTest() {
       });
     });
   });
+
+  test('requiredProp shorthands `const Accessor(isRequired: true)`', () {
+    expect(requiredProp, const Accessor(isRequired: true));
+  });
+
+  test('nullableRequiredProp shorthands `const Accessor(isRequired: true, isNullable: true)`', () {
+    expect(nullableRequiredProp, const Accessor(isRequired: true, isNullable: true));
+  });
 }
 
 @Factory()
@@ -139,12 +147,10 @@ UiFactory<ComponentTestProps> ComponentTest;
 
 @Props()
 class ComponentTestProps extends UiProps {
-  // ignore: deprecated_member_use
-  @Required(message: 'This Prop is Required for testing purposes.')
+  @Accessor(isRequired: true, requiredErrorMessage: 'This Prop is Required for testing purposes.')
   var requiredProp;
 
-  // ignore: deprecated_member_use
-  @Required(isNullable: true, message: 'This prop can be set to null!')
+  @Accessor(isRequired: true, isNullable: true, requiredErrorMessage: 'This prop can be set to null!')
   var nullableProp;
 }
 

--- a/test/over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart
@@ -26,20 +26,20 @@ void main() {
   group('properly identifies required props by', () {
     group('throwing when a prop is required and not set', () {
       test('on mount', () {
-        expect(() => render(ComponentTest()..nullableProp = true),
-            throwsPropError_Required('ComponentTestProps.requiredProp', 'This Prop is Required for testing purposes.')
+        expect(() => render(ComponentTest()..nullable = true),
+            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
         );
       });
 
       test('on re-render', () {
         var mountNode = new DivElement();
         react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode);
 
-        expect(() => react_dom.render((ComponentTest()..nullableProp = true)(), mountNode),
-            throwsPropError_Required('ComponentTestProps.requiredProp', 'This Prop is Required for testing purposes.')
+        expect(() => react_dom.render((ComponentTest()..nullable = true)(), mountNode),
+            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
         );
       });
     });
@@ -47,43 +47,43 @@ void main() {
     group('throwing when a prop is required and set to null', () {
       test('on mount', () {
         expect(() => render(ComponentTest()
-          ..requiredProp = null
-          ..nullableProp = true
-        ), throwsPropError_Required('ComponentTestProps.requiredProp'));
+          ..required = null
+          ..nullable = true
+        ), throwsPropError_Required('ComponentTestProps.required'));
       });
 
       test('on re-render', () {
         var mountNode = new DivElement();
         react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode);
 
         expect(
             () => react_dom.render((ComponentTest()
-              ..requiredProp = null
-              ..nullableProp = true
+              ..required = null
+              ..nullable = true
             )(), mountNode),
-            throwsPropError_Required('ComponentTestProps.requiredProp', 'This Prop is Required for testing purposes.')
+            throwsPropError_Required('ComponentTestProps.required', 'This Prop is Required for testing purposes.')
         );
       });
     });
 
     group('throwing when a prop is nullable and not set', () {
       test('on mount', () {
-        expect(() => render(ComponentTest()..requiredProp = true),
-            throwsPropError_Required('ComponentTestProps.nullableProp'));
+        expect(() => render(ComponentTest()..required = true),
+            throwsPropError_Required('ComponentTestProps.nullable'));
       });
 
       test('on re-render', () {
         var mountNode = new DivElement();
         react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode);
 
-        expect(() => react_dom.render((ComponentTest()..requiredProp = true)(), mountNode),
-            throwsPropError_Required('ComponentTestProps.nullableProp', 'This prop can be set to null!')
+        expect(() => react_dom.render((ComponentTest()..required = true)(), mountNode),
+            throwsPropError_Required('ComponentTestProps.nullable', 'This prop can be set to null!')
         );
       });
     });
@@ -91,21 +91,21 @@ void main() {
     group('not throwing when a prop is required and set', () {
       test('on mount', () {
         expect(() => render(ComponentTest()
-          ..nullableProp = true
-          ..requiredProp = true
+          ..nullable = true
+          ..required = true
         ), returnsNormally);
       });
 
       test('on re-render', () {
         var mountNode = new DivElement();
         react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode);
 
         expect(() => react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode), returnsNormally);
       });
     });
@@ -113,32 +113,24 @@ void main() {
     group('not throwing when a prop is nullable and set to null', () {
       test('on mount', () {
         expect(() => render(ComponentTest()
-          ..nullableProp = null
-          ..requiredProp = true
+          ..nullable = null
+          ..required = true
         ), returnsNormally);
       });
 
       test('on re-render', () {
         var mountNode = new DivElement();
         react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = true
+          ..required = true
+          ..nullable = true
         )(), mountNode);
 
         expect(() => react_dom.render((ComponentTest()
-          ..requiredProp = true
-          ..nullableProp = null
+          ..required = true
+          ..nullable = null
         )(), mountNode), returnsNormally);
       });
     });
-  });
-
-  test('requiredProp shorthands `const Accessor(isRequired: true)`', () {
-    expect(requiredProp, const Accessor(isRequired: true));
-  });
-
-  test('nullableRequiredProp shorthands `const Accessor(isRequired: true, isNullable: true)`', () {
-    expect(nullableRequiredProp, const Accessor(isRequired: true, isNullable: true));
   });
 }
 
@@ -148,10 +140,10 @@ UiFactory<ComponentTestProps> ComponentTest;
 @Props()
 class ComponentTestProps extends UiProps {
   @Accessor(isRequired: true, requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  var requiredProp;
+  var required;
 
   @Accessor(isRequired: true, isNullable: true, requiredErrorMessage: 'This prop can be set to null!')
-  var nullableProp;
+  var nullable;
 }
 
 @Component()

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -31,6 +31,7 @@ import 'over_react/component_declaration/transformer_integration_tests/abstract_
 import 'over_react/component_declaration/transformer_integration_tests/accessor_mixin_integration_test.dart' as accessor_mixin_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/component_integration_test.dart' as component_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/namespaced_accessor_integration_test.dart' as namespaced_accessor_integration_test;
+import 'over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart' as required_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/stateful_component_integration_test.dart' as stateful_component_integration_test;
 
 main() {
@@ -46,5 +47,6 @@ main() {
   accessor_mixin_integration_test.main();
   component_integration_test.main();
   namespaced_accessor_integration_test.main();
+  required_accessor_integration_test.main();
   stateful_component_integration_test.main();
 }

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -30,6 +30,7 @@ import 'over_react/component_declaration/transformer_helpers_test.dart' as trans
 import 'over_react/component_declaration/transformer_integration_tests/abstract_accessor_integration_test.dart' as abstract_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/accessor_mixin_integration_test.dart' as accessor_mixin_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/component_integration_test.dart' as component_integration_test;
+import 'over_react/component_declaration/transformer_integration_tests/constant_required_accessor_integration_test.dart' as constant_required_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/namespaced_accessor_integration_test.dart' as namespaced_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart' as required_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/stateful_component_integration_test.dart' as stateful_component_integration_test;
@@ -46,6 +47,7 @@ main() {
   abstract_accessor_integration_test.main();
   accessor_mixin_integration_test.main();
   component_integration_test.main();
+  constant_required_accessor_integration_test.main();
   namespaced_accessor_integration_test.main();
   required_accessor_integration_test.main();
   stateful_component_integration_test.main();

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -579,6 +579,9 @@ main() {
       });
 
       group('accessors have', () {
+        const expectedAccessorErrorMessage = '@requiredProp/@nullableProp/@Accessor cannot be used together.\n'
+            'You can use `@Accessor(required: true)` or `isNullable: true` instead of the shorthand versions.';
+
         test('the Accessor and requiredProp annotation', () {
           setUpAndGenerate('''
             @AbstractProps()
@@ -588,7 +591,7 @@ main() {
               var bar;
             }
           ''');
-          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+          verify(logger.error(expectedAccessorErrorMessage, span: any));
         });
 
         test('the Accessor and nullableRequiredProp annotation', () {
@@ -600,7 +603,7 @@ main() {
               var bar;
             }
           ''');
-          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+          verify(logger.error(expectedAccessorErrorMessage, span: any));
         });
 
         test('the requiredProp and nullableRequiredProp annotation', () {
@@ -612,7 +615,7 @@ main() {
               var bar;
             }
           ''');
-          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+          verify(logger.error(expectedAccessorErrorMessage, span: any));
         });
       });
     });

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -577,6 +577,44 @@ main() {
         ''');
         verify(logger.error('Fields are stubs for generated setters/getters and should not have initializers.', span: any));
       });
+
+      group('accessors have', () {
+        test('the Accessor and requiredProp annotation', () {
+          setUpAndGenerate('''
+            @AbstractProps()
+            class AbstractFooProps {
+              @Accessor()
+              @requiredProp
+              var bar;
+            }
+          ''');
+          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+        });
+
+        test('the Accessor and nullableRequiredProp annotation', () {
+          setUpAndGenerate('''
+            @AbstractProps()
+            class AbstractFooProps {
+              @Accessor()
+              @nullableRequiredProp
+              var bar;
+            }
+          ''');
+          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+        });
+
+        test('the requiredProp and nullableRequiredProp annotation', () {
+          setUpAndGenerate('''
+            @AbstractProps()
+            class AbstractFooProps {
+              @requiredProp
+              @nullableRequiredProp
+              var bar;
+            }
+          ''');
+          verify(logger.error('At most only a single annotation can be applied to an accessor.', span: any));
+        });
+      });
     });
 
     group('logs a warning when', () {


### PR DESCRIPTION
## Ultimate problem:
The `Required` annotation used by the `over_react` transformer collides with the annotation from `package:meta`.

## How it was fixed:
- Deprecate `Required`, and add more options to the `Accessor` annotation.
- Update logic around the transformer to support the new options on an `Accessor` annotation.
- Added shorthand consts for `Accessor(isRequired: true)` and `Accessor(isRequired: true, isNullable: true)`.

## Testing suggestions:
- Verify tests pass
- On one of the example components, make a prop required via the new options on an `Accessor` annotation.
  - Verify that when you don't set it, the component throws an error.

## Potential areas of regression:
- Required annotation support.

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
