### PR TITLE
AF-36 Use react-dart 4.x

### DIFF
--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -62,7 +62,7 @@ dynamic getInstanceKey(ReactElement instance) => instance.key;
 dynamic getInstanceRef(ReactElement instance) => instance.ref;
 
 /// Returns whether an [instance] is a native Dart component (react-dart [ReactElement] or [ReactComponent]).
-bool isDartComponent(/* [1] */ instance) {
+bool isDartComponent(/* ReactElement|ReactComponent */ instance) {
   // Don't try to access internal on a DOM component
   if (instance is Element) {
     return false;
@@ -273,9 +273,10 @@ ReactElement cloneElement(ReactElement element, [Map props, Iterable children]) 
   }
 }
 
-/// Returns the native Dart [ReactDartComponentInternal.component] associated with a [ReactComponent]
-/// [instance], or `null` if the component is not Dart-based _(an [Element] or a JS composite component)_.
-react.Component getDartComponent(/* [1] */ instance) {
+/// Returns the native Dart [ReactComponent.dartComponent] if [instance] is a [ReactComponent].
+///
+/// Returns `null` if the [instance] is not Dart-based _(an [Element] or a JS composite component)_.
+react.Component getDartComponent(/* ReactElement|ReactComponent */ instance) {
   if (instance is Element) {
     return null;
   }
@@ -289,12 +290,12 @@ react.Component getDartComponent(/* [1] */ instance) {
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
           * WARNING: `getDartComponent`                                                                                                       
           *                                                                                            
-          * react-dart 4.0 will no longer support retrieving Dart components from                                                                                           
+          * react-dart 4.0 no longer supports retrieving Dart components from                                                                                           
           * `ReactElement` (pre-mounted VDOM instances) in order to prevent memory leaks.                                                                                            
           *                                                                                            
-          * In react-dart 4.0, this call to `getDartComponent` will return `null`.                                                                                           
+          * This call to `getDartComponent` will return `null`.                                                                                           
           *                                                                                            
-          * Please switch over to using the mounted JS component instance.                                                                                           
+          * Start using the mounted JS component instance instead:                                                                                           
           *                                                                                            
           * Example:                                                                                           
           *     // Before                                                                                           
@@ -314,7 +315,8 @@ react.Component getDartComponent(/* [1] */ instance) {
     return true;
   });
 
-  return _getInternal(instance)?.component;
+  // ignore: avoid_as
+  return (instance as ReactComponent).dartComponent;
 }
 
 /// A function that, when supplied as [ReactPropsMixin.ref], is called with the component instance
@@ -400,7 +402,7 @@ final Function _get$R = () {
 /// Returns a reference to the currently selected component in the
 /// [React Dev Tools](https://github.com/facebook/react-devtools).
 ///
-/// Returns the associated [react.Component] for Dart components or the [ReactComponent]
+/// Returns the associated [ReactComponent.dartComponent] for Dart components or the [ReactComponent]
 /// for JS components.
 ///
 /// To use in Dartium, over_react must be imported in the current context.
@@ -408,6 +410,7 @@ dynamic get $r {
   var component = _get$R();
 
   return isDartComponent(component)
-      ? component.props.internal.component
+      // ignore: avoid_as
+      ? (component as ReactComponent).dartComponent
       : component;
 }

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -62,7 +62,7 @@ dynamic getInstanceKey(ReactElement instance) => instance.key;
 dynamic getInstanceRef(ReactElement instance) => instance.ref;
 
 /// Returns whether an [instance] is a native Dart component (react-dart [ReactElement] or [ReactComponent]).
-bool isDartComponent(/* ReactElement|ReactComponent */ instance) {
+bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   // Don't try to access internal on a DOM component
   if (instance is Element) {
     return false;
@@ -273,10 +273,10 @@ ReactElement cloneElement(ReactElement element, [Map props, Iterable children]) 
   }
 }
 
-/// Returns the native Dart [ReactComponent.dartComponent] if [instance] is a [ReactComponent].
+/// Returns the native Dart component associated with a mounted component [instance].
 ///
 /// Returns `null` if the [instance] is not Dart-based _(an [Element] or a JS composite component)_.
-react.Component getDartComponent(/* ReactElement|ReactComponent */ instance) {
+react.Component getDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   if (instance is Element) {
     return null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ">=0.11.3+1 <1.0.0"
   meta: ^1.0.4
   path: ^1.4.1
-  react: ^3.7.0
+  react: ^4.3.0
   source_span: ^1.4.0
   transformer_utils: ^0.1.1
   w_common: ^1.8.0

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -440,8 +440,13 @@ main() {
         expect(getDartComponent(renderedInstance), isNull);
       });
 
+      test('returns null for a ReactElement', () {
+        ReactElement instance = Wrapper()();
+        expect(getDartComponent(instance), isNull);
+      });
+
       group('', () {
-        final messageMatcher = contains('react-dart 4.0 will no longer support retrieving Dart components from');
+        final messageMatcher = contains('react-dart 4.0 no longer supports retrieving Dart components');
 
         test('warns when passed a ReactElement', () {
           ReactElement instance = Wrapper()();


### PR DESCRIPTION
## Ultimate problem:
The `react` 4.x line-of-release includes improvements to Dart component instance management that help avoid certain memory leaks. See more info here: https://github.com/cleandart/react-dart/pull/127.

While the `react 4.0.0` release contains "breaking" changes, those breakages are limited to internals that should be smoothed over by over_react, and should not affect the majority of consumers.

## How it was fixed:
Bump react-dart dependency to `^4.3.0`.

## Testing suggestions:

* Verify that all tests pass in all modes (Dart VM, dart2js, DDC)
* Regression test in low-level Workiva UI repos

## Consumer Test Results:

| Repo   | Smithy  | Shipyard  | Skynet: Smithy  | Skynet: Shipyard/Push  |
|---|---|---|---|---|
| [w_router](https://github.com/Workiva/w_router/pull/86)  | ✅ | n/a  | n/a  | n/a  |
| [wdesk_sdk](https://github.com/Workiva/wdesk_sdk/pull/2421)  | ✅ | n/a  | ✅  | ✅  |
| [truss](https://github.com/Workiva/truss/pull/1001)  | ✅ | n/a  | ✅  | ✅  |
| [graph_ui](https://github.com/Workiva/graph_ui/pull/222)  | ✅ | n/a  | n/a  | n/a  |
| [web_skin_dart](https://github.com/Workiva/web_skin_dart/pull/960)  | ✅ | n/a  | ❌ Unrelated Failure  | ❌Unrelated Failure  |
| [w_link_properties_ui](https://github.com/Workiva/w_link_properties_ui/pull/136)  | ✅ | n/a  | n/a  | n/a  |
| [w_table](https://github.com/Workiva/w_table/pull/2527)  | ✅ | n/a  | n/a  | n/a  |
| [text_doc_client](https://github.com/Workiva/text_doc_client/pull/2390)  | ✅ | ✅  | ✅  | ✅  |
| [datatables](https://github.com/Workiva/datatables/pull/4108)  | ✅ | ✅  | ✅  | ✅  |


---

> __FYA:__ @Workiva/app-frameworks 
