### PR TITLE
UIP-3043 Release over_react 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # OverReact Changelog
 
+## 1.21.0
+
+> [Complete `1.21.0` Changeset](https://github.com/Workiva/over_react/compare/1.20.2...1.21.0)
+
+__New Features__
+* [#140]: Add an option to make `BuiltReduxUiComponent` "pure"
+
+## 1.20.2
+
+> [Complete `1.20.2` Changeset](https://github.com/Workiva/over_react/compare/1.20.1...1.20.2)
+
+__Tech Debt__
+* [#137]: Get rid of dart2js compiler warnings
+
 ## 1.20.1
 
 > [Complete `1.20.1` Changeset](https://github.com/Workiva/over_react/compare/1.20.0...1.20.1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: ^1.20.1
+      over_react: ^1.21.0
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.20.2
+version: 1.21.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pulls Included in Release:
* [Add an option to make BuiltReduxUiComponent "pure"](https://github.com/Workiva/over_react/pull/140)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.20.2...Workiva:release_over_react_1_21_0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.20.2...1.21.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)