### PR TITLE
AF-2241 Auto-initialize a rem change sensor in Google Chrome

### DIFF
--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -20,6 +20,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:over_react/src/util/css_value_util.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:platform_detect/platform_detect.dart';
@@ -128,9 +129,16 @@ CssValue toRem(dynamic value, {bool treatNumAsRem: false, bool passThroughUnsupp
   // to automatically wire up the rem change sensor so that any calls to `toRem` when the viewport is
   // zoomed return an accurate value.
   //
+  // Only run them when `testMode` is false as a workaround to not break all the individual `toRem` tests
+  // that rely on `onRemChange.first`, and so that the dom node that is mounted via `_initRemChangeSensor`
+  // is not suddenly present in the dom of all consumer tests - which could break their assertions about
+  // a "clean" / empty `document.body`.
+  //
   // See: https://jira.atl.workiva.net/browse/AF-1048 / https://bugs.chromium.org/p/chromium/issues/detail?id=429140
-  if (browser.isChrome) {
-    Zone.ROOT.run(_initRemChangeSensor);
+  if (browser.isChrome && !component_base.UiProps.testMode) {
+    // TODO: Why does Zone.ROOT.run not work in unit tests?  Passing in Zone.current from the call to toRem() within the test also does not work.
+//    Zone.ROOT.run(_initRemChangeSensor);
+    _initRemChangeSensor();
   }
 
   if (value == null) return null;

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -22,6 +22,7 @@ import 'dart:html';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/util/css_value_util.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
+import 'package:platform_detect/platform_detect.dart';
 
 double _computeRootFontSize() {
   return new CssValue.parse(document.documentElement.getComputedStyle().fontSize).number.toDouble();
@@ -108,6 +109,15 @@ void recomputeRootFontSize() {
 ///
 /// > Related: [toPx]
 CssValue toRem(dynamic value, {bool treatNumAsRem: false, bool passThroughUnsupportedUnits: false}) {
+  // Because Chrome changes the value of its root font size when zoomed out lower than 90%, we need
+  // to automatically wire up the rem change sensor so that any calls to `toRem` when the viewport is
+  // zoomed return an accurate value.
+  //
+  // See: https://jira.atl.workiva.net/browse/AF-1048 / https://bugs.chromium.org/p/chromium/issues/detail?id=429140
+  if (browser.isChrome) {
+    Zone.ROOT.run(_initRemChangeSensor);
+  }
+
   if (value == null) return null;
 
   num remValueNum;

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -19,6 +19,7 @@ library over_react.rem_util;
 import 'dart:async';
 import 'dart:html';
 
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:over_react/src/util/css_value_util.dart';
@@ -32,7 +33,13 @@ double _computeRootFontSize() {
 double _rootFontSize = _computeRootFontSize();
 
 var _changeSensor;
+@visibleForTesting
+dynamic get changeSensor => _changeSensor;
+
 Element _changeSensorMountNode;
+@visibleForTesting
+Element get changeSensorMountNode => _changeSensorMountNode;
+
 void _initRemChangeSensor() {
   if (_changeSensor != null) return;
   // Force lazy-initialization of this variable if it hasn't happened already.
@@ -93,7 +100,7 @@ void recomputeRootFontSize() {
 /// A utility that destroys the [_changeSensor] added to the DOM by [_initRemChangeSensor].
 ///
 /// Can be used, for example, to clean up the DOM in the `tearDown` of a unit test.
-void destroyRemChangeSensor() {
+Future<Null> destroyRemChangeSensor() async {
   if (_changeSensor == null) return;
 
   _changeSensor = null;

--- a/test/over_react/util/rem_util_test.dart
+++ b/test/over_react/util/rem_util_test.dart
@@ -14,10 +14,12 @@
 
 library rem_util_test;
 
+import 'dart:async';
 import 'dart:html';
 
 import 'package:over_react/src/util/css_value_util.dart';
 import 'package:over_react/src/util/rem_util.dart';
+import 'package:over_react/src/util/test_mode.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/test_util.dart';
@@ -266,5 +268,47 @@ main() {
 
       expect(rootFontSize, 16);
     });
+
+    group('automatically mounts a "rem change sensor" when `toRem` is called for the first time', () {
+      setUp(() {
+        destroyRemChangeSensor();
+        // Disabling test mode to ensure that the rem change sensor is created.
+        // See workaround comment in `toRem`.
+        disableTestMode();
+      });
+
+      tearDown(() {
+        destroyRemChangeSensor();
+        // Re-enable test mode
+        enableTestMode();
+      });
+
+      group('in Google Chrome', () {
+        setUp(() {
+          expect(querySelector('#rem_change_sensor'), isNull,
+              reason: '#rem_change_sensor element should not get mounted until `toRem` is first called.');
+          expect(document.documentElement.getComputedStyle().fontSize, isNot('20px'),
+              reason: 'The tests in this group will not work if the root font size is already 20px.');
+
+          toRem('1rem');
+        });
+
+        test('', () {
+          expect(querySelector('#rem_change_sensor'), isNotNull, reason: 'test setup sanity check');
+        });
+
+        test('that results in `toRem` returning the expected value when the root document font size changes', () async {
+          setRootFontSize('20px');
+          await new Future.delayed(const Duration(milliseconds: 100));
+          expect(toRem('20px').number, 1);
+        });
+      }, testOn: 'dartium || chrome');
+
+      test('only in Google Chrome', () async {
+        toRem('1rem');
+        await new Future.delayed(const Duration(milliseconds: 100));
+        expect(querySelector('#rem_change_sensor'), isNull, reason: 'test setup sanity check');
+      }, testOn: '!chrome && !dartium');
+    }, testOn: 'browser');
   });
 }

--- a/test/over_react/util/rem_util_test.dart
+++ b/test/over_react/util/rem_util_test.dart
@@ -269,6 +269,32 @@ main() {
       expect(rootFontSize, 16);
     });
 
+    group('destroyRemChangeSensor', () {
+      StreamSubscription<double> listener;
+
+      setUpAll(() async {
+        listener = onRemChange.listen((_) {});
+        expect(changeSensor, isNotNull, reason: 'test setup sanity check');
+        expect(changeSensorMountNode, isNotNull, reason: 'test setup sanity check');
+        expect(document.body.children.single, changeSensorMountNode, reason: 'test setup sanity check');
+
+        await destroyRemChangeSensor();
+      });
+
+      tearDownAll(() async {
+        await listener?.cancel();
+      });
+
+      test('removes the `#rem_change_sensor` element', () {
+        expect(changeSensorMountNode, isNull);
+        expect(document.body.children, isEmpty);
+      });
+
+      test('sets `_changeSensor` to null', () {
+        expect(changeSensor, isNull);
+      });
+    });
+
     group('automatically mounts a "rem change sensor" when `toRem` is called for the first time', () {
       setUp(() {
         destroyRemChangeSensor();


### PR DESCRIPTION
Because Chrome changes the value of its root font size when zoomed out lower than 90%, we need to automatically wire up the rem change sensor when `toRem` is called the first time so that any subsequent calls to `toRem` when the viewport is zoomed return an accurate value.

> See: https://bugs.chromium.org/p/chromium/issues/detail?id=429140

---

> __FYA:__ @greglittlefield-wf
