### PR TITLE
Consume over_react_test 1.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.2.0"
+  over_react_test: "^1.2.2"
   test: "^0.12.24"
 
 transformers:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2674 add docs.yaml](https://github.com/Workiva/over_react_test/pull/20)
* [UIP-2681 Widen react-dart range to pull in memory leak fixes](https://github.com/Workiva/over_react_test/pull/21)
* [UIP-2638 Release over_react_test 1.2.2](https://github.com/Workiva/over_react_test/pull/22)


Requested by: @leviwith-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6030558111465472/logs/)