### PR TITLE
Update prop error message

### DIFF
--- a/lib/src/util/prop_errors.dart
+++ b/lib/src/util/prop_errors.dart
@@ -56,7 +56,7 @@ class PropError extends Error {
     if (_messagePrefix == requiredPrefix) {
       explanation = 'Prop $propName is required. ';
     } else if (_messagePrefix == invalidPrefix) {
-      explanation = 'Prop $propName set to ${Error.safeToString(invalidValue)}. ';
+      explanation = 'Prop $propName set to $invalidValue. ';
     } else if (_messagePrefix == combinationPrefix) {
       explanation = 'Prop $propName and prop $prop2Name are set to incompatible values. ';
     } else {


### PR DESCRIPTION
> Related to: https://github.com/Workiva/over_react_test/pull/8

## Ultimate problem:
When running tests in the DDC the `Error.safeToString` was kinda a PITA

## How it was fixed:
- Do not use `Error.safeToString`

## Testing suggestions:
??

## Potential areas of regression:
N/A

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
