### PR TITLE
UIP-2432 Release over_react 1.12.1 (HOTFIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # OverReact Changelog
 
-## 1.11.2
+## 1.12.1
 
-> [Complete `1.11.2` Changeset](https://github.com/Workiva/over_react/compare/1.11.1...1.11.2)
+> [Complete `1.12.1` Changeset](https://github.com/Workiva/over_react/compare/1.12.0...1.12.1)
 
-__Improvements__
+__Bug fixes__
 
-* [e805b79b](https://github.com/Workiva/over_react/commit/e805b79b56f90989194ebf0a7951357e7b40f75c) Null-coalesce `isDisposedOrDisposing` to ease consumer test breakages
+- Bump min source_span to version w/ `SourceFile.fromString`
     
 ## 1.12.0
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.12.0"
+      over_react: "^1.12.1"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   meta: "^1.0.4"
   path: "^1.4.1"
   react: "^3.4.0"
-  source_span: "^1.2.0"
+  source_span: "^1.4.0"
   transformer_utils: "^0.1.1"
   w_flux: "^2.7.1"
   platform_detect: "^1.3.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.12.0
+version: 1.12.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
- Bump source_span to version w/ SourceFile.fromString, which we started using in the last release



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
