### PR TITLE
UIP-1164 (OR): Provide easy access to DOM node in ValidationUtil.warn messages

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -182,14 +182,14 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
         warningMessage += ' Instead of setting this prop to 0, override the `hasTransition` getter to return false.';
       }
 
-      assert(ValidationUtil.warn(warningMessage));
+      assert(ValidationUtil.warn(warningMessage, this));
 
       skipCount = 0;
     }
 
     var timer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
-        'The number of transitions expected to complete have not completed. Something is most likely wrong.'
+        'The number of transitions expected to complete have not completed. Something is most likely wrong.', this
       ));
 
       complete();

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -189,7 +189,8 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
 
     var timer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
-          'The number of transitions expected to complete have not completed. Something is most likely wrong.'
+          'The number of transitions expected to complete have not completed. Something is most likely wrong.',
+          this
       ));
 
       complete();

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -189,8 +189,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
 
     var timer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
-        'The number of transitions expected to complete have not completed. Something is most likely wrong.',
-        this
+          'The number of transitions expected to complete have not completed. Something is most likely wrong.'
       ));
 
       complete();

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -189,7 +189,8 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
 
     var timer = new Timer(transitionTimeout, () {
       assert(ValidationUtil.warn(
-        'The number of transitions expected to complete have not completed. Something is most likely wrong.', this
+        'The number of transitions expected to complete have not completed. Something is most likely wrong.',
+        this
       ));
 
       complete();

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -113,7 +113,8 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
   void componentDidMount() {
     if (props.quickMount) {
       assert(props.onInitialize == null || ValidationUtil.warn(
-          'props.onInitialize will not be called when props.quickMount is true.', this
+          'props.onInitialize will not be called when props.quickMount is true.',
+          this
       ));
 
       // [1] Initialize/reset the sensor in the next animation frame after mount

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -113,7 +113,7 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
   void componentDidMount() {
     if (props.quickMount) {
       assert(props.onInitialize == null || ValidationUtil.warn(
-          'props.onInitialize will not be called when props.quickMount is true.'
+          'props.onInitialize will not be called when props.quickMount is true.', this
       ));
 
       // [1] Initialize/reset the sensor in the next animation frame after mount

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -401,7 +401,7 @@ abstract class UiProps
         );
 
         // TODO: Remove ValidationUtil.warn call when https://github.com/dart-lang/sdk/issues/26093 is resolved.
-        ValidationUtil.warn(errorMessage);
+        ValidationUtil.warn(errorMessage, this);
         throw new ArgumentError(errorMessage);
       }
     }

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -138,7 +138,7 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
             Google Chrome does not support `setSelectionRange` on email or number inputs.
             See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             '''
-        )));
+        ), input));
 
         return;
       }

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -16,6 +16,10 @@ library over_react.validation_util;
 
 import 'dart:html';
 
+import 'package:over_react/src/util/pretty_print.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:react/react.dart' as react;
+
 typedef void ValidationUtilWarningCallback(String message);
 
 /// Utility for logging validation errors or warning.
@@ -31,13 +35,13 @@ class ValidationUtil {
   ///
   ///     assert(ValidationUtil.warn('Some warning message'));
   ///
-  /// Optionally, a component can be passed as the second parameter
+  /// Optionally, a component or element can be passed as the second parameter
   /// to provide additional information in the console.
   ///
   ///     assert(ValidationUtil.warn('Some warning message', component));
   ///
   /// The message will be printed out to the console.
-  static bool warn(String message, [dynamic component]) {
+  static bool warn(String message, [dynamic data]) {
     WARNING_COUNT += 1;
 
     if (onWarning != null) {
@@ -51,11 +55,15 @@ class ValidationUtil {
 
       window.console.warn('VALIDATION WARNING: $message');
 
-      if (component != null) {
+      if (data != null) {
           window.console.groupCollapsed('(Warning info)');
+          window.console.log(data);
 
-          window.console.log(component);
-          window.console.log('props: ${component.props}');
+          if (isValidElement(data)) {
+            window.console.log('props: ${prettyPrintMap(getProps(data))}');
+          } else if (data is react.Component){
+            window.console.log('props: ${data.props}');
+          }
 
           window.console.groupEnd();
       }

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -16,6 +16,8 @@ library over_react.validation_util;
 
 import 'dart:html';
 
+import 'package:over_react/over_react.dart';
+
 typedef void ValidationUtilWarningCallback(String message);
 
 /// Utility for logging validation errors or warning.
@@ -31,7 +33,7 @@ class ValidationUtil {
   ///     assert(ValidationUtil.warn('Some warning message'));
   ///
   /// The message will get print out to the console.
-  static bool warn(String message) {
+  static bool warn(String message, [dynamic element]) {
     WARNING_COUNT += 1;
 
     if (onWarning != null) {
@@ -44,6 +46,10 @@ class ValidationUtil {
       }
 
       window.console.warn('VALIDATION WARNING: $message');
+
+      if(element != null) {
+          window.console.warn(findDomNode(element));
+      }
     }
 
     return true;

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -61,7 +61,7 @@ class ValidationUtil {
 
           if (isValidElement(data)) {
             window.console.log('props: ${prettyPrintMap(getProps(data))}');
-          } else if (data is react.Component){
+          } else if (data is react.Component) {
             window.console.log('props: ${data.props}');
           }
 

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -16,8 +16,6 @@ library over_react.validation_util;
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
-
 typedef void ValidationUtilWarningCallback(String message);
 
 /// Utility for logging validation errors or warning.
@@ -30,15 +28,16 @@ class ValidationUtil {
   /// Use this to log warnings to the console in dev mode only.
   /// This is to be used in assert calls for dev help only so that it gets
   /// compiled out for production.
+  ///
   ///     assert(ValidationUtil.warn('Some warning message'));
   ///
-  /// Optionally, an element can be passed as the second parameter
-  /// to help devs locate the offending DOM node in the inspector.
+  /// Optionally, a component can be passed as the second parameter
+  /// to provide additional information in the console.
   ///
-  ///     assert(ValidationUtil.warn('Some warning message', element));
+  ///     assert(ValidationUtil.warn('Some warning message', component));
   ///
   /// The message will be printed out to the console.
-  static bool warn(String message, [dynamic element]) {
+  static bool warn(String message, [dynamic component]) {
     WARNING_COUNT += 1;
 
     if (onWarning != null) {
@@ -52,8 +51,13 @@ class ValidationUtil {
 
       window.console.warn('VALIDATION WARNING: $message');
 
-      if (element != null) {
-          window.console.warn(findDomNode(element));
+      if (component != null) {
+          window.console.groupCollapsed('(Warning info)');
+
+          window.console.log(component);
+          window.console.log('props: ${component.props}');
+
+          window.console.groupEnd();
       }
     }
 

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -32,7 +32,12 @@ class ValidationUtil {
   /// compiled out for production.
   ///     assert(ValidationUtil.warn('Some warning message'));
   ///
-  /// The message will get print out to the console.
+  /// Optionally, an element can be passed as the second parameter
+  /// to help devs locate the offending DOM node in the inspector.
+  ///
+  ///     assert(ValidationUtil.warn('Some warning message', element));
+  ///
+  /// The message will be printed out to the console.
   static bool warn(String message, [dynamic element]) {
     WARNING_COUNT += 1;
 
@@ -47,7 +52,7 @@ class ValidationUtil {
 
       window.console.warn('VALIDATION WARNING: $message');
 
-      if(element != null) {
+      if (element != null) {
           window.console.warn(findDomNode(element));
       }
     }

--- a/web/src/demo_components/button_group.dart
+++ b/web/src/demo_components/button_group.dart
@@ -100,14 +100,16 @@ class ButtonGroupComponent<T extends ButtonGroupProps, S extends ButtonGroupStat
     if (isValidElement(child)) {
       if (!isComponentOfType(child, childFactory)) {
         assert(ValidationUtil.warn(
-            'An unexpected child type was found within this component.', this
+            'An unexpected child type was found within this component.',
+            this
         ));
       }
 
       isCloneable = true;
     } else if (child != null) {
       assert(ValidationUtil.warn(
-          'You are not using a valid ReactElement.', this
+          'You are not using a valid ReactElement.',
+          this
       ));
     }
 

--- a/web/src/demo_components/button_group.dart
+++ b/web/src/demo_components/button_group.dart
@@ -100,14 +100,14 @@ class ButtonGroupComponent<T extends ButtonGroupProps, S extends ButtonGroupStat
     if (isValidElement(child)) {
       if (!isComponentOfType(child, childFactory)) {
         assert(ValidationUtil.warn(
-            'An unexpected child type was found within this component.'
+            'An unexpected child type was found within this component.', this
         ));
       }
 
       isCloneable = true;
     } else if (child != null) {
       assert(ValidationUtil.warn(
-          'You are not using a valid ReactElement.'
+          'You are not using a valid ReactElement.', this
       ));
     }
 


### PR DESCRIPTION
This pull request is connected with [UIP-1164 (WSD)](https://github.com/Workiva/web_skin_dart/pull/716)

## Ultimate problem:
`ValidationUtil.warn` should take an optional `Element` parameter which will be `console.log/.warn'd `to the browser console, allowing consumers to navigate to the offending DOM node in the inspector.

All usages of `ValidationUtil.warn` should be updated to pass in the corresponding DOM node, where applicable.

## How it was fixed:
- Because `ValidationUtil.warn` is often used in components' `render` methods, it cannot use the `findDomNode` method, since it causes the following error message:

> render() should be a pure function of props and state. It should never access something that requires stale data from the previous render, such as refs. Move this logic to componentDidMount and componentDidUpdate instead.

- To get around this issue, `findDomNode` will no longer be called within the `ValidationUtil.warn` method. As a result, the component will be logged to the console rather than the DOM node itself.

- Make the `ValidationUtil.warn` method accept an optional second parameter for a component.
- Following the standard warning message, log the component itself as well as its props in a collapsed group.

## Testing suggestions:
- Verify that all current tests continue to pass.

## Potential areas of regression:
- N/A


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
