### PR TITLE
AF-188 Release over_react 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # OverReact Changelog
 
+## 1.24.0
+
+> [Complete `1.24.0` Changeset](https://github.com/Workiva/over_react/compare/1.23.1...1.24.0)
+
+__Dependency Updates__
+
+* [#153] react `^4.3.0` (was `^3.7.0`)
+* [#151] 
+    * built_redux `^7.4.1` (was `>=6.1.0 <8.0.0`)
+    * built_value `>=4.2.0 <5.2.0` (was `>=4.2.0 <6.0.0`)
+    
+__New Features__ 
+
+* [#154]: Expose `react_dom.render`/`react_dom.unmountComponentAtNode` from the react library
+    
+__Tech Debt__
+
+* [#151] Prepare for Dart 2 SDK
+    * Address Dart 2.x SDK lints / warnings that do not constitute breaking changes
+    * Address `DisposableManagerV6` deprecation
+    * `UiProps` and `UiState` now extend from `MapBase`
+    
+
 ## 1.23.1
 
 > [Complete `1.23.1` Changeset](https://github.com/Workiva/over_react/compare/1.23.0...1.23.1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: ^1.22.0
+      over_react: ^1.24.0
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.23.1
+version: 1.24.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
__Dependency Updates__

* #153 react `^4.3.0` (was `^3.7.0`)
* #151 
    * built_redux `^7.4.1` (was `>=6.1.0 <8.0.0`)
    * built_value `>=4.2.0 <5.2.0` (was `>=4.2.0 <6.0.0`)
    
__New Features__ 

* #154: Expose `react_dom.render`/`react_dom.unmountComponentAtNode` from the react library
    * __Warning:__ This will be deprecated in an upcoming release in favor of a different approach to creating a `built_redux` component.
    
__Tech Debt__

* #151 Prepare for Dart 2 SDK
    * Address Dart 2.x SDK lints / warnings that do not constitute breaking changes
    * Address `DisposableManagerV6` deprecation
    * `UiProps` and `UiState` now extend from `MapBase`



---

> __FYA:__ @greglittlefield-wf @clairesarsam-wf @sebastianmalysa-wf @dustinlessard-wf 
