### PR TITLE
AF-1850-transformer-compat: make new factory boiler plate compatible with dart 1 transformers

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -103,10 +103,12 @@ class ImplGenerator {
             span: getSpan(sourceFile, declarations.factory.node.variables));
       }
 
+      /// Factories are stubbed for the generated factories and may only be initialized with the generated factory.
+
       declarations.factory.node.variables.variables.forEach((variable) {
-        if (variable.initializer != null) {
+        if (variable.initializer?.toSource() != '\$$factoryName' && variable.initializer != null) {
           logger.error(
-              'Factory variables are stubs for the generated factories, and should not have initializers.',
+              'Factories are stubbed for the generated factories and may only be initialized with the generated factory.',
               span: getSpan(sourceFile, variable.initializer)
           );
         }
@@ -117,8 +119,13 @@ class ImplGenerator {
               declarations.factory.node.variables.variables.first.name.end,
               declarations.factory.node.semicolon.offset
           ),
-          ' = ([Map backingProps]) => new $propsImplName(backingProps)'
+          ' = \$$factoryName'
       );
+
+      ///_$BasicProps $Basic([Map backingProps]) => new _$BasicProps(backingProps);
+
+      transformedFile.insert(sourceFile.location(declarations.factory.node.semicolon.end),
+          '$propsImplName \$$factoryName([Map backingProps]) => new $propsImplName(backingProps);');
 
       String parentTypeParam = 'null';
       String parentTypeParamComment = '';

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -52,6 +52,7 @@ import 'package:transformer_utils/transformer_utils.dart';
 class WebSkinDartTransformer extends Transformer implements LazyTransformer {
   final BarbackSettings _settings;
   final bool _shouldFixDdcAbstractAccessors;
+  final generatedNameSpace = 'generated';
 
   WebSkinDartTransformer.asPlugin(this._settings) :
       _shouldFixDdcAbstractAccessors = _loadBoolConfig(_settings, 'fixDdcAbstractAccessors');
@@ -70,6 +71,7 @@ class WebSkinDartTransformer extends Transformer implements LazyTransformer {
   @override
   void declareOutputs(DeclaringTransform transform) {
     transform.declareOutput(transform.primaryId);
+    transform.declareOutput(transform.primaryId.changeExtension('.$generatedNameSpace.dart'));
     transform.consumePrimary();
 
     if (_settings.mode == BarbackMode.DEBUG) {
@@ -116,6 +118,11 @@ class WebSkinDartTransformer extends Transformer implements LazyTransformer {
         new ImplGenerator(logger, transformedFile)
             ..shouldFixDdcAbstractAccessors = _shouldFixDdcAbstractAccessors
             ..generate(declarations);
+
+        var partOf = unit.directives.firstWhere((directive) => directive is PartOfDirective, orElse: () => null)?.toSource();
+
+        transform.addOutput(new Asset.fromString(transform.primaryInput.id.changeExtension('.$generatedNameSpace.dart'),
+            partOf ?? 'part of ${p.basename(transform.primaryInput.id.path)}'));
       }
     }
 

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -134,7 +134,7 @@ main() {
         test('without extends/with/implements clause', () {
           preservedLineNumbersTest('''
             @Factory()
-            UiFactory<FooProps> Foo;
+            UiFactory<FooProps> Foo = \$Foo;
 
             @Props()
             class FooProps {}
@@ -589,7 +589,7 @@ main() {
             $restOfComponent
           ''');
 
-          verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers.', span: any));
+          verify(logger.error('Factories are stubbed for the generated factories and may only be initialized with the generated factory.', span: any));
         });
       });
 


### PR DESCRIPTION
Adds the compatibility for the new Dart 2 factory boiler plate. 

```
// ignore: uri_has_not_been_generated
part 'foo.tbd.dart'; 

// ignore: undefined_identifier
@Factory()
UiFactory<FooProps> Foo = $Foo;
```

@Workiva/app-frameworks 
