### PR TITLE
AF-3731: Carry type parameters on generated empty prop/state mixins classes

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -355,7 +355,7 @@ class ImplGenerator {
       /// This is because with the builder compatible boilerplate, Props
       /// and State mixin classes are renamed to include a $ prefix with the assumption that
       /// the actual class with concrete accessor implementations will be generated.
-      transformedFile.insert(sourceFile.location(propMixin.node.end), ' abstract class \$${propMixin.node.name.name} {}');
+      transformedFile.insert(sourceFile.location(propMixin.node.end), ' abstract class \$${propMixin.node.name.name}${propMixin.node.typeParameters ?? ''} {}');
     });
 
     declarations.stateMixins.forEach((stateMixin) {
@@ -375,7 +375,7 @@ class ImplGenerator {
       /// This is because with the builder compatible boilerplate, Props
       /// and State mixin classes are renamed to include a $ prefix with the assumption that
       /// the actual class with concrete accessor implementations will be generated.
-      transformedFile.insert(sourceFile.location(stateMixin.node.end), 'abstract class \$${stateMixin.node.name.name} {}');
+      transformedFile.insert(sourceFile.location(stateMixin.node.end), 'abstract class \$${stateMixin.node.name.name}${stateMixin.node.typeParameters ?? ''} {}');
     });
 
     // ----------------------------------------------------------------------

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -382,32 +382,60 @@ main() {
         });
       });
 
-      test('props mixins', () {
-        preservedLineNumbersTest('''
-          @PropsMixin() class FooPropsMixin {
-            Map get props;
+      group('for props mixins', () {
+        test('without type parameters', () {
+          preservedLineNumbersTest('''
+            @PropsMixin() class FooPropsMixin {
+              Map get props;
 
-            var bar;
-            var baz;
-          }
-        ''');
+              List<T> bar;
+              var baz;
+            }
+          ''');
 
-        var transformedSource = transformedFile.getTransformedText();
-        expect(transformedSource, contains('abstract class \$FooPropsMixin {}'));
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooPropsMixin {}'));
+        });
+
+        test('with type parameters', () {
+          preservedLineNumbersTest('''
+            @PropsMixin() class FooPropsMixin<T> {
+              Map get props;
+
+              List<T> bar;
+              var baz;
+            }
+          ''');
+
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooPropsMixin<T> {}'));
+        });
       });
 
-      test('state mixins', () {
-        preservedLineNumbersTest('''
-          @StateMixin() class FooStateMixin {
-            Map get state;
+      group('for state mixins', () {
+        test('without type parameters', () {
+          preservedLineNumbersTest('''
+            @StateMixin() class FooStateMixin {
+              Map get state;
 
-            var bar;
-            var baz;
-          }
-        ''');
+              var bar;
+              var baz;
+            }
+          ''');
 
-        var transformedSource = transformedFile.getTransformedText();
-        expect(transformedSource, contains('abstract class \$FooStateMixin {}'));
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooStateMixin {}'));
+        });
+
+        test('with type parameters', () {
+          preservedLineNumbersTest('''
+            @StateMixin() class FooStateMixin<T> {
+              Map get state;
+
+              List<T> bar;
+              var baz;
+            }
+          ''');
+
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooStateMixin<T> {}'));
+        });
       });
 
       test('abstract props classes', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -388,7 +388,7 @@ main() {
             @PropsMixin() class FooPropsMixin {
               Map get props;
 
-              List<T> bar;
+              var bar;
               var baz;
             }
           ''');
@@ -398,15 +398,15 @@ main() {
 
         test('with type parameters', () {
           preservedLineNumbersTest('''
-            @PropsMixin() class FooPropsMixin<T> {
+            @PropsMixin() class FooPropsMixin<T extends Iterable<T>, U> {
               Map get props;
 
               List<T> bar;
-              var baz;
+              U baz;
             }
           ''');
 
-          expect(transformedFile.getTransformedText(), contains('abstract class \$FooPropsMixin<T> {}'));
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooPropsMixin<T extends Iterable<T>, U> {}'));
         });
       });
 
@@ -426,15 +426,15 @@ main() {
 
         test('with type parameters', () {
           preservedLineNumbersTest('''
-            @StateMixin() class FooStateMixin<T> {
+            @StateMixin() class FooStateMixin<T extends Iterable<T>, U> {
               Map get state;
 
               List<T> bar;
-              var baz;
+              U baz;
             }
           ''');
 
-          expect(transformedFile.getTransformedText(), contains('abstract class \$FooStateMixin<T> {}'));
+          expect(transformedFile.getTransformedText(), contains('abstract class \$FooStateMixin<T extends Iterable<T>, U> {}'));
         });
       });
 


### PR DESCRIPTION
## Ultimate problem:
The transformer does not carry props/state mixins that have type parameters through to the generated `$` prefixed class. Example:
```
@PropsMixin()
abstract class FooPropsMixin<T> {...}

// This is an analyzer error since $FooPropsMixin does not have any type parameters.
// We need the typing on $FooPropsMixin since, under Dart 2, the implemented getters 
// and setters for the mixin are in $FooPropsMixin and not FooPropsMixin.
class BarProps extends UiProps with FooPropsMixin<String>, $FooPropsMixin<String> {...}

// In the generated output:
abstract class $FooPropsMixin {...}
```

## How it was fixed:
Carry type parameters from the declared props/state mixin class and add tests.

## Testing suggestions:
* CI Passes

## Potential areas of regression:
Mixin generation

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @sebastianmalysa-wf
