### PR TITLE
WP-5859 UIP-2998 Release over_react 1.20.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.20.1
+version: 1.20.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [UIP-3039 Get rid of dart2js compiler warnings](https://github.com/Workiva/over_react/pull/137)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.20.1...Workiva:release_over_react_1_20_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.20.1...1.20.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)