### PR TITLE
AF-3084: Transformer should handle new boilerplate for Props and State classes

### DIFF
--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -53,12 +53,12 @@ class ParsedDeclarations {
       key_stateMixin:        <CompilationUnitMember>[],
     };
 
-    var propsClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
+    var propsAndStateClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
 
     unit.declarations.forEach((CompilationUnitMember member) {
       member.metadata.forEach((annotation) {
         var name = annotation.name.toString();
-        var match = propsClassPattern.firstMatch(member.toString());
+        var match = propsAndStateClassPattern.firstMatch(member.toString());
 
         if ((name == 'Props' || name == 'State') && match != null) {
           var publicMember = unit.declarations.where((CompilationUnitMember member) => member.toString().contains(match.group(1).substring(2)));

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -53,7 +53,7 @@ class ParsedDeclarations {
       key_stateMixin:        <CompilationUnitMember>[],
     };
 
-    var privatePropsAndStateClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
+    var privatePropsAndStateClassPattern = new RegExp(r'^(?:\@Props\(\)\s*|\@State\(\)\s*)(?:abstract\s)?class\s(_\$\w*?)\s');
 
     unit.declarations.forEach((CompilationUnitMember member) {
       member.metadata.forEach((annotation) {
@@ -61,9 +61,10 @@ class ParsedDeclarations {
         var match = privatePropsAndStateClassPattern.firstMatch(member.toString());
 
         if ((name == 'Props' || name == 'State') && match != null) {
-          var publicMember = unit.declarations.where((CompilationUnitMember member) => member.toString().contains(match.group(1).substring(2)));
+          var publicName = match.group(1).replaceFirst('_\$', '');
+          var publicMember = unit.declarations.firstWhere((CompilationUnitMember member) => member is ClassDeclaration && member.name.name == publicName, orElse: () => null);
 
-          declarationMap[name]?.add(publicMember.first);
+          declarationMap[name]?.add(publicMember ?? member);
         } else {
           declarationMap[name]?.add(member);
         }

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -53,12 +53,12 @@ class ParsedDeclarations {
       key_stateMixin:        <CompilationUnitMember>[],
     };
 
-    var propsAndStateClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
+    var privatePropsAndStateClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
 
     unit.declarations.forEach((CompilationUnitMember member) {
       member.metadata.forEach((annotation) {
         var name = annotation.name.toString();
-        var match = propsAndStateClassPattern.firstMatch(member.toString());
+        var match = privatePropsAndStateClassPattern.firstMatch(member.toString());
 
         if ((name == 'Props' || name == 'State') && match != null) {
           var publicMember = unit.declarations.where((CompilationUnitMember member) => member.toString().contains(match.group(1).substring(2)));

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -58,13 +58,19 @@ class ParsedDeclarations {
         var name = annotation.name.toString();
         var publicMember;
 
-        if (member is ClassDeclaration && member.name.name.startsWith('_\$')) {
-          unit.declarations.forEach((CompilationUnitMember innerLoopMember) {
-            // Look for a matching public class.
-            if (innerLoopMember is ClassDeclaration && member.name.name.substring(2) == innerLoopMember.name.name) {
-              publicMember = innerLoopMember;
+        if (name == 'Props' || name == 'State' || name == 'AbstractProps' || name == 'AbstractState') {
+          if (member is ClassDeclaration && member.name.name.startsWith('_\$')) {
+            var matchingPublicPropsOrStateClasses =
+              unit.declarations.where((CompilationUnitMember innerLoopMember) =>
+                innerLoopMember is ClassDeclaration && member.name.name.substring(2) == innerLoopMember.name.name);
+
+            if (matchingPublicPropsOrStateClasses.isEmpty) {
+              error('${member.name.name} must have an accompanying public class within the '
+                  'same file for Dart 2 builder compatibility, but one was not found.', getSpan(sourceFile, member));
+            } else {
+              publicMember = matchingPublicPropsOrStateClasses.first;
             }
-          });
+          }
         }
 
         declarationMap[name]?.add(publicMember ?? member);

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -53,11 +53,20 @@ class ParsedDeclarations {
       key_stateMixin:        <CompilationUnitMember>[],
     };
 
+    var propsClassPattern = new RegExp(r'^.*class\s(_[$].*?\s)');
+
     unit.declarations.forEach((CompilationUnitMember member) {
       member.metadata.forEach((annotation) {
         var name = annotation.name.toString();
+        var match = propsClassPattern.firstMatch(member.toString());
 
-        declarationMap[name]?.add(member);
+        if ((name == 'Props' || name == 'State') && match != null) {
+          var publicMember = unit.declarations.where((CompilationUnitMember member) => member.toString().contains(match.group(1).substring(2)));
+
+          declarationMap[name]?.add(publicMember.first);
+        } else {
+          declarationMap[name]?.add(member);
+        }
       });
     });
 

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -32,6 +32,7 @@ import 'package:transformer_utils/transformer_utils.dart';
 /// * Any number of mixins: `@PropsMixin()`, `@StateMixin()`
 class ParsedDeclarations {
   factory ParsedDeclarations(CompilationUnit unit, SourceFile sourceFile, TransformLogger logger) {
+    const companionPrefix = r'_$';
     bool hasErrors = false;
 
     void error(String message, [SourceSpan span]) {
@@ -60,9 +61,9 @@ class ParsedDeclarations {
         var name = annotation.name.toString();
 
         if (name == 'Props' || name == 'State' || name == 'AbstractProps' || name == 'AbstractState') {
-          if (member is ClassDeclaration && member.name.name.startsWith('_\$')) {
+          if (member is ClassDeclaration && member.name.name.startsWith(companionPrefix)) {
             final className = member.name.name;
-            final companionName = member.name.name.substring(2);
+            final companionName = member.name.name.substring(companionPrefix.length);
             final companionClass = unit.declarations.firstWhere(
               (innerLoopMember) => innerLoopMember is ClassDeclaration && innerLoopMember.name.name == companionName,
               orElse: () => null);

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -92,7 +92,10 @@ class ImplGenerator {
         // The public props class signature includes a with <PropsClass>AccessorsMixin clause
         // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
         // the concrete accessors inline without a separate mixin. For this reason, the transformer
-        // first removes this with clause and then generates the concrete accessors.
+        // removes this with clause and then generates the concrete accessors. To prevent the
+        // with clause being removed unnecessarily a check is preformed to identify if the class
+        // has an annotation since the public class added for dart 2 builder compatibility will not be
+        // annotated.
         if (declarations.props.node.metadata.isEmpty && declarations.props.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.props.node.withClause));
         }
@@ -223,10 +226,13 @@ class ImplGenerator {
         final String stateName = declarations.state.node.name.toString();
         final String stateImplName = '$generatedPrefix${stateName}Impl';
 
-        // The public state class signature includes a with <PropsClass>AccessorsMixin clause
+        // The public state class signature includes a with <StateClass>AccessorsMixin clause
         // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
         // the concrete accessors inline without a separate mixin. For this reason, the transformer
-        // first removes this with clause and then generates the concrete accessors.
+        // removes this with clause and then generates the concrete accessors. To prevent the
+        // with clause being removed unnecessarily a check is preformed to identify if the class
+        // has an annotation since the public class added for dart 2 builder compatibility will not be
+        // annotated.
         if (declarations.state.node.metadata.isEmpty && declarations.state.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.state.node.withClause));
         }
@@ -373,10 +379,32 @@ class ImplGenerator {
     //   Abstract Props/State implementations
     // ----------------------------------------------------------------------
     declarations.abstractProps.forEach((abstractPropsClass) {
+      // The public abstract props class signature includes a with <AbstractPropsClass>AccessorsMixin clause
+      // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
+      // the concrete accessors inline without a separate mixin. For this reason, the transformer
+      // removes this with clause and then generates the concrete accessors. To prevent the
+      // with clause being removed unnecessarily a check is preformed to identify if the class
+      // has an annotation since the public class added for dart 2 builder compatibility will not be
+      // annotated.
+      if (abstractPropsClass.node.metadata.isEmpty && abstractPropsClass.node.withClause != null) {
+        transformedFile.remove(getSpan(sourceFile, abstractPropsClass.node.withClause));
+      }
+
       generateAccessors(AccessorType.props, abstractPropsClass);
     });
 
     declarations.abstractState.forEach((abstractStateClass) {
+      // The public abstract state class signature includes a with <AbstractStateClass>AccessorsMixin clause
+      // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
+      // the concrete accessors inline without a separate mixin. For this reason, the transformer
+      // removes this with clause and then generates the concrete accessors. To prevent the
+      // with clause being removed unnecessarily a check is preformed to identify if the class
+      // has an annotation since the public class added for dart 2 builder compatibility will not be
+      // annotated.
+      if (abstractStateClass.node.metadata.isEmpty && abstractStateClass.node.withClause != null) {
+        transformedFile.remove(getSpan(sourceFile, abstractStateClass.node.withClause));
+      }
+
       generateAccessors(AccessorType.state, abstractStateClass);
     });
   }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -736,10 +736,10 @@ class ImplGenerator {
 
 enum AccessorType {props, state}
 
-/// Check if the passed in class declaration is null, if not, remove it's with clause.
+/// Check if the passed in class declaration is null, if not, remove its with clause.
 ///
 /// The public Props|State|AbstractProps|AbstractState class signatures includes a with
-/// <PropsClass>AccessorsMixin clause for dart 2 builder compatibility. But in Dart 1,
+/// <Class>AccessorsMixin clause for dart 2 builder compatibility. But in Dart 1,
 /// the transformer is able to generate the concrete accessors inline without a separate
 /// mixin. For this reason, the transformer removes the with clause from the public class
 /// signatures.
@@ -759,7 +759,5 @@ enum AccessorType {props, state}
 /// is not required and needs to be removed.
 void removeWithClauseIfNecessary(ClassDeclaration declaration, SourceFile sourceFile, TransformedSourceFile transformedFile) {
   if (declaration == null) return;
-  else {
-    transformedFile.remove(getSpan(sourceFile, declaration.withClause));
-  }
+  transformedFile.remove(getSpan(sourceFile, declaration.withClause));
 }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -89,10 +89,10 @@ class ImplGenerator {
       // instantiated.
       if (!declarations.props.node.isAbstract) {
 
-        // Remove the with clause from the public props class signature for dart 2 builder compatibility.
-        // In Dart 2 there will be a dual class set up requiring a private and public props class. The private
-        // annotated class defines the interface via uninitialized fields. The public un-annotated class is a
-        // stub and needs to be transformed to include the concrete accessor implementations.
+        // The public props class signature includes a with <PropsClass>AccessorsMixin clause
+        // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
+        // the concrete accessors inline without a separate mixin. For this reason, the transformer
+        // first removes this with clause and then generates the concrete accessors.
         if (declarations.props.node.metadata.isEmpty && declarations.props.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.props.node.withClause));
         }
@@ -223,10 +223,10 @@ class ImplGenerator {
         final String stateName = declarations.state.node.name.toString();
         final String stateImplName = '$generatedPrefix${stateName}Impl';
 
-        // Remove the with clause from the public state class signature for dart 2 builder compatibility.
-        // In Dart 2 there will be a dual class set up requiring a private and public state class. The private
-        // annotated class defines the interface via uninitialized fields. The public un-annotated class is a
-        // stub and needs to be transformed to include the concrete accessor implementations.
+        // The public state class signature includes a with <PropsClass>AccessorsMixin clause
+        // for dart 2 builder compatibility. But in Dart 1, the transformer is able to generate
+        // the concrete accessors inline without a separate mixin. For this reason, the transformer
+        // first removes this with clause and then generates the concrete accessors.
         if (declarations.state.node.metadata.isEmpty && declarations.state.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.state.node.withClause));
         }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -89,6 +89,10 @@ class ImplGenerator {
       // instantiated.
       if (!declarations.props.node.isAbstract) {
 
+        // Remove the with clause from the public props class signature for dart 2 builder compatibility.
+        // In Dart 2 there will be a dual class set up requiring a private and public props class. The private
+        // annotated class defines the interface via uninitialized fields. The public un-annotated class is a
+        // stub and needs to be transformed to include the concrete accessor implementations.
         if (declarations.props.node.metadata.isEmpty && declarations.props.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.props.node.withClause));
         }
@@ -219,6 +223,10 @@ class ImplGenerator {
         final String stateName = declarations.state.node.name.toString();
         final String stateImplName = '$generatedPrefix${stateName}Impl';
 
+        // Remove the with clause from the public state class signature for dart 2 builder compatibility.
+        // In Dart 2 there will be a dual class set up requiring a private and public state class. The private
+        // annotated class defines the interface via uninitialized fields. The public un-annotated class is a
+        // stub and needs to be transformed to include the concrete accessor implementations.
         if (declarations.state.node.metadata.isEmpty && declarations.state.node.withClause != null) {
           transformedFile.remove(getSpan(sourceFile, declarations.state.node.withClause));
         }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -88,6 +88,11 @@ class ImplGenerator {
       // We can safely make this abstract, since we already have a runtime warning when it's
       // instantiated.
       if (!declarations.props.node.isAbstract) {
+
+        if (declarations.props.node.metadata.isEmpty && declarations.props.node.withClause != null) {
+          transformedFile.remove(getSpan(sourceFile, declarations.props.node.withClause));
+        }
+
         transformedFile.insert(
             sourceFile.location(declarations.props.node.classKeyword.offset),
             'abstract '
@@ -213,6 +218,10 @@ class ImplGenerator {
       if (declarations.state != null) {
         final String stateName = declarations.state.node.name.toString();
         final String stateImplName = '$generatedPrefix${stateName}Impl';
+
+        if (declarations.state.node.metadata.isEmpty && declarations.state.node.withClause != null) {
+          transformedFile.remove(getSpan(sourceFile, declarations.state.node.withClause));
+        }
 
         generateAccessors(AccessorType.state, declarations.state);
 
@@ -415,7 +424,7 @@ class ImplGenerator {
           final field = _field as FieldDeclaration; // ignore: avoid_as
 
           final name = typedMap.node.name.name;
-          final metaType = type == AccessorType.props ? 'Props' : 'State';
+          final metaType = isProps ? 'Props' : 'State';
 
           field.fields.variables.forEach((VariableDeclaration variable) {
             if (variable.name.toString() == 'meta' && variable.initializer != null) {

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -736,16 +736,30 @@ class ImplGenerator {
 
 enum AccessorType {props, state}
 
-// The public Props|State|AbstractProps|AbstractState class signatures includes a with
-// <PropsClass>AccessorsMixin clause for dart 2 builder compatibility. But in Dart 1,
-// the transformer is able to generate the concrete accessors inline without a separate
-// mixin. For this reason, the transformer removes this with clause and then generates
-// the concrete accessors. To prevent the with clause being removed unnecessarily a check
-// is preformed to identify if the class has an annotation since the public class added
-// for dart 2 builder compatibility will not be annotated.
+/// Check if the passed in class declaration is null, if not, remove it's with clause.
+///
+/// The public Props|State|AbstractProps|AbstractState class signatures includes a with
+/// <PropsClass>AccessorsMixin clause for dart 2 builder compatibility. But in Dart 1,
+/// the transformer is able to generate the concrete accessors inline without a separate
+/// mixin. For this reason, the transformer removes the with clause from the public class
+/// signatures.
+///
+/// Builder-compatible dual class props setup example:
+///
+///     class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
+///       // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+///       static const PropsMeta meta = $metaForFooProps;
+///     }
+///
+///     @Props()
+///     class _$FooProps extends UiProps {}
+///
+/// The builder is responsible for generating the _$FooPropsAccessorsMixin found in FooProps
+/// with clause, but since the transformer can inline concrete accessors _$FooPropsAccessorsMixin
+/// is not required and needs to be removed.
 void removeWithClauseIfNecessary(ClassDeclaration declaration, SourceFile sourceFile, TransformedSourceFile transformedFile) {
   if (declaration == null) return;
-  if (declaration.metadata.isEmpty && declaration.withClause != null) {
+  else {
     transformedFile.remove(getSpan(sourceFile, declaration.withClause));
   }
 }

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -140,6 +140,26 @@ main() {
           expect(declarations.declaresComponent, isTrue);
         });
 
+        test('a component with builder compatible annotated private props class', () {
+          setUpAndParse('''
+            @Factory()    UiFactory<FooProps> Foo;
+            class FooProps {}
+            @Props()      class _\$FooProps {}
+            @Component()  class FooComponent {}
+          ''');
+
+          expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
+          expect(declarations.props.node?.name?.name, 'FooProps');
+          expect(declarations.component.node?.name?.name, 'FooComponent');
+
+          expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
+          expect(declarations.props.meta,     null);
+          expect(declarations.component.meta, new isInstanceOf<annotations.Component>());
+
+          expectEmptyDeclarations(factory: false, props: false, component: false);
+          expect(declarations.declaresComponent, isTrue);
+        });
+
         test('a stateful component', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
@@ -156,6 +176,29 @@ main() {
           expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
           expect(declarations.props.meta,     new isInstanceOf<annotations.Props>());
           expect(declarations.state.meta,     new isInstanceOf<annotations.State>());
+          expect(declarations.component.meta, new isInstanceOf<annotations.Component>());
+
+          expectEmptyDeclarations(factory: false, props: false, state: false, component: false);
+          expect(declarations.declaresComponent, isTrue);
+        });
+
+        test('a stateful component with builder compatible annotated private state class', () {
+          setUpAndParse('''
+            @Factory()    UiFactory<FooProps> Foo;
+            @Props()      class FooProps {}
+            class FooState {}
+            @State()      class _\$FooState {}
+            @Component()  class FooComponent {}
+          ''');
+
+          expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
+          expect(declarations.props.node?.name?.name, 'FooProps');
+          expect(declarations.state.node?.name?.name, 'FooState');
+          expect(declarations.component.node?.name?.name, 'FooComponent');
+
+          expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
+          expect(declarations.props.meta,     new isInstanceOf<annotations.Props>());
+          expect(declarations.state.meta,     null);
           expect(declarations.component.meta, new isInstanceOf<annotations.Component>());
 
           expectEmptyDeclarations(factory: false, props: false, state: false, component: false);

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -143,7 +143,7 @@ main() {
         test('a component with builder compatible annotated private props class', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
-            class FooProps {}
+            class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {}
             @Props()      class _\$FooProps {}
             @Component()  class FooComponent {}
           ''');
@@ -186,7 +186,7 @@ main() {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
             @Props()      class FooProps {}
-            class FooState {}
+            class FooState extends _\$FooState with _\$FooStateAccessorsMixin {}
             @State()      class _\$FooState {}
             @Component()  class FooComponent {}
           ''');

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -152,9 +152,9 @@ main() {
           expect(declarations.props.node?.name?.name, 'FooProps');
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
-          expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
-          expect(declarations.props.meta,     null);
-          expect(declarations.component.meta, new isInstanceOf<annotations.Component>());
+          expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
+          expect(declarations.props.meta,     isNull);
+          expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
 
           expectEmptyDeclarations(factory: false, props: false, component: false);
           expect(declarations.declaresComponent, isTrue);
@@ -196,10 +196,10 @@ main() {
           expect(declarations.state.node?.name?.name, 'FooState');
           expect(declarations.component.node?.name?.name, 'FooComponent');
 
-          expect(declarations.factory.meta,   new isInstanceOf<annotations.Factory>());
-          expect(declarations.props.meta,     new isInstanceOf<annotations.Props>());
-          expect(declarations.state.meta,     null);
-          expect(declarations.component.meta, new isInstanceOf<annotations.Component>());
+          expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
+          expect(declarations.props.meta,     const isInstanceOf<annotations.Props>());
+          expect(declarations.state.meta,     isNull);
+          expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
 
           expectEmptyDeclarations(factory: false, props: false, state: false, component: false);
           expect(declarations.declaresComponent, isTrue);

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -140,25 +140,6 @@ main() {
           expect(declarations.declaresComponent, isTrue);
         });
 
-        test('a component with a private \$ prefixed props class without a matching public class', () {
-          setUpAndParse('''
-            @Factory()    UiFactory<FooProps> Foo;
-            @Props()      class _\$FooProps {}
-            @Component()  class FooComponent {}
-          ''');
-
-          expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
-          expect(declarations.props.node?.name?.name, '_\$FooProps');
-          expect(declarations.component.node?.name?.name, 'FooComponent');
-
-          expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
-          expect(declarations.props.meta,     const isInstanceOf<annotations.Props>());
-          expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
-
-          expectEmptyDeclarations(factory: false, props: false, component: false);
-          expect(declarations.declaresComponent, isTrue);
-        });
-
         test('a component with builder compatible annotated private props class', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;
@@ -482,6 +463,20 @@ main() {
       });
 
       group('and throws an error when', () {
+        test('a public props class when an private \$ prefixed props class is declared', () {
+          setUpAndParse('''
+              @Factory()    
+              UiFactory<FooProps> Foo;
+              
+              @Props()      
+              class _\$FooProps {}
+              
+              @Component()  
+              class FooComponent {}
+            ''');
+          verify(logger.error('_\$FooProps must have an accompanying public class within the same file for Dart 2 builder compatibility, but one was not found.', span: any));
+        });
+
         test('`subtypeOf` is an unsupported expression that is not an identifier', () {
           expect(() {
             setUpAndParse('''

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -140,6 +140,25 @@ main() {
           expect(declarations.declaresComponent, isTrue);
         });
 
+        test('a component with a private \$ prefixed props class without a matching public class', () {
+          setUpAndParse('''
+            @Factory()    UiFactory<FooProps> Foo;
+            @Props()      class _\$FooProps {}
+            @Component()  class FooComponent {}
+          ''');
+
+          expect(declarations.factory.node?.variables?.variables?.single?.name?.name, 'Foo');
+          expect(declarations.props.node?.name?.name, '_\$FooProps');
+          expect(declarations.component.node?.name?.name, 'FooComponent');
+
+          expect(declarations.factory.meta,   const isInstanceOf<annotations.Factory>());
+          expect(declarations.props.meta,     const isInstanceOf<annotations.Props>());
+          expect(declarations.component.meta, const isInstanceOf<annotations.Component>());
+
+          expectEmptyDeclarations(factory: false, props: false, component: false);
+          expect(declarations.declaresComponent, isTrue);
+        });
+
         test('a component with builder compatible annotated private props class', () {
           setUpAndParse('''
             @Factory()    UiFactory<FooProps> Foo;

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -463,7 +463,7 @@ main() {
       });
 
       group('and throws an error when', () {
-        test('a public props class when an private \$ prefixed props class is declared', () {
+        test('a public props class is not found when an private \$ prefixed props class is declared', () {
           setUpAndParse('''
               @Factory()    
               UiFactory<FooProps> Foo;
@@ -475,6 +475,57 @@ main() {
               class FooComponent {}
             ''');
           verify(logger.error('_\$FooProps must have an accompanying public class within the same file for Dart 2 builder compatibility, but one was not found.', span: any));
+        });
+
+        test('a public state class is not found when an private \$ prefixed state class is declared', () {
+          setUpAndParse('''
+              @Factory()    
+              UiFactory<FooProps> Foo;
+              
+              @Props()      
+              class FooProps {}
+              
+              @State()
+              class _\$FooState {}
+              
+              @Component()  
+              class FooComponent {}
+            ''');
+          verify(logger.error('_\$FooState must have an accompanying public class within the same file for Dart 2 builder compatibility, but one was not found.', span: any));
+        });
+
+        test('a public abstract props class is not found  when an private \$ prefixed abstract props class is declared', () {
+          setUpAndParse('''
+              @Factory()    
+              UiFactory<FooProps> Foo;
+              
+              @Props()      
+              class FooProps {}
+              
+              @Component()  
+              class FooComponent {}
+              
+              @AbstractProps() 
+              class _\$AbstractFooProps {}
+            ''');
+          verify(logger.error('_\$AbstractFooProps must have an accompanying public class within the same file for Dart 2 builder compatibility, but one was not found.', span: any));
+        });
+
+        test('a public abstract state class is not found when an private \$ prefixed abstract state class is declared', () {
+          setUpAndParse('''
+              @Factory()    
+              UiFactory<FooProps> Foo;
+              
+              @Props()      
+              class FooProps {}
+              
+              @Component()  
+              class FooComponent {}
+              
+              @AbstractState() 
+              class _\$AbstractStateProps {}
+             ''');
+          verify(logger.error('_\$AbstractStateProps must have an accompanying public class within the same file for Dart 2 builder compatibility, but one was not found.', span: any));
         });
 
         test('`subtypeOf` is an unsupported expression that is not an identifier', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -415,14 +415,6 @@ main() {
            
             @Props()
             class _\$FooProps extends UiProps {}
-            
-            @AbstractProps() class AbstractFooProps {
-              var bar;
-              var baz;
-            }
-            
-            @State()
-            class FooState {}
            
             @Component()
             class FooComponent {
@@ -482,20 +474,9 @@ main() {
           final transformedFooStateLine = 'class AbstractFooProps extends _\$AbstractFooProps';
 
           preservedLineNumbersTest('''
-            @Factory()
-            UiFactory<FooProps> Foo;
-            
-            @Props()
-            class FooProps extends UiProps {}
-            
-            @Component()
-            class FooComponent {
-              render() => null;
-            }
-          
             class AbstractFooProps extends _\$AbstractFooProps with _\$AbstractFooPropsAccessorsMixin {
               // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-              static const AbstractFooPropsMeta meta = \$metaForAbstractFooProps;
+              static const PropsMeta meta = \$metaForAbstractFooProps;
             }
             
             @AbstractProps() 
@@ -518,20 +499,9 @@ main() {
           final transformedFooStateLine = 'class AbstractStateProps extends _\$AbstractStateProps';
 
           preservedLineNumbersTest('''
-            @Factory()
-            UiFactory<FooProps> Foo;
-            
-            @Props()
-            class FooProps extends UiProps {}
-            
-            @Component()
-            class FooComponent {
-              render() => null;
-            }
-            
             class AbstractStateProps extends _\$AbstractStateProps with _\$AbstractFooStateAccessorsMixin {
               // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-              static const AbstractFooStateMeta meta = \$metaForAbstractStateProps;
+              static const StateMeta meta = \$metaForAbstractFooState;
             }
               
             @AbstractState() 

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -336,71 +336,70 @@ main() {
           final fooPropsImplExtendsPrivateClass = 'class _\$FooPropsImpl extends _\$FooProps';
 
           preservedLineNumbersTest('''
-           @Factory()
-           UiFactory<FooProps> Foo;
+            @Factory()
+            UiFactory<FooProps> Foo;
         
-           class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps {
-           // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-           static const PropsMeta meta = \$metaForFooProps;
-           }
+            class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps {
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              static const PropsMeta meta = \$metaForFooProps;
+            }
            
-           @Props()
-           class _\$FooProps extends UiProps {}
+            @Props()
+            class _\$FooProps extends UiProps {}
+            
+            @State()
+            class FooState {}
            
-           @State()
-           class FooState {}
-           
-           @Component()
-           class FooComponent {
-            render() => null;
-           }
-           '''
+            @Component()
+            class FooComponent {
+              render() => null;
+            }
+          '''
           );
 
           var transformedSource = transformedFile.getTransformedText();
-          print(transformedSource);
           expect(transformedSource, contains(originalPrivateFooPropsLine));
-          expect(transformedSource.contains(originalPublicFooPropsLine), isFalse);
+          expect(transformedSource, isNot(contains(originalPublicFooPropsLine)));
           expect(transformedSource, contains(transformedFooPropsLine));
           expect(transformedSource, contains(fooPropsImplExtendsPublicClass));
-          expect(transformedSource.contains(fooPropsImplExtendsPrivateClass), isFalse);
+          expect(transformedSource, isNot(contains(fooPropsImplExtendsPrivateClass)));
         });
 
         test('with builder compatible private state class', () {
-          final originalPrivateFooPropsLine = 'class _\$FooState extends UiState {}';
-          final originalPublicFooPropsLine = 'class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState';
-          final transformedFooPropsLine = 'class FooState extends UiState  implements _\$FooState';
+          final originalPrivateFooStateLine = 'class _\$FooState extends UiState {}';
+          final originalPublicFooStateLine = 'class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState';
+          final transformedFooStateLine = 'class FooState extends UiState  implements _\$FooState';
           final fooStateImplExtendsPublicClass = 'class _\$FooStateImpl extends FooState';
           final fooStateImplExtendsPrivateClass = 'class _\$FooStateImpl extends _\$FooState';
 
           preservedLineNumbersTest('''
-           @Factory()
-           UiFactory<FooProps> Foo;
+            @Factory()
+            UiFactory<FooProps> Foo;
         
-           class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState {
-           // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-           static const StateMeta meta = \$metaForFooState;
-           }
+            class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState {
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              static const StateMeta meta = \$metaForFooState;
+            }
            
-           @Props()
-           class FooProps extends UiProps {}
+            @Props()
+            class FooProps extends UiProps {}
            
-           @State()
-           class _\$FooState extends UiState {}
+            @State()
+            class _\$FooState extends UiState {}
            
-           @Component()
-           class FooComponent {
-            render() => null;
-           }
-           '''
+            @Component()
+            class FooComponent {
+              render() => null;
+            }
+          '''
           );
 
           var transformedSource = transformedFile.getTransformedText();
-          expect(transformedSource, contains(originalPrivateFooPropsLine));
-          expect(transformedSource.contains(originalPublicFooPropsLine), isFalse);
-          expect(transformedSource, contains(transformedFooPropsLine));
+          expect(transformedSource, contains(originalPrivateFooStateLine));
+          expect(transformedSource, isNot(contains(originalPublicFooStateLine)));
+          expect(transformedSource, contains(transformedFooStateLine));
           expect(transformedSource, contains(fooStateImplExtendsPublicClass));
-          expect(transformedSource.contains(fooStateImplExtendsPrivateClass), isFalse);
+          expect(transformedSource, isNot(contains(fooStateImplExtendsPrivateClass)));
         });
 
         group('that subtypes another component, referencing the component class via', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -335,7 +335,7 @@ main() {
           final fooPropsImplExtendsPublicClass = 'class _\$FooPropsImpl extends FooProps';
           final fooPropsImplExtendsPrivateClass = 'class _\$FooPropsImpl extends _\$FooProps';
 
-          setUpAndGenerate('''
+          preservedLineNumbersTest('''
             @Factory()
             UiFactory<FooProps> Foo;
         
@@ -346,6 +346,11 @@ main() {
            
             @Props()
             class _\$FooProps extends UiProps {}
+            
+            @AbstractProps() class AbstractFooProps {
+              var bar;
+              var baz;
+            }
             
             @State()
             class FooState {}
@@ -372,7 +377,7 @@ main() {
           final fooStateImplExtendsPublicClass = 'class _\$FooStateImpl extends FooState';
           final fooStateImplExtendsPrivateClass = 'class _\$FooStateImpl extends _\$FooState';
 
-          setUpAndGenerate('''
+          preservedLineNumbersTest('''
             @Factory()
             UiFactory<FooProps> Foo;
         
@@ -400,6 +405,78 @@ main() {
           expect(transformedSource, contains(transformedFooStateLine));
           expect(transformedSource, contains(fooStateImplExtendsPublicClass));
           expect(transformedSource, isNot(contains(fooStateImplExtendsPrivateClass)));
+        });
+
+        test('with builder compatible private abstract props class', () {
+          final originalPrivateClassLine = 'class _\$AbstractFooProps {';
+          final originalPublicClassLine = 'class AbstractFooProps extends _\$AbstractFooProps with _\$AbstractFooPropsAccessorsMixin {';
+          final transformedFooStateLine = 'class AbstractFooProps extends _\$AbstractFooProps';
+
+          preservedLineNumbersTest('''
+            @Factory()
+            UiFactory<FooProps> Foo;
+            
+            @Props()
+            class FooProps extends UiProps {}
+            
+            @Component()
+            class FooComponent {
+              render() => null;
+            }
+          
+            class AbstractFooProps extends _\$AbstractFooProps with _\$AbstractFooPropsAccessorsMixin {
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              static const AbstractFooPropsMeta meta = \$metaForAbstractFooProps;
+            }
+            
+            @AbstractProps() 
+            class _\$AbstractFooProps {
+              var bar;
+              var baz;
+            }
+          '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(originalPrivateClassLine));
+          expect(transformedSource, isNot(contains(originalPublicClassLine)));
+          expect(transformedSource, contains(transformedFooStateLine));
+        });
+
+        test('with builder compatible private abstract state class', () {
+          final originalPrivateClassLine = 'class _\$AbstractStateProps {';
+          final originalPublicClassLine = 'class AbstractStateProps extends _\$AbstractStateProps with _\$AbstractStatePropsAccessorsMixin {';
+          final transformedFooStateLine = 'class AbstractStateProps extends _\$AbstractStateProps';
+
+          preservedLineNumbersTest('''
+            @Factory()
+            UiFactory<FooProps> Foo;
+            
+            @Props()
+            class FooProps extends UiProps {}
+            
+            @Component()
+            class FooComponent {
+              render() => null;
+            }
+            
+            class AbstractStateProps extends _\$AbstractStateProps with _\$AbstractFooStateAccessorsMixin {
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              static const AbstractFooStateMeta meta = \$metaForAbstractStateProps;
+            }
+              
+            @AbstractState() 
+            class _\$AbstractStateProps {
+              var bar;
+              var baz;
+            }
+          '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(originalPrivateClassLine));
+          expect(transformedSource, isNot(contains(originalPublicClassLine)));
+          expect(transformedSource, contains(transformedFooStateLine));
         });
 
         group('that subtypes another component, referencing the component class via', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -330,16 +330,16 @@ main() {
 
         test('with builder compatible private props class', () {
           final originalPrivateFooPropsLine = 'class _\$FooProps extends UiProps {}';
-          final originalPublicFooPropsLine = 'class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps';
-          final transformedFooPropsLine = 'class FooProps extends UiProps  implements _\$FooProps';
+          final originalPublicFooPropsLine = 'class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {';
+          final transformedFooPropsLine = 'class FooProps extends _\$FooProps';
           final fooPropsImplExtendsPublicClass = 'class _\$FooPropsImpl extends FooProps';
           final fooPropsImplExtendsPrivateClass = 'class _\$FooPropsImpl extends _\$FooProps';
 
-          preservedLineNumbersTest('''
+          setUpAndGenerate('''
             @Factory()
             UiFactory<FooProps> Foo;
         
-            class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps {
+            class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {
               // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
               static const PropsMeta meta = \$metaForFooProps;
             }
@@ -367,16 +367,16 @@ main() {
 
         test('with builder compatible private state class', () {
           final originalPrivateFooStateLine = 'class _\$FooState extends UiState {}';
-          final originalPublicFooStateLine = 'class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState';
-          final transformedFooStateLine = 'class FooState extends UiState  implements _\$FooState';
+          final originalPublicFooStateLine = 'class FooState extends _\$FooState with _\$FooStateAccessorsMixin {';
+          final transformedFooStateLine = 'class FooState extends _\$FooState';
           final fooStateImplExtendsPublicClass = 'class _\$FooStateImpl extends FooState';
           final fooStateImplExtendsPrivateClass = 'class _\$FooStateImpl extends _\$FooState';
 
-          preservedLineNumbersTest('''
+          setUpAndGenerate('''
             @Factory()
             UiFactory<FooProps> Foo;
         
-            class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState {
+            class FooState extends _\$FooState with _\$FooStateAccessorsMixin {
               // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
               static const StateMeta meta = \$metaForFooState;
             }

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -328,6 +328,81 @@ main() {
           expect(transformedSource, contains(transformedLine));
         });
 
+        test('with builder compatible private props class', () {
+          final originalPrivateFooPropsLine = 'class _\$FooProps extends UiProps {}';
+          final originalPublicFooPropsLine = 'class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps';
+          final transformedFooPropsLine = 'class FooProps extends UiProps  implements _\$FooProps';
+          final fooPropsImplExtendsPublicClass = 'class _\$FooPropsImpl extends FooProps';
+          final fooPropsImplExtendsPrivateClass = 'class _\$FooPropsImpl extends _\$FooProps';
+
+          preservedLineNumbersTest('''
+           @Factory()
+           UiFactory<FooProps> Foo;
+        
+           class FooProps extends UiProps with _\$FooPropsAccessorsMixin implements _\$FooProps {
+           // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+           static const PropsMeta meta = \$metaForFooProps;
+           }
+           
+           @Props()
+           class _\$FooProps extends UiProps {}
+           
+           @State()
+           class FooState {}
+           
+           @Component()
+           class FooComponent {
+            render() => null;
+           }
+           '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          print(transformedSource);
+          expect(transformedSource, contains(originalPrivateFooPropsLine));
+          expect(transformedSource.contains(originalPublicFooPropsLine), isFalse);
+          expect(transformedSource, contains(transformedFooPropsLine));
+          expect(transformedSource, contains(fooPropsImplExtendsPublicClass));
+          expect(transformedSource.contains(fooPropsImplExtendsPrivateClass), isFalse);
+        });
+
+        test('with builder compatible private state class', () {
+          final originalPrivateFooPropsLine = 'class _\$FooState extends UiState {}';
+          final originalPublicFooPropsLine = 'class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState';
+          final transformedFooPropsLine = 'class FooState extends UiState  implements _\$FooState';
+          final fooStateImplExtendsPublicClass = 'class _\$FooStateImpl extends FooState';
+          final fooStateImplExtendsPrivateClass = 'class _\$FooStateImpl extends _\$FooState';
+
+          preservedLineNumbersTest('''
+           @Factory()
+           UiFactory<FooProps> Foo;
+        
+           class FooState extends UiState with _\$FooStateAccessorsMixin implements _\$FooState {
+           // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+           static const StateMeta meta = \$metaForFooState;
+           }
+           
+           @Props()
+           class FooProps extends UiProps {}
+           
+           @State()
+           class _\$FooState extends UiState {}
+           
+           @Component()
+           class FooComponent {
+            render() => null;
+           }
+           '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(originalPrivateFooPropsLine));
+          expect(transformedSource.contains(originalPublicFooPropsLine), isFalse);
+          expect(transformedSource, contains(transformedFooPropsLine));
+          expect(transformedSource, contains(fooStateImplExtendsPublicClass));
+          expect(transformedSource.contains(fooStateImplExtendsPrivateClass), isFalse);
+        });
+
         group('that subtypes another component, referencing the component class via', () {
           test('a simple identifier', () {
             preservedLineNumbersTest('''


### PR DESCRIPTION
## Ultimate problem:

With the new boilerplate, props and state classes (including abstract variants) will have a dual-class setup:

 - a private class that defines the interface via uninitialized fields
 - a public class that is essentially a stub and needs to be transformed to include the concrete accessor implementations

## How it was fixed:

- When parsing declarations if a class annotated with ```@Props()``` or ```@State()``` is private look for the public ```Props|State``` class and add that to the ```declarationMap``` instead. 
- Remove the ```with _$<Name>(Props|State)AcessorsMixin``` from the public signature

## Testing suggestions:

- CI passes
- Code changes and tests make sense 

> __FYA:__ @corwinsheahan-wf @evanweible-wf @greglittlefield-wf 
