### PR TITLE
AF-3749: Loosen validation on Factory and meta initializers

### DIFF
--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -105,11 +105,6 @@ class ImplGenerator {
       //   Factory implementation
       // ----------------------------------------------------------------------
 
-      if (declarations.factory.node.variables.variables.length != 1) {
-        logger.error('Factory declarations must a single variable.',
-            span: getSpan(sourceFile, declarations.factory.node.variables));
-      }
-
       transformedFile.replace(
           sourceFile.span(
               declarations.factory.node.variables.variables.first.name.end,

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -112,14 +112,14 @@ class ImplGenerator {
 
       declarations.factory.node.variables.variables.forEach((variable) {
         final isPrivate = factoryName.startsWith(privatePrefix);
-        final validInitializer = isPrivate
-            ? '$generatedPrefix${factoryName.substring(privatePrefix.length)}'
-            : '$publicGeneratedPrefix$factoryName';
-        if (variable.initializer != null && variable.initializer.toString() != validInitializer) {
+        final validInitializers = isPrivate
+            ? ['$generatedPrefix${factoryName.substring(privatePrefix.length)}', '$generatedPrefix$factoryName']
+            : ['$publicGeneratedPrefix$factoryName'];
+        if (variable.initializer != null && !validInitializers.contains(variable.initializer.toString())) {
           logger.error(
               'Factory variables are stubs for the generated factories, and should not have initializers '
               'unless initialized with \$$factoryName for Dart 2 builder compatibility. '
-              'Should be:\n    $validInitializer',
+              'Should be one of:\n    $validInitializers',
               span: getSpan(sourceFile, variable.initializer)
           );
         }

--- a/lib/src/transformer/impl_generation.dart
+++ b/lib/src/transformer/impl_generation.dart
@@ -18,7 +18,7 @@ import 'package:analyzer/analyzer.dart';
 import 'package:barback/barback.dart';
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
 import 'package:over_react/src/transformer/declaration_parsing.dart';
-import 'package:over_react/src/transformer/text_util.dart';
+import 'package:over_react/src/transformer/util.dart';
 import 'package:source_span/source_span.dart';
 import 'package:transformer_utils/src/text_util.dart' show stringLiteral;
 import 'package:transformer_utils/src/transformed_source_file.dart' show getSpan;
@@ -109,21 +109,6 @@ class ImplGenerator {
         logger.error('Factory declarations must a single variable.',
             span: getSpan(sourceFile, declarations.factory.node.variables));
       }
-
-      declarations.factory.node.variables.variables.forEach((variable) {
-        final isPrivate = factoryName.startsWith(privatePrefix);
-        final validInitializers = isPrivate
-            ? ['$generatedPrefix${factoryName.substring(privatePrefix.length)}', '$generatedPrefix$factoryName']
-            : ['$publicGeneratedPrefix$factoryName'];
-        if (variable.initializer != null && !validInitializers.contains(variable.initializer.toString())) {
-          logger.error(
-              'Factory variables are stubs for the generated factories, and should not have initializers '
-              'unless initialized with \$$factoryName for Dart 2 builder compatibility. '
-              'Should be one of:\n    $validInitializers',
-              span: getSpan(sourceFile, variable.initializer)
-          );
-        }
-      });
 
       transformedFile.replace(
           sourceFile.span(
@@ -682,27 +667,30 @@ class ImplGenerator {
           staticGettersCompanionImpl
       );
     }
-    
-    final name = (companionNode ?? typedMap.node).name.name;
-    final isPrivate = name.startsWith(privatePrefix);
-    final publicName = isPrivate ? name.substring(privatePrefix.length) : name;
-    final metaClassName = '$generatedPrefix${name}Meta';
-    final metaInstanceName = isPrivate
-        ? '${generatedPrefix}metaFor$publicName'
-        : '${publicGeneratedPrefix}metaFor$publicName';
-    final metaStructName = type == AccessorType.props
-        ? 'PropsMeta'
-        : 'StateMeta';
+
+    final classDeclaration = (companionNode ?? typedMap.node);
+    final metaField = getMetaField(classDeclaration);
     final output = new StringBuffer();
-    output.writeln('/// A class that allows us to reuse generated code from the accessors class.');
-    output.writeln('/// This is only used by other generated code, and can be simplified if needed.');
-    output.writeln('class $metaClassName {');
-    output.writeln(staticVariablesImpl);
-    output.writeln('}');
-    output.writeln('const $metaStructName $metaInstanceName = const $metaStructName(');
-    output.writeln('  fields: $metaClassName.$constantListName,');
-    output.writeln('  keys: $metaClassName.$keyListName,');
-    output.writeln(');');
+    // if metaField is null, we are on Dart 1 code which has not transitioned
+    // to the transitional Dart 2 compatible boilerplate, and thus the $metaFor
+    // constant is not needed
+    if (metaField != null) {
+      final name = classDeclaration.name.name;
+      final metaClassName = '$generatedPrefix${name}Meta';
+      final metaInstanceName = metaField.fields.variables.single.initializer.toSource();
+      final metaStructName = type == AccessorType.props
+          ? 'PropsMeta'
+          : 'StateMeta';
+      output.writeln('/// A class that allows us to reuse generated code from the accessors class.');
+      output.writeln('/// This is only used by other generated code, and can be simplified if needed.');
+      output.writeln('class $metaClassName {');
+      output.writeln(staticVariablesImpl);
+      output.writeln('}');
+      output.writeln('const $metaStructName $metaInstanceName = const $metaStructName(');
+      output.writeln('  fields: $metaClassName.$constantListName,');
+      output.writeln('  keys: $metaClassName.$keyListName,');
+      output.writeln(');');
+    }
     return new AccessorOutput(output.toString());
   }
 

--- a/lib/src/transformer/util.dart
+++ b/lib/src/transformer/util.dart
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library over_react.transformer.text_util;
+library over_react.transformer.util;
+
+import 'package:analyzer/analyzer.dart';
 
 String commentBanner(String bannerText, {
     int bannerWidth: 80, int textIndent: 2, bool topBorder: true, bool bottomBorder: true
@@ -29,4 +31,18 @@ String commentBanner(String bannerText, {
       '${bannerLead.trimRight()}\n' +
       (bottomBorder ? bannerBorder : '') +
       '\n';
+}
+
+/// Returns a [FieldDeclaration] for the meta field on a [ClassDeclaration] if
+/// it exists, otherwise returns null.
+FieldDeclaration getMetaField(ClassDeclaration cd) {
+  bool isPropsOrStateMeta(ClassMember member) {
+    if (member is! FieldDeclaration) return false;
+    final FieldDeclaration fd = member;
+    if (!fd.isStatic) return false;
+    if (fd.fields.variables.length > 1) return false;
+    if (fd.fields.variables.single.name.name != 'meta') return false;
+    return true;
+  }
+  return cd.members.firstWhere(isPropsOrStateMeta, orElse: () => null);
 }

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -422,7 +422,7 @@ main() {
             test('_\$ prefixed variable name with private prefix stripped', () {
               setUpAndParse('''
                 @Factory()
-                UiFactory<FooProps> _Foo = _\$_Foo;
+                UiFactory<FooProps> _Foo = _\$Foo;
 
                 $restOfComponent
               ''');
@@ -569,32 +569,43 @@ main() {
         });
 
         group('a factory is', () {
-          test('public and declared with an initializer', () {
+          test('declared using multiple variables', () {
             setUpAndParse('''
-            @Factory()
-            UiFactory<FooProps> Foo = null;
+              @Factory()
+              UiFactory<FooProps> Foo, Bar;
 
-            $restOfComponent
-          ''');
+              $restOfComponent
+            ''');
 
-            verify(logger.error(
-                'Factory variables are stubs for the generated factories, and should not have initializers'
-                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be one of:\n'
-                    '    [\$Foo, _\$Foo]', span: any));
+            verify(logger.error('Factory declarations must be a single variable.', span: any));
           });
 
-          test('private and declared with an initializer', () {
+          test('public and declared with an invalid initializer', () {
             setUpAndParse('''
-            @Factory()
-            UiFactory<FooProps> _Foo = null;
+              @Factory()
+              UiFactory<FooProps> Foo = null;
 
-            $restOfComponent
-          ''');
+              $restOfComponent
+            ''');
 
             verify(logger.error(
                 'Factory variables are stubs for the generated factories, and should not have initializers'
-                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be one of:\n'
-                    '    [\$_Foo, _\$_Foo, _\$Foo]', span: any));
+                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be:\n'
+                    '    _\$Foo', span: any));
+          });
+
+          test('private and declared with an invalid initializer', () {
+            setUpAndParse('''
+              @Factory()
+              UiFactory<FooProps> _Foo = null;
+
+              $restOfComponent
+            ''');
+
+            verify(logger.error(
+                'Factory variables are stubs for the generated factories, and should not have initializers'
+                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be:\n'
+                    '    _\$_Foo', span: any));
           });
         });
 
@@ -615,8 +626,8 @@ main() {
                   static const PropsMeta meta = \$metaForBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaForFooProps, _\$metaForFooProps]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                  '`_\$metaForFooProps`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -625,8 +636,8 @@ main() {
                   static const PropsMeta meta = \$metaForBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaFor_FooProps, _\$metaFor_FooProps, _\$metaForFooProps]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                  '`_\$metaFor_FooProps`', span: any));
             });
           });
 
@@ -646,8 +657,8 @@ main() {
                   static const StateMeta meta = \$metaForBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaForFooState, _\$metaForFooState]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaForFooState`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -656,8 +667,8 @@ main() {
                   static const StateMeta meta = \$metaForBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaFor_FooState, _\$metaFor_FooState, _\$metaForFooState]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaFor_FooState`', span: any));
             });
           });
 
