### PR TITLE
CPLAT-246 CPLAT-245 Release over_react 2.0.0-alpha

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.30.2
+version: 2.0.0-alpha
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [[2.0.0-dev - dart2] AF-233 Consume react-dart callable class fixes](https://github.com/Workiva/over_react/pull/155)
* [CPLAT-1858, CPLAT-1857: Builder to build on backwards compatible boilerplate](https://github.com/Workiva/over_react/pull/211)
* [CPLAT-4031: Make builder compatible with Dart 2 only boilerplate](https://github.com/Workiva/over_react/pull/227)
* [CPLAT-3974 Remove workaround for DDC bug that is fixed in Dart 2](https://github.com/Workiva/over_react/pull/229)
* [CPLAT-4109: Update documentation for dart2](https://github.com/Workiva/over_react/pull/231)
* [CPLAT-4124: Changelog for V2](https://github.com/Workiva/over_react/pull/232)
* [CPLAT-4107 Remove getJsProps()](https://github.com/Workiva/over_react/pull/233)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.31.0...Workiva:release_over_react_2.0.0-alpha
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.31.0...2.0.0-alpha

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)