### PR TITLE
Consume over_react_test 1.3.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.7.6"
   mockito: "^0.11.0"
-  over_react_test: "^1.2.0"
+  over_react_test: "^1.3.1"
   test: "^0.12.24"
 
 transformers:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2727 Release over_react_test 1.3.1](https://github.com/Workiva/over_react_test/pull/25)


Requested by: @clairesarsam-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6030558111465472/logs/)