### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -171,7 +171,7 @@ class ParsedDeclarations {
           }
         }
 
-        if (noneOfAnyRequiredDecl && declarations.length != 0) {
+        if (noneOfAnyRequiredDecl && declarations.isNotEmpty) {
           error(
               'To define a component, a `@$annotationName` must be accompanied by '
               'the following annotations within the same file: '


### PR DESCRIPTION
## Ultimate problem:

Looks like this can be isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)

## How it was fixed:

Uses `isNotEmpty` check.

## Testing suggestions:

CI/tests pass.

## Potential areas of regression:



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
