### PR TITLE
Address deprecation lints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,8 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.0.0"
-  test: "^0.12.6+2"
+  over_react_test: "^1.0.1"
+  test: "^0.12.24"
 
 transformers:
   - over_react:

--- a/test/over_react/component/prop_mixins_test.dart
+++ b/test/over_react/component/prop_mixins_test.dart
@@ -17,6 +17,7 @@ library prop_mixins_test;
 import 'dart:collection' show MapView;
 
 import 'package:over_react/over_react.dart';
+import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
 
 import '../../wsd_test_util/prop_utils.dart';
@@ -68,7 +69,8 @@ main() {
   group('AriaProps', () {
       test('cannot set / read values that are not its prop map', () {
         var instance = new AriaPropMixinsTest({});
-        expect(() {instance['notThere'];}, throws);
+        expect(() {instance['notThere'];},
+            throwsA(hasToStringValue(contains('Map does not contain this key'))));
       });
 
       for (var propKey in const $PropKeys(AriaPropsMixin)) {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -45,7 +45,7 @@ main() {
         });
 
         test('when a single non-invoked builder child is passed in', () {
-          expect(() => Dom.div()(Dom.div()), throws);
+          expect(() => Dom.div()(Dom.div()), throwsArgumentError);
           verifyValidationWarning(contains('It looks like you are trying to use a non-invoked builder as a child.'));
         });
 
@@ -158,7 +158,7 @@ main() {
             Dom.div(),
             Dom.p()(),
             Dom.div()
-          ]), throws);
+          ]), throwsArgumentError);
           verifyValidationWarning(contains('It looks like you are trying to use a non-invoked builder as a child.'));
         });
 

--- a/test/over_react/component_declaration/transformer_helpers_test.dart
+++ b/test/over_react/component_declaration/transformer_helpers_test.dart
@@ -17,8 +17,8 @@ library over_react.transformer_generation.helpers_test;
 import 'package:over_react/src/component_declaration/transformer_helpers.dart';
 import 'package:test/test.dart';
 
-const Matcher throwsUngeneratedError          = const Throws(const isInstanceOf<UngeneratedError>());
-const Matcher throwsIllegalInstantiationError = const Throws(const isInstanceOf<IllegalInstantiationError>());
+final Matcher throwsUngeneratedError          = throwsA(const isInstanceOf<UngeneratedError>());
+final Matcher throwsIllegalInstantiationError = throwsA(const isInstanceOf<IllegalInstantiationError>());
 
 main() {
   group('transformation generation helpers:', () {

--- a/test/over_react/component_declaration/transformer_integration_tests/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/stateful_component_integration_test.dart
@@ -24,7 +24,7 @@ main() {
     test('state class cannot be instantiated directly', () {
       expect(() {
         new StatefulComponentTestState();
-      }, throws);
+      }, throwsA(const isInstanceOf<IllegalInstantiationError>()));
     });
 
     test('renders a component from end to end, successfully reading state via typed getters', () {

--- a/test/over_react/util/handler_chain_util_test.dart
+++ b/test/over_react/util/handler_chain_util_test.dart
@@ -147,7 +147,8 @@ main() {
 
                 var chained = callbackUtil.chain(a, b);
 
-                expect(() => Function.apply(chained, generateBadTypeArgs()), throws);
+                expect(() => Function.apply(chained, generateBadTypeArgs()),
+                    throwsA(const isInstanceOf<TypeError>()));
               }, testOn: 'dart-vm');
             }
           });
@@ -245,7 +246,8 @@ main() {
 
               var chained = callbackUtil.chainFromList(functions);
 
-              expect(() => Function.apply(chained, generateBadTypeArgs()), throws);
+              expect(() => Function.apply(chained, generateBadTypeArgs()),
+                  throwsA(const isInstanceOf<TypeError>()));
             }, testOn: 'dart-vm');
           }
         });
@@ -257,7 +259,8 @@ main() {
 
           if (arity != 0) {
             test('with arguments typed to the specified generic parameters', () {
-              expect(() => Function.apply(callbackUtil.noop, generateBadTypeArgs()), throws);
+              expect(() => Function.apply(callbackUtil.noop, generateBadTypeArgs()),
+                  throwsA(const isInstanceOf<TypeError>()));
             }, testOn: 'dart-vm');
           }
         });

--- a/test/wsd_test_util/prop_utils.dart
+++ b/test/wsd_test_util/prop_utils.dart
@@ -22,9 +22,10 @@ library test_util.prop_utils;
 ])
 import 'dart:mirrors';
 
+import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
 
-void testProp (Symbol name, dynamic expectedKey, instance, testValue) {
+void testProp(Symbol name, dynamic expectedKey, instance, testValue) {
   InstanceMirror mirror = reflect(instance);
 
   mirror.setField(name, testValue);
@@ -32,10 +33,11 @@ void testProp (Symbol name, dynamic expectedKey, instance, testValue) {
   expect(mirror.getField(name).reflectee, equals(testValue));
 }
 
-void testKeys (List<String> keys, dynamic instanceBuilder()) {
+void testKeys(List<String> keys, dynamic instanceBuilder()) {
   test('cannot set / read values that are not its prop map', () {
     var instance = instanceBuilder();
-    expect(() {instance['notThere'];}, throws);
+    expect(() {instance['notThere'];},
+        throwsA(hasToStringValue(contains('Map does not contain this key'))));
   });
   for (var propKey in keys) {
     test('prop: $propKey can have its value set / read', () {

--- a/test/wsd_test_util/zone.dart
+++ b/test/wsd_test_util/zone.dart
@@ -34,14 +34,13 @@ void storeZone([Zone zone]) {
   _zone = zone;
 }
 
-/// Calls [expect] in package:test/test.dart in the zone stored in [setZone].
+/// Calls [expect] in package:test/test.dart in the zone stored in [storeZone].
 ///
 /// Useful for expectations in blocks called in other zones.
-void zonedExpect(actual, matcher,
-    {String reason, bool verbose: false, ErrorFormatter formatter}) {
+void zonedExpect(actual, matcher, {String reason}) {
   validateZone();
 
   return _zone.run(() {
-    expect(actual, matcher, verbose: verbose, formatter: formatter);
+    expect(actual, matcher);
   });
 }


### PR DESCRIPTION
## Ultimate problem:
The `dart-lang/test` has a number of deprecations that we couldn't address previously because of some issues with the `throwsA` replacement.  Those issues appear to have been fixed in a recent update to the test package.

## How it was fixed:
Address deprecations

## Testing suggestions:
Passing CI build

## Areas of regression
Tests

---

__FYA:__ @greglittlefield-wf @jacehensley-wf @clairesarsam-wf 
