### PR TITLE
Add an option to make BuiltReduxUiComponent "pure"

### DIFF
--- a/lib/src/experimental/built_redux_component.dart
+++ b/lib/src/experimental/built_redux_component.dart
@@ -61,6 +61,7 @@ abstract class BuiltReduxUiComponent<
   @override
   void componentWillMount() {
     super.componentWillMount();
+    _isDirty = false;
     _setUpSub();
   }
 
@@ -68,14 +69,20 @@ abstract class BuiltReduxUiComponent<
   @override
   void componentWillReceiveProps(Map nextProps) {
     super.componentWillReceiveProps(nextProps);
-    _tearDownSub();
+    var tNextProps = typedPropsFactory(nextProps);
+
+    if (tNextProps.store != props.store) {
+      _tearDownSub();
+      _setUpSub(nextProps);
+    }
   }
 
   @mustCallSuper
   @override
-  void componentWillUpdate(Map nextProps, Map nextState) {
-    // _storeSub will only be null when props get updated, not on every re-render.
-    if (_storeSub == null) _setUpSub(nextProps);
+  bool shouldComponentUpdate(Map nextProps, Map nextState) {
+    if (isPure) return _isDirty || typedPropsFactory(nextProps).store != props.store;
+
+    return true;
   }
 
   @mustCallSuper
@@ -84,6 +91,19 @@ abstract class BuiltReduxUiComponent<
     super.componentWillUnmount();
     _tearDownSub();
   }
+
+  @override
+  void redraw([callback()]) {
+    _isDirty = true;
+
+    super.redraw(() {
+      _isDirty = false;
+
+      if (callback != null) callback();
+    });
+  }
+
+  bool _isDirty;
 
   Substate _connectedState;
 
@@ -144,6 +164,13 @@ abstract class BuiltReduxUiComponent<
   ///
   /// Related: [connectedState]
   Substate connect(V state);
+
+  /// Whether the component should be a "pure" component.
+  ///
+  /// A "pure" component will only re-render when [connectedState] is updated or [redraw] is called directly.
+  ///
+  /// Related: [shouldComponentUpdate]
+  bool get isPure => false;
 
   StreamSubscription _storeSub;
 

--- a/test/over_react/experimental/redux_component_test.dart
+++ b/test/over_react/experimental/redux_component_test.dart
@@ -14,6 +14,7 @@ import 'redux_component_test/test_reducer.dart';
 
 part 'redux_component_test/default.dart';
 part 'redux_component_test/connect.dart';
+part 'redux_component_test/pure.dart';
 
 void main() {
   ReducerBuilder<BaseState, BaseStateBuilder> baseReducerBuilder;
@@ -93,6 +94,31 @@ void main() {
       stores.actions.trigger2();
       await new Future.delayed(Duration.ZERO);
       expect(component.numberOfRedraws, 1);
+    });
+
+    test('properly redraws when isPure is true', () async {
+      var store = new Store<BaseState, BaseStateBuilder, BaseActions>(
+        baseReducerBuilder.build(),
+        baseState,
+        baseActions,
+      );
+      var jacket = mount<TestDefaultComponent>((TestDefault()..store = store)());
+      TestDefaultComponent component = jacket.getDartInstance();
+
+      store.actions.trigger1();
+      await new Future.delayed(Duration.ZERO);
+      expect(component.numberOfRedraws, 1);
+
+      jacket.rerender((TestDefault()
+        ..store = store
+        ..id = 'new id'
+      )());
+
+      expect(component.numberOfRedraws, 1);
+
+      component.redraw();
+
+      expect(component.numberOfRedraws, 2);
     });
 
     test('updates subscriptions when new props are passed', () async {

--- a/test/over_react/experimental/redux_component_test/pure.dart
+++ b/test/over_react/experimental/redux_component_test/pure.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: deprecated_member_use
+
+part of over_react.component_declaration.redux_component_test;
+
+@Factory()
+UiFactory<TestPureProps> TestPure;
+
+@Props()
+class TestPureProps extends BuiltReduxUiProps<BaseState, BaseStateBuilder, BaseActions> {}
+
+@Component()
+class TestPureComponent extends BuiltReduxUiComponent<BaseState, BaseStateBuilder, BaseActions, TestPureProps, BaseState> {
+  int numberOfRedraws = 0;
+
+  @override
+  bool get isPure => true;
+
+  @override
+  BaseState connect(BaseState state) => state;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}


### PR DESCRIPTION
## Ultimate problem:
Implementing a "pure" component by extending `BuiltReduxUiComponent` proved to not be possible without making certain methods public and overridable.

## How it was fixed:
- Add an `isPure` getter that, when returns `true`, makes the component implement `shouldComponentUpdate` and only redraw when `connectedState` is changed.

## Testing suggestions:
- Verify tests pass

## Potential areas of regression:
- None expected, all new logic is behind the new getter

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf 