### PR TITLE
UIP-3062 Do not execute prop validation logic in dart2js code

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -27,7 +27,7 @@ export 'package:react/react.dart' show
     SyntheticUIEvent,
     SyntheticWheelEvent;
 
-export 'package:react/react_client.dart' show setClientConfiguration, ReactElement, inReactDevMode;
+export 'package:react/react_client.dart' show setClientConfiguration, ReactElement;
 
 export 'src/component/abstract_transition.dart';
 export 'src/component/abstract_transition_props.dart';

--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -27,7 +27,7 @@ export 'package:react/react.dart' show
     SyntheticUIEvent,
     SyntheticWheelEvent;
 
-export 'package:react/react_client.dart' show setClientConfiguration, ReactElement;
+export 'package:react/react_client.dart' show setClientConfiguration, ReactElement, inReactDevMode;
 
 export 'src/component/abstract_transition.dart';
 export 'src/component/abstract_transition_props.dart';

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -197,17 +197,15 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
 
   /// Validates that props with the `@requiredProp` annotation are present.
   void validateRequiredProps(Map appliedProps) {
-    if (inReactDevMode) {
-      consumedProps?.forEach((ConsumedProps consumedProps) {
-        consumedProps.props.forEach((PropDescriptor prop) {
-          if (!prop.isRequired) return;
-          if (prop.isNullable && appliedProps.containsKey(prop.key)) return;
-          if (!prop.isNullable && appliedProps[prop.key] != null) return;
+    consumedProps?.forEach((ConsumedProps consumedProps) {
+      consumedProps.props.forEach((PropDescriptor prop) {
+        if (!prop.isRequired) return;
+        if (prop.isNullable && appliedProps.containsKey(prop.key)) return;
+        if (!prop.isNullable && appliedProps[prop.key] != null) return;
 
-          throw new PropError.required(prop.key, prop.errorMessage);
-        });
+        throw new PropError.required(prop.key, prop.errorMessage);
       });
-    }
+    });
   }
 
   /// Returns a new ClassNameBuilder with className and blacklist values added from [CssClassPropsMixin.className] and

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -195,16 +195,19 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     validateRequiredProps(appliedProps);
   }
 
+  /// Validates that props with the `@requiredProp` annotation are present.
   void validateRequiredProps(Map appliedProps) {
-    consumedProps?.forEach((ConsumedProps consumedProps) {
-      consumedProps.props.forEach((PropDescriptor prop) {
-        if (!prop.isRequired) return;
-        if (prop.isNullable && appliedProps.containsKey(prop.key)) return;
-        if (!prop.isNullable && appliedProps[prop.key] != null) return;
+    if (inReactDevMode) {
+      consumedProps?.forEach((ConsumedProps consumedProps) {
+        consumedProps.props.forEach((PropDescriptor prop) {
+          if (!prop.isRequired) return;
+          if (prop.isNullable && appliedProps.containsKey(prop.key)) return;
+          if (!prop.isNullable && appliedProps[prop.key] != null) return;
 
-        throw new PropError.required(prop.key, prop.errorMessage);
+          throw new PropError.required(prop.key, prop.errorMessage);
+        });
       });
-    });
+    }
   }
 
   /// Returns a new ClassNameBuilder with className and blacklist values added from [CssClassPropsMixin.className] and
@@ -220,13 +223,17 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
   @override
   @mustCallSuper
   void componentWillReceiveProps(Map nextProps) {
-    validateProps(nextProps);
+    if (inReactDevMode) {
+      validateProps(nextProps);
+    }
   }
 
   @override
   @mustCallSuper
   void componentWillMount() {
-    validateProps(props);
+    if (inReactDevMode) {
+      validateProps(props);
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,3 +53,11 @@ transformers:
         - --use-new-source-info
         - --show-package-warnings
         - --enable-experimental-mirrors
+
+
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:aaronlademann-wf/react-dart.git
+      ref: 15df78bde30745503e2f82e6ff4ed9c99da13193 # from dev-mode-flag/3.x
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ">=0.11.3+1 <1.0.0"
   meta: ^1.0.4
   path: ^1.4.1
-  react: ^3.4.3
+  react: ^3.7.0
   source_span: ^1.4.0
   transformer_utils: ^0.1.1
   w_common: ^1.8.0
@@ -53,11 +53,3 @@ transformers:
         - --use-new-source-info
         - --show-package-warnings
         - --enable-experimental-mirrors
-
-
-dependency_overrides:
-  react:
-    git:
-      url: git@github.com:aaronlademann-wf/react-dart.git
-      ref: 15df78bde30745503e2f82e6ff4ed9c99da13193 # from dev-mode-flag/3.x
-


### PR DESCRIPTION
## Ultimate problem:
The `validateProps` method is currently called in `componentWillMount` and `componentWillReceiveProps` - even in production (dart2js) code.

This means that our internal `validateRequiredProps` is always called when a component mounts / updates - and any consumer validations are also always called if/when they override `validateProps`.

There is a not-insignificant performance cost to this, and there is no reason for prop validation to be happening in a dart2js scenario.  

## How it was fixed:
1. Wrap both calls to `validateProps` in an `assert` to improve performance in dart2js builds.
2. Update tests.

## Testing suggestions:
1. Pull this branch locally
2. Run `pub get` and `ddev test -p chrome`
3. Verify that all tests pass in chrome. 
    * _(NOTE: focusing the chrome window running the tests greatly speeds up test execution)_.

## Potential areas of regression:
Tests?


---

> __FYA:__ @Workiva/ui-platform-pp @sebastianmalysa-wf @evanweible-wf @corwinsheahan-wf 
