### PR TITLE
UIP-2258 Workaround for Dart 1.23 strong mode issue with MapViewMixin

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -416,8 +416,8 @@ abstract class UiProps
 ///
 /// Necessary in order to work around Dart 1.23 strong mode change that disallows conflicting private members
 /// in mixins: <https://github.com/dart-lang/sdk/issues/28809>.
-abstract class _OverReactMapViewBase {
-  Map get _map;
+abstract class _OverReactMapViewBase<K, V> {
+  Map<K, V> get _map;
 }
 
 /// Works in conjunction with [MapViewMixin] to provide [dart.collection.MapView]-like
@@ -453,7 +453,7 @@ abstract class StateMapViewMixin implements _OverReactMapViewBase {
 ///
 /// For use by concrete [UiProps] and [UiState] implementations (either generated or manual),
 /// and thus must remain public.
-abstract class MapViewMixin<K, V> implements _OverReactMapViewBase {
+abstract class MapViewMixin<K, V> implements _OverReactMapViewBase<K, V> {
   V operator[](Object key) => _map[key];
   void operator[]=(K key, V value) { _map[key] = value; }
   void addAll(Map<K, V> other) { _map.addAll(other); }

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -412,12 +412,22 @@ abstract class UiProps
   Function get componentFactory;
 }
 
+/// A class that declares the `_map` getter shared by [PropsMapViewMixin]/[StateMapViewMixin] and [MapViewMixin].
+///
+/// Necessary in order to work around Dart 1.23 strong mode change that disallows conflicting private members
+/// in mixins: <https://github.com/dart-lang/sdk/issues/28809>.
+abstract class _OverReactMapViewBase {
+  Map get _map;
+}
+
 /// Works in conjunction with [MapViewMixin] to provide [dart.collection.MapView]-like
 /// functionality to [UiProps] subclasses.
-abstract class PropsMapViewMixin {
+abstract class PropsMapViewMixin implements _OverReactMapViewBase {
   /// The props maintained by this builder and used passed into the component when built.
   /// In this case, it's the current MapView object.
   Map get props;
+
+  @override
   Map get _map => this.props;
 
   @override
@@ -426,8 +436,10 @@ abstract class PropsMapViewMixin {
 
 /// Works in conjunction with [MapViewMixin] to provide [dart.collection.MapView]-like
 /// functionality to [UiState] subclasses.
-abstract class StateMapViewMixin {
+abstract class StateMapViewMixin implements _OverReactMapViewBase {
   Map get state;
+
+  @override
   Map get _map => this.state;
 
   @override
@@ -441,9 +453,7 @@ abstract class StateMapViewMixin {
 ///
 /// For use by concrete [UiProps] and [UiState] implementations (either generated or manual),
 /// and thus must remain public.
-abstract class MapViewMixin<K, V> {
-  Map<K, V> get _map;
-
+abstract class MapViewMixin<K, V> implements _OverReactMapViewBase {
   V operator[](Object key) => _map[key];
   void operator[]=(K key, V value) { _map[key] = value; }
   void addAll(Map<K, V> other) { _map.addAll(other); }


### PR DESCRIPTION
## Ultimate problem:
A strong mode change was made in Dart 1.23 that disallows conflicting private members in mixins: <https://github.com/dart-lang/sdk/issues/28809>.

This was causing issues in w_filing when manually mixing in MapViewMixin/PropsMapViewMixin  https://github.com/Workiva/w_filing/blob/1c9a406b59daf3c178d0c69336690c5ce28763f0/lib/src/shared/services/configs/service_props_base.dart#L3

This would have been an issue in over_react if UiProps was in a separate library from these classes.

## How it was fixed:
Declare conflicting `_props` getter in common base class.

## Testing suggestions:
- Verify unit tests pass
- Verify analyzer passes in Dart 1.22.0
- Pull the branch into w_filing in Dart 1.23.0 and verify that tehre are no strong mode errors in ServicePropsBase.

## Potential areas of regression:
UiProps class


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
