### PR TITLE
UIP-2304 Don't run ValidationUtil-related tests in dart2js

### DIFF
--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -470,7 +470,7 @@ main() {
 
         rejectValidationWarning(anything);
       });
-    });
+    }, testOn: '!js');
 
     test('does not set hidden state when not mounted', () async {
       var renderedInstance = render(Transitioner());


### PR DESCRIPTION
## Ultimate problem:
A test was failing in dart2js due to validation warnings being compiled out.

## How it was fixed:
Don't run those tests in js.

## Testing suggestions:
* Pull this branch
* Run `pub run dart_dev test -p chrome` and verify that all tests pass

## Potential areas of regression:
Unit tests


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