@@ -679,8 +690,8 @@ main() {
                   static const PropsMeta meta = \$metaForAbstractBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                    '`[\$metaForAbstractFooProps, _\$metaForAbstractFooProps]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                    '`_\$metaForAbstractFooProps`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -690,8 +701,8 @@ main() {
                   static const PropsMeta meta = \$metaForAbstractBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                    '`[\$metaFor_AbstractFooProps, _\$metaFor_AbstractFooProps, _\$metaForAbstractFooProps]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                    '`_\$metaFor_AbstractFooProps`', span: any));
             });
           });
 
@@ -713,8 +724,8 @@ main() {
                   static const StateMeta meta = \$metaForAbstractBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaForAbstractFooState, _\$metaForAbstractFooState]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaForAbstractFooState`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -724,8 +735,8 @@ main() {
                   static const StateMeta meta = \$metaForAbstractBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaFor_AbstractFooState, _\$metaFor_AbstractFooState, _\$metaForAbstractFooState]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaFor_AbstractFooState`', span: any));
             });
           });
 
@@ -745,8 +756,8 @@ main() {
                   static const PropsMeta meta = \$metaForBarPropsMixin;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaForFooPropsMixin, _\$metaForFooPropsMixin]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                  '`_\$metaForFooPropsMixin`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -755,8 +766,8 @@ main() {
                   static const PropsMeta meta = \$metaForBarPropsMixin;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaFor_FooPropsMixin, _\$metaFor_FooPropsMixin, _\$metaForFooPropsMixin]`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to:'
+                  '`_\$metaFor_FooPropsMixin`', span: any));
             });
           });
 
@@ -776,8 +787,8 @@ main() {
                   static const StateMeta meta = \$metaForBarStateMixin;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaForFooStateMixin, _\$metaForFooStateMixin]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaForFooStateMixin`', span: any));
             });
 
             test('is private and initialized incorrectly', () {
@@ -786,8 +797,8 @@ main() {
                   static const StateMeta meta = \$metaForBarStateMixin;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
-                  '`[\$metaFor_FooStateMixin, _\$metaFor_FooStateMixin, _\$metaForFooStateMixin]`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to:'
+                  '`_\$metaFor_FooStateMixin`', span: any));
             });
           });
         });

