### PR TITLE
UIP-2120 Fix strong mode warning

### DIFF
--- a/lib/src/component/prop_typedefs.dart
+++ b/lib/src/component/prop_typedefs.dart
@@ -19,4 +19,4 @@ import 'package:over_react/src/component_declaration/component_base.dart' as com
 import 'package:react/react_client.dart';
 
 /// A typedef for props that allow a custom rendering function to be provided to render some part of a component.
-typedef ReactElement CustomRenderFunction<TProps extends UiProps, TState extends UiState, TComponent extends component_base.UiComponent> (TProps props, TState state, TComponent component);
+typedef ReactElement CustomRenderFunction<TProps extends UiProps, TState extends UiState, TComponent extends component_base.UiComponent<TProps>> (TProps props, TState state, TComponent component);


### PR DESCRIPTION
## Ultimate problem:
There was a strong mode warning on a typedef on Dart 1.22.0.

## How it was fixed:
- Add a type parameter to base_component.UiComponent.

## Testing suggestions:
- Verify that there are no analyzer warnings on Dart 1.22.0

## Potential areas of regression:
N/A

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
