### PR TITLE
UIP-2153: Transition warning sometimes fires when it shouldn't

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -188,10 +188,10 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       assert(ValidationUtil.warn(warningMessage));
 
       skipCount = 0;
-
-      _cancelTransitionEventListener();
-      _cancelTransitionEndTimer();
     }
+
+    _cancelTransitionEventListener();
+    _cancelTransitionEndTimer();
 
     _transitionEndTimer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
@@ -199,7 +199,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       ));
 
       _cancelTransitionEventListener();
-      
+
       complete();
     });
 
@@ -312,8 +312,6 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
 
   /// Method that will be called when [AbstractTransitionComponent]  first enters the `preShowing` state.
   void handlePreShowing() {
-    _cancelTransitionEndTimer();
-
     onNextTransitionEnd(() {
       if (state.transitionPhase == TransitionPhase.SHOWING) {
         setState(newState()
@@ -348,6 +346,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
         );
       });
 
+      _cancelTransitionEventListener();
       _cancelTransitionEndTimer();
     } else {
       onNextTransitionEnd(() {

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -126,6 +126,9 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
   /// The duration that can elapse before a transition timeout occurs.
   Duration get transitionTimeout => const Duration(seconds: 1);
 
+  /// Timer used to determine if a transition timeout has occurred.
+  Timer _transitionEndTimer;
+
   // --------------------------------------------------------------------------
   // Private Utility Methods
   // --------------------------------------------------------------------------
@@ -187,16 +190,22 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       skipCount = 0;
     }
 
-    var timer = new Timer(transitionTimeout, () {
+    _transitionEndTimer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
         'The number of transitions expected to complete have not completed. Something is most likely wrong.'
       ));
 
+      _cancelTransitionEventListener();
       complete();
     });
 
     _endTransitionSubscription = getTransitionDomNode()?.onTransitionEnd?.skip(skipCount)?.take(1)?.listen((_) {
-      timer.cancel();
+
+      if (_transitionEndTimer != null) {
+        _transitionEndTimer.cancel();
+        _transitionEndTimer = null;
+      }
+
       complete();
     });
   }
@@ -331,6 +340,11 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
           ..transitionPhase = TransitionPhase.HIDDEN
         );
       });
+
+      if (_transitionEndTimer != null) {
+        _transitionEndTimer.cancel();
+        _transitionEndTimer = null;
+      }
     } else {
       onNextTransitionEnd(() {
         if (state.transitionPhase == TransitionPhase.HIDING) {

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -188,6 +188,9 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       assert(ValidationUtil.warn(warningMessage));
 
       skipCount = 0;
+
+      _cancelTransitionEventListener();
+      _cancelTransitionEndTimer();
     }
 
     _transitionEndTimer = new Timer(transitionTimeout, () {
@@ -309,6 +312,8 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
 
   /// Method that will be called when [AbstractTransitionComponent]  first enters the `preShowing` state.
   void handlePreShowing() {
+    _cancelTransitionEndTimer();
+
     onNextTransitionEnd(() {
       if (state.transitionPhase == TransitionPhase.SHOWING) {
         setState(newState()

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -196,15 +196,12 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       ));
 
       _cancelTransitionEventListener();
+      
       complete();
     });
 
     _endTransitionSubscription = getTransitionDomNode()?.onTransitionEnd?.skip(skipCount)?.take(1)?.listen((_) {
-
-      if (_transitionEndTimer != null) {
-        _transitionEndTimer.cancel();
-        _transitionEndTimer = null;
-      }
+      _cancelTransitionEndTimer();
 
       complete();
     });
@@ -213,6 +210,11 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
   void _cancelTransitionEventListener() {
     _endTransitionSubscription?.cancel();
     _endTransitionSubscription = null;
+  }
+
+  void _cancelTransitionEndTimer() {
+    _transitionEndTimer?.cancel();
+    _transitionEndTimer = null;
   }
 
   /// Whether the [AbstractTransitionComponent] should render.
@@ -341,10 +343,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
         );
       });
 
-      if (_transitionEndTimer != null) {
-        _transitionEndTimer.cancel();
-        _transitionEndTimer = null;
-      }
+      _cancelTransitionEndTimer();
     } else {
       onNextTransitionEnd(() {
         if (state.transitionPhase == TransitionPhase.HIDING) {


### PR DESCRIPTION
## Ultimate problem:
The newly-added transition warning ([UIP-1802](https://github.com/Workiva/over_react/pull/55)),
`VALIDATION WARNING: The number of transitions expected to complete have not completed. Something is most likely wrong.` fires sometimes when it shouldn't.

For instance, sometimes `transitionend` events never fire on purpose, such as when the user cancels the transition (think hiding a popover while it's still showing). This results in a warning when it should not.

I also noticed in the code that the timer does not unsubscribe the listener function, which it probably should.

## How it was fixed:
- Create an instance field, `_transitionEndTimer`, that keeps track of whether a transition timeout has occurred.
- When a transition is canceled (ie, after hiding a popover while it's still showing), `_transitionEndTimer` is canceled as well.
- Make the timer unsubscribe the listener function.

## Testing suggestions:
- Verify that the tests pass.
- While in Dart checked mode, verify that rapidly clicking the "Pick a date" button twice (on [WSD Docs](https://docs.workiva.org/web_skin_dart/latest/components/#datepicker-custom-usage)) does not result in a validation warning.


## Potential areas of regression:



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
