### PR TITLE
UIP-2742 Improve error message when UiState classes aren't set up properly

### DIFF
--- a/lib/src/component_declaration/transformer_helpers.dart
+++ b/lib/src/component_declaration/transformer_helpers.dart
@@ -145,7 +145,13 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
   /// Returns a typed state object backed by the specified [stateMap].
   ///
   /// Required to properly instantiate the generic [TState] class.
-  @override @toBeGenerated TState typedStateFactory(Map stateMap) => throw new UngeneratedError(member: #typedStateFactory);
+  @override @toBeGenerated TState typedStateFactory(Map stateMap) => throw new UngeneratedError(member: #typedStateFactory, message:
+      '${#typedStateFactory}` should be implemented by code generation.\n\n'
+      'This error may be due to your `UiState` class not being annotated with `@State()`,\n'
+      'or because you are extending a stateful component without redeclaring your own `@State()`, like so:\n\n'
+      '    @State()\n'
+      '    class MyState extends SuperState {}\n'
+  );
 }
 
 /// A [dart.collection.MapView]-like class with strongly-typed getters/setters for React props that


### PR DESCRIPTION
## Ultimate problem:
An `UngeneratedError` was thrown in some cases without a useful error message.

## How it was fixed:
Improve error message

## Testing suggestions:
- Verify tests pass.
- Verify that rendering the following faulty component results in a useful error message:
   ```dart
    @Factory()
    UiFactory<FooProps> Foo;
    
    @Props()
    class FooProps extends UiProps {}
    
    class FooState extends UiState {}
    
    @Component()
    class FooComponent extends UiStatefulComponent<FooProps, FooState> {
      @override
      Map getInitialState() => newState();
    
      @override
      render() {
        return Dom.div()();
      }
    }
    ```

## Potential areas of regression:
`typedStateFactory` error messages.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
