### PR TITLE
UIP-2637 Release over_react 1.16.1 (HOTFIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OverReact Changelog
 
+## 1.16.1
+
+> [Complete `1.16.1` Changeset](https://github.com/Workiva/over_react/compare/1.16.0...1.16.1)
+
+__Bug fixes__
+
+* [#108]: Fix case where `setState` and store trigger only result in one `FluxUiComponent` render
+
 ## 1.16.0
 
 > [Complete `1.16.0` Changeset](https://github.com/Workiva/over_react/compare/1.15.1...1.16.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: "^1.16.0"
+      over_react: "^1.16.1"
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -175,7 +175,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
     });
   }
 
-  void componentDidUpdate(Map prevProps, Map prevState) {
+  void componentWillReceiveProps(Map prevProps) {
     // Let BatchedRedraws know that this component has redrawn in the current batch
     didBatchRedraw = true;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.16.0
+version: 1.16.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -210,6 +210,31 @@ void main() {
       expect(nested1.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
       expect(nested2.renderCount, 3, reason: 'should have rerendered once in response to the store triggering');
     });
+
+    test('redraws twice in response to a the component calling setState and a store trigger happening at the same time', () async {
+      var store = new Store();
+
+      TestNestedComponent nested0;
+
+      render(
+          (TestNested()
+            ..store = store
+            ..ref = (ref) { nested0 = ref; }
+          )()
+      );
+      expect(nested0.renderCount, 1, reason: 'setup check: initial render');
+
+      nested0.setState({});
+      store.trigger();
+      // Two async gaps just to be safe, since we're
+      // asserting that additional redraws don't happen.
+      await nextTick();
+      await nextTick();
+
+      expect(nested0.renderCount, 3,
+          reason: 'should have rerendered once in response to the store triggering'
+                  ' and once in response to setState');
+    });
   });
 }
 


### PR DESCRIPTION
# Fix case where setState and store trigger only result in one render

## Ultimate problem:
Currently, when a component calls `setState` at the same time the store triggers, the rerender with the updated store does not take place.

## How it was fixed:
Use `componentWillReceiveProps` to mark batch redraws instead of `componentDidUpdate`.

This will mark only components that are getting excessive rerenders from parent components, and not components that have unrelated `setState` calls.

## Testing suggestions:
- Verify tests pass
- Pull this branch into graph_app tag 1.320.0 and verify there are no longer any failing tests.
    - Build: https://ci.webfilings.com/build/987215


## Potential areas of regression:
FluxUiComponent batch redrawing.


---

@Workiva/ui-platform-pp @Workiva/web-platform-pp @kylemcmorrow-wf 
