### PR TITLE
UIP-2052 Release over_react 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # OverReact Changelog
 
+
+## 1.7.0
+
+> [Complete `1.6.0` Changeset](https://github.com/Workiva/over_react/compare/1.6.0...1.7.0)
+
+* Eliminate dart2js warnings on component props classes #52
+* Deprecate the `@Required()` annotation since it conflicts with the `meta` package. #51 Replaced by:
+    * arguments to the `Accessor` annotation:
+        ```dart
+        @Accessor(isRequired: true, isNullable: true, requiredErrorMessage: 'foo')
+        ```
+
+    * shorthand aliases: `@requiredProp`/`@nullableRequiredProp`
+
 ## 1.6.0
 
 > [Complete `1.6.0` Changeset](https://github.com/Workiva/over_react/compare/1.5.0...1.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 1.7.0
 
-> [Complete `1.6.0` Changeset](https://github.com/Workiva/over_react/compare/1.6.0...1.7.0)
+> [Complete `1.7.0` Changeset](https://github.com/Workiva/over_react/compare/1.6.0...1.7.0)
 
 * Eliminate dart2js warnings on component props classes #52
 * Deprecate the `@Required()` annotation since it conflicts with the `meta` package. #51 Replaced by:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.6.0
+version: 1.7.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
> [Complete `1.7.0` Changeset](https://github.com/Workiva/over_react/compare/1.6.0...1.7.0)

* Eliminate dart2js warnings on component props classes #52
* Deprecate the `@Required()` annotation since it conflicts with the `meta` package. #51 Replaced by:
    * arguments to the `Accessor` annotation:
        ```dart
        @Accessor(isRequired: true, isNullable: true, requiredErrorMessage: 'foo')
        ```

    * shorthand aliases: `@requiredProp`/`@nullableRequiredProp`
