### PR TITLE
UIP-2399 Release over_react 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OverReact Changelog
 
+## 1.11.2
+
+> [Complete `1.11.2` Changeset](https://github.com/Workiva/over_react/compare/1.11.1...1.11.2)
+
+__Improvements__
+
+* [e805b79b](https://github.com/Workiva/over_react/commit/e805b79b56f90989194ebf0a7951357e7b40f75c) Null-coalesce `isDisposedOrDisposing` to ease consumer test breakages
+    
 ## 1.11.1
 
 > [Complete `1.11.1` Changeset](https://github.com/Workiva/over_react/compare/1.11.0...1.11.1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.11.1"
+      over_react: "^1.11.2"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -152,7 +152,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
 
     handlers.forEach((store, handler) {
       String message = 'Cannot listen to a disposed/disposing Store.';
-      assert(!store.isDisposedOrDisposing, '$message This can be caused by BatchedRedraws '
+      assert(!(store.isDisposedOrDisposing ?? false), '$message This can be caused by BatchedRedraws '
         'mounting the component asynchronously after the store has been disposed. If you are '
         'in a test environment, try adding an `await window.animationFrame;` before disposing your '
         'store.');

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -152,12 +152,15 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
 
     handlers.forEach((store, handler) {
       String message = 'Cannot listen to a disposed/disposing Store.';
-      assert(!(store.isDisposedOrDisposing ?? false), '$message This can be caused by BatchedRedraws '
+      
+      var isDisposedOrDisposing = store.isDisposedOrDisposing ?? false;
+      
+      assert(!isDisposedOrDisposing, '$message This can be caused by BatchedRedraws '
         'mounting the component asynchronously after the store has been disposed. If you are '
         'in a test environment, try adding an `await window.animationFrame;` before disposing your '
         'store.');
 
-      if (store.isDisposedOrDisposing) _logger.warning(message);
+      if (isDisposedOrDisposing) _logger.warning(message);
 
       StreamSubscription subscription = store.listen(handler);
       _subscriptions.add(subscription);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.11.1
+version: 1.11.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
## Ultimate problem:
Some Store mocks in consumer tests don't properly mock `isDisposedOrDisposing`, which results in breakages caused by this new check.

We can fix all those tests here by accounting for this case.

## How it was fixed:
Null-coalesce `isDisposedOrDisposing` to ease test breakages

## Testing suggestions:
Pull into a branch that was previously failing with the error:
```
Failed assertion: boolean expression must not be null
#0      UiComponent&&_FluxComponentMixin.componentWillMount.<anonymous closure> (package:over_react/src/component_declaration/flux_component.dart:155:21)
```


## Potential areas of regression:
`isDisposedOrDisposing` error message


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
