### PR TITLE
UIP-2450 Update quiver dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   transformer_utils: "^0.1.1"
   w_flux: "^2.7.1"
   platform_detect: "^1.3.2"
-  quiver: ">=0.21.4 <0.25.0"
+  quiver: ">=0.21.4 <0.26.0"
 dev_dependencies:
   matcher: ">=0.11.0 <0.13.0"
   coverage: "^0.7.2"


### PR DESCRIPTION
+ DDC compilation errors are still present even in 0.24.0

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
