### PR TITLE
Consume over_react_test 1.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.1.1"
+  over_react_test: "^1.2.0"
   test: "^0.12.24"
 
 transformers:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-1682: Test that testId is forwarded in commonComponentTests](https://github.com/Workiva/over_react_test/pull/15)
* [UIP-1112: Support passing in components in getByTestId](https://github.com/Workiva/over_react_test/pull/16)
* [UIP-2556 Release over_react_test 1.2.0](https://github.com/Workiva/over_react_test/pull/17)


Requested by: @clairesarsam-wf