### PR TITLE
UIP-2458 Release over_react 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # OverReact Changelog
 
+## 1.14.0
+
+> [Complete `1.14.0` Changeset](https://github.com/Workiva/over_react/compare/1.14.0...1.13.0)
+
+__Dependency Updates__
+
+* react `^3.4.3` (was `^3.4.1`)
+* w_common `^1.6.0` (new)
+
+__New Features__
+
+* [#91]: Implement [`DisposableManagerV3`](https://github.com/Workiva/w_common/blob/master/lib/src/common/disposable_manager.dart#L71) for `UiComponent`
+  * Assists with cleaning up streams and other data structures that won't 
+    necessarily be garbage collected without some manual intervention.
+
+__Misc__
+
+* [#92]: Update prop error message to make it more DDC friendly
+
+&nbsp;
+
 ## 1.13.0
 
 > [Complete `1.13.0` Changeset](https://github.com/Workiva/over_react/compare/1.13.0...1.12.1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.13.0"
+      over_react: "^1.14.0"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.13.0
+version: 1.14.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
@@ -13,7 +13,7 @@ dependencies:
   logging: ">=0.11.3+1 <1.0.0"
   meta: "^1.0.4"
   path: "^1.4.1"
-  react: "^3.4.1"
+  react: "^3.4.3"
   source_span: "^1.4.0"
   transformer_utils: "^0.1.1"
   w_common: "^1.6.0"


### PR DESCRIPTION
__Dependency Updates__

* react `^3.4.3` (was `^3.4.1`)
* w_common `^1.6.0` (new)

__New Features__

* #91: Implement [`DisposableManagerV3`](https://github.com/Workiva/w_common/blob/master/lib/src/common/disposable_manager.dart#L71) for `UiComponent`
  * Assists with cleaning up streams and other data structures that won't 
    necessarily be garbage collected without some manual intervention.

__Misc__

* #92: Update prop error message to make it more DDC friendly


---

__FYA:__ @jacehensley-wf @clairesarsam-wf @greglittlefield-wf 
__FYI:__ @joelleibow-wf @bencampbell-wf 
