### PR TITLE
UIP-2835 Bump to react-dart 4.x

### DIFF
--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -314,7 +314,8 @@ react.Component getDartComponent(/* [1] */ instance) {
     return true;
   });
 
-  return _getInternal(instance)?.component;
+  // ignore: avoid_as
+  return (instance as ReactComponent).dartComponent;
 }
 
 /// A function that, when supplied as [ReactPropsMixin.ref], is called with the component instance
@@ -408,6 +409,7 @@ dynamic get $r {
   var component = _get$R();
 
   return isDartComponent(component)
-      ? component.props.internal.component
+      // ignore: avoid_as
+      ? (component as ReactComponent).dartComponent
       : component;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,8 +40,5 @@ transformers:
 
 
 dependency_overrides:
-  react:
-    git:
-      url: git@github.com:greglittlefield-wf/react-dart.git
-      ref: f1a562e864d07f9f47c39e2ceec7b162f13c2b2b # from internal_instance_refactor - Wed Aug 23 09:04:26 2017 -0700
+  react: ^4.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,3 +37,11 @@ transformers:
       $include: test/**_test{.*,}.dart
   # Reminder: dart2js should come after any other transformers that touch Dart code
   - $dart2js
+
+
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:greglittlefield-wf/react-dart.git
+      ref: f1a562e864d07f9f47c39e2ceec7b162f13c2b2b # from internal_instance_refactor - Wed Aug 23 09:04:26 2017 -0700
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ">=0.11.3+1 <1.0.0"
   meta: "^1.0.4"
   path: "^1.4.1"
-  react: "^3.4.3"
+  react: "^4.1.0"
   source_span: "^1.4.0"
   transformer_utils: "^0.1.1"
   w_common: "^1.8.0"
@@ -37,8 +37,3 @@ transformers:
       $include: test/**_test{.*,}.dart
   # Reminder: dart2js should come after any other transformers that touch Dart code
   - $dart2js
-
-
-dependency_overrides:
-  react: ^4.0.0
-


### PR DESCRIPTION
## Problem
react-dart 4.0.0 includes improvements to Dart component instance management that help avoid certain memory leaks. See more info here: https://github.com/cleandart/react-dart/pull/127.

While this release contains breaking changes, those breakages are limited to internals that should be smoothed over by over_react, and should not affect the majority of consumers.

## Solution
Bump react-dart dependency to 4.1.0.

## Test Overview (+10 Instructions)
- Verify that all tests pass in all modes (Dart VM, dart2js, DDC)
- Regression test in low-level Workiva UI repos

## Semantic Versioning
**Patch**
- [x] This change does not affect the public API

## Areas of Regression
React component rendering/testing

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
