### PR TITLE
Address Dart 2 infos

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,5 +25,5 @@ linter:
     - sort_constructors_first
     - sort_unnamed_constructors_first
     - type_init_formals
-    - unnecessary_brace_in_string_interp
+    - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -40,7 +40,7 @@ class Props implements TypedMap {
   /// overriding the default of `'${propsClassName}.'`.
   @override
   final String keyNamespace;
-  const Props({this.keyNamespace: null});
+  const Props({this.keyNamespace});
 }
 
 /// Annotation used with the `over_react` transformer to declare a [UiState] class for a component.
@@ -58,7 +58,7 @@ class State implements TypedMap {
   /// overriding the default of `'${stateClassName}.'`.
   @override
   final String keyNamespace;
-  const State({this.keyNamespace: null});
+  const State({this.keyNamespace});
 }
 
 /// Annotation used with the `over_react` transformer to declare a [UiComponent] class for a component.
@@ -117,7 +117,7 @@ class AbstractProps implements TypedMap {
   /// overriding the default of `'${propsClassName}.'`.
   @override
   final String keyNamespace;
-  const AbstractProps({this.keyNamespace: null});
+  const AbstractProps({this.keyNamespace});
 }
 
 /// Annotation used with the `over_react` transformer to declare an abstract [UiProps] class for an abstract component.
@@ -133,7 +133,7 @@ class AbstractState implements TypedMap {
   /// overriding the default of `'${stateClassName}.'`.
   @override
   final String keyNamespace;
-  const AbstractState({this.keyNamespace: null});
+  const AbstractState({this.keyNamespace});
 }
 
 /// Annotation used with the `over_react` transformer to declare an abstract [UiComponent] class for an abstract component.
@@ -161,7 +161,7 @@ class PropsMixin implements TypedMap {
   /// overriding the default of `'${propsClassName}.'`.
   @override
   final String keyNamespace;
-  const PropsMixin({this.keyNamespace: null});
+  const PropsMixin({this.keyNamespace});
 }
 
 /// Annotation used with the `over_react` transformer to declare a mixin for use in a [UiState] class.
@@ -181,7 +181,7 @@ class StateMixin implements TypedMap {
   /// overriding the default of `'${stateClassName}.'`.
   @override
   final String keyNamespace;
-  const StateMixin({this.keyNamespace: null});
+  const StateMixin({this.keyNamespace});
 }
 
 /// Marks a `prop` as required to be set.

--- a/lib/src/component_declaration/transformer_helpers.dart
+++ b/lib/src/component_declaration/transformer_helpers.dart
@@ -30,7 +30,6 @@ export './component_base.dart'
 /// in a static yet unsafe way.
 ///
 /// __For advanced usage only.__
