### PR TITLE
UIP-2303 getSelectionStart Util for CTE Cursor Caching

### DIFF
--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -154,6 +154,12 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
   }
 }
 
+/// Custom implementation to avoid issues with `selectionStart` when accessing
+/// an [EmailInputElement] or [NumberInputElement] on Chrome.
+///
+/// If `selectionStart` is not supported on the input, `null` will be returned.
+///
+/// See: <https://bugs.chromium.org/p/chromium/issues/detail?id=324360>
 int getSelectionStart(Element input) {
   if (input is TextAreaElement) {
     return input.selectionStart;

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -84,6 +84,10 @@ bool supportsSelectionRange(InputElement element) {
   // Uncomment once https://github.com/dart-lang/sdk/issues/22967 is fixed.
   // if (element is TextInputElementBase) return true;
 
+  if (element is TextAreaElement) {
+    return true;
+  }
+
   final type = element.getAttribute('type');
   return inputTypesWithSelectionRangeSupport.contains(type);
 }
@@ -145,6 +149,24 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
     }
 
     input.setSelectionRange(start, end, direction);
+  } else {
+    throw new ArgumentError.value(input, 'input', 'must be an instance of `TextInputElementBase`, `NumberInputElement` or `TextAreaElement`');
+  }
+}
+
+int getSelectionStart(Element input) {
+  if (input is TextAreaElement) {
+    return input.selectionStart;
+  } else if (input is TextInputElement && supportsSelectionRange(input)) {
+    final inputType = input.getAttribute('type');
+
+    if (browser.isChrome) {
+      if (inputType == 'email' || inputType == 'number') {
+        return null;
+      }
+    }
+
+    return input.selectionStart;
   } else {
     throw new ArgumentError.value(input, 'input', 'must be an instance of `TextInputElementBase`, `NumberInputElement` or `TextAreaElement`');
   }

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -167,7 +167,7 @@ int getSelectionStart(Element input) {
     }
 
     return input.selectionStart;
-  } else {
-    throw new ArgumentError.value(input, 'input', 'must be an instance of `TextInputElementBase`, `NumberInputElement` or `TextAreaElement`');
   }
+
+  return null;
 }

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -150,10 +150,10 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
   }
 }
 
-/// Custom implementation to avoid issues with `selectionStart` when accessing
-/// an [EmailInputElement] or [NumberInputElement] on Chrome.
+/// Returns the index of the first selected character in [input].
 ///
-/// If `selectionStart` is not supported on the input, `null` will be returned.
+/// Due to a bug in Chrome, returns `null` for [EmailInputElement] and [NumberInputElement] on Chrome.
+/// `null` will also be returned for any [input] that does not support `selectionStart`.
 ///
 /// See: <https://bugs.chromium.org/p/chromium/issues/detail?id=324360>
 int getSelectionStart(Element input) {

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -152,7 +152,7 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
 
 /// Returns the index of the first selected character in [input].
 ///
-/// Due to a bug in Chrome, returns `null` for [EmailInputElement] and [NumberInputElement] on Chrome.
+/// To workaround a bug in Chrome, returns `null` for [EmailInputElement] and [NumberInputElement] on Chrome.
 /// `null` will also be returned for any [input] that does not support `selectionStart`.
 ///
 /// See: <https://bugs.chromium.org/p/chromium/issues/detail?id=324360>

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -84,10 +84,6 @@ bool supportsSelectionRange(InputElement element) {
   // Uncomment once https://github.com/dart-lang/sdk/issues/22967 is fixed.
   // if (element is TextInputElementBase) return true;
 
-  if (element is TextAreaElement) {
-    return true;
-  }
-
   final type = element.getAttribute('type');
   return inputTypesWithSelectionRangeSupport.contains(type);
 }

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -270,7 +270,7 @@ main() {
     });
   });
 
-  group('getSelectionStart ', () {
+  group('getSelectionStart', () {
     test('returns null if called on an unsupported Element type', () {
       var invalidElement = new DivElement();
 
@@ -319,9 +319,7 @@ main() {
               sharedInputGetSelectionStartTest(type);
             }, testOn: 'js && !chrome');
           } else {
-            test(type, () {
-              sharedInputGetSelectionStartTest(type);
-            });
+            test(type, () { sharedInputGetSelectionStartTest(type); });
           }
         }
       });
@@ -331,10 +329,6 @@ main() {
           ..defaultValue = testValue
         )());
         textareaElement = findDomNode(renderedInstance);
