### PR TITLE
CPLAT-4107 Remove getJsProps()

### DIFF
--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -71,31 +71,13 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   return _getInternal(instance) != null;
 }
 
-@JS('Object.keys')
-external Iterable _objectKeys(object);
-
-/// Returns a Dart Map copy of the JS property key-value pairs in [jsMap].
-Map _dartifyJsMap(jsMap) {
-  return new Map.fromIterable(_objectKeys(jsMap),
-      value: (key) => getProperty(jsMap, key)
-  );
-}
-
 /// Returns the props for a [ReactElement] or composite [ReactComponent] [instance],
 /// shallow-converted to a Dart Map for convenience.
 ///
 /// If `style` is specified in props, then it too is shallow-converted and included
 /// in the returned Map.
 Map getJsProps(/* ReactElement|ReactComponent */ instance) {
-  var props = _dartifyJsMap(instance.props);
-
-  // Convert the nested style map so it can be read by Dart code.
-  var style = props['style'];
-  if (style != null) {
-    props['style'] = _dartifyJsMap(style);
-  }
-
-  return props;
+  return unconvertJsProps(instance);
 }
 
 /// Whether [Expando]s can be used on [ReactElement]s.
@@ -167,7 +149,7 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers:
       if (cachedView != null) return cachedView;
     }
 
-    var propsMap = isDartComponent(instance) ? _getExtendedProps(instance) : getJsProps(instance);
+    var propsMap = isDartComponent(instance) ? _getExtendedProps(instance) : unconvertJsProps(instance);
     var view = new UnmodifiableMapView(propsMap);
 
     if (_elementPropsCache != null && !isCompositeComponent) {

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -71,15 +71,6 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   return _getInternal(instance) != null;
 }
 
-/// Returns the props for a [ReactElement] or composite [ReactComponent] [instance],
-/// shallow-converted to a Dart Map for convenience.
-///
-/// If `style` is specified in props, then it too is shallow-converted and included
-/// in the returned Map.
-Map getJsProps(/* ReactElement|ReactComponent */ instance) {
-  return unconvertJsProps(instance);
-}
-
 /// Whether [Expando]s can be used on [ReactElement]s.
 ///
 /// At the time this was written, this should return:
@@ -110,7 +101,7 @@ final Expando<UnmodifiableMapView> _elementPropsCache = _canUseExpandoOnReactEle
 /// Returns an unmodifiable Map view of props for a [ReactElement] or composite [ReactComponent] [instance].
 ///
 /// For a native Dart component, this returns its [react.Component.props] in an unmodifiable Map view.
-/// For a JS component, this returns the result of [getJsProps] in an unmodifiable Map view.
+/// For a JS component, this returns the result of [unconvertJsProps] in an unmodifiable Map view.
 ///
 /// If [traverseWrappers] is `true` then it will return an unmodifiable Map view of props of the first non-"Wrapper"
 /// instance.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,8 +39,3 @@ dev_dependencies:
   mockito: ^4.0.0
   over_react_test: ^2.2.0
   test: ^1.0.0
-dependency_overrides:
-  react:
-    git:
-      url: git://github.com/evanweible-wf/react-dart.git
-      ref: unconvertJsProps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^4.5.0
+  react: ^4.6.0
   source_gen: ^0.9.0
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
@@ -39,4 +39,8 @@ dev_dependencies:
   mockito: ^4.0.0
   over_react_test: ^2.2.0
   test: ^1.0.0
-
+dependency_overrides:
+  react:
+    git:
+      url: git://github.com/evanweible-wf/react-dart.git
+      ref: unconvertJsProps

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -940,7 +940,7 @@ main() {
   });
 }
 
-dynamic getJsChildren(instance) => getJsProps(instance)['children'];
+dynamic getJsChildren(instance) => unconvertJsProps(instance)['children'];
 
 dynamic getDartChildren(var renderedInstance) {
   assert(isDartComponent(renderedInstance));

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -50,8 +50,8 @@ main() {
           // If these objects are equal, then they proxy the same JS props object.
           expect(clone.props, isNot(equals(original.props)));
 
-          Map originalProps = getJsProps(original);
-          Map cloneProps = getJsProps(clone);
+          Map originalProps = unconvertJsProps(original);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (children included) are equal.
           expect(cloneProps, equals(originalProps));
@@ -64,8 +64,8 @@ main() {
           // If these objects are equal, then they proxy the same JS props object.
           expect(clone.props, isNot(equals(original.props)));
 
-          Map originalProps = getJsProps(original);
-          Map cloneProps = getJsProps(clone);
+          Map originalProps = unconvertJsProps(original);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (including children, excluding react-dart internals) are equal.
           Map originalShallowProps = new Map.from(originalProps);
@@ -105,7 +105,7 @@ main() {
           var original = (Dom.div()..addProps(testProps))(testChildren);
           var clone = cloneElement(original, testPropsToAdd);
 
-          Map cloneProps = getJsProps(clone);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (children included) are equal.
           expect(cloneProps, equals(expectedPropsMerge));
@@ -196,7 +196,7 @@ main() {
               var clone = cloneElement(original, testPropsToAdd);
 
               var renderedClone = react_test_utils.renderIntoDocument(clone);
-              Map cloneProps = getJsProps(renderedClone);
+              Map cloneProps = unconvertJsProps(renderedClone);
 
               expect(() {
                 // Retrieve an automatically JS-proxied version of the callback passed to the component.
@@ -281,7 +281,7 @@ main() {
           var original = (Dom.div()..addProps(testProps))(testChildren);
           var clone = cloneElement(original, null, testOverrideChildren);
 
-          Map cloneProps = getJsProps(clone);
+          Map cloneProps = unconvertJsProps(clone);
 
           expect(cloneProps['children'], equals(testOverrideChildren));
         });
@@ -293,7 +293,7 @@ main() {
           var renderedClone = render(clone);
 
           // Verify that children are overridden according to React
-          Map cloneProps = getJsProps(renderedClone);
+          Map cloneProps = unconvertJsProps(renderedClone);
           expect(cloneProps['children'], equals(testOverrideChildren));
 
           // Verify that children are overridden according to the Dart component.


### PR DESCRIPTION
**_This is dependent on https://github.com/cleandart/react-dart/pull/153 - should be released in `react-dart v4.6.0`_**

## Ultimate problem:
`getJsProps()` was deprecated in 1.x and needs to be removed in 2.0.0.

## How it was fixed:
Remove it and update usages to the new `unconvertJsProps()` method in react-dart.

## Testing suggestions:
- [ ] CI passes

## Potential areas of regression:
- Calls to `getJsProps()`, should all be tested via unit tests


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf 