-@proxy
 class $PropKeys implements List<String> {
   /// A placeholder that gets swapped out by the `over_react` transformer
   /// with the prop keys defined in [propsClass].
@@ -49,7 +48,6 @@ class $PropKeys implements List<String> {
 /// in a static yet unsafe way.
 ///
 /// __For advanced usage only.__
-@proxy
 class $Props implements component_base.ConsumedProps {
   /// A placeholder that gets swapped out by the `over_react` transformer
   /// with the prop keys defined in [propsClass].

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -32,7 +32,7 @@ Map getPropsToForward(Map props, {
     Iterable keysToOmit,
     Iterable<Iterable> keySetsToOmit
 }) {
-  Map propsToForward = new Map.from(props);
+  var propsToForward = new Map<String, dynamic>.from(props);
 
   if (omitReactProps) {
     propsToForward
@@ -56,13 +56,13 @@ Map getPropsToForward(Map props, {
   }
 
   if (onlyCopyDomProps) {
-    new List.from(propsToForward.keys).forEach((String key) {
-      if (key.startsWith('aria-')) return;
-      if (key.startsWith('data-')) return;
-      if (_validDomProps.contains(key)) return;
+    for (var key in new List.from(propsToForward.keys)) {
+      if (key.startsWith('aria-')) continue;
+      if (key.startsWith('data-')) continue;
+      if (_validDomProps.contains(key)) continue;
 
       propsToForward.remove(key);
-    });
+    }
   }
 
   return propsToForward;

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -121,7 +121,7 @@ final bool _canUseExpandoOnReactElement = (() {
 ///
 /// If caching isn't possible due to [_canUseExpandoOnReactElement] being false,
 /// then this will be initialized to `null`, and caching will be disabled.
-final Expando<UnmodifiableMapView> _elementPropsCache = _canUseExpandoOnReactElement
+final Expando<UnmodifiableMapView<String, dynamic>> _elementPropsCache = _canUseExpandoOnReactElement
     ? new Expando<UnmodifiableMapView>('_elementPropsCache')
     : null;
 
@@ -134,7 +134,7 @@ final Expando<UnmodifiableMapView> _elementPropsCache = _canUseExpandoOnReactEle
 /// instance.
 ///
 /// Throws if [instance] is not a valid [ReactElement] or composite [ReactComponent] .
-Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers: false}) {
+Map<String, dynamic> getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers: false}) {
   var isCompositeComponent = _isCompositeComponent(instance);
 
   if (isValidElement(instance) || isCompositeComponent) {
@@ -168,7 +168,7 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers:
     }
 
     var propsMap = isDartComponent(instance) ? _getExtendedProps(instance) : getJsProps(instance);
-    var view = new UnmodifiableMapView(propsMap);
+    var view = new UnmodifiableMapView<String, dynamic>(propsMap);
 
     if (_elementPropsCache != null && !isCompositeComponent) {
       _elementPropsCache[instance] = view;
@@ -286,27 +286,27 @@ react.Component getDartComponent(/* [1] */ instance) {
       // in the test output when running `ddev test`.
       print(unindent(
           '''
-          * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
-          * WARNING: `getDartComponent`                                                                                                       
-          *                                                                                            
-          * react-dart 4.0 will no longer support retrieving Dart components from                                                                                           
-          * `ReactElement` (pre-mounted VDOM instances) in order to prevent memory leaks.                                                                                            
-          *                                                                                            
-          * In react-dart 4.0, this call to `getDartComponent` will return `null`.                                                                                           
-          *                                                                                            
-          * Please switch over to using the mounted JS component instance.                                                                                           
-          *                                                                                            
-          * Example:                                                                                           
-          *     // Before                                                                                           
-          *     var vdom = Button()('Click me');                                                                                           
-          *     react_dom.render(vdom, mountNode);                                                                                           
-          *     var dartInstance = getDartComponent(vdom);                                                                                           
-          *                                                                                                
-          *     // Fixed                                                                                           
-          *     var vdom = Button()('Click me');                                                                                           
-          *     var jsInstance = react_dom.render(vdom, mountNode);                                                                                           
-          *     var dartInstance = getDartComponent(jsInstance);                            
-          *                                                                                 
+          * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+          * WARNING: `getDartComponent`
+          *
+          * react-dart 4.0 will no longer support retrieving Dart components from
+          * `ReactElement` (pre-mounted VDOM instances) in order to prevent memory leaks.
+          *
+          * In react-dart 4.0, this call to `getDartComponent` will return `null`.
+          *
+          * Please switch over to using the mounted JS component instance.
+          *
+          * Example:
+          *     // Before
+          *     var vdom = Button()('Click me');
+          *     react_dom.render(vdom, mountNode);
+          *     var dartInstance = getDartComponent(vdom);
+          *
+          *     // Fixed
+          *     var vdom = Button()('Click me');
+          *     var jsInstance = react_dom.render(vdom, mountNode);
+          *     var dartInstance = getDartComponent(jsInstance);
+          *
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
           '''
       ));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.23.0"
+  sdk: ">=1.23.0 <2.0.0-dev.infinity"
 dependencies:
   analyzer: ">=0.30.0 <0.31.0"
   barback: "^0.15.0"
@@ -21,12 +21,12 @@ dependencies:
   platform_detect: "^1.3.2"
   quiver: ">=0.21.4 <0.26.0"
 dev_dependencies:
-  matcher: ">=0.11.0 <0.13.0"
-  coverage: "^0.7.2"
-  dart_dev: "^1.7.6"
-  mockito: "^0.11.0"
-  over_react_test: "^1.2.0"
-  test: "^0.12.24"
+  matcher: ^0.12.1+4
+  coverage: ^0.7.9
+  dart_dev: ^1.8.0
+  mockito: ^2.2.0
+  over_react_test: ^1.2.1
+  test: ^0.12.24+6
 
 transformers:
   - over_react:


### PR DESCRIPTION
## Ultimate Problem
Dart 2 dev just got released, and when pulling it into OverReact there are some new infos.

## Solution
- Address all infos

## Testing Suggestions
- Run
```bash
brew upgrade dart --devel --with-content-shell --with-dartium
```
- Verify you have Dart version `2.0.0-dev.1.0`
- Verify that there are no infos

## Possible Areas of Regression
- N/A

---
FYA: @Workiva/ui-platform-pp 