### PR TITLE
UIP-2614 Update UiComponent to implement DisposableManagerV6

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -135,7 +135,7 @@ typedef TProps BuilderOnlyUiFactory<TProps extends UiProps>();
 ///     }
 ///
 /// > Related: [UiStatefulComponent]
-abstract class UiComponent<TProps extends UiProps> extends react.Component implements DisposableManagerV3 {
+abstract class UiComponent<TProps extends UiProps> extends react.Component implements DisposableManagerV6 {
   Disposable _disposableProxy;
 
   /// The props for the non-forwarding props defined in this component.
@@ -291,6 +291,9 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
   @override
   Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) =>
     _getDisposableProxy().getManagedDelayedFuture<T>(duration, callback);
+  
+  @override
+  ManagedDisposer getManagedDisposer(Disposer disposer) => _getDisposableProxy().getManagedDisposer(disposer);
 
   @override
   Timer getManagedPeriodicTimer(Duration duration, void callback(Timer timer)) =>
@@ -301,6 +304,17 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     _getDisposableProxy().getManagedTimer(duration, callback);
 
   @override
+  StreamSubscription<T> listenToStream<T>(
+      Stream<T> stream, void onData(T event),
+      {Function onError, void onDone(), bool cancelOnError}) =>
+      _getDisposableProxy().listenToStream(
+        stream, onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+  
+  @override
+  Disposable manageAndReturnDisposable(Disposable disposable) =>
+      _getDisposableProxy().manageAndReturnDisposable(disposable);
+
+  @override
   Completer<T> manageCompleter<T>(Completer<T> completer) =>
     _getDisposableProxy().manageCompleter<T>(completer);
 
@@ -308,20 +322,24 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
   void manageDisposable(Disposable disposable) =>
     _getDisposableProxy().manageDisposable(disposable);
 
+  /// DEPRECATED. Use [getManagedDisposer] instead.
+  @Deprecated('2.0.0')
   @override
   void manageDisposer(Disposer disposer) =>
     _getDisposableProxy().manageDisposer(disposer);
-
+  
   @override
   void manageStreamController(StreamController controller) =>
     _getDisposableProxy().manageStreamController(controller);
 
+  /// DEPRECATED. Use [listenToStream] instead.
+  @Deprecated('2.0.0')
   @override
   void manageStreamSubscription(StreamSubscription subscription) =>
     _getDisposableProxy().manageStreamSubscription(subscription);
 
   /// Instantiates a new [Disposable] instance on the first call to the
-  /// [DisposableManagerV3] method.
+  /// [DisposableManagerV6] method.
   Disposable _getDisposableProxy() {
     if (_disposableProxy == null) {
       _disposableProxy = new Disposable();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   react: "^3.4.3"
   source_span: "^1.4.0"
   transformer_utils: "^0.1.1"
-  w_common: "^1.6.0"
+  w_common: "^1.8.0"
   w_flux: "^2.7.1"
   platform_detect: "^1.3.2"
   quiver: ">=0.21.4 <0.26.0"


### PR DESCRIPTION
## Ultimate problem:
Version `1.8.0` of `w_common` includes a new version of the disposable manager interface that `UiComponent` implements.

## How it was fixed:
- Upgraded the minimum `w_common` version to `1.8.0`
- Updated `UiComponent` to implement `DisposableManagerV6`

## Testing suggestions:
- [x] Confirm CI passes

## Potential areas of regression:
🤷‍♂️ 

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf