### PR TITLE
UIP-2447 Make DomProps/SvgProps implement UiProps for more convenient DDC typing

### DIFF
--- a/lib/src/component/dom_components.dart
+++ b/lib/src/component/dom_components.dart
@@ -17,6 +17,7 @@ library over_react.dom_components;
 
 import 'package:over_react/src/component/prop_mixins.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
+import 'package:over_react/src/component_declaration/transformer_helpers.dart' as transformer_helpers;
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 
@@ -35,24 +36,40 @@ DomProps domProps([Map backingMap]) => new DomProps(null, backingMap);
 
 typedef DomProps DomPropsFactory();
 
-class DomProps extends component_base.UiProps with DomPropsMixin {
+// Include pieces from transformer_helpers so that consumers can type these instances
+// as the `UiProps` exposed in `over_react.dart` and not have to pull in `component_base`.
+class DomProps extends component_base.UiProps
+    with DomPropsMixin, transformer_helpers.GeneratedClass
+    implements transformer_helpers.UiProps {
   // Wrap Map literal in parens to work around https://github.com/dart-lang/sdk/issues/24410
   DomProps(this.componentFactory, [Map props]) : this.props = props ?? ({});
 
   @override
   final ReactDomComponentFactoryProxy componentFactory;
+
   @override
   final Map props;
+
+  @override
+  String get propKeyNamespace => '';
 }
 
-class SvgProps extends component_base.UiProps with DomPropsMixin, SvgPropsMixin implements DomProps {
+// Include pieces from transformer_helpers so that consumers can type these instances
+// as the `UiProps` exposed in `over_react.dart` and not have to pull in `component_base`.
+class SvgProps extends component_base.UiProps
+    with DomPropsMixin, SvgPropsMixin, transformer_helpers.GeneratedClass
+    implements DomProps {
   // Wrap Map literal in parens to work around https://github.com/dart-lang/sdk/issues/24410
   SvgProps(this.componentFactory, [Map props]) : this.props = props ?? ({});
 
   @override
   final ReactDomComponentFactoryProxy componentFactory;
+
   @override
   final Map props;
+
+  @override
+  String get propKeyNamespace => '';
 }
 
 /// A class that provides namespacing for static DOM component factory methods, much like `React.DOM` in React JS.

--- a/test/over_react/component/dom_components_test.dart
+++ b/test/over_react/component/dom_components_test.dart
@@ -57,5 +57,22 @@ main() {
         expect(component.type, equalsIgnoringCase(expectedTagName));
       });
     }
+
+    group('typing:', () {
+      final DomProps dom = Dom.div();
+      final SvgProps svg = Dom.circle();
+
+      test('DomProps is a subtype of `UiProps` exported by over_react.dart', () {
+        expect(dom, const isInstanceOf<UiProps>());
+      });
+
+      test('SvgProps is a subtype of `UiProps` exported by over_react.dart', () {
+        expect(svg, const isInstanceOf<UiProps>());
+      });
+
+      test('SvgProps is a subtype of `DomProps`', () {
+        expect(svg, const isInstanceOf<DomProps>());
+      });
+    });
   });
 }


### PR DESCRIPTION
## Ultimate problem:
The following code is affected by a DDC issue affecting emulated functions and `noSuchMethod` (issue: https://github.com/dart-lang/sdk/issues/29904):
```dart
render() {
  var builder;
  if (condition) {
    builder = Dom.div();
  } else {
    builder = Button();
  }

  return builder(); // throws `Uncaught TypeError: Cannot read property 'noSuchMethod' of undefined`
}
```

The easiest way for consumers to work around it, is to type `builder`. In this case, however, the least upper bound is `component_base.UiProps`, so consumers would have to import that.
```diff
+import 'package:over_react/component_base.dart' as component_base;

 render() {
-  var builder;
+  component_base.UiProps builder;
   ...
 }
```

It would be nice if they could just do `UiProps builder;`, using the `UiProps` exposed by over_react.dart.


## How it was fixed:
Make `DomProps`/`SvgProps` implement `UiProps` for more convenient typing in the scenario mentioned above.

## Testing suggestions:
- Verify all tests pass in content-shell and dart2js
- Smoke-test in WSD docs.
- Try executing the problematic code shown above in the DDC, and verify that it does not throw.


## Potential areas of regression:
- Dom components
- DDC/dart2js runtime issues


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
