### PR TITLE
UIP-2247 Fix docs.yml for publication

### DIFF
--- a/docs.yml
+++ b/docs.yml
@@ -2,6 +2,5 @@ title: over_react
 base: github:Workiva/over_react/
 src: README.md
 topics:
-  title: Transformer
-  base: github:Workiva/over_react/
-  src: lib/src/transformer/README.md
+  - title: Transformer
+    src: lib/src/transformer/README.md


### PR DESCRIPTION
## Ultimate problem:

Found this formatting issue while testing out the latest ApplicationFrameworks docs integration on staging.

## How it was fixed:

Define `topics` child as list.

## Testing suggestions:

Validated with `dev-portal-docs` cli tool:

```
workiva/over_react [master] » git checkout patch-1
Branch patch-1 set up to track remote branch patch-1 from fork.
Switched to a new branch 'patch-1'
workiva/over_react [patch-1] » docs validate
workiva/over_react [patch-1] »
```

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
