### PR TITLE
UIP-2751 Transition in/out-specific config, test attributes

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -28,7 +28,7 @@ abstract class AbstractTransitionProps extends UiProps with TransitionPropsMixin
 abstract class AbstractTransitionState extends UiState {
   /// The current phase of transition the [AbstractTransitionComponent] is in.
   ///
-  /// Default:  [AbstractTransitionComponent.initiallyShown] ? [TransitionState.SHOWN] : [TransitionState.HIDDEN]
+  /// Default:  [AbstractTransitionComponent.initiallyShown] ? [TransitionPhase.SHOWN] : [TransitionPhase.HIDDEN]
   TransitionPhase transitionPhase;
 }
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -129,10 +129,14 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
   bool get hasTransitionOut => hasTransition && transitionOutCount > 0;
 
   /// The number of `transitionend` events that occur when the transition node is shown.
-  int get transitionInCount => props.transitionInCount ?? props.transitionCount ?? 0;
+  ///
+  /// Defaults to `1` to match previous behavior in the case where `props.transitionCount` is `null`.
+  int get transitionInCount => props.transitionInCount ?? props.transitionCount ?? 1;
 
   /// The number of `transitionend` events that occur when the transition node is hidden.
-  int get transitionOutCount => props.transitionOutCount ?? props.transitionCount ?? 0;
+  ///
+  /// Defaults to `1` to match previous behavior in the case where `props.transitionCount` is `null`.
+  int get transitionOutCount => props.transitionOutCount ?? props.transitionCount ?? 1;
 
   /// The duration that can elapse before a transition timeout occurs.
   Duration get transitionTimeout => const Duration(seconds: 1);

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -19,6 +19,7 @@ import 'dart:html';
 
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
+import 'package:over_react/component_base.dart' as component_base;
 
 @AbstractProps()
 abstract class AbstractTransitionProps extends UiProps with TransitionPropsMixin {}
@@ -366,6 +367,23 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
     if (props.onDidShow != null) {
       props.onDidShow();
     }
+  }
+
+  /// Returns attributes only available during testing that indicate the state of the transition.
+  Map<String, String> getTransitionTestAttributes() {
+    if (!component_base.UiProps.testMode) return const {};
+
+    const enumToAttrValue = const <TransitionPhase, String>{
+      TransitionPhase.SHOWN: 'shown',
+      TransitionPhase.HIDDEN: 'hidden',
+      TransitionPhase.HIDING: 'hiding',
+      TransitionPhase.PRE_SHOWING: 'pre-showing',
+      TransitionPhase.SHOWING: 'showing',
+    };
+
+    return {
+      'data-transition-phase': enumToAttrValue[state.transitionPhase],
+    };
   }
 
   // --------------------------------------------------------------------------

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -82,6 +82,18 @@ abstract class AbstractTransitionState extends UiState {
 abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
                                            S extends AbstractTransitionState>
   extends UiStatefulComponent<T, S> {
+  /// The DOM attribute used to indicate the current transition phase,
+  /// added in test mode in [getTransitionTestAttributes].
+  ///
+  /// Possible values:
+  ///
+  /// - `pre-showing`
+  /// - `showing`
+  /// - `shown`
+  /// - `hiding`
+  /// - `hidden`
+  static const String transitionPhaseTestAttr = 'data-transition-phase';
+
   @override
   get consumedProps => const [
     const $Props(AbstractTransitionProps),
@@ -382,7 +394,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
     };
 
     return {
-      'data-transition-phase': enumToAttrValue[state.transitionPhase],
+      transitionPhaseTestAttr: enumToAttrValue[state.transitionPhase],
     };
   }
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -129,10 +129,10 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
   bool get hasTransitionOut => hasTransition && transitionOutCount > 0;
 
   /// The number of `transitionend` events that occur when the transition node is shown.
-  int get transitionInCount => props.transitionInCount ?? props.transitionCount;
+  int get transitionInCount => props.transitionInCount ?? props.transitionCount ?? 0;
 
   /// The number of `transitionend` events that occur when the transition node is hidden.
-  int get transitionOutCount => props.transitionOutCount ?? props.transitionCount;
+  int get transitionOutCount => props.transitionOutCount ?? props.transitionCount ?? 0;
 
   /// The duration that can elapse before a transition timeout occurs.
   Duration get transitionTimeout => const Duration(seconds: 1);

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -27,10 +27,22 @@ abstract class TransitionPropsMixin {
 
   Map get props;
 
-  /// Number of transitions to occur within the [AbstractTransitionComponent].
+  /// The number of `transitionend` event that occur when the transition node is shown/hidden.
   ///
-  /// Default: 1
+  /// Serves as the default for [transitionInCount]/[transitionOutCount] when they are not specified.
+  ///
+  /// Default: `1`
   int transitionCount;
+
+  /// The number of `transitionend` event that occur when the transition node is shown.
+  ///
+  /// Default: [transitionCount]
+  int transitionInCount;
+
+  /// The number of `transitionend` event that occur when the transition node is hidden.
+  ///
+  /// Default: [transitionCount]
+  int transitionOutCount;
 
   /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
   ///

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -262,6 +262,17 @@ main() {
             );
           });
 
+          test('null (should behave like 0)', () async {
+            var renderedInstance = render(Transitioner()
+              ..initiallyShown = false
+              ..transitionCount = null
+            );
+            await sharedTests(renderedInstance,
+              expectedTransitionInCount: 0,
+              expectedTransitionOutCount: 0,
+            );
+          });
+
           test('0', () async {
             var renderedInstance = render(Transitioner()
               ..initiallyShown = false

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -262,14 +262,14 @@ main() {
             );
           });
 
-          test('null (should behave like 0)', () async {
+          test('null (should behave like the default, 1, for backwards compatibility)', () async {
             var renderedInstance = render(Transitioner()
               ..initiallyShown = false
               ..transitionCount = null
             );
             await sharedTests(renderedInstance,
-              expectedTransitionInCount: 0,
-              expectedTransitionOutCount: 0,
+              expectedTransitionInCount: 1,
+              expectedTransitionOutCount: 1,
             );
           });
 

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -537,7 +537,7 @@ main() {
     });
 
     group('getTransitionTestAttributes returns attributes that indicate the state of the transition in component', () {
-      const transitionPhaseTestAttr = 'data-transition-phase';
+      const transitionPhaseTestAttr = AbstractTransitionComponent.transitionPhaseTestAttr;
 
       group('when the transition state is', () {
         test('PRE_SHOWING', () async {


### PR DESCRIPTION
## Ultimate problem:
- There wasn't a way to configure the number of transitions to be different between showing and hiding
- We want to add test attributes that mirror the state of the transition in the DOM in consistent way

## How it was fixed:
- Add `transitionInCount`/`transitionOutCount` props and update `AbstractTransitionComponent` to support them
- Add `AbstractTransitionComponent.getTransitionTestAttributes` for use in consumer implementations

## Testing suggestions:
- Verify that tests pass
- Verify that there are no regressions in AbstractTransition behavior in WSD branch: https://github.com/Workiva/web_skin_dart/pull/860
    - collapsible cards
    - overlay transitions (popovers, tooltips, modals)

## Potential areas of regression:
- AbstractTransition


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
