### PR TITLE
CPLAT-3616 Warn consumers about props / state mutation

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -245,7 +245,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     var unwrappedProps = this.unwrappedProps;
     var typedProps = _typedPropsCache[unwrappedProps];
     if (typedProps == null) {
-      typedProps = typedPropsFactory(unwrappedProps);
+      typedProps = typedPropsFactory(WarnOnModify(unwrappedProps));
       _typedPropsCache[unwrappedProps] = typedProps;
     }
     return typedProps;
@@ -415,7 +415,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-      typedState = typedStateFactory(unwrappedState);
+      typedState = typedStateFactory(WarnOnModify(unwrappedState));
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;
@@ -444,6 +444,18 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
   // ----------------------------------------------------------------------
 }
 
+class WarnOnModify<K, V> extends MapView<K, V> {
+  WarnOnModify(Map componentData): super(componentData);
+  
+  @override
+  operator []=(K key, V value) {
+    assert(
+      super[key] != value,
+      'Mutating the state or props directly will soon be impossible without causing breakages.'
+    );
+    super[key] = value;
+  }
+}
 
 /// A `dart.collection.MapView`-like class with strongly-typed getters/setters for React state.
 ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -446,7 +446,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
 
 class WarnOnModify<K, V> extends MapView<K, V> {
   WarnOnModify(Map componentData): super(componentData);
-  
+
   @override
   operator []=(K key, V value) {
     assert(

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -16,6 +16,7 @@ library over_react.component_declaration.component_base;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:html';
 
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
@@ -245,7 +246,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     var unwrappedProps = this.unwrappedProps;
     var typedProps = _typedPropsCache[unwrappedProps];
     if (typedProps == null) {
-      typedProps = typedPropsFactory(WarnOnModify(unwrappedProps));
+      typedProps = typedPropsFactory(inReactDevMode ? _WarnOnModify(unwrappedProps, true) : unwrappedProps);
       _typedPropsCache[unwrappedProps] = typedProps;
     }
     return typedProps;
@@ -415,7 +416,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-      typedState = typedStateFactory(WarnOnModify(unwrappedState));
+      typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedProps, false) : unwrappedProps);
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;
@@ -444,15 +445,35 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
   // ----------------------------------------------------------------------
 }
 