--- a/test/vm_tests/transformer/declaration_parsing_test.dart
+++ b/test/vm_tests/transformer/declaration_parsing_test.dart
@@ -362,6 +362,77 @@ main() {
         });
       });
 
+      const String restOfComponent = '''
+        @Props()
+        class FooProps {}
+
+        @Component()
+        class FooComponent {}
+      ''';
+
+      group('does not log a hard error when', () {
+        group('the factory is', () {
+          group('public and initialized with', () {
+            test('correct \$ prefixed variable name', () {
+              setUpAndParse('''
+                @Factory()
+                UiFactory<FooProps> Foo = \$Foo;
+
+                $restOfComponent
+              ''');
+
+              verifyNever(logger.error(any, span: any));
+            });
+
+            test('correct _\$ prefixed variable name', () {
+              setUpAndParse('''
+                @Factory()
+                UiFactory<FooProps> Foo = _\$Foo;
+
+                $restOfComponent
+              ''');
+
+              verifyNever(logger.error(any, span: any));
+            });
+          });
+
+          group('private and initialized with', () {
+            test('correct \$ prefixed variable name', () {
+              setUpAndParse('''
+                @Factory()
+                UiFactory<FooProps> _Foo = \$_Foo;
+
+                $restOfComponent
+              ''');
+
+              verifyNever(logger.error(any, span: any));
+            });
+
+            test('correct _\$ prefixed variable name', () {
+              setUpAndParse('''
+                @Factory()
+                UiFactory<FooProps> _Foo = _\$_Foo;
+
+                $restOfComponent
+              ''');
+
+              verifyNever(logger.error(any, span: any));
+            });
+
+            test('_\$ prefixed variable name with private prefix stripped', () {
+              setUpAndParse('''
+                @Factory()
+                UiFactory<FooProps> _Foo = _\$_Foo;
+
+                $restOfComponent
+              ''');
+
+              verifyNever(logger.error(any, span: any));
+            });
+          });
+        });
+      });
+
       group('and logs a hard error when', () {
         const String factorySrc      = '\n@Factory()\nUiFactory<FooProps> Foo;\n';
         const String propsSrc        = '\n@Props()\nclass FooProps {}\n';
@@ -497,6 +568,36 @@ main() {
           });
         });
 
