### PR TITLE
AF-3085: Transformer is aware of Dart 2 builder compatible boilerplate for Factories

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -107,7 +107,7 @@ class ImplGenerator {
         if (variable.initializer != null && !(variable.initializer.toString() == '\$$factoryName')) {
           logger.error(
               'Factory variables are stubs for the generated factories, and should not have initializers '
-              'unless initialized with \$<UiFactory> for Dart 2 builder compatibility.',
+              'unless initialized with \$$factoryName for Dart 2 builder compatibility.',
               span: getSpan(sourceFile, variable.initializer)
           );
         }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -104,9 +104,10 @@ class ImplGenerator {
       }
 
       declarations.factory.node.variables.variables.forEach((variable) {
-        if (variable.initializer != null) {
+        if (variable.initializer != null && !(variable.initializer.toString() == '\$$factoryName')) {
           logger.error(
-              'Factory variables are stubs for the generated factories, and should not have initializers.',
+              'Factory variables are stubs for the generated factories, and should not have initializers '
+              'unless initialized with \$<UiFactory> for Dart 2 builder compatibility.',
               span: getSpan(sourceFile, variable.initializer)
           );
         }

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -256,6 +256,28 @@ main() {
               reason: 'should preserve existing inheritance');
         });
 
+        test('with an initialized UiFactory with \$<UiFactory>', () {
+          final originalUiFactoryLine = 'UiFactory<FooProps> Foo = \$Foo;';
+          final transformedUiFactoryLine = 'UiFactory<FooProps> Foo = ([Map backingProps]) => new _\$FooPropsImpl(backingProps);';
+
+          preservedLineNumbersTest('''
+              @Factory()
+              UiFactory<FooProps> Foo = \$Foo;
+
+              @Props()
+              class FooProps {}
+
+              @Component()
+              class FooComponent {
+                render() => null;
+              }
+            ''');
+
+          var transformedSource = transformedFile.getTransformedText();
+          expect(transformedSource, isNot(contains(originalUiFactoryLine)));
+          expect(transformedSource, contains(transformedUiFactoryLine));
+        });
+
         test('with static PropsMeta and StateMeta declaration', () {
           final originalPropsMetaLine = 'static const PropsMeta meta = \$metaForFooProps;';
           final originalStateMetaLine = 'static const StateMeta meta = \$metaForFooState;';
@@ -661,7 +683,20 @@ main() {
             $restOfComponent
           ''');
 
-          verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers.', span: any));
+          verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
+              ' unless initialized with \$<UiFactory> for Dart 2 builder compatibility.', span: any));
+        });
+
+        test('declared with an \$ prefixed initializer', () {
+          setUpAndGenerate('''
+            @Factory()
+            UiFactory<FooProps> Foo = \$Foo;
+
+            $restOfComponent
+          ''');
+
+          verifyNever(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
+              ' unless initialized with \$<UiFactory> for Dart 2 builder compatibility.', span: any));
         });
       });
 

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -684,10 +684,10 @@ main() {
           ''');
 
           verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
-              ' unless initialized with \$<UiFactory> for Dart 2 builder compatibility.', span: any));
+              ' unless initialized with \$Foo for Dart 2 builder compatibility.', span: any));
         });
 
-        test('declared with an \$ prefixed initializer', () {
+        test('declared with an \$ prefixed initializer matching the factory name', () {
           setUpAndGenerate('''
             @Factory()
             UiFactory<FooProps> Foo = \$Foo;
@@ -696,7 +696,7 @@ main() {
           ''');
 
           verifyNever(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
-              ' unless initialized with \$<UiFactory> for Dart 2 builder compatibility.', span: any));
+              ' unless initialized with \$Foo for Dart 2 builder compatibility.', span: any));
         });
       });
 


### PR DESCRIPTION
## Ultimate problem:

The Dart 2 builder compatible boilerplate for factories includes an initialization statement for a UiFactory, e.g.:

```dart
@Factory()
- UiFactory<FooProps> Foo;
+ // ignore: undefined_identifier
+ UiFactory<FooProps> Foo = $Foo;
```

The problem is that the transformer throws an error if a UiFactory declaration is initialized. 

## How it was fixed:

- Make the transformer aware that Dart 2 builder compatible boiler plate initializes the UiFactory so it doesn't throw an error when initialized correctly 
- Ensure (by adding a test) that the transformer will replace the initialization with: 
```([Map backingProps]) => new _$FooPropsImpl(backingProps);```

## Testing suggestions:

CI passes 
Code changes and added tests make sense 

---

> __FYA:__ @aaronlademann-wf @corwinsheahan-wf @evanweible-wf @greglittlefield-wf 
