### PR TITLE
UIP-3156 Widen built_value version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=0.30.0 <0.31.0"
   barback: ^0.15.0
   built_redux: ">=6.1.0 < 8.0.0"
-  built_value: ^4.2.0
+  built_value: ">=4.2.0 <6.0.0"
   js: ^0.6.0
   logging: ">=0.11.3+1 <1.0.0"
   meta: ^1.0.4
@@ -24,8 +24,8 @@ dependencies:
   platform_detect: ^1.3.2
   quiver: ">=0.21.4 <0.26.0"
 dev_dependencies:
-  build_runner: ^0.5.0
-  built_value_generator: ^4.2.0
+  build_runner: ^0.6.0
+  built_value_generator: ^5.1.3
   coverage: ^0.7.2
   dart_dev: ^1.7.6
   dependency_validator: ^1.0.0


### PR DESCRIPTION
## Ultimate problem:
We need to widen the `built_value` version constraint.

## How it was fixed:
- Allow 4.x.x and 5.x.x of `built_value`
- Bump `build_runner` and `built_value_generator`

## Testing suggestions:
- Verify CI passes.
- Verify that `built_value` 5.x.x is pulled in
- Verify that `built_collection` 3.x.x is pulled in

## Potential areas of regression:
- Built stuff

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