+        group('a factory is', () {
+          test('public and declared with an initializer', () {
+            setUpAndParse('''
+            @Factory()
+            UiFactory<FooProps> Foo = null;
+
+            $restOfComponent
+          ''');
+
+            verify(logger.error(
+                'Factory variables are stubs for the generated factories, and should not have initializers'
+                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be one of:\n'
+                    '    [\$Foo, _\$Foo]', span: any));
+          });
+
+          test('private and declared with an initializer', () {
+            setUpAndParse('''
+            @Factory()
+            UiFactory<FooProps> _Foo = null;
+
+            $restOfComponent
+          ''');
+
+            verify(logger.error(
+                'Factory variables are stubs for the generated factories, and should not have initializers'
+                    ' unless initialized with a valid variable name for Dart 2 builder compatibility. Should be one of:\n'
+                    '    [\$_Foo, _\$_Foo, _\$Foo]', span: any));
+          });
+        });
+
         group('a static meta field', () {
           group('for a props class', () {
             test('has the wrong type', () {
@@ -514,7 +615,18 @@ main() {
                   static const PropsMeta meta = \$metaForBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to `\$metaForFooProps`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaForFooProps, _\$metaForFooProps]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse(factorySrc + privatePropsSrc + componentSrc + '''
+                class _FooProps {
+                  static const PropsMeta meta = \$metaForBarProps;
+                }
+              ''');
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaFor_FooProps, _\$metaFor_FooProps, _\$metaForFooProps]`', span: any));
             });
           });
 
@@ -534,7 +646,18 @@ main() {
                   static const StateMeta meta = \$metaForBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to `\$metaForFooState`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaForFooState, _\$metaForFooState]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse(factorySrc + propsSrc + privateStateSrc + componentSrc + '''
+                class _FooState {
+                  static const StateMeta meta = \$metaForBarState;
+                }
+              ''');
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaFor_FooState, _\$metaFor_FooState, _\$metaForFooState]`', span: any));
             });
           });
 
@@ -556,7 +679,19 @@ main() {
                   static const PropsMeta meta = \$metaForAbstractBarProps;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to `\$metaForAbstractFooProps`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                    '`[\$metaForAbstractFooProps, _\$metaForAbstractFooProps]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse('''
+                @AbstractProps() abstract class _\$AbstractFooProps {}
+                abstract class _AbstractFooProps {
+                  static const PropsMeta meta = \$metaForAbstractBarProps;
+                }
+              ''');
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                    '`[\$metaFor_AbstractFooProps, _\$metaFor_AbstractFooProps, _\$metaForAbstractFooProps]`', span: any));
             });
           });
 
@@ -578,7 +713,19 @@ main() {
                   static const StateMeta meta = \$metaForAbstractBarState;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to `\$metaForAbstractFooState`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaForAbstractFooState, _\$metaForAbstractFooState]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse('''
+                @AbstractState() abstract class _\$AbstractFooState {}
+                abstract class _AbstractFooState {
+                  static const StateMeta meta = \$metaForAbstractBarState;
+                }
+              ''');
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaFor_AbstractFooState, _\$metaFor_AbstractFooState, _\$metaForAbstractFooState]`', span: any));
             });
           });
 
@@ -598,7 +745,18 @@ main() {
                   static const PropsMeta meta = \$metaForBarPropsMixin;
                 }
               ''');
-              verify(logger.error('Static PropsMeta field in accessor class must be initialized to `\$metaForFooPropsMixin`', span: any));
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaForFooPropsMixin, _\$metaForFooPropsMixin]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse('''
+                @PropsMixin() abstract class _FooPropsMixin {
+                  static const PropsMeta meta = \$metaForBarPropsMixin;
+                }
+              ''');
+              verify(logger.error('Static PropsMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaFor_FooPropsMixin, _\$metaFor_FooPropsMixin, _\$metaForFooPropsMixin]`', span: any));
             });
           });
 
