### PR TITLE
Tweak version ranges to allow pub get in Dart 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ authors:
 environment:
   sdk: ">=1.24.2 <2.0.0"
 dependencies:
-  analyzer: ">=0.30.0 <=0.31.0"
-  barback: ">=0.15.2 <=0.15.2+14"
+  analyzer: ">=0.30.0 <0.33.0"
+  barback: ">=0.15.2 <0.16.0"
   built_redux: ^7.4.1
-  built_value: ">=4.2.0 <5.2.0" # >=5.2.0 is Dart 2 SDK only
+  built_value: ">=4.2.0 <6.0.0"
   js: ^0.6.0
   logging: ">=0.11.3+1 <1.0.0"
   meta: ^1.0.4
@@ -22,7 +22,7 @@ dependencies:
   w_common: ^1.10.0
   w_flux: ^2.7.1
   platform_detect: ^1.3.2
-  quiver: ">=0.21.4 <=0.28.0" # 0.28.0+ is Dart 2 only
+  quiver: ">=0.21.4 <1.0.0"
 dev_dependencies:
   build_runner: ^0.6.0
   built_value_generator: ^5.1.3


### PR DESCRIPTION
## Ultimate problem:
`over_react` specifies some maximum ranges to prevent Dart 2 resolutions.
The sdk 'environment' range should limit this for us.

## How it was fixed:
Expand version ranges on `analyzer`, `built_value`, and `quiver`

## Testing suggestions:
CI passes



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @jacehensley-wf @clairesarsam-wf @joelleibow-wf
