### PR TITLE
AF-1227: Adds merge method and merged constructor to ClassNameBuilder class.

### DIFF
--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -75,6 +75,22 @@ class ClassNameBuilder {
     addFromProps(props);
   }
 
+  /// Creates a new `ClassNameBuilder` with [_classNamesBuffer] and [_blacklistBuffer] merged from [a] and [b]
+  ///   
+  ///     ClassNameBuilder a = new ClassNameBuilder()
+  ///      ..add('a');
+  /// 
+  ///     ClassNameBuilder b = new ClassNameBuilder()
+  ///       ..add('b');
+  ///     
+  ///     ClassNameBuilder builder = new ClassNameBuilder.merged(a,b);
+  /// 
+  ///     print(builder.toClassName()); // 'a b'
+  ClassNameBuilder.merged(ClassNameBuilder a, ClassNameBuilder b) {
+    merge(a);
+    merge(b);
+  }
+
   /// Adds the [CssClassPropsMixin.className] and excludes the [CssClassPropsMixin.classNameBlacklist] values
   /// if specified within the provided [props] Map.
   ///

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -150,6 +150,32 @@ class ClassNameBuilder {
     _blacklistBuffer.write(className);
   }
 
+
+
+  /// Merges together the classes and blacklists present in another `ClassNameBuilder` instance.
+  /// 
+  /// Takes [other._blacklistBuffer] and merges it into [_blacklistBuffer]
+  /// and takes [other._classNamesBuffer] and merges it into [_classNamesBuffer].
+  void merge(ClassNameBuilder other) {
+    if (_blacklistBuffer == null) {
+      _blacklistBuffer = new StringBuffer();
+    } else {
+      if (_blacklistBuffer.isNotEmpty) {
+        _blacklistBuffer.write(' ');
+      }
+    }
+    _blacklistBuffer.write(other._blacklistBuffer);
+
+    if (_classNamesBuffer == null) {
+      _classNamesBuffer = new StringBuffer();
+    } else {
+      if (_classNamesBuffer.isNotEmpty) {
+        _classNamesBuffer.write(' ');
+      }
+    }
+    _classNamesBuffer.write(other._classNamesBuffer);
+  }
+
   /// Returns a String representation of the built className, which includes any added classes,
   /// and none of the blacklisted classes.
   ///

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -75,10 +75,10 @@ class ClassNameBuilder {
     addFromProps(props);
   }
 
-  /// Creates a new `ClassNameBuilder` with [_classNamesBuffer] and [_blacklistBuffer] merged from [a] and [b]
+  /// Creates a new `ClassNameBuilder` with [_classNamesBuffer] and [_blacklistBuffer] merged from [a] and [b].
   ///   
   ///     ClassNameBuilder a = new ClassNameBuilder()
-  ///      ..add('a');
+  ///       ..add('a');
   /// 
   ///     ClassNameBuilder b = new ClassNameBuilder()
   ///       ..add('b');
@@ -168,10 +168,7 @@ class ClassNameBuilder {
 
 
 
-  /// Merges together the classes and blacklists present in another `ClassNameBuilder` instance.
-  /// 
-  /// Takes [other._blacklistBuffer] and merges it into [_blacklistBuffer]
-  /// and takes [other._classNamesBuffer] and merges it into [_classNamesBuffer].
+  /// Merges the classes and blacklists from [other] into this builder.
   void merge(ClassNameBuilder other) {
     if (_blacklistBuffer == null) {
       _blacklistBuffer = new StringBuffer();
@@ -182,12 +179,8 @@ class ClassNameBuilder {
     }
     _blacklistBuffer.write(other._blacklistBuffer);
 
-    if (_classNamesBuffer == null) {
-      _classNamesBuffer = new StringBuffer();
-    } else {
-      if (_classNamesBuffer.isNotEmpty) {
-        _classNamesBuffer.write(' ');
-      }
+    if (_classNamesBuffer.isNotEmpty) {
+      _classNamesBuffer.write(' ');
     }
     _classNamesBuffer.write(other._classNamesBuffer);
   }

--- a/test/over_react/util/class_names_test.dart
+++ b/test/over_react/util/class_names_test.dart
@@ -239,6 +239,50 @@ main() {
             }));
           });
         });
