### PR TITLE
do not listen when warning that it cannot listen

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -168,7 +168,10 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
         'in a test environment, try adding an `await window.animationFrame;` before disposing your '
         'store.');
 
-      if (isDisposedOrDisposing) _logger.warning(message);
+      if (isDisposedOrDisposing) {
+        _logger.warning(message);
+        return;
+      }
 
       StreamSubscription subscription = store.listen(handler);
       _subscriptions.add(subscription);


### PR DESCRIPTION
## Ultimate problem:

A check is made to determine whether a store is disposed or disposing, and a warning is provided when a store cannot be listened to, yet despite this warning, an attempt is made to listen anyway.

## How it was fixed:

Do not listen to the store when this warning is provided.

## Testing suggestions:

- Provide a store as a prop to a FluxComponent, and dispose that store before mounting the component.
- When attempting to mount, the warning is provided but no attempt to listen is made.

## Potential areas of regression:



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
