### PR TITLE
AF-1896 Add PropsMeta and StateMeta classes as alternative to $Props/$PropKeys

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -21,6 +21,8 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/component_base.dart' as component_base;
 
+class TestPropsMeta extends PropsMeta {}
+
 @AbstractProps()
 abstract class AbstractTransitionProps extends UiProps with TransitionPropsMixin {}
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -21,8 +21,6 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/component_base.dart' as component_base;
 
-class TestPropsMeta extends PropsMeta {}
-
 @AbstractProps()
 abstract class AbstractTransitionProps extends UiProps with TransitionPropsMixin {}
 

--- a/lib/src/component/aria_mixin.dart
+++ b/lib/src/component/aria_mixin.dart
@@ -17,8 +17,8 @@ library over_react.aria_mixin;
 import 'dart:collection';
 
 // Must import these consts because they are used in the transformed code.
-// ignore: unused_import
-import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps;
+// ignore: unused_shown_name
+import 'package:over_react/over_react.dart' show PropDescriptor, PropsMeta, ConsumedProps;
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 /// Typed getters/setters for accessibility props.

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -15,10 +15,10 @@
 /// Various prop related mixins to be used with [UiComponent] descendants.
 library over_react.prop_mixins;
 
-import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps;
+import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps, PropsMeta;
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_import
-import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps;
+import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps, $Props;
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/annotations.dart';
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -760,11 +760,16 @@ abstract class MapViewMixin<K, V> implements _OverReactMapViewBase<K, V> {
   Iterable<V> get values => _map.values;
 }
 
+abstract class _Descriptor {
+  String get key;
+}
+
 /// Provides a representation of a single `prop` declared within a [UiProps] subclass or props mixin.
 ///
 /// > Related: [StateDescriptor]
