### PR TITLE
UIP-2528 Fix misleading typo in overriden parameter name

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -81,7 +81,7 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
   @override
   // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
   // ignore: must_call_super
-  void componentWillReceiveProps(Map prevProps);
+  void componentWillReceiveProps(Map nextProps);
 
   @mustCallSuper
   @override
@@ -118,7 +118,7 @@ abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extend
   @override
   // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
   // ignore: must_call_super
-  void componentWillReceiveProps(Map prevProps);
+  void componentWillReceiveProps(Map nextProps);
 
   @mustCallSuper
   @override


### PR DESCRIPTION
## Problem
The parameter for `componentWillReceiveProps` was incorrectly listed as `prevProps`.

This is very misleading when inspecting the super implementation when insde a flux component subclass.

## Testing
N/A (the name of the changed parameter has no effect in this case)

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
