### PR TITLE
Revert #171

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,10 @@ authors:
 environment:
   sdk: ">=1.24.2 <2.0.0"
 dependencies:
-  analyzer: ">=0.30.0 <0.33.0"
-  barback: ">=0.15.2 <0.16.0"
+  analyzer: ">=0.30.0 <=0.31.0"
+  barback: ">=0.15.2 <=0.15.2+14"
   built_redux: ^7.4.1
-  built_value: ">=4.2.0 <6.0.0"
+  built_value: ">=4.2.0 <5.2.0" # >=5.2.0 is Dart 2 SDK only
   js: ^0.6.0
   logging: ">=0.11.3+1 <1.0.0"
   meta: ^1.0.4
@@ -22,7 +22,7 @@ dependencies:
   w_common: ^1.10.0
   w_flux: ^2.7.1
   platform_detect: ^1.3.2
-  quiver: ">=0.21.4 <1.0.0"
+  quiver: ">=0.21.4 <=0.28.0" # 0.28.0+ is Dart 2 only
 dev_dependencies:
   build_runner: ^0.6.0
   built_value_generator: ^5.1.3


### PR DESCRIPTION
This reverts commit 0a4708ad94ecf8d43413cd7098b1ea33c6fb6150, reversing
changes made to 1827ad83468fe06b3b3207b8726410e51583beb8 / #171 

This revert is happening since it is causing 15+ minute `pub get` run times using the Dart 1.x version solver. These changes will be re-pr'd against the `2.0.0-dev` branch.


---

> __FYA:__ @greglittlefield-wf @maxwellpeterson-wf
