### PR TITLE
AF-1037 AF-1038 AF-2925 Flux components: fix disposal and prop validation, add hooks to support tracing

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -75,9 +75,10 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
 
   @mustCallSuper
   @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillMount();
+  void componentWillMount() {
+    super.componentWillMount();
+    _componentWillMount();
+  }
 
   @mustCallSuper
   @override
@@ -91,9 +92,10 @@ abstract class FluxUiComponent<TProps extends FluxUiProps> extends UiComponent<T
 
   @mustCallSuper
   @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillUnmount();
+  void componentWillUnmount() {
+    super.componentWillUnmount();
+    _componentWillUnmount();
+  }
 }
 
 /// Builds on top of [UiStatefulComponent], adding `w_flux` integration, much like the [FluxComponent] in w_flux.
@@ -114,9 +116,10 @@ abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extend
 
   @mustCallSuper
   @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillMount();
+  void componentWillMount() {
+    super.componentWillMount();
+    _componentWillMount();
+  }
 
   @mustCallSuper
   @override
@@ -130,9 +133,10 @@ abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extend
 
   @mustCallSuper
   @override
-  // Ignore this warning to work around https://github.com/dart-lang/sdk/issues/29860
-  // ignore: must_call_super
-  void componentWillUnmount();
+  void componentWillUnmount() {
+    super.componentWillUnmount();
+    _componentWillUnmount();
+  }
 }
 
 /// Helper mixin to keep [FluxUiComponent] and [FluxUiStatefulComponent] clean/DRY.
@@ -141,8 +145,8 @@ abstract class FluxUiStatefulComponent<TProps extends FluxUiProps, TState extend
 abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements UiComponent<TProps>, BatchedRedraws {
   static final Logger _logger = new Logger('over_react._FluxComponentMixin');
 
-  @override
-  void componentWillMount() {
+  // This is private and called by classes to work around super-calls not being supported in mixins
+  void _componentWillMount() {
     /// Subscribe to all applicable stores.
     ///
     /// [Store]s returned by [redrawOn] will have their triggers mapped directly to this components
@@ -169,8 +173,8 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements UiComp
     });
   }
 
