### PR TITLE
AF-3086: transformer generates empty $ sign prefixed mixin classes

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -167,6 +167,16 @@ class ImplGenerator {
       // ----------------------------------------------------------------------
       generateAccessors(AccessorType.props, declarations.props);
 
+      // Generate an empty abstract $ sign prefixed props mixins when found since Dart 2 builder compatible
+      // boiler plate prefixes props mixins with a $ sign and adds the mixin to props class via the with clause.
+      if (declarations.props.node.withClause != null) {
+        declarations.props.node.withClause.mixinTypes.forEach((type) {
+          if (type.toString().startsWith('\$')) {
+            transformedFile.insert(sourceFile.location(declarations.factory.node.end), '\n\nabstract class $type {}');
+          }
+        });
+      }
+
       final String propKeyNamespace = getAccessorKeyNamespace(declarations.props);
 
       implementations
@@ -211,6 +221,17 @@ class ImplGenerator {
       //   State implementation
       // ----------------------------------------------------------------------
       if (declarations.state != null) {
+
+        // Generate an empty abstract $ sign prefixed state mixins when found since Dart 2 builder compatible
+        // boiler plate prefixes state mixins with a $ sign and adds the mixin to state class via the with clause.
+        if (declarations.state.node.withClause != null) {
+          declarations.state.node.withClause.mixinTypes.forEach((type) {
+            if (type.toString().startsWith('\$')) {
+              transformedFile.insert(sourceFile.location(declarations.factory.node.end), '\n\nabstract class $type {}');
+            }
+          });
+        }
+
         final String stateName = declarations.state.node.name.toString();
         final String stateImplName = '$generatedPrefix${stateName}Impl';
 

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -328,6 +328,56 @@ main() {
           expect(transformedSource, contains(transformedLine));
         });
 
+        test ('with \$props|\$state mixin classes in props|state class with clause', () {
+          final transformedDollarPropsMixin = 'abstract class \$FooPropsMixin {}';
+          final transformedDollarStateMixin = 'abstract class \$FooStateMixin {}';
+
+          setUpAndGenerate('''
+           @Factory()
+           UiFactory<FooProps> Foo;
+           
+           @PropsMixin()
+           abstract class FooPropsMixin {
+              static const PropsMeta meta = \$metaForFooPropsMixin;
+              
+              Map get props;
+           }
+           
+           @StateMixin()
+           abstract class FooStateMixin {
+              static const StateMeta meta = \$metaForFooStateMixin;
+              
+              Map get state;
+           }
+                    
+           @Props()
+           class FooProps extends UiProps with FooPropsMixin, 
+           // TODO: AF-#### This will be removed once the transition to Dart 2 is complete.
+           // ignore: mixin_of_non_class,undefined_class
+           \$FooPropsMixin {
+            static const PropsMeta meta = \$metaForFooProps;
+           }
+           
+           @State()
+           class FooState extends UiState with FooStateMixin, 
+           // TODO: AF-#### This will be removed once the transition to Dart 2 is complete.
+           // ignore: mixin_of_non_class,undefined_class
+           \$FooStateMixin {
+            static const StateMeta meta = \$metaForFooState;
+           }
+           
+           @Component()
+           class FooComponent {
+            render() => null;
+           }
+           '''
+          );
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, contains(transformedDollarPropsMixin));
+          expect(transformedSource, contains(transformedDollarStateMixin));
+        });
+
         group('that subtypes another component, referencing the component class via', () {
           test('a simple identifier', () {
             preservedLineNumbersTest('''


### PR DESCRIPTION
## Ultimate problem:

With the builder-compat boilerplate, Props and State mixin classes are renamed to include a $ prefix with the assumption that the actual class with concrete accessor implementations will be generated.

```dart
@PropsMixin()
abstract class FooPropsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = $metaForBarPropsMixin;
+
  Map get props;
  
  String fooProp;
}

// --- mixin usages ---

@Props()
class BarProps extends UiProps
-     with FooPropsMixin {
+     with
+         FooPropsMixin,
+         // TODO: AF-#### This will be removed once the transition to Dart 2 is complete.
+         // ignore: mixin_of_non_class,undefined_class
+         $FooPropsMixin {
  // ...
}
```

Previously, the transformer would inline these implementations over top of the fields. To support this setup, the transformer needs to inline an implementation of the public mixin class that extends the $-prefixed class. With this approach, the mixin clauses for consuming these mixin classes can be left as-is.

## How it was fixed:

- When a $ sign prefixed mixin is found in the props|state class with clause an empty abstract $ sign prefixed mixin classes is generated.

## Testing suggestions:

- CI passes 
- Code changes and tests make sense 

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @evanweible-wf @corwinsheahan-wf 
