### PR TITLE
UIP-2762 More convenient ubiquitous access of DOM/aria props

### DIFF
--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -17,7 +17,7 @@ library over_react.prop_mixins;
 
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_import
-import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps;
+import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps;
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/annotations.dart';
 
@@ -120,6 +120,38 @@ abstract class SvgPropsMixin {
 @PropsMixin(keyNamespace: '')
 abstract class UbiquitousDomPropsMixin {
   Map get props;
+
+  /// A cache for the MapView used for [aria].
+  @Accessor(doNotGenerate: true)
+  AriaPropsMapView _aria;
+
+  /// A cache for the MapView used for [dom].
+  @Accessor(doNotGenerate: true)
+  DomProps _dom;
+
+  /// A view into this map that can be used to access `aria-` props, for convenience.
+  ///
+  /// Example:
+  ///
+  ///     (Button()
+  ///       ..aria.controls = 'my_popover'
+  ///     )('Open popover')
+  AriaPropsMixin get aria {
+    _aria ??= new AriaPropsMapView(props);
+    return _aria;
+  }
+
+  /// A view into this map that can be used to access DOM props, for convenience.
+  ///
+  /// Example:
+  ///
+  ///     (Tab()
+  ///       ..dom.draggable = true
+  ///     )('Untitled Document')
+  DomPropsMixin get dom {
+    _dom ??= new DomProps(null, props);
+    return _dom;
+  }
 
   /// Whether the element if focusable.
   /// Must be a valid integer or String of valid integer.

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -243,12 +243,16 @@ class Accessor {
   /// The error message displayed when the accessor is not set.
   final String requiredErrorMessage;
 
+  /// Whether to skip generating an accessor for this field.
+  final bool doNotGenerate;
+
   const Accessor({
     this.key,
     this.keyNamespace,
     this.isRequired = false,
     this.isNullable = false,
     this.requiredErrorMessage,
+    this.doNotGenerate = false,
   });
 }
 

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -413,6 +413,25 @@ class ImplGenerator {
         .where((member) => member is FieldDeclaration && !member.isStatic)
         .forEach((_field) {
           final field = _field as FieldDeclaration; // ignore: avoid_as
+
+          T getConstantAnnotation<T>(AnnotatedNode member, String name, T value) {
+            return member.metadata.any((annotation) => annotation.name?.name == name) ? value : null;
+          }
+
+          annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
+          annotations.Accessor requiredProp = getConstantAnnotation(field, 'requiredProp', annotations.requiredProp);
+          annotations.Accessor nullableRequiredProp = getConstantAnnotation(field, 'nullableRequiredProp', annotations.nullableRequiredProp);
+          // ignore: deprecated_member_use
+          annotations.Required requiredMeta = instantiateAnnotation(field, annotations.Required);
+
+          if (accessorMeta?.doNotGenerate == true) {
+            logger.fine('Skipping generation of field `$field`.',
+                span: getSpan(sourceFile, field)
+            );
+
+            return;
+          }
+
           // Remove everything in the field except the comments/meta and the variable names, preserving newlines.
           // TODO add support for preserving comment nodes between variable declarations.
 
@@ -445,16 +464,6 @@ class ImplGenerator {
             }
 
             String accessorName = variable.name.name;
-
-            T getConstantAnnotation<T>(AnnotatedNode member, String name, T value) {
-              return member.metadata.any((annotation) => annotation.name?.name == name) ? value : null;
-            }
-
-            annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
-            annotations.Accessor requiredProp = getConstantAnnotation(field, 'requiredProp', annotations.requiredProp);
-            annotations.Accessor nullableRequiredProp = getConstantAnnotation(field, 'nullableRequiredProp', annotations.nullableRequiredProp);
-            // ignore: deprecated_member_use
-            annotations.Required requiredMeta = instantiateAnnotation(field, annotations.Required);
 
             String individualKeyNamespace = accessorMeta?.keyNamespace ?? keyNamespace;
             String individualKey = accessorMeta?.key ?? accessorName;

--- a/test/over_react/component/prop_mixins_test.dart
+++ b/test/over_react/component/prop_mixins_test.dart
@@ -63,6 +63,26 @@ main() {
 
   group('UbiquitousProps', () {
     testKeys(const $PropKeys(UbiquitousDomPropsMixin), (() => new UbiquitousPropMixinsTest({})));
+
+    group('has a getter that provides a typed view of', () {
+      test('aria props', () {
+        var instance = new UbiquitousPropMixinsTest({})
+          ..aria.labelledby = 'foo';
+
+        expect(instance, equals(ariaProps()..labelledby = 'foo'), reason: 'should set the prop properly');
+        expect(instance.aria.labelledby, 'foo', reason: 'should be able to read the prop in addition to setting it');
+        expect(instance.aria, same(instance.aria), reason: 'should cache the backing typed MapView');
+      });
+
+      test('DOM props', () {
+        var instance = new UbiquitousPropMixinsTest({})
+          ..dom.target = 'foo';
+
+        expect(instance, equals(domProps()..target = 'foo'), reason: 'should set the prop properly');
+        expect(instance.dom.target, 'foo', reason: 'should be able to read the prop in addition to setting it');
+        expect(instance.dom, same(instance.dom), reason: 'should cache the backing typed MapView');
+      });
+    });
   });
 
   group('AriaProps', () {

--- a/test/over_react/component_declaration/transformer_integration_tests/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/do_not_generate_accessor_integration_test.dart
@@ -1,0 +1,122 @@
+// Copyright 2017 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library over_react.component_declaration.transformer_integration_tests.do_not_generate_accessor_integration_test;
+
+import 'package:over_react/over_react.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/test_util.dart';
+
+main() {
+  group('acessors with doNotGenerate integration', () {
+    group('generates prop getters/setters properly', () {
+      test('for prop fields listed before the field annotated with doNotGenerate', () {
+        expect((DoNotGenerateAccessorTest()..generated1Prop = 'test').values.single, 'test');
+      });
+
+      test('for prop fields listed after the field annotated with doNotGenerate', () {
+        expect((DoNotGenerateAccessorTest()..generated2Prop = 'test').values.single, 'test');
+      });
+
+      test('for prop fields annotated with `doNotGenerate: false`', () {
+        expect((DoNotGenerateAccessorTest()..explicitlyGeneratedProp = 'test').values.single, 'test');
+      });
+
+      test('except for the field annotated with doNotGenerate', () {
+        var instance = DoNotGenerateAccessorTest()..notGeneratedProp = 'test';
+        expect(instance.notGeneratedProp, 'test', reason: 'non-generated field should work as expected');
+        expect(instance, isEmpty, reason: 'accessor should not be backed by a key-value pair');
+      });
+
+      test('omitting the field annotated with doNotGenerate from the list of props', () {
+        expect(const $PropKeys(DoNotGenerateAccessorTestProps), [
+          contains('generated1Prop'),
+          contains('generated2Prop'),
+          contains('explicitlyGeneratedProp'),
+        ], reason: 'should only include generated props');
+
+        expect(const $Props(DoNotGenerateAccessorTestProps).props.map((prop) => prop.key).toList(), [
+          contains('generated1Prop'),
+          contains('generated2Prop'),
+          contains('explicitlyGeneratedProp'),
+        ], reason: 'should only include generated props');
+      });
+    });
+
+    group('generates state getters/setters properly', () {
+      DoNotGenerateAccessorTestComponent component;
+
+      setUp(() {
+        component = renderAndGetComponent(DoNotGenerateAccessorTest()());;
+      });
+
+      test('for state fields listed before the field annotated with doNotGenerate', () {
+        expect((component.newState()..generated1State = 'test').values.single, 'test');
+      });
+
+      test('for state fields listed after the field annotated with doNotGenerate', () {
+        expect((component.newState()..generated2State = 'test').values.single, 'test');
+      });
+
+      test('for state fields annotated with `doNotGenerate: false`', () {
+        expect((component.newState()..explicitlyGeneratedState = 'test').values.single, 'test');
+      });
+
+      test('except for the field annotated with doNotGenerate', () {
+        var instance = component.newState()..notGeneratedState = 'test';
+        expect(instance.notGeneratedState, 'test', reason: 'non-generated field should work as expected');
+        expect(instance, isEmpty, reason: 'accessor should not be backed by a key-value pair');
+      });
+    });
+  });
+}
+
+
+@Factory()
+UiFactory<DoNotGenerateAccessorTestProps> DoNotGenerateAccessorTest;
+
+@Props()
+class DoNotGenerateAccessorTestProps extends UiProps {
+  var generated1Prop;
+
+  @Accessor(doNotGenerate: true)
+  var notGeneratedProp;
+
+  var generated2Prop;
+
+  @Accessor(doNotGenerate: false)
+  var explicitlyGeneratedProp;
+}
+
+@State()
+class DoNotGenerateAccessorTestState extends UiState {
+  var generated1State;
+
+  @Accessor(doNotGenerate: true)
+  var notGeneratedState;
+
+  var generated2State;
+
+  @Accessor(doNotGenerate: false)
+  var explicitlyGeneratedState;
+}
+
+@Component()
+class DoNotGenerateAccessorTestComponent extends UiStatefulComponent<DoNotGenerateAccessorTestProps, DoNotGenerateAccessorTestState> {
+  @override
+  render() => (Dom.div()
+    ..addProps(copyUnconsumedProps())
+  )('rendered content');
+}

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -31,6 +31,7 @@ import 'over_react/component_declaration/transformer_integration_tests/abstract_
 import 'over_react/component_declaration/transformer_integration_tests/accessor_mixin_integration_test.dart' as accessor_mixin_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/component_integration_test.dart' as component_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/constant_required_accessor_integration_test.dart' as constant_required_accessor_integration_test;
+import 'over_react/component_declaration/transformer_integration_tests/do_not_generate_accessor_integration_test.dart' as do_not_generate_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/namespaced_accessor_integration_test.dart' as namespaced_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/required_accessor_integration_test.dart' as required_accessor_integration_test;
 import 'over_react/component_declaration/transformer_integration_tests/stateful_component_integration_test.dart' as stateful_component_integration_test;
@@ -48,6 +49,7 @@ main() {
   accessor_mixin_integration_test.main();
   component_integration_test.main();
   constant_required_accessor_integration_test.main();
+  do_not_generate_accessor_integration_test.main();
   namespaced_accessor_integration_test.main();
   required_accessor_integration_test.main();
   stateful_component_integration_test.main();


### PR DESCRIPTION
## Ultimate problem:
_I was bored after work yesterday 😄_

Adding aria/DOM props to components is a little clunky; you have to do something like this:
```dart
(Button()
  ..addProps(domProps()..draggable = true)
  ..addProps(ariaProps()
    ..controls = 'my_popover'
    ..labelledby = 'my_label'
  )
)('Click me')
```

What would be nicer is a syntax like this:
```dart
(Button()
  ..dom.draggable = true
  ..aria.controls = 'my_popover'
  ..aria.labelledby = 'my_label'
)('Click me')
```

## How it was fixed:
- Add `aria` and `dom` getters to `UbiquitousDomPropsMixin` that provide typed views into a given `UiProps` class that allow for reading/writing aria/DOM props.
- Add `doNotGenerate` option to `@Accessor()` annotation to allow declaring fields in accessor (props, props mixin, state, state mixin) classes that shouldn't be generated into key-value-pair-backed getters/setters.
    - Necessary to implement caching for `aria`/`dom` getters.

## Testing suggestions:
- Verify that tests pass.
- Render a component with the above syntax and verify that things work as expected.

## Potential areas of regression:
This could break consumer code if they've declared props or state fields named `aria` or `dom`.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
