### PR TITLE
UIP-2889 Use dependency_validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - sleep 3 # give xvfb some time to start
 script:
   - pub run dart_dev analyze
+  - pub run dependency_validator -i coverage
   - pub run dart_dev test --integration
   - ./tool/generate_coverage.sh
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,25 +8,25 @@ environment:
   sdk: ">=1.23.0"
 dependencies:
   analyzer: ">=0.30.0 <0.31.0"
-  barback: "^0.15.0"
-  js: "^0.6.0"
+  barback: ^0.15.0
+  js: ^0.6.0
   logging: ">=0.11.3+1 <1.0.0"
-  meta: "^1.0.4"
-  path: "^1.4.1"
-  react: "^3.4.3"
-  source_span: "^1.4.0"
-  transformer_utils: "^0.1.1"
-  w_common: "^1.8.0"
-  w_flux: "^2.7.1"
-  platform_detect: "^1.3.2"
+  meta: ^1.0.4
+  path: ^1.4.1
+  react: ^3.4.3
+  source_span: ^1.4.0
+  transformer_utils: ^0.1.1
+  w_common: ^1.8.0
+  w_flux: ^2.7.1
+  platform_detect: ^1.3.2
   quiver: ">=0.21.4 <0.26.0"
 dev_dependencies:
-  matcher: ">=0.11.0 <0.13.0"
-  coverage: "^0.7.2"
-  dart_dev: "^1.7.6"
-  mockito: "^0.11.0"
-  over_react_test: "^1.2.0"
-  test: "^0.12.24"
+  coverage: ^0.7.2
+  dart_dev: ^1.7.6
+  dependency_validator: ^1.0.0
+  mockito: ^0.11.0
+  over_react_test: ^1.2.0
+  test: ^0.12.24
 
 transformers:
   - over_react:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Team <uip@workiva.com>
 environment:
-  sdk: ">=1.23.0"
+  sdk: ">=1.24.2"
 dependencies:
   analyzer: ">=0.30.0 <0.31.0"
   barback: ^0.15.0

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,8 @@
 project: dart
 language: dart
 
-# dart 1.23.0
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:153818
+# Dart 1.24.2 image from https://github.com/Workiva/smithy-runner-generator
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735
 
 script:
   - pub get


### PR DESCRIPTION
## Ultimate problem:
Now that `dependency_validator` is published we should use it.

## How it was fixed:
- Add `dependency_validator` as a dev dep and runs its check during CI.

## Testing suggestions:
- Verify CI still passes

## Potential areas of regression:
N/A

---
FYA: @Workiva/ui-platform-pp @Workiva/web-platform-pp 