### PR TITLE
CPLAT-4129: Use `unconvertJsProps()` instead of `getJsProps()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ __Deprecations__
   * `$Props` and `$PropKeys` - see the [Dart 2 migration guide](https://github.com/Workiva/over_react/blob/master/doc/dart2_migration.md)
     for more information.
 
+* [#207] Override `call()` instead of `noSuchMethod()` in the `UiProps` class.
+    This was a requirement for Dart 2 compatibility, but also serves as an
+    improvement - by no longer overriding `noSuchMethod()`, we will no longer be
+    obscuring certain analyzer errors that should be seen by consumers.
+
 ## 1.30.2
 
 > [Complete `1.30.2` Changeset](https://github.com/Workiva/over_react/compare/1.30.1...1.30.2)

--- a/integrate/pubspec.yaml
+++ b/integrate/pubspec.yaml
@@ -3,11 +3,6 @@ version: 0.0.1
 description: Test importing over_react
 environment:
   sdk: ">=1.19.1 <2.0.0"
-dependency_overrides:
-  react:
-    git:
-      url: git://github.com/evanweible-wf/react-dart.git
-      ref: unconvertJsProps
 dependencies:
   browser: ">=0.10.0 <0.11.0"
   over_react:

--- a/integrate/pubspec.yaml
+++ b/integrate/pubspec.yaml
@@ -3,6 +3,11 @@ version: 0.0.1
 description: Test importing over_react
 environment:
   sdk: ">=1.19.1 <2.0.0"
+dependency_overrides:
+  react:
+    git:
+      url: git://github.com/evanweible-wf/react-dart.git
+      ref: unconvertJsProps
 dependencies:
   browser: ">=0.10.0 <0.11.0"
   over_react:

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -71,16 +71,6 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   return _getInternal(instance) != null;
 }
 
-@JS('Object.keys')
-external Iterable _objectKeys(object);
-
-/// Returns a Dart Map copy of the JS property key-value pairs in [jsMap].
-Map _dartifyJsMap(jsMap) {
-  return new Map.fromIterable(_objectKeys(jsMap),
-      value: (key) => getProperty(jsMap, key)
-  );
-}
-
 /// Returns the props for a [ReactElement] or composite [ReactComponent] [instance],
 /// shallow-converted to a Dart Map for convenience.
 ///
@@ -90,15 +80,7 @@ Map _dartifyJsMap(jsMap) {
 /// __Deprecated. Use [getProps] instead. Will be removed in 2.0.0.__
 @deprecated
 Map getJsProps(/* ReactElement|ReactComponent */ instance) {
-  var props = _dartifyJsMap(instance.props);
-
-  // Convert the nested style map so it can be read by Dart code.
-  var style = props['style'];
-  if (style != null) {
-    props['style'] = _dartifyJsMap(style);
-  }
-
-  return props;
+  return unconvertJsProps(instance);
 }
 
 /// Whether [Expando]s can be used on [ReactElement]s.
@@ -131,7 +113,7 @@ final Expando<UnmodifiableMapView> _elementPropsCache = _canUseExpandoOnReactEle
 /// Returns an unmodifiable Map view of props for a [ReactElement] or composite [ReactComponent] [instance].
 ///
 /// For a native Dart component, this returns its [react.Component.props] in an unmodifiable Map view.
-/// For a JS component, this returns the result of [getJsProps] in an unmodifiable Map view.
+/// For a JS component, this returns the result of [unconvertJsProps] in an unmodifiable Map view.
 ///
 /// If [traverseWrappers] is `true` then it will return an unmodifiable Map view of props of the first non-"Wrapper"
 /// instance.
@@ -170,7 +152,7 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers:
       if (cachedView != null) return cachedView;
     }
 
-    var propsMap = isDartComponent(instance) ? _getExtendedProps(instance) : getJsProps(instance);
+    var propsMap = isDartComponent(instance) ? _getExtendedProps(instance) : unconvertJsProps(instance);
     var view = new UnmodifiableMapView(propsMap);
 
     if (_elementPropsCache != null && !isCompositeComponent) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,6 @@ authors:
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
   sdk: ">=1.24.2 <2.0.0"
-dependency_overrides:
-  react:
-    git:
-      url: git://github.com/evanweible-wf/react-dart.git
-      ref: unconvertJsProps
 dependencies:
   analyzer: ">=0.30.0+4 <=0.31.0"
   barback: ">=0.15.2 <=0.15.2+14"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,11 @@ authors:
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
   sdk: ">=1.24.2 <2.0.0"
+dependency_overrides:
+  react:
+    git:
+      url: git://github.com/evanweible-wf/react-dart.git
+      ref: unconvertJsProps
 dependencies:
   analyzer: ">=0.30.0+4 <=0.31.0"
   barback: ">=0.15.2 <=0.15.2+14"
@@ -16,7 +21,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^4.4.2
+  react: ^4.6.0
   source_span: ^1.4.1
   transformer_utils: ^0.1.5
   w_common: ^1.13.0

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -969,7 +969,7 @@ main() {
   });
 }
 
-dynamic getJsChildren(instance) => getJsProps(instance)['children'];
+dynamic getJsChildren(instance) => unconvertJsProps(instance)['children'];
 
 dynamic getDartChildren(var renderedInstance) {
   assert(isDartComponent(renderedInstance));

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -50,8 +50,8 @@ main() {
           // If these objects are equal, then they proxy the same JS props object.
           expect(clone.props, isNot(equals(original.props)));
 
-          Map originalProps = getJsProps(original);
-          Map cloneProps = getJsProps(clone);
+          Map originalProps = unconvertJsProps(original);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (children included) are equal.
           expect(cloneProps, equals(originalProps));
@@ -64,8 +64,8 @@ main() {
           // If these objects are equal, then they proxy the same JS props object.
           expect(clone.props, isNot(equals(original.props)));
 
-          Map originalProps = getJsProps(original);
-          Map cloneProps = getJsProps(clone);
+          Map originalProps = unconvertJsProps(original);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (including children, excluding react-dart internals) are equal.
           Map originalShallowProps = new Map.from(originalProps);
@@ -105,7 +105,7 @@ main() {
           var original = (Dom.div()..addProps(testProps))(testChildren);
           var clone = cloneElement(original, testPropsToAdd);
 
-          Map cloneProps = getJsProps(clone);
+          Map cloneProps = unconvertJsProps(clone);
 
           // Verify all props (children included) are equal.
           expect(cloneProps, equals(expectedPropsMerge));
@@ -196,7 +196,7 @@ main() {
               var clone = cloneElement(original, testPropsToAdd);
 
               var renderedClone = react_test_utils.renderIntoDocument(clone);
-              Map cloneProps = getJsProps(renderedClone);
+              Map cloneProps = unconvertJsProps(renderedClone);
 
               expect(() {
                 // Retrieve an automatically JS-proxied version of the callback passed to the component.
@@ -281,7 +281,7 @@ main() {
           var original = (Dom.div()..addProps(testProps))(testChildren);
           var clone = cloneElement(original, null, testOverrideChildren);
 
-          Map cloneProps = getJsProps(clone);
+          Map cloneProps = unconvertJsProps(clone);
 
           expect(cloneProps['children'], equals(testOverrideChildren));
         });
@@ -293,7 +293,7 @@ main() {
           var renderedClone = render(clone);
 
           // Verify that children are overridden according to React
-          Map cloneProps = getJsProps(renderedClone);
+          Map cloneProps = unconvertJsProps(renderedClone);
           expect(cloneProps['children'], equals(testOverrideChildren));
 
           // Verify that children are overridden according to the Dart component.


### PR DESCRIPTION
# [CPLAT-4129](https://jira.atl.workiva.net/browse/CPLAT-4129)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-4129)

**_This is dependent on https://github.com/cleandart/react-dart/pull/153 - should be released in `react-dart v4.6.0`_**

## Ultimate problem:
`getJsProps()` is deprecated and the alternative (`unconvertJsProps()`) is available in react-dart 4.6.0.

## How it was fixed:
Update usages of the deprecated `getJsProps()` to the new `unconvertJsProps()` method in react-dart.

## Testing suggestions:
- [ ] CI passes

## Potential areas of regression:
- Calls to `getJsProps()`, should all be tested via unit tests


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf 