-class PropDescriptor {
+class PropDescriptor implements _Descriptor {
   /// The string key associated with the `prop`.
+  @override
   final String key;
   /// Whether the `prop` is required to be set.
   final bool isRequired;
@@ -779,8 +784,9 @@ class PropDescriptor {
 /// Provides a representation of a single `state` declared within a [UiState] subclass or state mixin.
 ///
 /// > Related: [PropDescriptor]
-class StateDescriptor {
+class StateDescriptor implements _Descriptor {
   /// The string key associated with the `state`.
+  @override
   final String key;
   /// Whether the `state` is required to be set.
   ///
@@ -808,4 +814,92 @@ class ConsumedProps {
   final List<String> keys;
 
   const ConsumedProps(this.props, this.keys);
+}
+
+abstract class AccessorMeta<T extends _Descriptor> {
+  List<T> get fields;
+  List<String> get keys;
+}
+
+/// Metadata for the prop fields declared in a specific props class--
+/// a class annotated with @[Props], @[PropsMixin], @[AbstractProps], etc.
+/// for which prop accessors are generated.
+///
+/// This metadata includes map key values corresponding to these fields, which
+/// is used in [UiComponent.consumedPropKeys], as well as other prop
+/// configuration done via @[Accessor]/@[requiredProp]/etc., which is used to
+/// perform prop validation within [UiComponent] lifecycle methods.
+///
+/// This metadata is generated as part of the over_react builder, and should be
+/// exposed like so:
+///     @Props()
+///     class FooProps {
+///       static const PropsMeta meta = $metaForFooProps;
+///
+///       String foo;
+///
+///       @Accessor(isRequired: true, key: 'custom_key', keyNamespace: 'custom_namespace')
+///       int bar;
+///     }
+///
+/// What the metadata looks like:
+///     main() {
+///       print(FooProps.meta.keys); // [FooProps.foo, custom_namespace.custom_key]
+///       print(FooProps.meta.props.map((p) => p.isRequired); // (false, true))
+///     }
+///
+/// _See also: [getPropKey]_
+class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
+  /// Rich views of prop field declarations.
+  ///
+  /// This includes string keys, and required prop validation related fields.
+  @override
+  final List<PropDescriptor> fields;
+
+  /// Top-level accessor of string keys of props stored in [fields].
+  @override
+  final List<String> keys;
+
+  const PropsMeta({this.fields, this.keys});
+
+  @override
+  List<PropDescriptor> get props => fields;
+}
+
+/// Metadata for the state fields declared in a specific state class--
+/// a class annotated with @[State], @[StateMixin], @[AbstractState], etc.
+/// for which state accessors are generated.
+///
+/// This metadata includes map key values corresponding to these fields, which
+/// is used to perform state validation within [UiComponent] lifecycle methods.
+///
+/// This metadata is generated as part of the over_react builder, and should be
+/// exposed like so:
+///     @State()
+///     class FooState {
+///       static const StateMeta meta = $metaForFooState;
+///
+///       String foo;
+///
+///       @Accessor(key: 'custom_key', keyNamespace: 'custom_namespace')
+///       int bar;
+///     }
+///
+/// What the metadata looks like:
+///     main() {
+///       print(FooState.meta.keys); // [FooState.foo, custom_namespace.custom_key]
+///       print(FooState.meta.fields.map((p) => p.key); // [FooState.foo, custom_namespace.custom_key]
+///     }
+class StateMeta implements AccessorMeta<StateDescriptor> {
+  /// Rich views of state field declarations.
+  ///
+  /// This includes string keys, and required state validation related fields.
+  @override
+  final List<StateDescriptor> fields;
+
+  /// Top-level accessor of string keys of props stored in [fields].
+  @override
+  final List<String> keys;
+
+  const StateMeta({this.fields, this.keys});
 }

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -888,7 +888,7 @@ class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
 /// What the metadata looks like:
 ///     main() {
 ///       print(FooState.meta.keys); // [FooState.foo, custom_namespace.custom_key]
-///       print(FooState.meta.fields.map((p) => p.key); // [FooState.foo, custom_namespace.custom_key]
+///       print(FooState.meta.fields.map((s) => s.key); // [FooState.foo, custom_namespace.custom_key]
 ///     }
 class StateMeta implements AccessorMeta<StateDescriptor> {
   /// Rich views of state field declarations.
@@ -897,7 +897,7 @@ class StateMeta implements AccessorMeta<StateDescriptor> {
   @override
   final List<StateDescriptor> fields;
 
-  /// Top-level accessor of string keys of props stored in [fields].
+  /// Top-level accessor of string keys of state stored in [fields].
   @override
   final List<String> keys;
 

--- a/lib/src/transformer/declaration_parsing.dart
+++ b/lib/src/transformer/declaration_parsing.dart
@@ -132,6 +132,14 @@ class ParsedDeclarations {
       declarationMap[annotationName] = classesOnly(annotationName, declarationMap[annotationName]);
     });
 
+    ClassDeclaration props;
+    ClassDeclaration propsCompanion;
+    ClassDeclaration state;
+    ClassDeclaration stateCompanion;
+    List<List<ClassDeclaration>> abstractPropsPairs;
+    List<List<ClassDeclaration>> abstractStatePairs;
+    List<ClassDeclaration> propsMixins;
+    List<ClassDeclaration> stateMixins;
 
     // Validate that all the declarations that make up a component are used correctly.
 
@@ -172,8 +180,6 @@ class ParsedDeclarations {
               );
             }
           }
-
-          declarationMap[annotationName] = [];
         });
       }
 
@@ -198,31 +204,87 @@ class ParsedDeclarations {
               getSpan(sourceFile, declarations.first)
           );
         }
-
-        declarationMap[annotationName] = [];
       });
