### PR TITLE
CPLAT-4038 Update transformer to support dart2 builder outputs to source.

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -27,7 +27,7 @@ export 'package:react/react.dart' show
     SyntheticUIEvent,
     SyntheticWheelEvent;
 
-export 'package:react/react_client.dart' show setClientConfiguration, ReactElement;
+export 'package:react/react_client.dart' show setClientConfiguration, ReactElement, ReactComponentFactoryProxy;
 
 export 'src/component/abstract_transition.dart';
 export 'src/component/abstract_transition_props.dart';


### PR DESCRIPTION
## Ultimate problem:
We're going to configure the over_react dart2 builder to build to source, meaning that the generated `.over_react.g.dart` outputs will be included alongside package source files. Previously, the transformer was assuming that these part files would not exist, so it would generate no-op files where necessary to ensure the build succeeds. Now that they may actually exist, the transformer needs to remove everything in them except the `part of` directive. This will not affect runtime functionality at all – the transformer is already providing (effectively) the same code that exists in these part files, just in different locations.

## How it was fixed:
- Don't output a new asset for a `.over_react.g.dart` part file if the asset already exists (would be a duplicate output transformer error)
- Transform all `.over_react.g.dart` files to remove everything after the `part of` directive.

## Testing suggestions:
- Consumer test this change to ensure no regressions in the transformer behavior.

## Potential areas of regression:
- Transformer.


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf @sebastianmalysa-wf @georgelesica-wf 
