### PR TITLE
AF-2361 AF-2360 Release over_react 1.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OverReact Changelog
 
+## 1.26.2
+
+__Bug fixes__
+
+* [5fb73f](https://github.com/Workiva/over_react/commit/5fb73f26f92182ebd5c45c2ad5bb015a662bc3b4) Make rem change sensor container is `overflow:hidden` so it doesn't interfere with the page layout
+
 ## 1.26.1
 
 __Dependency Updates__

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -52,6 +52,7 @@ void _initRemChangeSensor() {
   _changeSensorMountNode.style
     ..width = '0'
     ..height = '0'
+    ..overflow = 'hidden'
     ..position = 'absolute'
     ..zIndex = '-1';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.26.1
+version: 1.26.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Includes:

- [5fb73f](https://github.com/Workiva/over_react/commit/5fb73f26f92182ebd5c45c2ad5bb015a662bc3b4) Make rem change sensor container is `overflow:hidden` so it doesn't interfere with the page layout
    - Testing: verify unit tests for resize sensors still pass.

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
