### PR TITLE
AF-2937 Add hooks to support tracing

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -186,7 +186,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
 
   /// Used to register [handleRedrawOn] as a listener for the given [store].
   ///
-  /// Called for each the stores returned by [redrawOn] that don't have custom
+  /// Called for each of the stores returned by [redrawOn] that don't have custom
   /// store handlers (defined in [getStoreHandlers]).
   ///
   /// Override to set up custom listener behavior.

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -184,7 +184,7 @@ abstract class _FluxComponentMixin<TProps extends FluxUiProps> implements Batche
     storesWithoutCustomHandlers.forEach(listenToStoreForRedraw);
   }
 
-  /// Used to register [handleRedrawOn] as a listeners for the given [store].
+  /// Used to register [handleRedrawOn] as a listener for the given [store].
   ///
   /// Called for each the stores returned by [redrawOn] that don't have custom
   /// store handlers (defined in [getStoreHandlers]).

--- a/test/over_react/component_declaration/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test.dart
@@ -12,11 +12,13 @@ import 'package:over_react/over_react.dart';
 import '../../test_util/test_util.dart';
 
 part 'flux_component_test/basic.dart';
+part 'flux_component_test/handler_lifecycle.dart';
 part 'flux_component_test/handler_precedence.dart';
 part 'flux_component_test/prop_validation.dart';
 part 'flux_component_test/redraw_on.dart';
 part 'flux_component_test/store_handlers.dart';
 part 'flux_component_test/stateful/basic.dart';
+part 'flux_component_test/stateful/handler_lifecycle.dart';
 part 'flux_component_test/stateful/handler_precedence.dart';
 part 'flux_component_test/stateful/prop_validation.dart';
 part 'flux_component_test/stateful/redraw_on.dart';
@@ -138,6 +140,26 @@ void main() {
           reason: 'component should no longer be listening');
     });
 