-class WarnOnModify<K, V> extends MapView<K, V> {
-  WarnOnModify(Map componentData): super(componentData);
+class _WarnOnModify<K, V> extends MapView<K, V> {
+
+  //Used to customize warning based on whether the data is props or state
+  bool isProps;
+
+  _WarnOnModify(Map componentData, bool isProps): super(componentData){
+    this.isProps = isProps;
+  }
 
   @override
   operator []=(K key, V value) {
-    assert(
-      false,
-      'Mutating the state or props directly will soon be impossible without causing breakages.'
-    );
+    if (isProps) {
+      window.console.warn(unindent(
+        '''
+          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; props must be updated only by passing in new values when rerendering this component.
+
+          This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
+        '''
+      ));
+    } else {
+      window.console.warn(unindent(
+        '''
+          state["$key"] was updated incorrectly. Never this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
+
+          This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
+        '''
+      ));
+    }
+
     super[key] = value;
   }
 }

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -446,15 +446,12 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
 }
 
 class _WarnOnModify<K, V> extends MapView<K, V> {
-
   //Used to customize warning based on whether the data is props or state
   bool isProps;
 
   String message;
 
-  _WarnOnModify(Map componentData, bool isProps): super(componentData){
-    this.isProps = isProps;
-  }
+  _WarnOnModify(Map componentData, this.isProps): super(componentData);
 
   @override
   operator []=(K key, V value) {

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -461,14 +461,16 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
     if (isProps) {
       message =
         '''
-          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; props must be updated only by passing in new values when rerendering this component.
+          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; 
+          props must be updated only by passing in new values when re-rendering this component.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
         ''';
     } else {
       message =
         '''
-          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
+          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; 
+          state must be updated only via setState.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
         ''';

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -450,7 +450,7 @@ class WarnOnModify<K, V> extends MapView<K, V> {
   @override
   operator []=(K key, V value) {
     assert(
-      super[key] != value,
+      false,
       'Mutating the state or props directly will soon be impossible without causing breakages.'
     );
     super[key] = value;

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -473,7 +473,7 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
         ''';
     }
     super[key] = value;
-    ValidationUtil.warn(message);
+    ValidationUtil.warn(unindent(message));
   }
 }
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -416,7 +416,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-      typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedProps, false) : unwrappedProps);
+    typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedState, false) : unwrappedState);
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;
@@ -450,6 +450,8 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
   //Used to customize warning based on whether the data is props or state
   bool isProps;
 
+  String message;
+
   _WarnOnModify(Map componentData, bool isProps): super(componentData){
     this.isProps = isProps;
   }
@@ -457,24 +459,22 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
   @override
   operator []=(K key, V value) {
     if (isProps) {
-      window.console.warn(unindent(
+      message =
         '''
           props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; props must be updated only by passing in new values when rerendering this component.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
-        '''
-      ));
+        ''';
     } else {
-      window.console.warn(unindent(
+      message =
         '''
-          state["$key"] was updated incorrectly. Never this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
+          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
-        '''
-      ));
+        ''';
     }
-
     super[key] = value;
+    ValidationUtil.warn(message);
   }
 }
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -129,7 +129,6 @@ main() {
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
         var changeProps = () => component.props['id'] = 'test';
-
         changeProps();
         verifyValidationWarning(contains('Never mutate this.props directly'));
         stopRecordingValidationWarnings();
@@ -842,7 +841,6 @@ main() {
           test('warns against setting state directly', () {
             startRecordingValidationWarnings();
             var changeState = () => statefulComponent.state['test'] = true;
-
             changeState();
             verifyValidationWarning(contains('Never mutate this.state directly'));
             stopRecordingValidationWarnings();

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -124,6 +124,15 @@ main() {
         _commonNonInvokedBuilderTests(Dom.div());
       }, testOn: '!js');
 
+      test('warns against setting props directly', () {
+
+        var instance = render(TestComponent()());
+        var component = getDartComponent(instance);
+        var changeProps = () => component.props['id'] = 'test';
+
+        expect(changeProps, throwsA(const TypeMatcher<AssertionError>()));
+      });
+
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
 
@@ -800,7 +809,7 @@ main() {
 
       setUp(() {
         statefulComponent = new TestStatefulComponentComponent();
-        statefulComponent.unwrappedState = {};
+        statefulComponent.unwrappedState = {'test': true};
       });
 
       group('`state`', () {
@@ -826,6 +835,12 @@ main() {
             var stateAfterChange = statefulComponent.state;
 
             expect(stateBeforeChange, isNot(same(stateAfterChange)));
+          });
+
+          test('warns against setting state directly', () {
+            var changeState = () => statefulComponent.state['test'] = true;
+
+            expect(changeState, throwsA(const TypeMatcher<AssertionError>()));
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -127,9 +127,10 @@ main() {
       test('warns against setting props directly', () {
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
-        var changeProps = () => component.props['id'] = 'test';
 
-        expect(changeProps, throwsA(const TypeMatcher<AssertionError>()));
+        expect(() {
+          component.props['id'] = 'test';
+        }, throwsA(const TypeMatcher<AssertionError>()));
       });
 
       group('renders a DOM component with the correct children when', () {
@@ -837,9 +838,10 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            var changeState = () => statefulComponent.state['test'] = true;
-
-            expect(changeState, throwsA(const TypeMatcher<AssertionError>()));
+            
+            expect(() {
+              statefulComponent.state['test'] = true;
+            }, throwsA(const TypeMatcher<AssertionError>()));
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -125,13 +125,14 @@ main() {
       }, testOn: '!js');
 
       test('warns against setting props directly', () {
+        startRecordingValidationWarnings();
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
+        var test = () => component.props['id'] = 'test';
 
-        expect(() {
-          component.props['id'] = 'test';
-        }, throwsA(const TypeMatcher<AssertionError>()));
-      }, testOn: '!js');
+        test();
+        verifyValidationWarning(contains('Never mutate this.props directly'));
+      });
 
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
@@ -838,10 +839,11 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            expect(() {
-              statefulComponent.state['test'] = true;
-            }, throwsA(const TypeMatcher<AssertionError>()));
-          }, testOn: '!js');
+            var changeState = () => statefulComponent.state['test'] = true;
+
+            changeState();
+            verifyValidationWarning(contains('Never mutate this.state directly'));
+          });
         });
 
         group('setter:', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -131,7 +131,7 @@ main() {
         expect(() {
           component.props['id'] = 'test';
         }, throwsA(const TypeMatcher<AssertionError>()));
-      });
+      }, testOn: '!js');
 
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
@@ -838,11 +838,11 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            
+
             expect(() {
               statefulComponent.state['test'] = true;
             }, throwsA(const TypeMatcher<AssertionError>()));
-          });
+          }, testOn: '!js');
         });
 
         group('setter:', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -840,10 +840,12 @@ main() {
           });
 
           test('warns against setting state directly', () {
+            startRecordingValidationWarnings();
             var changeState = () => statefulComponent.state['test'] = true;
 
             changeState();
             verifyValidationWarning(contains('Never mutate this.state directly'));
+            stopRecordingValidationWarnings();
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -125,7 +125,6 @@ main() {
       }, testOn: '!js');
 
       test('warns against setting props directly', () {
-
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
         var changeProps = () => component.props['id'] = 'test';

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -128,10 +128,11 @@ main() {
         startRecordingValidationWarnings();
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
-        var test = () => component.props['id'] = 'test';
+        var changeProps = () => component.props['id'] = 'test';
 
-        test();
+        changeProps();
         verifyValidationWarning(contains('Never mutate this.props directly'));
+        stopRecordingValidationWarnings();
       });
 
       group('renders a DOM component with the correct children when', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -838,7 +838,6 @@ main() {
           });
 
           test('warns against setting state directly', () {
-
             expect(() {
               statefulComponent.state['test'] = true;
             }, throwsA(const TypeMatcher<AssertionError>()));


### PR DESCRIPTION
## Ultimate problem:
With the upcoming change to the component_base class, setting the state / props directly will cause breakages. To give consumers a heads up, we should emit warnings in the browser console when they directly mutate props / state values inside a component instance.

## How it was fixed:
Adding a class called WarnOnUpdate that watches for setting props / state directly and throws an error in dev mode using an Assert.

## Testing suggestions:
Run the test suite. Consider any ways the tests could return false results or miss a use case.

## Potential areas of regression:
None that are known as it's only in dev that the error will be thrown.

