### PR TITLE
AF-2922: add defaultProps getter to UiProp

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -691,6 +691,7 @@ abstract class UiProps extends MapBase
 
   Function get componentFactory;
 
+  /// The default props for this component brought in from the [componentFactory].
   Map get componentDefaultProps => componentFactory is ReactDartComponentFactoryProxy
       // ignore: avoid_as
       ? (componentFactory as ReactDartComponentFactoryProxy).defaultProps

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -691,7 +691,7 @@ abstract class UiProps extends MapBase
 
   Function get componentFactory;
 
-  Map get defaultProps => componentFactory is ReactDartComponentFactoryProxy
+  Map get componentDefaultProps => componentFactory is ReactDartComponentFactoryProxy
       // ignore: avoid_as
       ? (componentFactory as ReactDartComponentFactoryProxy).defaultProps
       : const {};

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -690,6 +690,11 @@ abstract class UiProps extends MapBase
   }
 
   Function get componentFactory;
+
+  Map get defaultProps => componentFactory is ReactDartComponentFactoryProxy
+      // ignore: avoid_as
+      ? (componentFactory as ReactDartComponentFactoryProxy).defaultProps
+      : const {};
 }
 
 /// A class that declares the `_map` getter shared by [PropsMapViewMixin]/[StateMapViewMixin] and [MapViewMixin].

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -47,7 +47,7 @@ class UiPropsMapView extends MapView with ReactPropsMixin, UbiquitousDomPropsMix
   String get testId => getTestId();
 
   @override
-  Map get defaultProps => throw new UnimplementedError('@PropsMixin instances do not implement defaultProps');
+  Map get componentDefaultProps => throw new UnimplementedError('@PropsMixin instances do not implement defaultProps');
 
   @override
   ReactElement build([dynamic children]) =>

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -47,6 +47,9 @@ class UiPropsMapView extends MapView with ReactPropsMixin, UbiquitousDomPropsMix
   String get testId => getTestId();
 
   @override
+  Map get defaultProps => throw new UnimplementedError('@PropsMixin instances do not implement defaultProps');
+
+  @override
   ReactElement build([dynamic children]) =>
       throw new UnimplementedError('@PropsMixin instances do not implement build');
 

--- a/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
@@ -105,6 +105,10 @@ main() {
       test('empty map when no default props set', () {
         expect(r.ComponentTest().componentDefaultProps, equals({}));
       });
+
+      test('empty map when componentFactory is not ReactDartComponentFactoryProxy', () {
+        expect(Dom.div().componentDefaultProps, equals({}));
+      });
     });
 
     test('omits props declared in the @Props() class when forwarding by default', () {

--- a/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
@@ -17,7 +17,7 @@ library over_react.component_declaration.transformer_integration_tests.component
 import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
 
-import './required_prop_integration_test.dart';
+import './required_prop_integration_test.dart' as r;
 import '../../../test_util/test_util.dart';
 
 main() {
@@ -97,6 +97,14 @@ main() {
         expect(ComponentTest()..customKeyAndNamespaceProp = 'test',
             containsPair('custom namespace~~custom key!', 'test'));
       });
+
+      test('default props', () {
+        expect(ComponentTest().defaultProps, equals({'id':'testId'}));
+      });
+
+      test('empty map when no default props set', () {
+        expect(r.ComponentTest().defaultProps, equals({}));
+      });
     });
 
     test('omits props declared in the @Props() class when forwarding by default', () {
@@ -113,10 +121,10 @@ main() {
       var shallowProps = getProps(shallowInstance);
       Iterable<String> shallowPropKeys = shallowProps.keys;
 
-      expect(shallowPropKeys.where((String key) => !key.startsWith('data-prop-')), unorderedEquals(['extraneous', 'children']));
+      expect(shallowPropKeys.where((String key) => !key.startsWith('data-prop-')), unorderedEquals(['id', 'extraneous', 'children']));
     });
 
-    requiredPropsIntegrationTest();
+    r.requiredPropsIntegrationTest();
   });
 }
 
@@ -142,6 +150,9 @@ class ComponentTestProps extends UiProps {
 
 @Component()
 class ComponentTestComponent extends UiComponent<ComponentTestProps> {
+  @override
+  Map getDefaultProps() => newProps()..id = 'testId';
+
   @override
   render() => (Dom.div()
     ..addProps(copyUnconsumedProps())

--- a/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
+++ b/test/over_react/component_declaration/transformer_integration_tests/component_integration_test.dart
@@ -99,11 +99,11 @@ main() {
       });
 
       test('default props', () {
-        expect(ComponentTest().defaultProps, equals({'id':'testId'}));
+        expect(ComponentTest().componentDefaultProps, equals({'id':'testId'}));
       });
 
       test('empty map when no default props set', () {
-        expect(r.ComponentTest().defaultProps, equals({}));
+        expect(r.ComponentTest().componentDefaultProps, equals({}));
       });
     });
 

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -33,7 +33,7 @@ main() {
       });
 
       test('`defaultProps`', () {
-        expect(() => mapView.defaultProps, throwsUnimplementedError);
+        expect(() => mapView.componentDefaultProps, throwsUnimplementedError);
       });
 
       test('`getTestId()`', () {

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -32,6 +32,10 @@ main() {
         expect(() => mapView.testId, throwsUnimplementedError);
       });
 
+      test('`defaultProps`', () {
+        expect(() => mapView.defaultProps, throwsUnimplementedError);
+      });
+
       test('`getTestId()`', () {
         expect(() => mapView.getTestId(), throwsUnimplementedError);
       });


### PR DESCRIPTION
## Ultimate problem:

With the new builder, the implementation of ```typedPropsFactory()``` will no longer be available on the component class defined by the consumer – it will only be available on the generated component class. As a consequence, all instances of ```new FooComponent().getDefaultProps()``` will break.

## How it was fixed:

Add a ```defaultProps``` getter on the ```UiProps``` as an alternative way to retrieve a component's default props since instantiating the component class directly is an anti-pattern anyway.

## Testing suggestions:

- [ ] Code changes and test updates make sense
- [ ] CI Passes 

---

@greglittlefield-wf @corwinsheahan-wf  @evanweible-wf 
