### PR TITLE
UIP-2529 Add validateProps method to UiComponent

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -126,8 +126,8 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
 
   /// Throws a [PropError] if [appliedProps] are invalid.
   ///
-  /// This is called automatically with during [componentWillReceiveProps] and [componentWillMount],
-  /// and can also be called manually for custom validation.
+  /// This is called automatically with the latest props available during [componentWillReceiveProps] and
+  /// [componentWillMount], and can also be called manually for custom validation.
   ///
   /// Override with a custom implementation to easily add validation (and don't forget to call super!)
   ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -124,6 +124,16 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
     );
   }
 
+  /// Validation method called during [componentWillReceiveProps], and [componentWillMount].
+  ///
+  /// Use this as an opportunity validate props during the correct lifecycle of the component.
+  @mustCallSuper
+  void validateProps([Map appliedProps]) {
+    appliedProps ??= props;
+
+    validateRequiredProps(appliedProps);
+  }
+
   void validateRequiredProps(Map appliedProps) {
     consumedProps?.forEach((ConsumedProps consumedProps) {
       consumedProps.props.forEach((PropDescriptor prop) {
@@ -147,13 +157,13 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
   @override
   @mustCallSuper
   void componentWillReceiveProps(Map newProps) {
-    validateRequiredProps(newProps);
+    validateProps(newProps);
   }
 
   @override
   @mustCallSuper
   void componentWillMount() {
-    validateRequiredProps(props);
+    validateProps();
   }
 
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -124,13 +124,24 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
     );
   }
 
-  /// Validation method called during [componentWillReceiveProps], and [componentWillMount].
+  /// Throws a [PropError] if [appliedProps] are invalid.
   ///
-  /// Use this as an opportunity validate props during the correct lifecycle of the component.
+  /// This is called automatically with during [componentWillReceiveProps] and [componentWillMount],
+  /// and can also be called manually for custom validation.
+  ///
+  /// Override with a custom implementation to easily add validation (and don't forget to call super!)
+  ///
+  ///     @mustCallSuper
+  ///     void validateProps(Map appliedProps) {
+  ///       super.validateProps(appliedProps);
+  ///
+  ///       var tProps = typedPropsFactory(appliedProps);
+  ///       if (tProps.items.length.isOdd) {
+  ///         throw new PropError.value(tProps.items, 'items', 'must have an even number of items, because reasons');
+  ///       }
+  ///     }
   @mustCallSuper
-  void validateProps([Map appliedProps]) {
-    appliedProps ??= props;
-
+  void validateProps(Map appliedProps) {
     validateRequiredProps(appliedProps);
   }
 
@@ -163,7 +174,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component {
   @override
   @mustCallSuper
   void componentWillMount() {
-    validateProps();
+    validateProps(props);
   }
 
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -627,24 +627,36 @@ main() {
       group('calls validateProps in', () {
         test('componentWillMount', () {
           var calls = [];
-          component.props = {
-            'onValidateProps': () { calls.add('onValidateProps'); },
+          var appliedProps;
+          var initialProps = {
+            'onValidateProps': (Map propsMap) {
+              appliedProps = propsMap;
+              calls.add('onValidateProps');
+            },
           };
+          component.props = initialProps;
 
           component.componentWillMount();
 
           expect(calls, ['onValidateProps']);
+          expect(appliedProps, initialProps);
         });
 
         test('componentWillReceiveProps', () {
           var calls = [];
+          var appliedProps;
+          var newProps = {'key': 'value'};
           component.props = {
-            'onValidateProps': () { calls.add('onValidateProps'); },
+            'onValidateProps': (Map propsMap) {
+              appliedProps = propsMap;
+              calls.add('onValidateProps');
+            },
           };
 
-          component.componentWillReceiveProps({});
+          component.componentWillReceiveProps(newProps);
 
           expect(calls, ['onValidateProps']);
+          expect(appliedProps, newProps);
         });
       });
     });
@@ -825,10 +837,10 @@ class TestComponentComponent extends UiComponent<TestComponentProps> {
   TestComponentProps typedPropsFactory(Map propsMap) => new TestComponentProps(propsMap);
 
   @override
-  void validateProps([Map appliedProps]) {
+  void validateProps(Map appliedProps) {
     super.validateProps(appliedProps);
 
-    if (props['onValidateProps'] != null) props['onValidateProps']();
+    if (props['onValidateProps'] != null) props['onValidateProps'](appliedProps);
   }
 }
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -623,6 +623,30 @@ main() {
         expect(classes.toClassName(), equals('class-1'));
         expect(classes.toClassNameBlacklist(), equals('blacklist-1'));
       });
+
+      group('calls validateProps in', () {
+        test('componentWillMount', () {
+          var calls = [];
+          component.props = {
+            'onValidateProps': () { calls.add('onValidateProps'); },
+          };
+
+          component.componentWillMount();
+
+          expect(calls, ['onValidateProps']);
+        });
+
+        test('componentWillReceiveProps', () {
+          var calls = [];
+          component.props = {
+            'onValidateProps': () { calls.add('onValidateProps'); },
+          };
+
+          component.componentWillReceiveProps({});
+
+          expect(calls, ['onValidateProps']);
+        });
+      });
     });
 
     group('UiStatefulComponent', () {
@@ -799,6 +823,13 @@ class TestComponentComponent extends UiComponent<TestComponentProps> {
 
   @override
   TestComponentProps typedPropsFactory(Map propsMap) => new TestComponentProps(propsMap);
+
+  @override
+  void validateProps([Map appliedProps]) {
+    super.validateProps(appliedProps);
+
+    if (props['onValidateProps'] != null) props['onValidateProps']();
+  }
 }
 
 


### PR DESCRIPTION
## Ultimate problem:
- Consumers need an easy way to validate props without having to override `componentWillReceiveProps` and `componentWillMount`.

## How it was fixed:
- Add `validateProps` method that is called automatically during those lifecycle methods.

## Testing suggestions:
- Verify tests pass

## Potential areas of regression:
- Required prop validation

---
> __FYA:__ @greglittlefield-wf @aaronlademann-wf @clairesarsam-wf @joelleibow-wf
