### PR TITLE
AF-3082: transform static meta fields

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -414,16 +414,6 @@ class ImplGenerator {
         .forEach((_field) {
           final field = _field as FieldDeclaration; // ignore: avoid_as
 
-          annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
-
-          if (accessorMeta?.doNotGenerate == true) {
-            logger.fine('Skipping generation of field `$field`.',
-                span: getSpan(sourceFile, field)
-            );
-
-            return;
-          }
-
           final name = typedMap.node.name.name;
           final metaType = type == AccessorType.props ? 'Props' : 'State';
 

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -410,6 +410,31 @@ class ImplGenerator {
     Map constants = {};
 
     typedMap.node.members
+        .where((member) => member is FieldDeclaration && member.isStatic)
+        .forEach((_field) {
+          final field = _field as FieldDeclaration; // ignore: avoid_as
+
+          annotations.Accessor accessorMeta = instantiateAnnotation(field, annotations.Accessor);
+
+          if (accessorMeta?.doNotGenerate == true) {
+            logger.fine('Skipping generation of field `$field`.',
+                span: getSpan(sourceFile, field)
+            );
+
+            return;
+          }
+
+          final name = typedMap.node.name.name;
+          final metaType = type == AccessorType.props ? 'Props' : 'State';
+
+          field.fields.variables.forEach((VariableDeclaration variable) {
+            if (variable.name.toString() == 'meta' && variable.initializer != null) {
+              transformedFile.replace(sourceFile.span(variable.initializer.offset, variable.initializer.end), '\$$metaType($name)');
+            }
+          });
+    });
+
+    typedMap.node.members
         .where((member) => member is FieldDeclaration && !member.isStatic)
         .forEach((_field) {
           final field = _field as FieldDeclaration; // ignore: avoid_as

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -256,6 +256,55 @@ main() {
               reason: 'should preserve existing inheritance');
         });
 
+        test('with static PropsMeta declaration', () {
+          final transformedLine = 'static const PropsMeta meta = \$Props(FooProps);';
+
+          setUpAndGenerate('''
+           @Factory()
+           UiFactory<FooProps> Foo;
+        
+           @Props()
+           class FooProps {
+            static const PropsMeta meta = \$metaForFooProps;
+           }
+           
+           @Component()
+           class FooComponent {
+            render() => null;
+           }
+           '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(transformedLine));
+        });
+
+        test('with static StateMeta declaration', () {
+          final transformedLine = 'static const StateMeta meta = \$State(FooState);';
+
+          setUpAndGenerate('''
+           @Factory()
+           UiFactory<FooProps> Foo;
+        
+           @Props()
+           class FooProps {}
+           
+           @State()
+           class FooState {
+            static const StateMeta meta = \$metaForFooState;
+           }
+           
+           @Component()
+           class FooComponent {
+            render() => null;
+           }
+           '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(transformedLine));
+        });
+
         group('that subtypes another component, referencing the component class via', () {
           test('a simple identifier', () {
             preservedLineNumbersTest('''

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -256,8 +256,11 @@ main() {
               reason: 'should preserve existing inheritance');
         });
 
-        test('with static PropsMeta declaration', () {
-          final transformedLine = 'static const PropsMeta meta = \$Props(FooProps);';
+        test('with static PropsMeta and StateMeta declaration', () {
+          final originalPropsMetaLine = 'static const PropsMeta meta = \$metaForFooProps;';
+          final originalStateMetaLine = 'static const StateMeta meta = \$metaForFooState;';
+          final transformedPropsMetaLine = 'static const PropsMeta meta = \$Props(FooProps);';
+          final transformedStateMetaLine = 'static const StateMeta meta = \$State(FooState);';
 
           setUpAndGenerate('''
            @Factory()
@@ -267,27 +270,6 @@ main() {
            class FooProps {
             static const PropsMeta meta = \$metaForFooProps;
            }
-           
-           @Component()
-           class FooComponent {
-            render() => null;
-           }
-           '''
-          );
-
-          var transformedSource = transformedFile.getTransformedText();
-          expect(transformedSource, contains(transformedLine));
-        });
-
-        test('with static StateMeta declaration', () {
-          final transformedLine = 'static const StateMeta meta = \$State(FooState);';
-
-          setUpAndGenerate('''
-           @Factory()
-           UiFactory<FooProps> Foo;
-        
-           @Props()
-           class FooProps {}
            
            @State()
            class FooState {
@@ -302,6 +284,28 @@ main() {
           );
 
           var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource.contains(originalPropsMetaLine), isFalse);
+          expect(transformedSource.contains(originalStateMetaLine), isFalse);
+          expect(transformedSource, contains(transformedPropsMetaLine));
+          expect(transformedSource, contains(transformedStateMetaLine));
+        });
+
+        test('with static PropsMeta declaration in PropsMixin', () {
+          final originalLine = 'static const PropsMeta meta = \$metaForFooPropsMixin;';
+          final transformedLine = 'static const PropsMeta meta = \$Props(FooPropsMixin);';
+
+          setUpAndGenerate('''
+            @PropsMixin()
+            class FooPropsMixin {
+              static const PropsMeta meta = \$metaForFooPropsMixin;
+              
+              Map get props;
+            }
+          '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource.contains(originalLine), isFalse);
           expect(transformedSource, contains(transformedLine));
         });
 

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -309,6 +309,25 @@ main() {
           expect(transformedSource, contains(transformedLine));
         });
 
+        test('with static StateMeta declaration in StateMixin', () {
+          final originalLine = 'static const StateMeta meta = \$metaForFooStateMixin; ';
+          final transformedLine = 'static const StateMeta meta = \$State(FooStateMixin);';
+
+          setUpAndGenerate('''
+            @StateMixin()
+            class FooStateMixin {
+              static const StateMeta meta = \$metaForFooStateMixin;   
+              
+              Map get state;           
+            }
+          '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource.contains(originalLine), isFalse);
+          expect(transformedSource, contains(transformedLine));
+        });
+
         group('that subtypes another component, referencing the component class via', () {
           test('a simple identifier', () {
             preservedLineNumbersTest('''


### PR DESCRIPTION
Proposed solution to https://jira.atl.workiva.net/browse/AF-3082

## Ultimate problem:

In anticipation of the Dart 2 transition, all props and state classes will have a static meta getter that is implemented to point to some symbol that needs to be generated, for example:

```
class FooProps {
  static const PropsMeta meta = $metaForFooProps;
  ...
}
```

The transformer will need to transform this meta static field inline:

```
class Foo Props{
  static const PropsMeta meta = $Props(FooProps);
```

## How it was fixed:

- identify static members with the ```meta``` variable name and replace the initializer to use the appropriate ```Props()``` or ```State()```  implementation within the source file . 

## Testing suggestions:

Code changes and tests make sense 
CI passes 

---

@corwinsheahan-wf @evanweible-wf @greglittlefield-wf 
