### PR TITLE
UIP-2615 Redraw only once when store triggers along with ancestor rerender

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -175,6 +175,11 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
     });
   }
 
+  void componentDidUpdate(Map prevProps, Map prevState) {
+    // Let BatchedRedraws know that this component has redrawn in the current batch
+    didBatchRedraw = true;
+  }
+
   void componentWillUnmount() {
     // Ensure that unmounted components don't batch render
     shouldBatchRedraw = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,3 +37,11 @@ transformers:
       $include: test/**_test{.*,}.dart
   # Reminder: dart2js should come after any other transformers that touch Dart code
   - $dart2js
+
+
+dependency_overrides:
+  w_flux:
+    git:
+      url: git@github.com:greglittlefield-wf/w_flux.git
+      ref: 189a1f97d95e0e3c446a5192c54e890fa61ebfb4 # from multiple_flux_redraws
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   source_span: "^1.4.0"
   transformer_utils: "^0.1.1"
   w_common: "^1.6.0"
-  w_flux: "^2.7.1"
+  w_flux: "^2.9.0"
   platform_detect: "^1.3.2"
   quiver: ">=0.21.4 <0.26.0"
 dev_dependencies:
@@ -37,11 +37,3 @@ transformers:
       $include: test/**_test{.*,}.dart
   # Reminder: dart2js should come after any other transformers that touch Dart code
   - $dart2js
-
-
-dependency_overrides:
-  w_flux:
-    git:
-      url: git@github.com:greglittlefield-wf/w_flux.git
-      ref: 189a1f97d95e0e3c446a5192c54e890fa61ebfb4 # from multiple_flux_redraws
-

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -13,6 +13,7 @@ import '../../test_util/test_util.dart';
 
 part 'flux_component_test/default.dart';
 part 'flux_component_test/handler_precedence.dart';
+part 'flux_component_test/nested.dart';
 part 'flux_component_test/redraw_on.dart';
 part 'flux_component_test/store_handlers.dart';
 
@@ -163,6 +164,51 @@ void main() {
       component.redraw();
       await nextTick();
       expect(component.numberOfRedraws, equals(0));
+    });
+
+    test('only redraws once in response to a store trigger combined with an ancestor rerendering', () async {
+      var store = new Store();
+
+      TestNestedComponent nested0;
+      TestNestedComponent nested1;
+      TestNestedComponent nested2;
+
+      render(
+          (TestNested()
+            ..store = store
+            ..ref = (ref) { nested0 = ref; }
+          )(
+            (TestNested()
+              ..store = store
+              ..ref = (ref) { nested1 = ref; }
+            )(
+              (TestNested()
+                ..store = store
+                ..ref = (ref) { nested2 = ref; }
+              )()
+            )
+          )
+      );
+      expect(nested0.renderCount, 1, reason: 'setup check: initial render');
+      expect(nested1.renderCount, 1, reason: 'setup check: initial render');
+      expect(nested2.renderCount, 1, reason: 'setup check: initial render');
+
+      nested0.redraw();
+      await nextTick();
+
+      expect(nested0.renderCount, 2, reason: 'setup check: components should rerender their children');
+      expect(nested1.renderCount, 2, reason: 'setup check: components should rerender their children');
+      expect(nested2.renderCount, 2, reason: 'setup check: components should rerender their children');
+
+      store.trigger();
+      // Two async gaps just to be safe, since we're
+      // asserting that additional redraws don't happen.
+      await nextTick();
+      await nextTick();
+
+      expect(nested0.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+      expect(nested1.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
+      expect(nested2.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
     });
   });
 }

--- a/test/over_react/component_declaration/flux_component_test/nested.dart
+++ b/test/over_react/component_declaration/flux_component_test/nested.dart
@@ -1,0 +1,27 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestNestedProps> TestNested;
+
+@Props()
+class TestNestedProps extends FluxUiProps {}
+
+@Component()
+class TestNestedComponent extends FluxUiComponent {
+  int renderCount = 0;
+
+  @override
+  render() {
+    renderCount++;
+
+    var keyCounter = 0;
+    var newChildren = props.children.map((child) {
+      // The keys are consistent across rerenders, so they aren't remounted,
+      // but cloning the element is necessary for react to consider it changed,
+      // since it returns new ReactElement instances.
+      return cloneElement(child, domProps()..key = keyCounter++);
+    }).toList();
+
+    return Dom.div()(newChildren);
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/Workiva/w_flux/pull/96

## Ultimate Problem
Flux components were rerendered excessively when nested inside each other and a store trigger caused rerendering of those nested components.

See reduced test case [here](https://gist.github.com/greglittlefield-wf/e2cd42b03261e1cb11817a6e5718025d).

## Solution
Track whether components were already redrawn during the current redraw batch.

All consumers will need to do is make sure to call `super.componentDidUpdate` in overrides, and they'll get this fix.

## Testing
- Verify tests pass.
- Verify issue is resolved in linked reduced test case.

## Areas of Regression
Flux component rerendering

---

FYA @Workiva/web-platform-pp @Workiva/ui-platform-pp 
FYI: @kylemcmorrow-wf @johnbland-wf @brentschuele-wf @brandonrodgers-wf @robbielamb-wf 