@@ -618,7 +776,18 @@ main() {
                   static const StateMeta meta = \$metaForBarStateMixin;
                 }
               ''');
-              verify(logger.error('Static StateMeta field in accessor class must be initialized to `\$metaForFooStateMixin`', span: any));
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaForFooStateMixin, _\$metaForFooStateMixin]`', span: any));
+            });
+
+            test('is private and initialized incorrectly', () {
+              setUpAndParse('''
+                @StateMixin() abstract class _FooStateMixin {
+                  static const StateMeta meta = \$metaForBarStateMixin;
+                }
+              ''');
+              verify(logger.error('Static StateMeta field in accessor class must be initialized to one of:'
+                  '`[\$metaFor_FooStateMixin, _\$metaFor_FooStateMixin, _\$metaForFooStateMixin]`', span: any));
             });
           });
         });

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -764,15 +764,40 @@ main() {
       });
     });
 
+    const String restOfComponent = '''
+      @Props()
+      class FooProps {}
+
+      @Component()
+      class FooComponent {}
+    ''';
+
+    group('does not log an error when', () {
+      test('declared with a \$ prefixed initializer matching the factory name', () {
+        setUpAndGenerate('''
+            @Factory()
+            UiFactory<FooProps> Foo = \$Foo;
+
+            $restOfComponent
+        ''');
+
+        verifyNever(logger.error(any, span: any));
+      });
+
+      test('declared with a _\$ prefixed initializer matching the private factory name', () {
+        setUpAndGenerate('''
+            @Factory()
+            UiFactory<FooProps> _Foo = _\$_Foo;
+
+            $restOfComponent
+        ''');
+
+        verifyNever(logger.error(any, span: any));
+      });
+    });
+
     group('logs an error when', () {
       group('a factory is', () {
-        const String restOfComponent = '''
-          @Props()
-          class FooProps {}
-
-          @Component()
-          class FooComponent {}
-        ''';
 
         test('declared using multiple variables', () {
           setUpAndGenerate('''
