### PR TITLE
UIP-2398 Release over_react 1.11.1 (HOTFIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 1.11.1
+
+> [Complete `1.11.1` Changeset](https://github.com/Workiva/over_react/compare/1.11.0...1.11.1)
+
+__Bug Fixes__
+
+* Revert _[#77]: Update `FluxUiComponent` subscriptions when new `props` are received._
+    * Reverted since this broke subclasses that weren't calling super in lifecycle methods `componentWillReceieveProps` and `componentDidUpdate`
+    * Keep `@mustCallSuper` annotations from this changeset  
 
 ## 1.11.0
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.11.0"
+      over_react: "^1.11.1"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -16,7 +16,9 @@ library over_react.component_declaration.flux_component;
 
 import 'dart:async';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:w_flux/w_flux.dart';
+
 import './annotations.dart' as annotations;
 import './transformer_helpers.dart';
 
@@ -65,7 +67,30 @@ abstract class FluxUiProps<ActionsT, StoresT> extends UiProps {
 ///
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<TProps>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {
+  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
+  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillMount();
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillReceiveProps(Map prevProps);
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState);
+
+  @mustCallSuper
+  @override
+  void componentWillUnmount();
+}
 
 /// Builds on top of [UiStatefulComponent], adding `w_flux` integration, much like the [FluxComponent] in w_flux.
 ///
@@ -77,7 +102,30 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extends UiState>
     extends UiStatefulComponent<TProps, TState>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {
+  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
+  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillMount();
+
+  @mustCallSuper
+  @override
+  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
+  // ignore: must_call_super
+  void componentWillReceiveProps(Map prevProps);
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState);
+
+  @mustCallSuper
+  @override
+  void componentWillUnmount();
+}
 
 /// Helper mixin to keep [FluxUiComponent] and [FluxUiStatefulComponent] clean/DRY.
 ///

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -16,9 +16,7 @@ library over_react.component_declaration.flux_component;
 
 import 'dart:async';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 import 'package:w_flux/w_flux.dart';
-
 import './annotations.dart' as annotations;
 import './transformer_helpers.dart';
 
@@ -67,30 +65,7 @@ abstract class FluxUiProps<ActionsT, StoresT> extends UiProps {
 ///
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<TProps>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {
-  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
-  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
-
-  @mustCallSuper
-  @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillMount();
-
-  @mustCallSuper
-  @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillReceiveProps(Map prevProps);
-
-  @mustCallSuper
-  @override
-  void componentDidUpdate(Map prevProps, Map prevState);
-
-  @mustCallSuper
-  @override
-  void componentWillUnmount();
-}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {}
 
 /// Builds on top of [UiStatefulComponent], adding `w_flux` integration, much like the [FluxComponent] in w_flux.
 ///
@@ -102,60 +77,31 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
 /// Use with the over_react transformer via the `@Component()` ([annotations.Component]) annotation.
 abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extends UiState>
     extends UiStatefulComponent<TProps, TState>
-    with _FluxComponentMixin<TProps>, BatchedRedraws {
-  // Redeclare these lifecycle methods with `mustCallSuper`, since `mustCallSuper` added to methods within
-  // mixins doesn't work. See https://github.com/dart-lang/sdk/issues/29861
-
-  @mustCallSuper
-  @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillMount();
-
-  @mustCallSuper
-  @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillReceiveProps(Map prevProps);
-
-  @mustCallSuper
-  @override
-  void componentDidUpdate(Map prevProps, Map prevState);
-
-  @mustCallSuper
-  @override
-  void componentWillUnmount();
-}
+    with _FluxComponentMixin<TProps>, BatchedRedraws {}
 
 /// Helper mixin to keep [FluxUiComponent] and [FluxUiStatefulComponent] clean/DRY.
 ///
 /// Private so it will only get used in this file, since having lifecycle methods in a mixin is risky.
-abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements BatchedRedraws, UiComponent<TProps> {
+abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements BatchedRedraws {
   static final Logger _logger = new Logger('_FluxComponentMixin');
+  TProps get props;
 
   /// List of store subscriptions created when the component mounts.
   ///
   /// These subscriptions are canceled when the component is unmounted.
-  List<StreamSubscription> _subscriptions;
+  List<StreamSubscription> _subscriptions = [];
 
-  bool get _areStoreHandlersBound => _subscriptions != null;
-
-  /// Subscribe to all applicable stores.
-  ///
-  /// [Store]s returned by [redrawOn] will have their triggers mapped directly to this component's
-  /// redraw function.
-  ///
-  /// [Store]s included in the [getStoreHandlers] result will be listened to and wired up to their
-  /// respective handlers.
-  void _bindStoreHandlers() {
-    if (_areStoreHandlersBound) {
-      throw new StateError('Store handlers are already bound');
-    }
-
+  void componentWillMount() {
+    /// Subscribe to all applicable stores.
+    ///
+    /// [Store]s returned by [redrawOn] will have their triggers mapped directly to this components
+    /// redraw function.
+    ///
+    /// [Store]s included in the [getStoreHandlers] result will be listened to and wired up to their
+    /// respective handlers.
     Map<Store, StoreHandler> handlers = new Map.fromIterable(redrawOn(),
         value: (_) => (_) => redraw())..addAll(getStoreHandlers());
 
-    _subscriptions = <StreamSubscription>[];
     handlers.forEach((store, handler) {
       String message = 'Cannot listen to a disposed/disposing Store.';
       assert(!store.isDisposedOrDisposing, '$message This can be caused by BatchedRedraws '
@@ -170,43 +116,16 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
     });
   }
 
-  /// Cancel all store subscriptions.
-  void _unbindStoreHandlers() {
-    if (!_areStoreHandlersBound) return;
-
-    for (var subscription in _subscriptions) {
-      subscription?.cancel();
-    }
-
-    _subscriptions = null;
-  }
-
-  @override
-  void componentWillMount() {
-    _bindStoreHandlers();
-  }
-
-  @override
-  void componentWillReceiveProps(Map prevProps) {
-    // Unbind store handlers so they can be re-bound in componentDidUpdate
-    // once the new props are available, ensuring the values returned by [redrawOn]
-    // are not outdated.
-    _unbindStoreHandlers();
-  }
-
-  @override
-  void componentDidUpdate(Map prevProps, Map prevState) {
-    // If the handlers are not bound at this point, then that means they were unbound by
-    // componentWillReceiveProps, and need to be re-bound now that new props are available.
-    if (!_areStoreHandlersBound) _bindStoreHandlers();
-  }
-
-  @override
   void componentWillUnmount() {
-    // Ensure that unmounted components don't batch render.
+    // Ensure that unmounted components don't batch render
     shouldBatchRedraw = false;
 
-    _unbindStoreHandlers();
+    // Cancel all store subscriptions.
+    _subscriptions.forEach((StreamSubscription subscription) {
+      if (subscription != null) {
+        subscription.cancel();
+      }
+    });
   }
 
   /// Define the list of [Store] instances that this component should listen to.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.11.0
+version: 1.11.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
-  over_react_test: "^1.0.0"
   mockito: "^0.11.0"
   test: "^0.12.6+2"
 

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -8,7 +8,8 @@ import 'dart:html';
 import 'package:test/test.dart';
 import 'package:w_flux/w_flux.dart';
 import 'package:over_react/over_react.dart';
-import 'package:over_react_test/over_react_test.dart';
+
+import '../../test_util/test_util.dart';
 
 part 'flux_component_test/default.dart';
 part 'flux_component_test/handler_precedence.dart';
@@ -162,30 +163,6 @@ void main() {
       component.redraw();
       await nextTick();
       expect(component.numberOfRedraws, equals(0));
-    });
-
-    test('updates the subscriptions registered from redrawOn when rerendered with new props', () async {
-      var stores = new TestStores();
-      var newStores = new TestStores();
-
-      var testJacket = mount<TestRedrawOnComponent>((TestRedrawOn()..store = stores)());
-      var dartInstance = testJacket.getDartInstance();
-      expect(dartInstance.numberOfRedraws, 0);
-
-      stores.store1.trigger();
-      await nextTick();
-      expect(dartInstance.numberOfRedraws, 1);
-
-      testJacket.rerender((TestRedrawOn()..store = newStores)());
-      dartInstance.numberOfRedraws = 0;
-
-      newStores.store1.trigger();
-      await nextTick();
-      expect(dartInstance.numberOfRedraws, 1, reason: 'should have redrawn from new store');
-
-      stores.store1.trigger();
-      await nextTick();
-      expect(dartInstance.numberOfRedraws, 1, reason: 'should not have redrawn from old store');
     });
   });
 }


### PR DESCRIPTION
* Revert _#77: Update `FluxUiComponent` subscriptions when new `props` are received._
     * Reverted since this broke subclasses that weren't calling super in lifecycle methods `componentWillReceieveProps` and `componentDidUpdate`
     * Keep `@mustCallSuper` annotations from this changeset  

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
