### PR TITLE
UIP-2186 Don't call setState when AbstractTransitionComponent is unmounting

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -281,8 +281,16 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
     }
   }
 
+  var _isMounted = false;
+
+  @override
+  void componentDidMount() {
+    _isMounted = true;
+  }
+
   @override
   void componentWillUnmount() {
+    _isMounted = false;
     _cancelTransitionEventListener();
   }
 
@@ -333,7 +341,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       });
     } else {
       onNextTransitionEnd(() {
-        if (state.transitionPhase == TransitionPhase.HIDING) {
+        if (_isMounted && state.transitionPhase == TransitionPhase.HIDING) {
           setState(newState()
             ..transitionPhase = TransitionPhase.HIDDEN
           );

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -440,6 +440,18 @@ main() {
 
       stopRecordingValidationWarnings();
     });
+
+    test('does not set hidden state when not mounted', () async {
+      var renderedInstance = render(Transitioner());
+      TransitionerComponent transitioner = getDartComponent(renderedInstance);
+      transitioner.setState(transitioner.newState()..transitionPhase = TransitionPhase.HIDING);
+
+      transitioner.handleHiding();
+      transitioner.componentWillUnmount();
+      await triggerTransitionEnd(transitioner.getTransitionDomNode());
+
+      expect(transitioner.transitionPhasesSet, orderedEquals([TransitionPhase.HIDING]));
+    });
   });
 }
 
@@ -551,5 +563,13 @@ class TransitionerComponent extends AbstractTransitionComponent<TransitionerProp
     if (props.onHandleHidden != null) {
       props.onHandleHidden();
     }
+  }
+
+  List<TransitionPhase> transitionPhasesSet = [];
+
+  @override
+  void setState(dynamic newState, [callback()]) {
+    super.setState(newState, callback);
+    transitionPhasesSet.add(newState.transitionPhase);
   }
 }


### PR DESCRIPTION
This resolves a warning of the form "Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op."

## Ultimate problem:
An AbstractTransitionComponent's `setState` call to set the transition phase to `TransitionPhase.HIDDEN` can occur after the component has been unmounted. This may happen if the component contains a button that causes the AbstractTransitionComponent to be unmounted when clicked.

## How it was fixed:
Added `_isMounted` boolean to the component to keep track of whether or not the component is mounted (it's set to true in `componentDidMount` and set to false in `componentWillUnmount`). The value of this boolean is checked before calling `setState` to set the transition phase to `TransitionPhase.HIDDEN`.

## Testing suggestions:
Verify that tests pass.

## Potential areas of regression:
Components based on AbstractTransitionComponent.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
