### PR TITLE
UIP-2260 Release over_react 1.9.1 (HOTFIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # OverReact Changelog
 
 
+## 1.9.1
+
+> [Complete `1.9.1` Changeset](https://github.com/Workiva/over_react/compare/1.9.0...1.9.1)
+
+__Bug Fixes__
+
+* [#66]: Fix regression with transitions not completing in consumers of AbstractTransition that don't call `super.componentDidMount`
+
+&nbsp;
+
 ## 1.9.0
 
 > [Complete `1.9.0` Changeset](https://github.com/Workiva/over_react/compare/1.8.0...1.9.0)

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -296,16 +296,11 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
     }
   }
 
-  var _isMounted = false;
-
-  @override
-  void componentDidMount() {
-    _isMounted = true;
-  }
+  var _isUnmounted = false;
 
   @override
   void componentWillUnmount() {
-    _isMounted = false;
+    _isUnmounted = true;
     _cancelTransitionEventListener();
   }
 
@@ -359,7 +354,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S 
       _cancelTransitionEndTimer();
     } else {
       onNextTransitionEnd(() {
-        if (_isMounted && state.transitionPhase == TransitionPhase.HIDING) {
+        if (!_isUnmounted && state.transitionPhase == TransitionPhase.HIDING) {
           setState(newState()
             ..transitionPhase = TransitionPhase.HIDDEN
           );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.9.0
+version: 1.9.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
## Ultimate problem:
Consumers of AbstractTransition (like `OverlayRenderer`) that didn't call `super.componentDidMount` stopped working properly in over_react 1.9.0: transitions never completed.

## How it was fixed:
Remove `componentDidMount` requirement as a quick fix.

## Testing suggestions:
Pull in this version of over_react, and verify that overlay DOM gets cleaned up when overlays (e.g., web_skin_dart Alerts, Popovers, etc.) are transitioned out:
```yaml
dependency_overrides:
  over_react:
    git:
      url: git@github.com:Workiva/over_react.git
      ref: 1f41e0b20a335264bdd60372f34d90199bb0d20c # from transition_hotfix
```

## Potential areas of regression:
Overlay `setState` warnings.


---
