### PR TITLE
Remove null elements from invocation.positionalArguments

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -647,11 +647,15 @@ abstract class UiProps extends MapBase
 
       final factory = componentFactory;
       if (factory is ReactComponentFactoryProxy) {
+        // In dart 2, invocation.positionalArguments will be a list of length
+        // equal to the number of positional arguments, with the unsupplied
+        // arguments replaced by `null`. This remove these.
+        var children = invocation.positionalArguments.where((child) => child != null).toList(growable: false);
         // Use `build` instead of using emulated function behavior to work around DDC issue
         // https://github.com/dart-lang/sdk/issues/29904
         // Should have the benefit of better performance; TODO optimize type check?
         // ignore: avoid_as
-        return factory.build(props, invocation.positionalArguments);
+        return factory.build(props, children);
       } else {
         var parameters = []
           ..add(props)


### PR DESCRIPTION
## Ultimate problem:
Dom elements which are not allowed to have children (e.g. `input`) were failing to render properly in Dart 2 due to this error: https://reactjs.org/docs/error-decoder.html/?invariant=137&args[]=input&args[]=

## How it was fixed:
In Dart 2, the list of positional args from an invocation is specified as a constant length list (of length equal to the number of positional args), where the un-supplied args are replaced by `null`. This removes those `null` elements from the list.

## Testing suggestions:
* CI Passes (Dart 1)
* Smoke test in WSD (consumer tests, examples) under Dart 1
* Dart 2 Testing: 
	* switch to dart 2.1.0
	* checkout [this](https://github.com/Workiva/over_react/tree/builder_generate_public_class) branch of over_react locally
	* Use [this](https://github.com/corwinsheahan-wf/git_playground/tree/test_fix_dart2_children) branch to get a super simple example app for testing (in `example_app` directory in that repo).
		* change the import paths in pubspec.yaml to the path to your over_react repo location
	* run `pub get` in example_app
	* run `pub run build_runner serve web` in `example_app`. Navigate to `localhost:8080` and verify that the input element shows up.
	* Optionally, undo these changes in that over_react branch and verify that the input field fails to be rendered.


## Potential areas of regression:
* Dart 1 over_react usages

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
