### PR TITLE
CPLAT-4360: Set auto_apply to dependents

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,7 +3,7 @@ builders:
     import: "package:over_react/builder.dart"
     builder_factories: ["overReactBuilder"]
     build_extensions: {".dart" : [".over_react.g.dart"]}
-    auto_apply: all_packages
+    auto_apply: dependents
     build_to: cache
 
   # Builder just for this package.


### PR DESCRIPTION
## Ultimate problem:
The over_react builder actually only needs to apply to packages which specify over_react as a direct dependency. This will speed up build times, especially for packages with many dependencies. This was trialed in a fairly large internal repo, and a build with just the over_react builder running completed in ~35s vs ~1m30s without this change.

## How it was fixed:
change auto_apply to dependents

## Testing suggestions:
* CI Passes
* Publink this over_react branch into this branch of [web_skin_dart](https://github.com/Workiva/web_skin_dart/tree/cplat-2734_dart2) and run `pub run build_runner build`. Verify that a build succeeds.
## Potential areas of regression:



---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @evanweible-wf @maxwellpeterson-wf @sebastianmalysa-wf @seanburke-wf @smaifullerton-wk 
