### PR TITLE
UIP-1802 CSS Transition Timeout/Warning

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -123,6 +123,9 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
   /// Whether the Element returned by [getTransitionDomNode] will have a transition event.
   bool get hasTransition => true;
 
+  /// The duration that can elapse before a transition timeout occurs.
+  Duration get transitionTimeout => const Duration(seconds: 15);
+
   // --------------------------------------------------------------------------
   // Private Utility Methods
   // --------------------------------------------------------------------------
@@ -184,7 +187,12 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       skipCount = 0;
     }
 
+    var timer = new Timer(transitionTimeout, () {
+      assert(ValidationUtil.warn("A transition timeout has occurred."));
+    });
+
     _endTransitionSubscription = getTransitionDomNode()?.onTransitionEnd?.skip(skipCount)?.take(1)?.listen((_) {
+      timer.cancel();
       complete();
     });
   }

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -124,7 +124,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
   bool get hasTransition => true;
 
   /// The duration that can elapse before a transition timeout occurs.
-  Duration get transitionTimeout => const Duration(seconds: 15);
+  Duration get transitionTimeout => const Duration(seconds: 1);
 
   // --------------------------------------------------------------------------
   // Private Utility Methods
@@ -188,7 +188,9 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
     }
 
     var timer = new Timer(transitionTimeout, () {
-      assert(ValidationUtil.warn("A transition timeout has occurred."));
+      assert(ValidationUtil.warn(
+        'The number of transitions expected to complete have not completed. Something is most likely wrong.'
+      ));
     });
 
     _endTransitionSubscription = getTransitionDomNode()?.onTransitionEnd?.skip(skipCount)?.take(1)?.listen((_) {

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -191,6 +191,8 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       assert(ValidationUtil.warn(
         'The number of transitions expected to complete have not completed. Something is most likely wrong.'
       ));
+
+      complete();
     });
 
     _endTransitionSubscription = getTransitionDomNode()?.onTransitionEnd?.skip(skipCount)?.take(1)?.listen((_) {

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -428,9 +428,11 @@ main() {
 
       transitioner.hide();
 
+      expect(transitioner.state.transitionPhase, TransitionPhase.HIDING);
+
       await new Future.delayed(Duration.ZERO);
 
-      expect(transitioner.state.transitionPhase, TransitionPhase.HIDING);
+      expect(transitioner.state.transitionPhase, TransitionPhase.HIDDEN);
 
       verifyValidationWarning(
         'The number of transitions expected to complete have not completed. Something is most likely wrong.'
@@ -471,7 +473,7 @@ class TransitionerComponent extends AbstractTransitionComponent<TransitionerProp
     ..addProps(super.getDefaultProps())
     ..hasTransition = true
     ..initiallyShown = true
-    ..transitionTimeout = const Duration(seconds: 15)
+    ..transitionTimeout = const Duration(seconds: 1)
   );
 
 

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -413,6 +413,25 @@ main() {
         });
       }, testOn: '!js');
     });
+
+    test('times out after the duration specified in timeoutDuration has elapsed', () async {
+      startRecordingValidationWarnings();
+
+      var renderedInstance = render(Transitioner()
+        ..transitionCount = 1
+        ..transitionTimeout = const Duration(seconds: 0)
+      );
+
+      TransitionerComponent transitioner = getDartComponent(renderedInstance);
+
+      transitioner.hide();
+
+      await new Future.delayed(Duration.ZERO);
+
+      verifyValidationWarning("A transition timeout has occurred.");
+
+      stopRecordingValidationWarnings();
+    });
   });
 }
 
@@ -432,6 +451,8 @@ class TransitionerProps extends AbstractTransitionProps {
 
   bool hasTransition;
   bool initiallyShown;
+
+  Duration transitionTimeout;
 }
 
 @State()
@@ -444,6 +465,7 @@ class TransitionerComponent extends AbstractTransitionComponent<TransitionerProp
     ..addProps(super.getDefaultProps())
     ..hasTransition = true
     ..initiallyShown = true
+    ..transitionTimeout = const Duration(seconds: 15)
   );
 
 
@@ -455,6 +477,9 @@ class TransitionerComponent extends AbstractTransitionComponent<TransitionerProp
 
   @override
   bool get hasTransition => props.hasTransition;
+
+  @override
+  Duration get transitionTimeout => props.transitionTimeout;
 
   @override
   render() {

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -424,11 +424,17 @@ main() {
 
       TransitionerComponent transitioner = getDartComponent(renderedInstance);
 
+      expect(transitioner.state.transitionPhase, TransitionPhase.SHOWN);
+
       transitioner.hide();
 
       await new Future.delayed(Duration.ZERO);
 
-      verifyValidationWarning("A transition timeout has occurred.");
+      expect(transitioner.state.transitionPhase, TransitionPhase.HIDING);
+
+      verifyValidationWarning(
+        'The number of transitions expected to complete have not completed. Something is most likely wrong.'
+      );
 
       stopRecordingValidationWarnings();
     });


### PR DESCRIPTION
## Ultimate problem:

When creating custom `Modals`, it's possible to set transition to a value that `ModalTrigger` doesn't know about, which causes the cleanup of the modal to hang.

We add a timeout to ensure that the modal is cleaned up even if something goes wrong with the transition, and warn the consumer.

## How it was fixed:

- Add a `transitionTimeout` getter to `AbstractTransitionComponent` that can be overridden to adjust the desired timeout duration.
- Use a `Timer` and display a warning after a timeout has occurred.
- Write a test to verify that the timeout actually occurs.

## Testing suggestions:
- Verify that the tests pass.

## Potential areas of regression:
- N/A

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
