### PR TITLE
Add ability to override wrapper styles on resize-sensor

### DIFF
--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -176,10 +176,13 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
       wrapperStyles = _wrapperStyles;;
     }
 
+    var mergedStyle = newStyleFromProps(props);
+    mergedStyle = {}..addAll(wrapperStyles)..addAll(mergedStyle);
+
     return (Dom.div()
       ..addProps(copyUnconsumedDomProps())
       ..className = forwardingClassNameBuilder().toClassName()
-      ..style = wrapperStyles
+      ..style = mergedStyle
     )(
       props.children,
       resizeSensor

--- a/test/over_react/component/resize_sensor_test.dart
+++ b/test/over_react/component/resize_sensor_test.dart
@@ -169,6 +169,14 @@ void main() {
           expect(nodeStyleDecl.getPropertyValue('flex'), '1 1 0%');
         }
       });
+
+      test('when overridden by consumer', () {
+        var renderedNode = renderAndGetDom((ResizeSensor()..style = {'width':'auto','height':'auto'})());
+
+        expect(renderedNode.style.position, equals('relative'));
+        expect(renderedNode.style.width, equals('auto'));
+        expect(renderedNode.style.height, equals('auto'));
+      });
     });
 
     // Test that every last ResizeSensor node is hidden with both visibility and opacity,


### PR DESCRIPTION
## Ultimate problem:
ResizeSensor wrapper forces certain inline styles

## How it was fixed:
Added mergedStyles to apply to wrapper styles so that users can override the inline styles.

## Testing suggestions:
1. pull branch
2. run `ddev test test/over_react_component_test.dart`

## Potential areas of regression:
This could cause issues issue to how the resizesensor functions if used incorrectly but allows more consumer control.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @evanweible-wf @maxwellpeterson-wf
