### PR TITLE
CPLAT-4154: Widen `over_react_test` range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
   dart_dev: ^1.9.6
   dependency_validator: ^1.2.2
   mockito: ^2.2.2
-  over_react_test: ^1.5.0
+  over_react_test: '>=1.6.0 <3.0.0'
   source_gen: ^0.7.4+3
   test: ^0.12.34
 


### PR DESCRIPTION
# [CPLAT-4154](https://jira.atl.workiva.net/browse/CPLAT-4154)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-4154)

## Ultimate problem:
To support the dual release line for 2.x, we need to widen the `over_react_test` range on the dart 1 version.

## How it was fixed:
Widen it to include `over_react_test` 2.x.

## Testing suggestions:
- [ ] CI passes
- [ ] Verify that pub gets and CI passes on this PR that includes the same change: https://github.com/Workiva/over_react/pull/237

## Potential areas of regression:
n/a

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf 