+    test('should call lifecycle methods related to store handlers', () async {
+      final store = new TestStore();
+      var renderedInstance = render(testComponents.handlerLifecycle()..store = store);
+      dynamic component = getDartComponent(renderedInstance);
+
+      expect(component.lifecycleCalls, [
+        ['listenToStoreForRedraw', store],
+      ]);
+      component.lifecycleCalls.clear();
+
+      // Cause store to trigger, wait for it to propagate
+      store.trigger();
+      await nextTick();
+      await nextTick();
+
+      expect(component.lifecycleCalls, [
+        ['handleRedrawOn', store],
+      ]);
+    });
+
     test('cancels any subscriptions added with addSubscription', () async {
       // Setup a new subscription on a component
       int numberOfCalls = 0;
@@ -225,6 +247,7 @@ abstract class BaseTestComponents {
   TestPropValidationProps propValidation();
   TestRedrawOnProps redrawOn();
   TestStoreHandlersProps storeHandlers();
+  TestHandlerLifecycleProps handlerLifecycle();
 }
 
 class TestComponents extends BaseTestComponents {
@@ -233,6 +256,7 @@ class TestComponents extends BaseTestComponents {
   @override TestPropValidationProps propValidation() => TestPropValidation();
   @override TestRedrawOnProps redrawOn() => TestRedrawOn();
   @override TestStoreHandlersProps storeHandlers() => TestStoreHandlers();
+  @override TestHandlerLifecycleProps handlerLifecycle() => TestHandlerLifecycle();
 }
 
 class TestStatefulComponents extends BaseTestComponents {
@@ -241,4 +265,5 @@ class TestStatefulComponents extends BaseTestComponents {
   @override TestStatefulPropValidationProps propValidation() => TestStatefulPropValidation();
   @override TestStatefulRedrawOnProps redrawOn() => TestStatefulRedrawOn();
   @override TestStatefulStoreHandlersProps storeHandlers() => TestStatefulStoreHandlers();
+  @override TestStatefulHandlerLifecycleProps handlerLifecycle() => TestStatefulHandlerLifecycle();
 }

--- a/test/over_react/component_declaration/flux_component_test/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/handler_lifecycle.dart
@@ -1,0 +1,28 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestHandlerLifecycleProps> TestHandlerLifecycle;
+
+@Props()
+class TestHandlerLifecycleProps extends FluxUiProps<TestActions, TestStore> {}
+
+@Component()
+class TestHandlerLifecycleComponent extends FluxUiComponent<TestHandlerLifecycleProps> {
+  List<List<dynamic>> lifecycleCalls = [];
+
+  @override
+  void handleRedrawOn(Store store) {
+    lifecycleCalls.add(['handleRedrawOn', store]);
+    super.handleRedrawOn(store);
+  }
+
+  @override
+  void listenToStoreForRedraw(Store store) {
+    lifecycleCalls.add(['listenToStoreForRedraw', store]);
+    super.listenToStoreForRedraw(store);
+  }
+
+  @override
+  render() => Dom.div()();
+}
+

--- a/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
@@ -6,8 +6,11 @@ UiFactory<TestStatefulBasicProps> TestStatefulBasic;
 @Props()
 class TestStatefulBasicProps extends FluxUiProps implements TestBasicProps {}
 
+@State()
+class TestStatefulBasicState extends UiState {}
+
 @Component()
-class TestStatefulBasicComponent extends FluxUiComponent<TestStatefulBasicProps> {
+class TestStatefulBasicComponent extends FluxUiStatefulComponent<TestStatefulBasicProps, TestStatefulBasicState> {
   int numberOfRedraws = 0;
 
   @override

--- a/test/over_react/component_declaration/flux_component_test/stateful/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/handler_lifecycle.dart
@@ -1,0 +1,31 @@
+part of over_react.component_declaration.flux_component_test;
+
+@Factory()
+UiFactory<TestStatefulHandlerLifecycleProps> TestStatefulHandlerLifecycle;
+
+@Props()
+class TestStatefulHandlerLifecycleProps extends FluxUiProps<TestActions, TestStore> implements TestHandlerLifecycleProps {}
+
+@State()
+class TestStatefulHandlerLifecycleState extends UiState {}
+
+@Component()
+class TestStatefulHandlerLifecycleComponent extends FluxUiStatefulComponent<TestStatefulHandlerLifecycleProps, TestStatefulHandlerLifecycleState> {
+  List<List<dynamic>> lifecycleCalls = [];
+
+  @override
+  void handleRedrawOn(Store store) {
+    lifecycleCalls.add(['handleRedrawOn', store]);
+    super.handleRedrawOn(store);
+  }
+
+  @override
+  void listenToStoreForRedraw(Store store) {
+    lifecycleCalls.add(['listenToStoreForRedraw', store]);
+    super.listenToStoreForRedraw(store);
+  }
+
+  @override
+  render() => Dom.div()();
+}
+

--- a/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
@@ -6,8 +6,11 @@ UiFactory<TestStatefulHandlerPrecedenceProps> TestStatefulHandlerPrecedence;
 @Props()
 class TestStatefulHandlerPrecedenceProps extends FluxUiProps<TestActions, TestStores> implements TestHandlerPrecedenceProps {}
 
+@State()
+class TestStatefulHandlerPrecedenceState extends UiState {}
+
 @Component()
-class TestStatefulHandlerPrecedenceComponent extends FluxUiComponent<TestStatefulHandlerPrecedenceProps> {
+class TestStatefulHandlerPrecedenceComponent extends FluxUiStatefulComponent<TestStatefulHandlerPrecedenceProps, TestStatefulHandlerPrecedenceState> {
   int numberOfRedraws = 0;
   int numberOfHandlerCalls = 0;
 

--- a/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
@@ -10,8 +10,11 @@ class TestStatefulPropValidationProps extends FluxUiProps implements TestPropVal
   String required;
 }
 
+@State()
+class TestStatefulPropValidationState extends UiState {}
+
 @Component()
-class TestStatefulPropValidationComponent extends FluxUiComponent<TestStatefulPropValidationProps> {
+class TestStatefulPropValidationComponent extends FluxUiStatefulComponent<TestStatefulPropValidationProps, TestStatefulPropValidationState> {
   @override
   render() => Dom.div()();
 }

--- a/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
@@ -6,8 +6,11 @@ UiFactory<TestStatefulRedrawOnProps> TestStatefulRedrawOn;
 @Props()
 class TestStatefulRedrawOnProps extends FluxUiProps<TestActions, TestStores> implements TestRedrawOnProps {}
 
+@State()
+class TestStatefulRedrawOnState extends UiState {}
+
 @Component()
-class TestStatefulRedrawOnComponent extends FluxUiComponent<TestStatefulRedrawOnProps> {
+class TestStatefulRedrawOnComponent extends FluxUiStatefulComponent<TestStatefulRedrawOnProps, TestStatefulRedrawOnState> {
   int numberOfRedraws = 0;
 
   @override

--- a/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
@@ -6,8 +6,11 @@ UiFactory<TestStoreHandlersProps> TestStatefulStoreHandlers;
 @Props()
 class TestStatefulStoreHandlersProps extends FluxUiProps<TestActions, TestStore> implements TestStoreHandlersProps {}
 
+@State()
+class TestStatefulStoreHandlersState extends UiState {}
+
 @Component()
-class TestStatefulStoreHandlersComponent extends FluxUiComponent<TestStatefulStoreHandlersProps> {
+class TestStatefulStoreHandlersComponent extends FluxUiStatefulComponent<TestStatefulStoreHandlersProps, TestStatefulStoreHandlersState> {
   int numberOfHandlerCalls = 0;
 
   @override


### PR DESCRIPTION
## Ultimate problem:
__I forgot to add the core changes I needed in https://github.com/Workiva/over_react/pull/193 🤦‍♂️__


> - We needed some new lifecyle hooks to to implement tracing of Flux components. _These changes mirror those in https://github.com/Workiva/w_flux/pull/120; see that PR for more info._

## How it was fixed:
> - Add lifecycle methods to allow subclasses to safely hook into and override store redraw logic _These changes mirror those in https://github.com/Workiva/w_flux/pull/120; see that PR for more info._
    - `listenToStoreForRedraw`
    - `handleRedrawOn`

Also fixed test setup for changes I made in #193:
- https://github.com/Workiva/over_react/commit/0a7f3939473b9915ca6d7ac888f6c9b82517dfa4 "Make stateful test components actually stateful >_>"

## Testing suggestions:
- Verify tests pass

## Potential areas of regression:
Flux component store subscriptions

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
