### PR TITLE
UIP-2373 Make AbstractTransitionProps available in mixin form

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -30,6 +30,7 @@ export 'package:react/react.dart' show
 export 'package:react/react_client.dart' show setClientConfiguration, ReactElement;
 
 export 'src/component/abstract_transition.dart';
+export 'src/component/abstract_transition_props.dart';
 export 'src/component/aria_mixin.dart';
 export 'src/component/callback_typedefs.dart';
 export 'src/component/dom_components.dart';

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -20,30 +20,7 @@ import 'dart:html';
 import 'package:over_react/over_react.dart';
 
 @AbstractProps()
-abstract class AbstractTransitionProps extends UiProps {
-  /// Number of transitions to occur within the [AbstractTransitionComponent].
-  ///
-  /// _If the [AbstractTransitionComponent] does not transition set [AbstractTransitionProps.transition] to [Transition.NONE] rather than setting this to 0._
-  ///
-  /// Default: 1
-  int transitionCount;
-
-  /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
-  ///
-  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will remain visible.
-  Callback onWillHide;
-
-  /// Optional callback that fires after the [AbstractTransitionComponent] is hidden.
-  Callback onDidHide;
-
-  /// Optional callback that fires before the [AbstractTransitionComponent] appears.
-  ///
-  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will not appear.
-  Callback onWillShow;
-
-  /// Optional callback that fires after the [AbstractTransitionComponent] appears.
-  Callback onDidShow;
-}
+abstract class AbstractTransitionProps extends UiProps with TransitionPropsMixin {}
 
 @AbstractState()
 abstract class AbstractTransitionState extends UiState {
@@ -100,10 +77,18 @@ abstract class AbstractTransitionState extends UiState {
 ///   * [hide]
 ///   * [toggle]
 @AbstractComponent()
-abstract class AbstractTransitionComponent<T extends AbstractTransitionProps, S extends AbstractTransitionState> extends UiStatefulComponent<T, S> {
+abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
+                                           S extends AbstractTransitionState>
+  extends UiStatefulComponent<T, S> {
+  @override
+  get consumedProps => const [
+    const $Props(AbstractTransitionProps),
+    const $Props(TransitionPropsMixin),
+  ];
+
   @override
   Map getDefaultProps() => (newProps()
-    ..transitionCount = 1
+    ..addProps(TransitionPropsMixin.defaultProps)
   );
 
   @override

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -1,0 +1,61 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library abstract_transition_props;
+
+import 'dart:collection';
+
+import 'package:over_react/over_react.dart';
+
+/// Props that mirror the implementation of [AbstractTransitionProps], made available as a mixin for components
+/// that cannot extend directly from [AbstractTransitionComponent].
+@PropsMixin()
+abstract class TransitionPropsMixin {
+  static final TransitionPropsMapView defaultProps = new TransitionPropsMapView({})
+    ..transitionCount = 1;
+
+  Map get props;
+
+  /// Number of transitions to occur within the [AbstractTransitionComponent].
+  ///
+  /// Default: 1
+  int transitionCount;
+
+  /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will remain visible.
+  Callback onWillHide;
+
+  /// Optional callback that fires after the [AbstractTransitionComponent] is hidden.
+  Callback onDidHide;
+
+  /// Optional callback that fires before the [AbstractTransitionComponent] appears.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will not appear.
+  Callback onWillShow;
+
+  /// Optional callback that fires after the [AbstractTransitionComponent] appears.
+  Callback onDidShow;
+}
+
+class TransitionPropsMapView extends MapView with
+    TransitionPropsMixin {
+  /// Create a new instance backed by the specified map.
+  TransitionPropsMapView(Map map) : super(map);
+
+  /// The props to be manipulated via the getters/setters.
+  /// In this case, it's the current MapView object.
+  @override
+  Map get props => this;
+}


### PR DESCRIPTION
## Ultimate problem:
The props in `AbstractTransitionProps` cannot be consumed as a mixin, which makes component extension difficult if the consumer cannot extend directly from `AbstractTransitionProps`.

## How it was fixed:
A props mixin / map view were added, and the existing abstract props class now mixes in the new mixin.

## Testing suggestions:
Verify that tests pass

## Potential areas of regression:
None expected


---

> __FYA:__ @Workiva/ui-platform-pp 
