### PR TITLE
UIP-2546 Release OverReact 1.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: dart
+dist: precise
 dart:
-  - "1.23.0"
+  - "1.24.2"
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # OverReact Changelog
 
+## 1.15.1
+
+> [Complete `1.15.1` Changeset](https://github.com/Workiva/over_react/compare/1.15.0...1.15.1)
+
+__Dependency Updates__
+
+* over_react_test `^1.1.1` (was `^1.0.1`)
+
+__Tech Debt__
+
+* [#97]: Improve some documentation comments.
+* [#95]: Move internal test utils to [over_react_test](https://github.com/Workiva/over_react_test/pull/11), and consume them.
+
+&nbsp;
+
 ## 1.15.0
 
 > [Complete `1.15.0` Changeset](https://github.com/Workiva/over_react/compare/1.14.0...1.15.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 > [Complete `1.15.1` Changeset](https://github.com/Workiva/over_react/compare/1.15.0...1.15.1)
 
-__Dependency Updates__
-
-* over_react_test `^1.1.1` (was `^1.0.1`)
-
 __Tech Debt__
 
 * [#97]: Improve some documentation comments.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.15.0"
+      over_react: "^1.15.1"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.15.0
+version: 1.15.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
__Dependency Updates__

* over_react_test `^1.1.1` (was `^1.0.1`)

__Tech Debt__

* #97: Improve some documentation comments.
* #95: Move internal test utils to [over_react_test](https://github.com/Workiva/over_react_test/pull/11), and consume them.


---

> __FYA:__ @Workiva/ui-platform-pp 