@@ -794,21 +819,10 @@ main() {
           ''');
 
           verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
-              ' unless initialized with \$Foo for Dart 2 builder compatibility. Should be:\n'
-              '    \$Foo', span: any));
+              ' unless initialized with \$Foo for Dart 2 builder compatibility. Should be one of:\n'
+              '    [\$Foo]', span: any));
         });
 
-        test('declared with an \$ prefixed initializer matching the factory name', () {
-          setUpAndGenerate('''
-            @Factory()
-            UiFactory<FooProps> Foo = \$Foo;
-
-            $restOfComponent
-          ''');
-
-          verifyNever(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
-              ' unless initialized with \$Foo for Dart 2 builder compatibility.', span: any));
-        });
       });
 
       group('a component class', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -764,22 +764,8 @@ main() {
       });
     });
 
-
     group('logs an error when', () {
-      test('a factory is declared using multiple variables', () {
-        setUpAndGenerate('''
-          @Factory()
-          UiFactory<FooProps> Foo, Bar;
 
-          @Props()
-          class FooProps {}
-
-          @Component()
-          class FooComponent {}
-        ''');
-
-        verify(logger.error('Factory declarations must a single variable.', span: any));
-      });
 
       group('a component class', () {
         test('subtypes itself', () {

--- a/test/vm_tests/transformer/impl_generation_test.dart
+++ b/test/vm_tests/transformer/impl_generation_test.dart
@@ -764,65 +764,21 @@ main() {
       });
     });
 
-    const String restOfComponent = '''
-      @Props()
-      class FooProps {}
-
-      @Component()
-      class FooComponent {}
-    ''';
-
-    group('does not log an error when', () {
-      test('declared with a \$ prefixed initializer matching the factory name', () {
-        setUpAndGenerate('''
-            @Factory()
-            UiFactory<FooProps> Foo = \$Foo;
-
-            $restOfComponent
-        ''');
-
-        verifyNever(logger.error(any, span: any));
-      });
-
-      test('declared with a _\$ prefixed initializer matching the private factory name', () {
-        setUpAndGenerate('''
-            @Factory()
-            UiFactory<FooProps> _Foo = _\$_Foo;
-
-            $restOfComponent
-        ''');
-
-        verifyNever(logger.error(any, span: any));
-      });
-    });
 
     group('logs an error when', () {
-      group('a factory is', () {
+      test('a factory is declared using multiple variables', () {
+        setUpAndGenerate('''
+          @Factory()
+          UiFactory<FooProps> Foo, Bar;
 
-        test('declared using multiple variables', () {
-          setUpAndGenerate('''
-            @Factory()
-            UiFactory<FooProps> Foo, Bar;
+          @Props()
+          class FooProps {}
 
-            $restOfComponent
-          ''');
+          @Component()
+          class FooComponent {}
+        ''');
 
-          verify(logger.error('Factory declarations must a single variable.', span: any));
-        });
-
-        test('declared with an initializer', () {
-          setUpAndGenerate('''
-            @Factory()
-            UiFactory<FooProps> Foo = null;
-
-            $restOfComponent
-          ''');
-
-          verify(logger.error('Factory variables are stubs for the generated factories, and should not have initializers'
-              ' unless initialized with \$Foo for Dart 2 builder compatibility. Should be one of:\n'
-              '    [\$Foo]', span: any));
-        });
-
+        verify(logger.error('Factory declarations must a single variable.', span: any));
       });
 
       group('a component class', () {

--- a/test/vm_tests/transformer/util_test.dart
+++ b/test/vm_tests/transformer/util_test.dart
@@ -15,7 +15,7 @@
 @TestOn('vm')
 library text_util_test;
 
-import 'package:over_react/src/transformer/text_util.dart';
+import 'package:over_react/src/transformer/util.dart';
 import 'package:test/test.dart';
 
 main() {


### PR DESCRIPTION
## Ultimate problem:
The new version of codemod will update the initializer for private factories to `_$_Foo` if the factory name is `_Foo`. We need to relax the validation on this initializer to allow for this.
It will do the same with the `metaFor` constant.

All of the following variations should be supported:

- Factories:
  - For a public factory:
    - `$Foo`
    - `_$Foo`
  - For a private factory:
    - `$_Foo`
    - `_$_Foo`
    - `_$Foo`

- Meta fields:
  - For a public containing class:
  	- `$metaForFoo`
  	- `_$metaForFoo`
  - For a private containing class:
    - `$metaFor_Foo`
    - `_$metaFor_Foo`
    - `_$metaForFoo`
    
Note: once the Dart 2 transition is complete, these restrictions will be tightened down to:
- Factories:
  - For a public factory:
    - `_$Foo`
  - For a private factory:
    - `_$_Foo`

- Meta fields:
  - For a public containing class:
  	- `_$metaForFoo`
  - For a private containing class:
    - `_$metaFor_Foo`

## How it was fixed:
* Relax the validation + add tests
* Moved validation for factory names to declaration parsing

## Testing suggestions:
* CI Passes
* Publink into WSD and verify that running tests start without errors, since the validation will run before tests begin running.

## Potential areas of regression:
False positive validation warnings on the already codemodded WSD. Hitting the testing suggestions will cover this possible regression.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @sebastianmalysa-wf 
