### PR TITLE
UIP-2463 Release OverReact 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.14.0
 
-> [Complete `1.14.0` Changeset](https://github.com/Workiva/over_react/compare/1.14.0...1.13.0)
+> [Complete `1.14.0` Changeset](https://github.com/Workiva/over_react/compare/1.13.0...1.14.0)
 
 __Dependency Updates__
 
@@ -12,7 +12,7 @@ __Dependency Updates__
 __New Features__
 
 * [#91]: Implement [`DisposableManagerV3`](https://github.com/Workiva/w_common/blob/master/lib/src/common/disposable_manager.dart#L71) for `UiComponent`
-  * Assists with cleaning up streams and other data structures that won't 
+  * Assists with cleaning up streams and other data structures that won't
     necessarily be garbage collected without some manual intervention.
 
 __Misc__
@@ -23,7 +23,7 @@ __Misc__
 
 ## 1.13.0
 
-> [Complete `1.13.0` Changeset](https://github.com/Workiva/over_react/compare/1.13.0...1.12.1)
+> [Complete `1.13.0` Changeset](https://github.com/Workiva/over_react/compare/1.12.1...1.13.0)
 
 __Dependency Updates__
 
@@ -47,9 +47,9 @@ __Misc__
 __Bug fixes__
 
 - Bump min source_span to version w/ `SourceFile.fromString`
-    
+
 &nbsp;
-    
+
 ## 1.12.0
 
 > [Complete `1.12.0` Changeset](https://github.com/Workiva/over_react/compare/1.11.2...1.12.0)
@@ -81,7 +81,7 @@ __Bug Fixes__
 
 * Revert _[#77]: Update `FluxUiComponent` subscriptions when new `props` are received._
     * Reverted since this broke subclasses that weren't calling super in lifecycle methods `componentWillReceieveProps` and `componentDidUpdate`
-    * Keep `@mustCallSuper` annotations from this changeset  
+    * Keep `@mustCallSuper` annotations from this changeset
 
 &nbsp;
 
@@ -93,10 +93,10 @@ __New Features__
 
 * [#76]: Add support for [`covariant`](http://news.dartlang.org/2017/02/dart-122-faster-tools-assert-messages.html) props / state fields.
   * Closes [#49]
-  
+
 __Bug Fixes__
 
-* [#77]: Update `FluxUiComponent` subscriptions when new `props` are received. 
+* [#77]: Update `FluxUiComponent` subscriptions when new `props` are received.
 
 __Tech Debt Paid__
 
@@ -115,13 +115,13 @@ __Misc__
 
 __Improvements__
 
-* [#69]: New top-level `getSelectionStart` function to normalize `selectionStart` across browsers for both 
+* [#69]: New top-level `getSelectionStart` function to normalize `selectionStart` across browsers for both
   `TextInputElement`s and `TextAreaElement`s
-  
+
 
 __Tech Debt Paid__
 
-* [#68]: Declare explicitly-used transitive imports in `pubspec.yaml`  
+* [#68]: Declare explicitly-used transitive imports in `pubspec.yaml`
 * [#70]: Don't run `ValidationUtil`-related tests in dart2js
 
 &nbsp;
@@ -132,7 +132,7 @@ __Tech Debt Paid__
 
 __Dependency Updates__
 
-* analyzer `>=0.26.1+3 <0.31.0` (was `>=0.26.1+3 <0.30.0`) 
+* analyzer `>=0.26.1+3 <0.31.0` (was `>=0.26.1+3 <0.30.0`)
 
 &nbsp;
 
@@ -157,7 +157,7 @@ __Improvements__
   * Export `setClientConfiguration` and `ReactElement`
   * Export all `Synthetic*Event` classes
   * Add capturing event handlers supported by ReactJS
-  
+
 
 __Bug Fixes__
 
@@ -237,7 +237,7 @@ __Dependency Updates__
 __[#40]: Sync changes from original private repo library__
   > _This is the last time we'll do this - as the original library has now been completely switched over to use `over_react`_
 
-  * __Switched dependency__ from `browser_detect` to our 
+  * __Switched dependency__ from `browser_detect` to our
   [new `platform_detect` library](https://github.com/Workiva/platform_detect)!
 
   * __Improved__ `toString` method of `DebugFriendlyConstant`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # OverReact Changelog
 
+## 1.15.0
+
+> [Complete `1.15.0` Changeset](https://github.com/Workiva/over_react/compare/1.14.0...1.15.0)
+
+__Dependency Updates__
+
+* over_react_test `^1.0.1` (was `^1.0.0`)
+* test `^0.12.24` (was `^0.12.6+2`)
+
+__New Features__
+
+* [#88]: Add `validateProps` method to `UiComponent`
+  * Will automatically validate props annotated with `@requiredProp` 
+    within `componentWillMount` and `componentWillReceiveProps`
+
+__Tech Debt__
+
+* [#94]: Address deprecations from `package:test`
+* [#98]: Fix misleading typo in overridden parameter name
+
+__Misc__
+
+* [#73]: Add callout for the [OverReact Snippet VS Code Extension](https://marketplace.visualstudio.com/items?itemName=JaceHensley.over-react-snippets)
+
+&nbsp;
+
 ## 1.14.0
 
 > [Complete `1.14.0` Changeset](https://github.com/Workiva/over_react/compare/1.13.0...1.14.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.14.0"
+      over_react: "^1.15.0"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.14.0
+version: 1.15.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
__Dependency Updates__

* over_react_test `^1.0.1` (was `^1.0.0`)
* test `^0.12.24` (was `^0.12.6+2`)

__New Features__

* #88: Add `validateProps` method to `UiComponent`
  * Will automatically validate props annotated with `@requiredProp` 
    within `componentWillMount` and `componentWillReceiveProps`

__Tech Debt__

* #94: Address deprecations from `package:test`
* #98: Fix misleading typo in overridden parameter name

__Misc__

* #73: Add callout for the [OverReact Snippet VS Code Extension](https://marketplace.visualstudio.com/items?itemName=JaceHensley.over-react-snippets)


---

__FYA:__ @clairesarsam-wf @greglittlefield-wf @jacehensley-wf 
