### PR TITLE
UIP-2629 getDartComponent warning for ReactElements

### DIFF
--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -128,7 +128,7 @@ void setSelectionRange(/* TextInputElement | TextAreaElement */Element input, in
   if (input is TextAreaElement) {
     input.setSelectionRange(start, end, direction);
   } else if (input is InputElement && supportsSelectionRange(input)) {
-    if (browser.isChrome) {
+    if (browser.isChrome || browser.isFirefox) {
       final inputType = input.getAttribute('type');
 
       if (inputType == 'email' || inputType == 'number') {
@@ -161,7 +161,7 @@ int getSelectionStart(Element input) {
   } else if (input is TextInputElement && supportsSelectionRange(input)) {
     final inputType = input.getAttribute('type');
 
-    if (browser.isChrome) {
+    if (browser.isChrome || browser.isFirefox) {
       if (inputType == 'email' || inputType == 'number') {
         return null;
       }

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -280,6 +280,43 @@ react.Component getDartComponent(/* [1] */ instance) {
     return null;
   }
 
+  // Split out into a separate function since the DDC doesn't support
+  // functions as assert params.
+  bool warn() {
+    if (isValidElement(instance)) {
+      // `print` instead of `ValidationUtil.warn` so that this message shows up
+      // in the test output when running `ddev test`.
+      print(unindent(
+          '''
+          * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
+          * WARNING: `getDartComponent`                                                                                                       
+          *                                                                                            
+          * react-dart 4.0 will no longer support retrieving Dart components from                                                                                           
+          * `ReactElement` (pre-mounted VDOM instances) in order to prevent memory leaks.                                                                                            
+          *                                                                                            
+          * In react-dart 4.0, this call to `getDartComponent` will return `null`.                                                                                           
+          *                                                                                            
+          * Please switch over to using the mounted JS component instance.                                                                                           
+          *                                                                                            
+          * Example:                                                                                           
+          *     // Before                                                                                           
+          *     var vdom = Button()('Click me');                                                                                           
+          *     react_dom.render(vdom, mountNode);                                                                                           
+          *     var dartInstance = getDartComponent(vdom);                                                                                           
+          *                                                                                                
+          *     // Fixed                                                                                           
+          *     var vdom = Button()('Click me');                                                                                           
+          *     var jsInstance = react_dom.render(vdom, mountNode);                                                                                           
+          *     var dartInstance = getDartComponent(jsInstance);                            
+          *                                                                                 
+          * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+          '''
+      ));
+    }
+    return true;
+  }
+  assert(warn());
+
   return _getInternal(instance)?.component;
 }
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -280,9 +280,7 @@ react.Component getDartComponent(/* [1] */ instance) {
     return null;
   }
 
-  // Split out into a separate function since the DDC doesn't support
-  // functions as assert params.
-  bool warn() {
+  assert(() {
     if (isValidElement(instance)) {
       // `print` instead of `ValidationUtil.warn` so that this message shows up
       // in the test output when running `ddev test`.
@@ -314,8 +312,7 @@ react.Component getDartComponent(/* [1] */ instance) {
       ));
     }
     return true;
-  }
-  assert(warn());
+  });
 
   return _getInternal(instance)?.component;
 }

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -214,7 +214,11 @@ main() {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
-            }, testOn: '!(blink || firefox)');
+
+            // Tests run in `ddev coverage` don't respect tags and show up as the 'vm' platform
+            // so we can use this to disable certain browser tests during coverage.
+            // Workaround for https://github.com/Workiva/dart_dev/issues/200
+            }, testOn: '!(blink || firefox || vm)');
           } else {
             test(type, () { sharedInputSetSelectionRangeTest(type); });
           }
@@ -323,7 +327,11 @@ main() {
 
             test(type, () {
               sharedInputGetSelectionStartTest(type, shouldReturnNull: false);
-            }, testOn: '!(blink || firefox)');
+
+            // Tests run in `ddev coverage` don't respect tags and show up as the 'vm' platform
+            // so we can use this to disable certain browser tests during coverage.
+            // Workaround for https://github.com/Workiva/dart_dev/issues/200
+            }, testOn: '!(blink || firefox || vm)');
           } else {
             test(type, () { sharedInputGetSelectionStartTest(type); });
           }

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -214,7 +214,7 @@ main() {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
-            }, testOn: '!blink');
+            }, testOn: '!(blink || firefox)');
           } else {
             test(type, () { sharedInputSetSelectionRangeTest(type); });
           }