+    } else {
+      void validateMetaField(ClassDeclaration cd, String expectedType) {
+        bool isPropsOrStateMeta(ClassMember member) {
+          if (member is! FieldDeclaration) return false;
+          final FieldDeclaration fd = member;
+          if (!fd.isStatic) return false;
+          if (fd.fields.variables.length > 1) return false;
+          if (fd.fields.variables.single.name.name != 'meta') return false;
+          return true;
+        }
+        final FieldDeclaration metaField = cd.members.firstWhere(isPropsOrStateMeta, orElse: () => null);
+        if (metaField == null) return;
+
+        if (metaField.fields.type?.toSource() != expectedType) {
+          error(
+              'Static meta field in accessor class must be of type `$expectedType`',
+              getSpan(sourceFile, metaField),
+          );
+        }
+        final initializer = metaField.fields.variables.single.initializer.toSource();
+        final targetClass = initializer.replaceFirst('\$metaFor', '');
+        if (!initializer.startsWith('\$metaFor') || targetClass != cd.name.name) {
+          error(
+              'Static $expectedType field in accessor class must be initialized to '
+              '`\$metaFor${cd.name.name}`',
+              getSpan(sourceFile, metaField),
+          );
+        }
+      }
+
+      props = singleOrNull(declarationMap[key_props]);
+      if (props != null && companionMap.containsKey(props.name.name)) {
+        propsCompanion = companionMap[props.name.name];
+        validateMetaField(propsCompanion, 'PropsMeta');
+      }
+
+      state = singleOrNull(declarationMap[key_state]);
+      if (state != null && companionMap.containsKey(state.name.name)) {
+        stateCompanion = companionMap[state.name.name];
+        validateMetaField(stateCompanion, 'StateMeta');
+      }
+
+      List<ClassDeclaration> pairClassWithCompanion(ClassDeclaration cd, String expectedType) {
+        if (companionMap.containsKey(cd.name.name)) {
+          validateMetaField(companionMap[cd.name.name], expectedType);
+          return [cd, companionMap[cd.name.name]];
+        }
+        return [cd];
+      }
+
+      List<ClassDeclaration> abstractProps = declarationMap[key_abstractProps];
+      abstractPropsPairs = abstractProps.map((cd) => pairClassWithCompanion(cd, 'PropsMeta')).toList();
+
+      List<ClassDeclaration> abstractStates = declarationMap[key_abstractState];
+      abstractStatePairs = abstractStates.map((cd) => pairClassWithCompanion(cd, 'StateMeta')).toList();
+
+      propsMixins = declarationMap[key_propsMixin];
+      for (final propsMixin in propsMixins) {
+        validateMetaField(propsMixin, 'PropsMeta');
+      }
+
+      stateMixins = declarationMap[key_stateMixin];
+      for (final stateMixin in stateMixins) {
+        validateMetaField(stateMixin, 'StateMeta');
+      }
     }
 