-        setSelectionRange(textareaElement, testValue.length, testValue.length);
-
-        expect(textareaElement.selectionStart, equals(testValue.length));
-        expect(textareaElement.selectionEnd, equals(testValue.length));
 
         var selectionStart = getSelectionStart(textareaElement);
 
@@ -342,10 +336,14 @@ main() {
       });
 
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
-      group('without throwing an error in Google Chrome when `props.type` is', () {
-        void verifyLackOfException() {
+      group('by returning null and not throwing an error in Google Chrome when `props.type` is', () {
+        void verifyReturnsNullWithoutException() {
           expect(renderedInstance, isNotNull, reason: 'test setup sanity check');
           expect(inputElement, isNotNull, reason: 'test setup sanity check');
+
+          var selectionStart = getSelectionStart(inputElement);
+
+          expect(selectionStart, isNull);
 
           expect(() => getSelectionStart(inputElement), returnsNormally);
         }
@@ -356,7 +354,7 @@ main() {
             ..type = 'email'
           )());
           inputElement = findDomNode(renderedInstance);
-          verifyLackOfException();
+          verifyReturnsNullWithoutException();
         });
 
         test('number', () {
@@ -365,7 +363,7 @@ main() {
             ..type = 'number'
           )());
           inputElement = findDomNode(renderedInstance);
-          verifyLackOfException();
+          verifyReturnsNullWithoutException();
         });
       }, testOn: 'chrome');
     });

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -269,6 +269,10 @@ main() {
       }, testOn: 'chrome');
     });
   });
+
+  group('getSelectionRange', () {
+
+  });
 }
 
 @Factory()

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -235,17 +235,15 @@ main() {
         }
 
         for (var type in inputTypesWithSelectionRangeSupport) {
+          test(type, () { sharedInputGetSelectionStartTest(type); });
+
           if (type == 'email' || type == 'number') {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
-              sharedInputGetSelectionStartTest(type);
             }, testOn: 'js && !chrome');
           } else {
-            test(type, () {
-              sharedInputSetSelectionRangeTest(type);
-              sharedInputGetSelectionStartTest(type);
-            });
+            test(type, () { sharedInputSetSelectionRangeTest(type); });
           }
         }
       });

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -227,23 +227,21 @@ main() {
           inputElement = findDomNode(renderedInstance);
           var selectionStart = getSelectionStart(inputElement);
 
-          if (type == 'email' || type == 'number') {
-            expect(selectionStart, isNull);
-          } else {
-            expect(selectionStart, testValue.length);
-          }
+          expect(selectionStart, testValue.length);
         }
 
         for (var type in inputTypesWithSelectionRangeSupport) {
-          test(type, () { sharedInputGetSelectionStartTest(type); });
-
           if (type == 'email' || type == 'number') {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
+              sharedInputGetSelectionStartTest(type);
             }, testOn: 'js && !chrome');
           } else {
-            test(type, () { sharedInputSetSelectionRangeTest(type); });
+            test(type, () {
+              sharedInputSetSelectionRangeTest(type);
+              sharedInputGetSelectionStartTest(type);
+            });
           }
         }
       });

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -329,6 +329,7 @@ main() {
           ..defaultValue = testValue
         )());
         textareaElement = findDomNode(renderedInstance);
+        setSelectionRange(textareaElement, testValue.length, testValue.length);
 
         var selectionStart = getSelectionStart(textareaElement);
 

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -154,31 +154,41 @@ main() {
     });
   });
 