@@ -233,7 +233,7 @@ main() {
       });
 
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
-      group('without throwing an error in Google Chrome when `props.type` is', () {
+      group('without throwing an error in Google Chrome (or Dartium/content_shell) or Firefox when `props.type` is', () {
         void verifyLackOfException() {
           expect(renderedInstance, isNotNull, reason: 'test setup sanity check');
           expect(inputElement, isNotNull, reason: 'test setup sanity check');
@@ -266,7 +266,7 @@ main() {
           inputElement = findDomNode(renderedInstance);
           verifyLackOfException();
         });
-      }, testOn: 'chrome');
+      }, testOn: 'blink || firefox');
     });
   });
 
@@ -317,13 +317,13 @@ main() {
         for (var type in inputTypesWithSelectionRangeSupport) {
           if (type == 'email' || type == 'number') {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
-            test('$type, returning null in Chrome/Dartium/content-shell', () {
+            test('$type, returning null in Google Chrome (or Dartium/content_shell) or Firefox', () {
               sharedInputGetSelectionStartTest(type, shouldReturnNull: true);
-            }, testOn: 'blink');
+            }, testOn: 'blink || firefox');
 
             test(type, () {
               sharedInputGetSelectionStartTest(type, shouldReturnNull: false);
-            }, testOn: '!blink');
+            }, testOn: '!(blink || firefox)');
           } else {
             test(type, () { sharedInputGetSelectionStartTest(type); });
           }
@@ -343,7 +343,7 @@ main() {
       });
 
       // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
-      group('by returning null and not throwing an error in Google Chrome when `props.type` is', () {
+      group('by returning null and not throwing an error in Google Chrome (or Dartium/content_shell) or Firefox when `props.type` is', () {
         void verifyReturnsNullWithoutException() {
           expect(renderedInstance, isNotNull, reason: 'test setup sanity check');
           expect(inputElement, isNotNull, reason: 'test setup sanity check');
@@ -372,7 +372,7 @@ main() {
           inputElement = findDomNode(renderedInstance);
           verifyReturnsNullWithoutException();
         });
-      }, testOn: 'chrome');
+      }, testOn: 'blink || firefox');
     });
   });
 }

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -214,7 +214,7 @@ main() {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
             test(type, () {
               sharedInputSetSelectionRangeTest(type);
-            }, testOn: 'js && !chrome');
+            }, testOn: '!blink');
           } else {
             test(type, () { sharedInputSetSelectionRangeTest(type); });
           }
