### PR TITLE
CPLAT-4061 Deprecate getJsProps(), $Props, and $PropKeys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OverReact Changelog
 
+## 1.31.0
+
+> [Complete `1.31.0` Changeset](https://github.com/Workiva/over_react/compare/1.30.2...1.31.0)
+
+__Deprecations__
+
+* [#230] Deprecate the following APIs (they will be removed in 2.0.0):
+  * `getJsProps()` - use `getProps()` instead.
+  * `$Props` and `$PropKeys` - see the [Dart 2 migration guide](https://github.com/Workiva/over_react/blob/master/doc/dart2_migration.md)
+    for more information.
+
 ## 1.30.2
 
 > [Complete `1.30.2` Changeset](https://github.com/Workiva/over_react/compare/1.30.1...1.30.2)

--- a/lib/src/component_declaration/transformer_helpers.dart
+++ b/lib/src/component_declaration/transformer_helpers.dart
@@ -30,6 +30,9 @@ export './component_base.dart'
 /// in a static yet unsafe way.
 ///
 /// __For advanced usage only.__
+///
+/// __Deprecated. Will be removed in 2.0.0.__
+@deprecated
 @proxy
 class $PropKeys implements List<String> {
   /// A placeholder that gets swapped out by the `over_react` transformer
@@ -49,6 +52,9 @@ class $PropKeys implements List<String> {
 /// in a static yet unsafe way.
 ///
 /// __For advanced usage only.__
+///
+/// __Deprecated. Will be removed in 2.0.0.__
+@deprecated
 @proxy
 class $Props implements component_base.ConsumedProps {
   /// A placeholder that gets swapped out by the `over_react` transformer

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -86,6 +86,9 @@ Map _dartifyJsMap(jsMap) {
 ///
 /// If `style` is specified in props, then it too is shallow-converted and included
 /// in the returned Map.
+///
+/// __Deprecated. Use [getProps] instead. Will be removed in 2.0.0.__
+@deprecated
 Map getJsProps(/* ReactElement|ReactComponent */ instance) {
   var props = _dartifyJsMap(instance.props);
 


### PR DESCRIPTION
Fixes #213.

## Description
The following APIs are being removed in v2.0.0, and consequently need to be deprecated in a 1.x release:

- `getJsProps()` (use `getProps()` instead)
- `$Props` and `$PropKeys` (being replaced by the static `meta` getters on props/state classes)

## Testing suggestions:
- [ ] CI passes

## Potential areas of regression:
n/a


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf 
