### PR TITLE
UIP-2024 Add support for covariant prop / state fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - "1.21.1"
+  - "1.23.0"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -28,7 +28,7 @@ import 'package:transformer_utils/transformer_utils.dart';
 ///
 /// Generates implementations for:
 ///
-/// * A component commprised of a `@Factory()`, `@Component()`, `@Props()`, and optionally a `@State()`
+/// * A component comprised of a `@Factory()`, `@Component()`, `@Props()`, and optionally a `@State()`
 ///
 ///     * Generates:
 ///
@@ -296,7 +296,7 @@ class ImplGenerator {
             !member.isSynthetic &&
             member.isAbstract &&
             member.name.name == name &&
-            member.returnType?.name?.name == type
+            member.returnType?.toSource() == type
         );
       });
     }
@@ -484,10 +484,13 @@ class ImplGenerator {
 
             TypeName type = field.fields.type;
             String typeString = type == null ? '' : '$type ';
+            String setterTypeString = field.covariantKeyword == null
+                ? typeString
+                : '${field.covariantKeyword} $typeString';
 
             String generatedAccessor =
                 '${typeString}get $accessorName => $proxiedMapName[$keyConstantName];  '
-                'set $accessorName(${typeString}value) => $proxiedMapName[$keyConstantName] = value;';
+                'set $accessorName(${setterTypeString}value) => $proxiedMapName[$keyConstantName] = value;';
 
             transformedFile.replace(
                 sourceFile.span(variable.firstTokenAfterCommentAndMetadata.offset, variable.name.end),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,9 +5,9 @@ homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.21.1"
+  sdk: ">=1.23.0"
 dependencies:
-  analyzer: ">=0.26.1+3 <0.31.0"
+  analyzer: ">=0.30.0 <0.31.0"
   barback: "^0.15.0"
   js: "^0.6.0"
   meta: "^1.0.4"
@@ -15,13 +15,13 @@ dependencies:
   react: "^3.1.0"
   source_span: "^1.2.0"
   transformer_utils: "^0.1.1"
-  w_flux: "^2.5.0"
+  w_flux: "^2.7.1"
   platform_detect: "^1.3.2"
   quiver: ">=0.21.4 <0.25.0"
 dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"
-  dart_dev: "^1.0.5"
+  dart_dev: "^1.7.6"
   mockito: "^0.11.0"
   test: "^0.12.6+2"
 

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# dart 1.21.1, built from https://github.com/Workiva/smithy-runner-dart/tree/0.0.4
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-dart:119662
+# dart 1.23.0
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818
 
 script:
   - pub get

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -328,6 +328,19 @@ main() {
         ''');
       });
 
+      test('covariant keyword', () {
+        preservedLineNumbersTest('''
+          @AbstractProps()
+          class AbstractFooProps {
+            covariant String foo;
+          }
+        ''');
+
+        expect(transformedFile.getTransformedText(), contains('String get foo => props[_\$key__foo];'));
+        expect(transformedFile.getTransformedText(),
+            contains('set foo(covariant String value) => props[_\$key__foo] = value;'));
+      });
+
       group('accessors', () {
         test('that are absent', () {
           preservedLineNumbersTest('''


### PR DESCRIPTION
> NOTE: This is not a clean diff.
>
> It will be clean once #75 merges

## Ultimate problem:
The `over_react` transformer did not support the `covariant` keyword recently added by the Dart SDK.

## How it was fixed:
The transformer was updated to detect the presence of the keyword, and place it within the setter parameter only.

![over_react_covariant-prop-support](https://user-images.githubusercontent.com/1750797/27092057-ef1eaff2-5016-11e7-85fb-f9e298d74883.gif)


## Testing suggestions:
1. Verify that tests pass

## Potential areas of regression:
Transformed code


---

> __FYA:__ @Workiva/ui-platform-pp 
