### PR TITLE
CPLAT-4297: Use `+dart1` suffix instead of `-dart1`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,13 @@ For every release, do the following:
 
     Name | Branch
     ---- | ------
-    over_react 2.x.x-dart1 | master_dart1
+    over_react 2.x.x+dart1 | master_dart1
     over_react 2.x.x | master
 
-1. Trigger the `over_react 2.x.x-dart1` release first and review the PR:
+1. Trigger the `over_react 2.x.x+dart1` release first and review the PR:
 
    - Ensure the updated `pubspec.yaml` version is correct, including the
-     `-dart1` suffix.
+     `+dart1` suffix.
 
    - Ensure the build passes.
 


### PR DESCRIPTION
# [CPLAT-4297](https://jira.atl.workiva.net/browse/CPLAT-4297)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-4297)

## Description
Pub/semver treats `-` version suffixes as pre-releases, meaning that a `1.x` version will be prioritized above it. We need to use the `+` suffix (which is treated as build metadata and has no impact on prioritization).

## Testing suggestions:
We already made this change when releasing over_react, just needed to update the documentation.

## Potential areas of regression:
n/a

---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @corwinsheahan-wf @maxwellpeterson-wf
