### PR TITLE
WP-5222 UIP-2741 Release over_react 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OverReact Changelog
 
+## 1.18.0
+
+> [Complete `1.18.0` Changeset](https://github.com/Workiva/over_react/compare/1.17.0...1.18.0)
+
+__Improvements__
+* [#177] Improve error message when UiState classes aren't set up properly.
+
+__New Features__
+* [#119] More convenient ubiquitous access of DOM/aria props.
+* [#120] Transition in/out-specific config, test attributes.
+
 ## 1.17.0
 
 > [Complete `1.17.0` Changeset](https://github.com/Workiva/over_react/compare/1.16.2...1.17.0)
@@ -69,7 +80,7 @@ __Tech Debt__
 __New Features__
 
 * [#88]: Add `validateProps` method to `UiComponent`
-  * Will automatically validate props annotated with `@requiredProp` 
+  * Will automatically validate props annotated with `@requiredProp`
     within `componentWillMount` and `componentWillReceiveProps`
 
 __Tech Debt__

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.17.0
+version: 1.18.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-2742 Improve error message when UiState classes aren't set up properly](https://github.com/Workiva/over_react/pull/117)
* [UIP-2762 More convenient ubiquitous access of DOM/aria props](https://github.com/Workiva/over_react/pull/119)
* [UIP-2751 Transition in/out-specific config, test attributes](https://github.com/Workiva/over_react/pull/120)


Requested by: @jacehensley-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.17.0...Workiva:release_over_react_1_18_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.17.0...1.18.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)