### PR TITLE
UIP-2806: Release over_react 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 __New Features__
 * [#118] Add `BuiltReduxUiComponent` and `BuiltReduxUiProps`.
 
+__Tech Debt__
+* [#126]: Use dependency_validator.
+
 ## 1.18.1
 
 > [Complete `1.18.1` Changeset](https://github.com/Workiva/over_react/compare/1.18.0...1.18.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 > [Complete `1.19.0` Changeset](https://github.com/Workiva/over_react/compare/1.18.1...1.19.0)
 
+__Dependency Updates__
+
+* [#126]: Update minimum Dart SDK version to `1.24.2`.
+
 __New Features__
 * [#118] Add `BuiltReduxUiComponent` and `BuiltReduxUiProps`.
+  - These classes are considered unstable and can be imported via `import "package:over_react/experimental.dart";`
 
 __Tech Debt__
 * [#126]: Use dependency_validator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Changelog
 
+## 1.19.0
+
+> [Complete `1.19.0` Changeset](https://github.com/Workiva/over_react/compare/1.18.1...1.19.0)
+
+__New Features__
+* [#118] Add `BuiltReduxUiComponent` and `BuiltReduxUiProps`.
+
 ## 1.18.1
 
 > [Complete `1.18.1` Changeset](https://github.com/Workiva/over_react/compare/1.18.0...1.18.1)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.18.1
+version: 1.19.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Pulls Included in Release:
* [Add BuiltReduxUiComponent](https://github.com/Workiva/over_react/pull/118)
* [UIP-2889 Use dependency_validator](https://github.com/Workiva/over_react/pull/126)

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.18.1...jacehensley-wf:release_1_19_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.18.1...1.19.0