-  group('setSelectionRange', () {
-    test('throws an ArgumentError if called on an unsupported Element type', () {
+  group('setSelectionRange and getSelectionStart', () {
+    test('both throw an ArgumentError if called on an unsupported Element type', () {
       var invalidElement = new DivElement();
+
       expect(() => setSelectionRange(invalidElement, 0, 0), throwsArgumentError);
+      expect(() => getSelectionStart(invalidElement), throwsArgumentError);
     });
 
-    test('throws an ArgumentError if called on an unsupported InputElement type', () {
+    test('both throw an ArgumentError if called on an unsupported InputElement type', () {
       var invalidElement = new CheckboxInputElement();
 
       // Note: For some unknown reason - when running the exact same expect() we use for DivElement above,
       // this one fails with "Invalid Object" - the stack trace never leaves test()
       //
       // ¯\_(ツ)_/¯
-      var error;
+      var setSelectionError;
+      var getSelectionError;
 
       try {
         setSelectionRange(invalidElement, 0, 0);
       } catch (err) {
-        error = err;
+        setSelectionError = err;
       }
 
-      expect(error, isNotNull);
+      try {
+        getSelectionStart(invalidElement);
+      } catch (err) {
+        getSelectionError = err;
+      }
+
+      expect(setSelectionError, isNotNull);
+      expect(getSelectionError, isNotNull);
     });
 
-    group('correctly calls setSelectionRange', () {
+    group('correctly call their respective methods', () {
       var renderedInstance;
       InputElement inputElement;
       TextAreaElement textareaElement;
@@ -209,14 +219,33 @@ main() {
           }
         }
 
+        void sharedInputGetSelectionStartTest(String type) {
+          renderedInstance = renderAttachedToDocument((Dom.input()
+            ..defaultValue = testValue
+            ..type = type
+          )());
+          inputElement = findDomNode(renderedInstance);
+          var selectionStart = getSelectionStart(inputElement);
+
+          if (type == 'email' || type == 'number') {
+            expect(selectionStart, isNull);
+          } else {
+            expect(selectionStart, testValue.length);
+          }
+        }
+
         for (var type in inputTypesWithSelectionRangeSupport) {
           if (type == 'email' || type == 'number') {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
+              sharedInputGetSelectionStartTest(type);
             }, testOn: 'js && !chrome');
           } else {
-            test(type, () { sharedInputSetSelectionRangeTest(type); });
+            test(type, () {
+              sharedInputSetSelectionRangeTest(type);
+              sharedInputGetSelectionStartTest(type);
+            });
           }
         }
       });
@@ -230,6 +259,10 @@ main() {
 
         expect(textareaElement.selectionStart, equals(testValue.length));
         expect(textareaElement.selectionEnd, equals(testValue.length));
+
+        var selectionStart = getSelectionStart(textareaElement);
+
+        expect(selectionStart, testValue.length);
       });
 
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
@@ -239,6 +272,7 @@ main() {
           expect(inputElement, isNotNull, reason: 'test setup sanity check');
 
           expect(() => setSelectionRange(inputElement, testValue.length, testValue.length), returnsNormally);
+          expect(() => getSelectionStart(inputElement), returnsNormally);
         }
 
         setUp(() {
@@ -268,10 +302,6 @@ main() {
         });
       }, testOn: 'chrome');
     });
-  });
-
-  group('getSelectionRange', () {
-
   });
 }
 

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -154,15 +154,15 @@ main() {
     });
   });
 
-  group('setSelectionRange and getSelectionStart', () {
-    test('both throw an ArgumentError if called on an unsupported Element type', () {
+  group('setSelectionRange and getSelectionStart: ', () {
+    test('setSelectionRange throws an ArgumentError if called on an unsupported Element type', () {
       var invalidElement = new DivElement();
 
       expect(() => setSelectionRange(invalidElement, 0, 0), throwsArgumentError);
-      expect(() => getSelectionStart(invalidElement), throwsArgumentError);
+      expect(() => getSelectionStart(invalidElement), returnsNormally);
     });
 
-    test('both throw an ArgumentError if called on an unsupported InputElement type', () {
+    test('setSelectionRange throws an ArgumentError if called on an unsupported InputElement type', () {
       var invalidElement = new CheckboxInputElement();
 
       // Note: For some unknown reason - when running the exact same expect() we use for DivElement above,
@@ -185,7 +185,7 @@ main() {
       }
 
       expect(setSelectionError, isNotNull);
-      expect(getSelectionError, isNotNull);
+      expect(getSelectionError, isNull);
     });
 
     group('correctly call their respective methods', () {


### PR DESCRIPTION
## Ultimate Problem
In order to implement cursor index caching in CTEs, we need a streamlined function that gives us the `selectionStart` value for any input type. 

The `getSelectionStart` function in this PR handles inconsistent behavior across browsers—Chrome does not support `selectionStart` for number and email inputs—while also properly handling text areas.
## Solution
- Create a `getSelectionStart` function similar to the already existing `setSelectionRange` utility.
- Write tests to verify the functionality of the `getSelectionStart` utility.
## Testing Suggestions
- Verify that tests pass.
## Possible Areas of Regression
- N/A
---
FYA: @aaronlademann-wf @greglittlefield-wf @clairesarsam-wf @joelleibow-wf @jacehensley-wf