-    final ClassDeclaration props = singleOrNull(declarationMap[key_props]);
-    var propsCompanion;
-    if (props != null && companionMap.containsKey(props.name.name)) {
-      propsCompanion = companionMap[props.name.name];
+    if (hasErrors) {
+      for (final key in declarationMap.keys) {
+        declarationMap[key] = [];
+      }
+      props = null;
+      propsCompanion = null;
+      state = null;
+      stateCompanion = null;
+      abstractPropsPairs = [];
+      abstractStatePairs = [];
+      propsMixins = [];
+      stateMixins = [];
     }
-
-    final ClassDeclaration state = singleOrNull(declarationMap[key_state]);
-    var stateCompanion;
-    if (state != null && companionMap.containsKey(state.name.name)) {
-      stateCompanion = companionMap[state.name.name];
-    }
-
-    List<ClassDeclaration> pairClassWithCompanion(ClassDeclaration cd)
-      => companionMap.containsKey(cd.name.name) ? [cd, companionMap[cd.name.name]] : [cd];
-
-    final List<ClassDeclaration> abstractProps = declarationMap[key_abstractProps];
-    final abstractPropsPairs = abstractProps.map(pairClassWithCompanion).toList();
-
-    final List<ClassDeclaration> abstractStates = declarationMap[key_abstractState];
-    final abstractStatePairs = abstractStates.map(pairClassWithCompanion).toList();
 
     return new ParsedDeclarations._(
         factory:        singleOrNull(declarationMap[key_factory]),
@@ -235,8 +297,8 @@ class ParsedDeclarations {
         abstractProps:  abstractPropsPairs,
         abstractState:  abstractStatePairs,
 
-        propsMixins:    declarationMap[key_propsMixin],
-        stateMixins:    declarationMap[key_stateMixin],
+        propsMixins:    propsMixins,
+        stateMixins:    stateMixins,
 
         hasErrors: hasErrors
     );

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -682,16 +682,16 @@ class ImplGenerator {
     final metaStructName = type == AccessorType.props
         ? 'PropsMeta'
         : 'StateMeta';
-    final metaInstanceName = '${publicGeneratedPrefix}metaFor$name'; // FIXME validate boilerplate to avoid typos
-     var output = new StringBuffer();
+    final metaInstanceName = '${publicGeneratedPrefix}metaFor$name';
+    final output = new StringBuffer();
     output.writeln('/// A class that allows us to reuse generated code from the accessors class.');
     output.writeln('/// This is only used by other generated code, and can be simplified if needed.');
     output.writeln('class $metaClassName {');
     output.writeln(staticVariablesImpl);
     output.writeln('}');
     output.writeln('const $metaStructName $metaInstanceName = const $metaStructName(');
-    output.writeln('  fields: $metaClassName.$constantListName,'); // todo don't include generated prefix
-    output.writeln('  keys: $metaClassName.$keyListName,'); // todo don't include generated prefix
+    output.writeln('  fields: $metaClassName.$constantListName,');
+    output.writeln('  keys: $metaClassName.$keyListName,');
     output.writeln(');');
     return new AccessorOutput(output.toString());
   }

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -20,7 +20,7 @@ import 'dart:collection';
 import 'package:over_react/over_react.dart' show
     // Must import these consts because they are used in the transformed code.
     PropDescriptor, ConsumedProps, // ignore: unused_shown_name
-    UiComponent, UiProps;
+    PropsMeta, UiComponent, UiProps;
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 /// Typed getters/setters for props related to CSS class manipulation.


### PR DESCRIPTION
**_DEPENDS ON https://github.com/Workiva/over_react/pull/203_**

## Ultimate problem:
The existing API for obtaining a list of props or a list of prop keys from a props class is via `$Props` or `$PropKeys`, but these options rely on the transformer to replace these instances inline with actual lists. Going forward in Dart2 with a builder, this approach will not work.

The alternative is to introduce `PropsMeta` and `StateMeta` classes and (eventually) have the builder generate a static `meta` field on the generated version of every consumer-defined props and state class. This meta field will map to a `PropsMeta` or `StateMeta` instance that is generated by the builder.

This PR introduces this approach ahead of the Dart 2 transition by adding the classes and updating the transformer to generate the meta instances for every props and state class, which will allow consumers to migrate away from `$Props()` and `$PropKeys()` usages ahead of time.

## How it was fixed:
- Transformer now generates a `_$<Class>Meta` class for every class annotated with one of:
  - `@Props()`
  - `@State()`
  - `@PropsMixin()`
  - `@StateMixin()`
  - `@AbstractProps()`
  - `@AbstractState()`

    As a part of the Dart1->Dart2 transition, props, state, abstract props, and abstract state classes will be renamed to have a `_$` prefix and an accompanying public class will be either generated by the builder, or during the transition, generated by a codemod script and committed. The transformer takes this into account and will strip the `_$` prefix from the annotated classes so that it generates the correct meta instance name.

- ~~All props and state classes in `over_react` itself have been updated to include the static meta field, and all references to `$Props()` and `$PropKeys()` have been updated accordingly. This was done so that existing tests can verify that the new `PropsMeta` and `StateMeta` classes and the accompanying transformations are working correctly.~~
  - Instead of doing this, we're going to run the complete codemod as the last commit in the series of commits that are required to update over_react transformer for builder compatibility.

## Testing suggestions:
- TBD

## Potential areas of regression:
- `$Props()` and `$PropKeys()` usages

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