@@ -301,23 +301,29 @@ main() {
       });
 
       group('for an `<input>` of type:', () {
-        void sharedInputGetSelectionStartTest(String type) {
+        void sharedInputGetSelectionStartTest(String type, {bool shouldReturnNull: false}) {
           renderedInstance = renderAttachedToDocument((Dom.input()
             ..defaultValue = testValue
             ..type = type
           )());
           inputElement = findDomNode(renderedInstance);
+          setSelectionRange(inputElement, testValue.length, testValue.length);
+
           var selectionStart = getSelectionStart(inputElement);
 
-          expect(selectionStart, testValue.length);
+          expect(selectionStart, shouldReturnNull ? isNull : testValue.length);
         }
 
         for (var type in inputTypesWithSelectionRangeSupport) {
           if (type == 'email' || type == 'number') {
             // See: https://bugs.chromium.org/p/chromium/issues/detail?id=324360
+            test('$type, returning null in Chrome/Dartium/content-shell', () {
+              sharedInputGetSelectionStartTest(type, shouldReturnNull: true);
+            }, testOn: 'blink');
+
             test(type, () {
-              sharedInputGetSelectionStartTest(type);
-            }, testOn: 'js && !chrome');
+              sharedInputGetSelectionStartTest(type, shouldReturnNull: false);
+            }, testOn: '!blink');
           } else {
             test(type, () { sharedInputGetSelectionStartTest(type); });
           }

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -452,7 +452,7 @@ main() {
         test('does not when passed a ReactElement in JS', () {
           ReactElement instance = Wrapper()();
           expect(() => getDartComponent(instance), isNot(prints(messageMatcher)));
-        }, testOn: 'js');
+        }, testOn: 'js', tags: 'no-ddc');
 
         test('does not warn when passed a ReactComponent', () {
           var renderedInstance = render(Wrapper());

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -15,6 +15,7 @@
 @JS()
 library react_wrappers_test;
 
+import 'dart:async';
 import 'dart:html';
 
 import 'package:js/js.dart';
@@ -438,6 +439,30 @@ main() {
       test('returns null for a DOM component', () {
         var renderedInstance = render(Dom.div());
         expect(getDartComponent(renderedInstance), isNull);
+      });
+
+      group('', () {
+        final messageMatcher = contains('react-dart 4.0 will no longer support retrieving Dart components from');
+
+        test('warns when passed a ReactElement', () {
+          ReactElement instance = Wrapper()();
+          expect(() => getDartComponent(instance), prints(messageMatcher));
+        }, testOn: 'dart-vm');
+
+        test('does not when passed a ReactElement in JS', () {
+          ReactElement instance = Wrapper()();
+          expect(() => getDartComponent(instance), isNot(prints(messageMatcher)));
+        }, testOn: 'js');
+
+        test('does not warn when passed a ReactComponent', () {
+          var renderedInstance = render(Wrapper());
+          expect(() => getDartComponent(renderedInstance), isNot(prints(messageMatcher)));
+        });
+
+        test('does not warn when passed a DOM component', () {
+          var renderedInstance = render(Dom.div());
+          expect(() => getDartComponent(renderedInstance), isNot(prints(messageMatcher)));
+        });
       });
     });
 


### PR DESCRIPTION
# Ultimate problem:
The soon to be released react-dart 4.0 will no longer support retrieving Dart components via `getDartComponent` from `ReactElements` (pre-mounted VDOM instances) in order to avoid memory leaks.

We should have a warning in place for when this occurs so that consumers will:
- be able to identify problematic usages that need to be updated
- be able to tell why things are breaking if they don't fix them in time:


# How it was fixed:
- Add error message that prints when a ReactElement is passed into `getDartComponent`
        <img width="791" alt="screen shot 2017-08-11 at 11 09 13 am" src="https://user-images.githubusercontent.com/1713967/29226081-8b15dc68-7e85-11e7-8321-6ecc1d2ebd40.png">
- Add tests

#### Boy-scouted:
- Fixes to selection range tests that were failing in Chrome
- [UIP-2322](https://jira.atl.workiva.net/browse/UIP-2322) Fixes to selection range logic in Firefox

# Testing suggestions:
Verify that tests pass in all platforms:
- Dart VM
    - `ddev test -p content-shell`
    - `ddev test -p dartium`
- dart2js
    - `ddev test -p chrome`
    - `ddev test -p firefox`
        - Watch out for unrelated failing `getActiveElement` test in master
- DDC
    - `ddev test -p chrome --web-compiler=dartdevc test/*_test.dart -x no-ddc`
        - Watch out for unrelated intermittently-failing `getActiveElement` test in master
        - Watch out for unrelated failing `ObjectDisposedException` test in master

# Potential areas of regression:
- `getDartComponent`
- `setSelectionRange/`getSelectionRange`

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
