### PR TITLE
UIP-3039 Get rid of dart2js compiler warnings

### DIFF
--- a/integrate/lib/test_component_declaration.dart
+++ b/integrate/lib/test_component_declaration.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library test_component_declaration;
+library over_react.integrate.test_component_declaration;
 
 import 'package:over_react/over_react.dart';
 

--- a/integrate/test/test_runtime_import.dart
+++ b/integrate/test/test_runtime_import.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 @TestOn('content-shell || dartium')
-library test;
+library over_react.integrate.test_runtime_import;
 
 import 'package:react/react_client.dart' show setClientConfiguration;
 import 'package:react/react_test_utils.dart' as react_test_utils;

--- a/integrate/tool/dev.dart
+++ b/integrate/tool/dev.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library tool.dev;
+library over_react.integrate.tool.dev;
 
 import 'package:dart_dev/dart_dev.dart' show dev, config;
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library abstract_transition;
+library over_react.abstract_transition;
 
 import 'dart:async';
 import 'dart:html';

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library abstract_transition_props;
+library over_react.abstract_transition_props;
 
 import 'dart:collection';
 

--- a/lib/src/component/dom_components.dart
+++ b/lib/src/component/dom_components.dart
@@ -52,6 +52,9 @@ class DomProps extends component_base.UiProps
 
   @override
   String get propKeyNamespace => '';
+
+  @override
+  ReactElement call([children, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]);
 }
 
 // Include pieces from transformer_helpers so that consumers can type these instances
@@ -70,6 +73,9 @@ class SvgProps extends component_base.UiProps
 
   @override
   String get propKeyNamespace => '';
+
+  @override
+  ReactElement call([children, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]);
 }
 
 /// A class that provides namespacing for static DOM component factory methods, much like `React.DOM` in React JS.

--- a/lib/src/component/dummy_component.dart
+++ b/lib/src/component/dummy_component.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library dummy_component;
+library over_react.dummy_component;
 
 import 'package:react/react.dart' as react;
 

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -14,7 +14,7 @@
 
 /// Thanks!
 /// https://github.com/marcj/css-element-queries/blob/master/src/ResizeSensor.js
-library resize_sensor;
+library over_react.resize_sensor;
 
 import 'dart:collection';
 import 'dart:html';

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library dom_util;
+library over_react.dom_util;
 
 import 'dart:html';
 

--- a/lib/src/util/guid_util.dart
+++ b/lib/src/util/guid_util.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library guid_util;
+library over_react.guid_util;
 
 import 'dart:math' show Random;
 

--- a/lib/src/util/key_constants.dart
+++ b/lib/src/util/key_constants.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library key_constants;
+library over_react.key_constants;
 
 import 'package:over_react/over_react.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,4 +42,14 @@ transformers:
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
   # Reminder: dart2js should come after any other transformers that touch Dart code
-  - $dart2js
+  - $dart2js:
+      csp: true
+      sourceMaps: true
+      minify: true
+      suppressHints: false
+      commandLineOptions:
+        - --verbose
+        - --dump-info
+        - --use-new-source-info
+        - --show-package-warnings
+        - --enable-experimental-mirrors


### PR DESCRIPTION
## Ultimate problem:
A few pieces of our code was causing noisy dart2js compiler output for our consumers.

## How it was fixed:
Address those items.

## Testing suggestions:
Passing CI build

## Potential areas of regression:
None expected.


---

> __FYA:__ @Workiva/app-frameworks 