-  @override
-  void componentWillUnmount() {
+  // This is private and called by classes to work around super-calls not being supported in mixins
+  void _componentWillUnmount() {
     // Ensure that unmounted components don't batch render
     shouldBatchRedraw = false;
   }

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -183,10 +183,7 @@ void main() {
         var jacket = mount((testComponents.propValidation()..required = 'foo')());
         expect(() {
           jacket.rerender(testComponents.propValidation()());
-        }, throwsA(anyOf(
-          hasToStringValue('V8 Exception'), /* workaround for https://github.com/dart-lang/sdk/issues/26093 */
-          hasToStringValue(contains('RequiredPropError:')),
-        )),
+        }, throwsA(hasToStringValue(contains('RequiredPropError:'))),
             reason: 'should have called super, triggering prop validation logic');
       });
 

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -174,8 +174,8 @@ void main() {
     group('calls super in the appropriate lifecycle methods', () {
       test('componentWillMount', () {
         expect(() {
-          mount(TestPropValidation()());
-        }, throwsPropError_Required('TestPropValidationProps.required'),
+          mount(testComponents.propValidation()());
+        }, throwsA(hasToStringValue(contains('RequiredPropError:'))),
             reason: 'should have called super, triggering prop validation logic');
       });
 

--- a/test/over_react/component_declaration/flux_component_test/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/basic.dart
@@ -1,0 +1,21 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestBasicProps> TestBasic;
+
+@Props()
+class TestBasicProps extends FluxUiProps {}
+
+@Component()
+class TestBasicComponent extends FluxUiComponent<TestBasicProps> {
+  int numberOfRedraws = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}

--- a/test/over_react/component_declaration/flux_component_test/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/prop_validation.dart
@@ -1,0 +1,24 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestPropValidationProps> TestPropValidation;
+
+@Props()
+class TestPropValidationProps extends FluxUiProps {
+  @requiredProp
+  String required;
+}
+
+@Component()
+class TestPropValidationComponent extends FluxUiComponent<TestPropValidationProps> {
+  int numberOfRedraws = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}

--- a/test/over_react/component_declaration/flux_component_test/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/prop_validation.dart
@@ -11,14 +11,6 @@ class TestPropValidationProps extends FluxUiProps {
 
 @Component()
 class TestPropValidationComponent extends FluxUiComponent<TestPropValidationProps> {
-  int numberOfRedraws = 0;
-
   @override
   render() => Dom.div()();
-
-  @override
-  void setState(_, [callback()]) {
-    numberOfRedraws++;
-    if (callback != null) callback();
-  }
 }

--- a/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
@@ -1,13 +1,13 @@
 part of over_react.component_declaration.flux_component_test;
 
 @Factory()
-UiFactory<TestDefaultProps> TestDefault;
+UiFactory<TestStatefulBasicProps> TestStatefulBasic;
 
 @Props()
-class TestDefaultProps extends FluxUiProps {}
+class TestStatefulBasicProps extends FluxUiProps implements TestBasicProps {}
 
 @Component()
-class TestDefaultComponent extends FluxUiComponent {
+class TestStatefulBasicComponent extends FluxUiComponent<TestStatefulBasicProps> {
   int numberOfRedraws = 0;
 
   @override

--- a/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
@@ -1,0 +1,32 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestStatefulHandlerPrecedenceProps> TestStatefulHandlerPrecedence;
+
+@Props()
+class TestStatefulHandlerPrecedenceProps extends FluxUiProps<TestActions, TestStores> implements TestHandlerPrecedenceProps {}
+
+@Component()
+class TestStatefulHandlerPrecedenceComponent extends FluxUiComponent<TestStatefulHandlerPrecedenceProps> {
+  int numberOfRedraws = 0;
+  int numberOfHandlerCalls = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  redrawOn() => [props.store.store1, props.store.store2];
+
+  @override
+  getStoreHandlers() => {props.store.store1: increment};
+
+  increment(Store store) {
+    numberOfHandlerCalls += 1;
+  }
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}

--- a/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
@@ -12,14 +12,6 @@ class TestStatefulPropValidationProps extends FluxUiProps implements TestPropVal
 
 @Component()
 class TestStatefulPropValidationComponent extends FluxUiComponent<TestStatefulPropValidationProps> {
-  int numberOfRedraws = 0;
-
   @override
   render() => Dom.div()();
-
-  @override
-  void setState(_, [callback()]) {
-    numberOfRedraws++;
-    if (callback != null) callback();
-  }
 }

--- a/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
@@ -1,0 +1,25 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestStatefulPropValidationProps> TestStatefulPropValidation;
+
+@Props()
+class TestStatefulPropValidationProps extends FluxUiProps implements TestPropValidationProps {
+  @override
+  @requiredProp
+  String required;
+}
+
+@Component()
+class TestStatefulPropValidationComponent extends FluxUiComponent<TestStatefulPropValidationProps> {
+  int numberOfRedraws = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}

--- a/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
@@ -1,0 +1,24 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestStatefulRedrawOnProps> TestStatefulRedrawOn;
+
+@Props()
+class TestStatefulRedrawOnProps extends FluxUiProps<TestActions, TestStores> implements TestRedrawOnProps {}
+
+@Component()
+class TestStatefulRedrawOnComponent extends FluxUiComponent<TestStatefulRedrawOnProps> {
+  int numberOfRedraws = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  redrawOn() => [props.store.store1, props.store.store2];
+
+  @override
+  void setState(_, [callback()]) {
+    numberOfRedraws++;
+    if (callback != null) callback();
+  }
+}

--- a/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
@@ -1,0 +1,22 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestStoreHandlersProps> TestStatefulStoreHandlers;
+
+@Props()
+class TestStatefulStoreHandlersProps extends FluxUiProps<TestActions, TestStore> implements TestStoreHandlersProps {}
+
+@Component()
+class TestStatefulStoreHandlersComponent extends FluxUiComponent<TestStatefulStoreHandlersProps> {
+  int numberOfHandlerCalls = 0;
+
+  @override
+  render() => Dom.div()();
+
+  @override
+  getStoreHandlers() => {props.store: increment};
+
+  increment(Store store) {
+    numberOfHandlerCalls += 1;
+  }
+}


### PR DESCRIPTION
## Ultimate problem:
- We needed some new lifecyle hooks to to implement tracing of Flux components. _These changes mirror those in https://github.com/Workiva/w_flux/pull/120; see that PR for more info._

## How it was fixed:
- Add lifecycle methods to allow subclasses to safely hook into and override store redraw logic _These changes mirror those in https://github.com/Workiva/w_flux/pull/120; see that PR for more info._
    - `listenToStoreForRedraw`
    - `handleRedrawOn`

##### Boyscouting
- Add shared tests to beef up test coverage for FluxUiStatefulComponent, which wasn't being fully excercised
- Work around mixins not calling super, which was causing prop validation and disposal logic in `UiProps` to not get called, and add functional regression tests
    - I had these changes ready to go as part of a spike I did a while ago, but I thought they were blocked. However, while I was in this code, I remembered a similar workaround from my other tracing work, and realized I could apply it here to unblock this issue!

## Testing suggestions:
Verify tests pass

## Potential areas of regression:
Consumers breaking due to not expecting things to get disposed.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
