### PR TITLE
UIP-2114: Update FluxUiComponent subscriptions when props are updated

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -166,6 +166,8 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
     for (var subscription in _subscriptions) {
       subscription?.cancel();
     }
+
+    _subscriptions = null;
   }
 
   @override

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -139,7 +139,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
 
   /// Subscribe to all applicable stores.
   ///
-  /// [Store]s returned by [redrawOn] will have their triggers mapped directly to this components
+  /// [Store]s returned by [redrawOn] will have their triggers mapped directly to this component's
   /// redraw function.
   ///
   /// [Store]s included in the [getStoreHandlers] result will be listened to and wired up to their
@@ -178,7 +178,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
   @override
   void componentWillReceiveProps(Map prevProps) {
     // Unbind store handlers so they can be re-bound in componentDidUpdate
-    // once the new props are available, ensuring the values returned [redrawOn]
+    // once the new props are available, ensuring the values returned by [redrawOn]
     // are not outdated.
     _unbindStoreHandlers();
   }
@@ -192,7 +192,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
 
   @override
   void componentWillUnmount() {
-    // Ensure that unmounted components don't batch render
+    // Ensure that unmounted components don't batch render.
     shouldBatchRedraw = false;
 
     _unbindStoreHandlers();

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -15,7 +15,9 @@
 library over_react.component_declaration.flux_component;
 
 import 'dart:async';
+import 'package:meta/meta.dart';
 import 'package:w_flux/w_flux.dart';
+
 import './annotations.dart' as annotations;
 import './transformer_helpers.dart';
 
@@ -64,7 +66,30 @@ abstract class FluxUiProps<ActionsT, StoresT> extends UiProps {
 ///
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<TProps>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {
+  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
+  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillMount();
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillReceiveProps(Map prevProps);
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState);
+
+  @mustCallSuper
+  @override
+  void componentWillUnmount();
+}
 
 /// Builds on top of [UiStatefulComponent], adding `w_flux` integration, much like the [FluxComponent] in w_flux.
 ///
@@ -76,7 +101,30 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extends UiState>
     extends UiStatefulComponent<TProps, TState>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {
+  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
+  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillMount();
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillReceiveProps(Map prevProps);
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState);
+
+  @mustCallSuper
+  @override
+  void componentWillUnmount();
+}
 
 /// Helper mixin to keep [FluxUiComponent] and [FluxUiStatefulComponent] clean/DRY.
 ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"
   dart_dev: "^1.0.5"
+  over_react_test: "^1.0.0"
   mockito: "^0.11.0"
   test: "^0.12.6+2"
 

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -8,8 +8,7 @@ import 'dart:html';
 import 'package:test/test.dart';
 import 'package:w_flux/w_flux.dart';
 import 'package:over_react/over_react.dart';
-
-import '../../test_util/test_util.dart';
+import 'package:over_react_test/over_react_test.dart';
 
 part 'flux_component_test/default.dart';
 part 'flux_component_test/handler_precedence.dart';
@@ -161,6 +160,30 @@ void main() {
       component.redraw();
       await nextTick();
       expect(component.numberOfRedraws, equals(0));
+    });
+
+    test('updates the subscriptions registered from redrawOn when rerendered with new props', () async {
+      var stores = new TestStores();
+      var newStores = new TestStores();
+
+      var testJacket = mount<TestRedrawOnComponent>((TestRedrawOn()..store = stores)());
+      var dartInstance = testJacket.getDartInstance();
+      expect(dartInstance.numberOfRedraws, 0);
+
+      stores.store1.trigger();
+      await nextTick();
+      expect(dartInstance.numberOfRedraws, 1);
+
+      testJacket.rerender((TestRedrawOn()..store = newStores)());
+      dartInstance.numberOfRedraws = 0;
+
+      newStores.store1.trigger();
+      await nextTick();
+      expect(dartInstance.numberOfRedraws, 1, reason: 'should have redrawn from new store');
+
+      stores.store1.trigger();
+      await nextTick();
+      expect(dartInstance.numberOfRedraws, 1, reason: 'should not have redrawn from old store');
     });
   });
 }


### PR DESCRIPTION
## Ultimate problem:
If a `FluxUiComponent` is rerendered with different `props.store` or different props that affect the return value of `redrawOn`, it does not currently update its subscriptions to look at the latest store. This can happen indirectly as a result of rerendering larger views.

## How it was fixed:
- Re-bind store handlers/subscriptions whenever a component is rerendered with new props, ensuring that the latest are always referenced.
- Add `mustCallSuper` annotations to help consumers detect when they're interfering with existing mount/unmount hooks, as well as the new lifecycle hooks added to support this new behavior
    - __Note:__ If existing consumers don't call super on `componentWillReceiveProps`/`componentDidUpdate`, then they just won't get this improved behavior. However, they may hit state issues if they call super on one and not the other.
- Add test

## Testing suggestions:
* Verify that tests pass

## Potential areas of regression:
* `FluxUiComponent` rerendering


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