+
+        group('merge', () {
+          test('returns className merged from second builder instance', (){
+            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+
+            builder
+              ..add('a');
+              
+            otherBuilder
+              ..add('b');
+            
+            builder.merge(otherBuilder);
+
+            expect(builder.toClassName(), equals('a b'));
+          });
+          
+          test('returns blacklist merged from second builder instance', (){
+            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+
+            builder
+              ..blacklist('a-blacklist');
+            
+            otherBuilder
+              ..blacklist('b-blacklist');
+            
+            builder.merge(otherBuilder);
+
+            expect(builder.toClassNameBlacklist(), equals('a-blacklist b-blacklist'));
+          });
+
+          test('returns classname and blacklist merged from second builder instance', (){
+            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+
+            builder
+              ..add('a');
+            
+            otherBuilder
+              ..blacklist('b-blacklist');
+            
+            builder.merge(otherBuilder);
+            expect(builder.toClassName(), equals('a'));
+            expect(builder.toClassNameBlacklist(), equals('b-blacklist'));
+          });
+        }); 
       });
 
       group('created with .fromProps() constructor', () {

--- a/test/over_react/util/class_names_test.dart
+++ b/test/over_react/util/class_names_test.dart
@@ -241,42 +241,31 @@ main() {
         });
 
         group('merge', () {
-          test('returns className merged from second builder instance', (){
-            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+          test('merges the className from the provided builder instance', () {
+            var otherBuilder = new ClassNameBuilder();
 
-            builder
-              ..add('a');
-              
-            otherBuilder
-              ..add('b');
-            
+            builder.add('a');
+            otherBuilder.add('b');
+  
             builder.merge(otherBuilder);
-
             expect(builder.toClassName(), equals('a b'));
           });
 
-          test('returns blacklist merged from second builder instance', (){
-            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+          test('returns blacklist merged from second builder instance', () {
+            var otherBuilder = new ClassNameBuilder();
 
-            builder
-              ..blacklist('a-blacklist');
-            
-            otherBuilder
-              ..blacklist('b-blacklist');
+            builder.blacklist('a-blacklist');
+            otherBuilder.blacklist('b-blacklist');
             
             builder.merge(otherBuilder);
-
             expect(builder.toClassNameBlacklist(), equals('a-blacklist b-blacklist'));
           });
 
-          test('returns classname and blacklist merged from second builder instance', (){
-            ClassNameBuilder otherBuilder = new ClassNameBuilder();
+          test('returns classname and blacklist merged from second builder instance', () {
+            var otherBuilder = new ClassNameBuilder();
 
-            builder
-              ..add('a');
-            
-            otherBuilder
-              ..blacklist('b-blacklist');
+            builder.add('a');
+            otherBuilder.blacklist('b-blacklist');
             
             builder.merge(otherBuilder);
             expect(builder.toClassName(), equals('a'));
@@ -286,15 +275,14 @@ main() {
       });
       
       group('created with .merged() constructor', () {
-        test('',(){
-          ClassNameBuilder a = new ClassNameBuilder()
+        test('', () {
+          var a = new ClassNameBuilder()
             ..add('a')
             ..blacklist('a-blacklist');
-          ClassNameBuilder b = new ClassNameBuilder()
+          var b = new ClassNameBuilder()
             ..add('b')
             ..blacklist('b-blacklist');
-          ClassNameBuilder builder = new ClassNameBuilder.merged(a,b);
-
+          var builder = new ClassNameBuilder.merged(a,b);
           expect(builder.toClassName(), equals('a b'));
           expect(builder.toClassNameBlacklist(), equals('a-blacklist b-blacklist'));
         });

--- a/test/over_react/util/class_names_test.dart
+++ b/test/over_react/util/class_names_test.dart
@@ -254,7 +254,7 @@ main() {
 
             expect(builder.toClassName(), equals('a b'));
           });
-          
+
           test('returns blacklist merged from second builder instance', (){
             ClassNameBuilder otherBuilder = new ClassNameBuilder();
 
@@ -283,6 +283,21 @@ main() {
             expect(builder.toClassNameBlacklist(), equals('b-blacklist'));
           });
         }); 
+      });
+      
+      group('created with .merged() constructor', () {
+        test('',(){
+          ClassNameBuilder a = new ClassNameBuilder()
+            ..add('a')
+            ..blacklist('a-blacklist');
+          ClassNameBuilder b = new ClassNameBuilder()
+            ..add('b')
+            ..blacklist('b-blacklist');
+          ClassNameBuilder builder = new ClassNameBuilder.merged(a,b);
+
+          expect(builder.toClassName(), equals('a b'));
+          expect(builder.toClassNameBlacklist(), equals('a-blacklist b-blacklist'));
+        });
       });
 
       group('created with .fromProps() constructor', () {


### PR DESCRIPTION
AF-1227

## Ultimate problem:
As a consumer, I should be able to easily merge together the classes and blacklists present in two ClassNameBuilders.

## How it was fixed:
Added `merge` method to `ClassNameBuilder` class.
Added `merged` constructor to `ClassNameBuilder` class.

## Testing suggestions:
Run the unit tests they should pass.

## Potential areas of regression:
None.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @clairesarsam-wf
