### PR TITLE
AF-2344 Release over_react 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Changelog
 
+## 1.26.1
+
+__Dependency Updates__
+
+* [e8fc86](https://github.com/Workiva/over_react/commit/e8fc86c9748c4cfb8af7bde91b0959827a5a7a63) Loosen lower bound of `built_value`
+    * built_value `>=4.6.1 <5.2.0` (was `>=5.1.3 <5.2.0`)
+
 ## 1.26.0
 
 > [Complete `1.26.0` Changeset](https://github.com/Workiva/over_react/compare/1.25.0...1.26.0)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: ^1.26.0
+      over_react: ^1.26.1
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.26.0
+version: 1.26.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=0.30.0+4 <=0.31.0"
   barback: ">=0.15.2 <=0.15.2+14"
   built_redux: ^7.4.2
-  built_value: ">=5.1.3 <5.2.0" # >=5.2.0 is Dart 2 SDK only
+  built_value: ">=4.6.1 <5.2.0" # >=5.2.0 is Dart 2 SDK only
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6


### PR DESCRIPTION
__Dependency Updates__

The lower bound of `built-value` in [the `1.26.0` release](https://github.com/Workiva/over_react/pull/182) turned out to be too restrictive for some consumers that need to remain on the `4.x` line-of-release for that package.

* [e8fc86](https://github.com/Workiva/over_react/commit/e8fc86c9748c4cfb8af7bde91b0959827a5a7a63) Loosen lower bound of `built_value`
    * built_value `>=4.6.1 <5.2.0` (was `>=5.1.3 <5.2.0`)



---

> __FYA:__ @kealjones-wk 
