### PR TITLE
UIP-2588 Release over_react 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # OverReact Changelog
 
+## 1.16.0
+
+> [Complete `1.16.0` Changeset](https://github.com/Workiva/over_react/compare/1.15.1...1.16.0)
+
+__Dependency Updates__
+
+* w_common `^1.8.0` (was `^1.6.0`)
+* w_flux `^2.9.0` (was `^2.7.1`)
+
+__New Features__
+
+* [#104]: Update `UiComponent` to implement `DisposableManagerV6`.
+
+
+__Improvements__
+
+* [#103]: `FluxUiComponent` redraws only once when store triggers along with ancestor rerender.
+
+
+__Tech Debt__
+
+* [#105]: Add warning for incorrect usage of `getDartComponent`.
+
+&nbsp;
+
 ## 1.15.1
 
 > [Complete `1.15.1` Changeset](https://github.com/Workiva/over_react/compare/1.15.0...1.15.1)
@@ -14,11 +39,6 @@ __Tech Debt__
 ## 1.15.0
 
 > [Complete `1.15.0` Changeset](https://github.com/Workiva/over_react/compare/1.14.0...1.15.0)
-
-__Dependency Updates__
-
-* over_react_test `^1.0.1` (was `^1.0.0`)
-* test `^0.12.24` (was `^0.12.6+2`)
 
 __New Features__
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.15.1"
+      over_react: "^1.16.0"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.15.1
+version: 1.16.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.1.1"
+  over_react_test: "^1.2.0"
   test: "^0.12.24"
 
 transformers:

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -688,7 +688,7 @@ main() {
           component.awaitBeforeDispose(completer.future);
 
           // Add events to stream
-          component.manageDisposer(() async => streamController.add('disposalFuture'));
+          component.manageDisposer(() async => streamController.add('disposalFuture')); // ignore: deprecated_member_use
           completer.future.then(streamController.add);
 
           // Perform events out of order
@@ -783,7 +783,7 @@ main() {
 
         test('should call managed disposers', () async {
           var disposerCalled = false;
-          component.manageDisposer(() async => disposerCalled = true);
+          component.manageDisposer(() async => disposerCalled = true); // ignore: deprecated_member_use
           expect(disposerCalled, isFalse);
           await unmountAndDisposal();
           expect(disposerCalled, isTrue);
@@ -806,7 +806,7 @@ main() {
               count: 0,
               reason: 'Did not expect event after cancelling subscription'));
 
-          component.manageStreamSubscription(streamSubscription);
+          component.manageStreamSubscription(streamSubscription); // ignore: deprecated_member_use
           await unmountAndDisposal();
 
           streamController

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -15,7 +15,6 @@
 @JS()
 library react_wrappers_test;
 
-import 'dart:async';
 import 'dart:html';
 
 import 'package:js/js.dart';


### PR DESCRIPTION
__Dependency Updates__

* w_common `^1.8.0` (was `^1.6.0`)
* w_flux `^2.9.0` (was `^2.7.1`)

__New Features__

* #104: Update `UiComponent` to implement `DisposableManagerV6`.

__Improvements__

* #103: `FluxUiComponent` redraws only once when store triggers along with ancestor rerender.


__Tech Debt__

* #105: Add warning for incorrect usage of `getDartComponent`.



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
