### PR TITLE
WP-5352 UIP-2794 Release over_react 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Changelog
 
+## 1.18.1
+
+> [Complete `1.18.1` Changeset](https://github.com/Workiva/over_react/compare/1.18.0...1.18.1)
+
+__Bug fixes__
+* Fix regression in `prop_mixins.dart` introduced by [#119].
+
 ## 1.18.0
 
 > [Complete `1.18.0` Changeset](https://github.com/Workiva/over_react/compare/1.17.0...1.18.0)

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -15,9 +15,10 @@
 /// Various prop related mixins to be used with [UiComponent] descendants.
 library over_react.prop_mixins;
 
+import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps;
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_import
-import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps;
+import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps;
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/annotations.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.18.0
+version: 1.18.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
## Ultimate problem:
Imported members used by generated code were removed, which for some reason only affected the DDC.

## How it was fixed:
Re-add the imports.

## Testing suggestions:
Verify tests pass in DDC:
```bash
ddev test -p chrome --web-compiler=dartdevc -- \
    test/over_react_component_test.dart test/over_react_component_declaration_test.dart test/over_react_util_test.dart \
    -x no-ddc
```

## Potential areas of regression:
None


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
