### PR TITLE
AF-2719 AF-2718 Release over_react 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # OverReact Changelog
 
+## 1.28.0
+
+> [Complete `1.28.0` Changeset](https://github.com/Workiva/over_react/compare/1.27.0...1.28.0)
+
+__Bug fixes__
+
+* [#193] Fix missing super calls in Flux component lifecycle methods that prevented disposal and prop validation
+
+__New Features__
+
+* [#193]: Add hooks for Flux component redraws that occur in response to store updates: `listenToStoreForRedraw`/`handleRedrawOn` 
+
+__Improvements__
+
+* [#192]: Make return type of `getDartComponent` generic
+
+
 ## 1.27.0
 
 > [Complete `1.27.0` Changeset](https://github.com/Workiva/over_react/compare/1.26.2...1.27.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ __New Features__
 __Improvements__
 
 * [#192]: Make return type of `getDartComponent` generic
+* [#190]: Merge `style` prop into styles applied to the top-level ResizeSensor node
 
 
 ## 1.27.0

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
     ```yaml
     dependencies:
-      over_react: ^1.27.0
+      over_react: ^1.28.0
     ```
 
 2. Add the `over_react` [transformer] to your `pubspec.yaml`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.27.0
+version: 1.28.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
[Complete `1.28.0` Changeset](https://github.com/Workiva/over_react/compare/1.27.0...release-1.28.0)

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
