### PR TITLE
Consume over_react_test 1.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.2.0"
+  over_react_test: "^1.3.0"
   test: "^0.12.24"
 
 transformers:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2718 Make triggerTransitionEnd work for Chrome 61](https://github.com/Workiva/over_react_test/pull/23)
* [UIP-2686 Release over_react_test 1.3.0](https://github.com/Workiva/over_react_test/pull/24)


Requested by: @clairesarsam-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6030558111465472/logs/)