### PR TITLE
Export react-dart members and add capturing event handlers

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -15,6 +15,20 @@
 /// Base classes for UI components and related utilities.
 library over_react;
 
+export 'package:react/react.dart' show
+    SyntheticEvent,
+    SyntheticClipboardEvent,
+    SyntheticKeyboardEvent,
+    SyntheticFocusEvent,
+    SyntheticFormEvent,
+    SyntheticDataTransfer,
+    SyntheticMouseEvent,
+    SyntheticTouchEvent,
+    SyntheticUIEvent,
+    SyntheticWheelEvent;
+
+export 'package:react/react_client.dart' show setClientConfiguration, ReactElement;
+
 export 'src/component/abstract_transition.dart';
 export 'src/component/aria_mixin.dart';
 export 'src/component/callback_typedefs.dart';

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -84,6 +84,17 @@ abstract class DomPropsMixin {
   UIEventCallback onScroll;
   WheelEventCallback onWheel;
 
+  ClipboardEventCallback onCopyCapture, onCutCapture, onPasteCapture;
+  KeyboardEventCallback onKeyDownCapture, onKeyPressCapture, onKeyUpCapture;
+  FocusEventCallback onFocusCapture, onBlurCapture;
+  FormEventCallback onChangeCapture, onInputCapture, onSubmitCapture, onResetCapture;
+  MouseEventCallback
+    onClickCapture, onContextMenuCapture, onDoubleClickCapture, onDragCapture, onDragEndCapture, onDragEnterCapture, onDragExitCapture, onDragLeaveCapture, onDragOverCapture,
+    onDragStartCapture, onDropCapture, onMouseDownCapture, onMouseEnterCapture, onMouseLeaveCapture, onMouseMoveCapture, onMouseOutCapture, onMouseOverCapture, onMouseUpCapture;
+  TouchEventCallback onTouchCancelCapture, onTouchEndCapture, onTouchMoveCapture, onTouchStartCapture;
+  UIEventCallback onScrollCapture;
+  WheelEventCallback onWheelCapture;
+
   // props specific to React.INPUT
   bool defaultChecked;
   dynamic defaultValue;


### PR DESCRIPTION
## Ultimate problem:

* Using synthetic event classes required importing `react:react.dart` in addition to `over_react:over_react.dart`.
* Using `setClientConfiguration` and `ReactElement` required importing `react:react_client.dart`.
* ReactJS supports capturing event handlers ([briefly mentioned here](https://facebook.github.io/react/docs/events.html#supported-events)) and so does `react-dart`, but OverReact didn't.

## How it was fixed:

* Export synthetic event classes (this doesn't generate any warnings/infos for consumers already importing `react:react.dart`.
* Export `setClientConfiguration` and `ReactElement`.
* Add capturing event handlers to `DomPropsMixin`.

## Testing suggestions:

* Consume this branch in WSD and note no issues occur.

## Potential areas of regression:

None.

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
