### PR TITLE
UIP-3041 Add a null check when canceling the store stream subscription

### DIFF
--- a/lib/src/experimental/built_redux_component.dart
+++ b/lib/src/experimental/built_redux_component.dart
@@ -163,7 +163,7 @@ abstract class BuiltReduxUiComponent<
   }
 
   void _tearDownSub() {
-    _storeSub.cancel();
+    _storeSub?.cancel();
     _storeSub = null;
   }
 }


### PR DESCRIPTION
## Ultimate problem:
I ran into an issue when implementing a `shouldComponentUpdate` method in a class that extends `BuiltReduxUiComponent`.

## How it was fixed:
- Null check `_storeSubs`

## Testing suggestions:
- CI still passes

## Potential areas of regression:
N/A

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf