### PR TITLE
CPLAT-4476: Create workaround for ddc bug related to uninitialized maps

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -40,7 +40,7 @@ targets:
       build_web_compilers|entrypoint:
         generate_for:
           include:
-            - "example/builder/**"
+            - "example/**"
             - "lib/*.dart"
             - "test/*.dart"
             - "web/*.dart"

--- a/example/builder/abstract_inheritance.over_react.g.dart
+++ b/example/builder/abstract_inheritance.over_react.g.dart
@@ -22,8 +22,9 @@ abstract class _$SubPropsAccessorsMixin implements _$SubProps {
 
   /// Go to [_$SubProps.subProp] to see the source code for this prop
   @override
-  String get subProp => props[_$key__subProp___$SubProps];
-
+  String get subProp =>
+      props[_$key__subProp___$SubProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SubProps.subProp] to see the source code for this prop
   @override
   set subProp(String value) => props[_$key__subProp___$SubProps] = value;
@@ -81,8 +82,9 @@ abstract class _$SubStateAccessorsMixin implements _$SubState {
 
   /// Go to [_$SubState.subState] to see the source code for this prop
   @override
-  String get subState => state[_$key__subState___$SubState];
-
+  String get subState =>
+      state[_$key__subState___$SubState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SubState.subState] to see the source code for this prop
   @override
   set subState(String value) => state[_$key__subState___$SubState] = value;
@@ -151,8 +153,9 @@ abstract class _$SuperPropsAccessorsMixin implements _$SuperProps {
 
   /// Go to [_$SuperProps.superProp] to see the source code for this prop
   @override
-  String get superProp => props[_$key__superProp___$SuperProps];
-
+  String get superProp =>
+      props[_$key__superProp___$SuperProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SuperProps.superProp] to see the source code for this prop
   @override
   set superProp(String value) => props[_$key__superProp___$SuperProps] = value;
@@ -182,8 +185,9 @@ abstract class _$SuperStateAccessorsMixin implements _$SuperState {
 
   /// Go to [_$SuperState.superState] to see the source code for this prop
   @override
-  String get superState => state[_$key__superState___$SuperState];
-
+  String get superState =>
+      state[_$key__superState___$SuperState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SuperState.superState] to see the source code for this prop
   @override
   set superState(String value) =>

--- a/example/builder/basic.dart
+++ b/example/builder/basic.dart
@@ -31,6 +31,7 @@ class BasicComponent extends UiComponent<BasicProps> {
         Dom.div()('prop id: ${props.id}'),
         Dom.div()('default prop testing: ${props.basicProp}'), // ignore: deprecated_member_use
         Dom.div()('default prop testing: ${props.basic1}'),
+        Dom.div()(null, props.basic4, 'children: ${props.children}' ),
     );
   }
 }

--- a/example/builder/basic.over_react.g.dart
+++ b/example/builder/basic.over_react.g.dart
@@ -24,8 +24,9 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp => props[_$key__basicProp___$BasicProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basicProp] to see the source code for this prop
   @override
   @deprecated
@@ -34,40 +35,45 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/example/builder/basic_library.over_react.g.dart
+++ b/example/builder/basic_library.over_react.g.dart
@@ -24,8 +24,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
-  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
   set basicProp(String value) =>
@@ -33,8 +34,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) =>
@@ -42,8 +44,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) =>
@@ -51,8 +54,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) =>
@@ -60,8 +64,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) =>
@@ -69,8 +74,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) =>
@@ -166,8 +172,9 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
-  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
-
+  String get basicState =>
+      state[_$key__basicState___$BasicPartOfLibState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
   set basicState(String value) =>
@@ -257,8 +264,9 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
-  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
-
+  String get subProp =>
+      props[_$key__subProp___$SubPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
   set subProp(String value) =>
@@ -345,8 +353,9 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
-  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
-
+  String get superProp =>
+      props[_$key__superProp___$SuperPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
   set superProp(String value) =>

--- a/example/builder/basic_with_state.over_react.g.dart
+++ b/example/builder/basic_with_state.over_react.g.dart
@@ -22,48 +22,54 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// Go to [_$BasicProps.basicProp] to see the source code for this prop
   @override
-  String get basicProp => props[_$key__basicProp___$BasicProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basicProp] to see the source code for this prop
   @override
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
@@ -148,8 +154,9 @@ abstract class _$BasicStateAccessorsMixin implements _$BasicState {
 
   /// Go to [_$BasicState.basicState] to see the source code for this prop
   @override
-  String get basicState => state[_$key__basicState___$BasicState];
-
+  String get basicState =>
+      state[_$key__basicState___$BasicState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicState.basicState] to see the source code for this prop
   @override
   set basicState(String value) =>

--- a/example/builder/basic_with_type_params.over_react.g.dart
+++ b/example/builder/basic_with_type_params.over_react.g.dart
@@ -24,8 +24,8 @@ abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
   /// Go to [_$BasicProps.someGenericListProp] to see the source code for this prop
   @override
   List<T> get someGenericListProp =>
-      props[_$key__someGenericListProp___$BasicProps];
-
+      props[_$key__someGenericListProp___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.someGenericListProp] to see the source code for this prop
   @override
   set someGenericListProp(List<T> value) =>
@@ -33,8 +33,9 @@ abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
 
   /// Go to [_$BasicProps.somePropsClass] to see the source code for this prop
   @override
-  U get somePropsClass => props[_$key__somePropsClass___$BasicProps];
-
+  U get somePropsClass =>
+      props[_$key__somePropsClass___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.somePropsClass] to see the source code for this prop
   @override
   set somePropsClass(U value) =>

--- a/example/builder/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/generic_inheritance_sub.over_react.g.dart
@@ -23,8 +23,9 @@ abstract class _$GenericSubPropsAccessorsMixin implements _$GenericSubProps {
 
   /// Go to [_$GenericSubProps.subProp] to see the source code for this prop
   @override
-  String get subProp => props[_$key__subProp___$GenericSubProps];
-
+  String get subProp =>
+      props[_$key__subProp___$GenericSubProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSubProps.subProp] to see the source code for this prop
   @override
   set subProp(String value) => props[_$key__subProp___$GenericSubProps] = value;
@@ -88,8 +89,9 @@ abstract class _$GenericSubStateAccessorsMixin implements _$GenericSubState {
 
   /// Go to [_$GenericSubState.subState] to see the source code for this prop
   @override
-  String get subState => state[_$key__subState___$GenericSubState];
-
+  String get subState =>
+      state[_$key__subState___$GenericSubState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSubState.subState] to see the source code for this prop
   @override
   set subState(String value) =>

--- a/example/builder/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/generic_inheritance_super.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$GenericSuperPropsAccessorsMixin
   /// Go to [_$GenericSuperProps.otherSuperProp] to see the source code for this prop
   @override
   String get otherSuperProp =>
-      props[_$key__otherSuperProp___$GenericSuperProps];
-
+      props[_$key__otherSuperProp___$GenericSuperProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSuperProps.otherSuperProp] to see the source code for this prop
   @override
   set otherSuperProp(String value) =>
@@ -34,8 +34,9 @@ abstract class _$GenericSuperPropsAccessorsMixin
 
   /// Go to [_$GenericSuperProps.superProp] to see the source code for this prop
   @override
-  String get superProp => props[_$key__superProp___$GenericSuperProps];
-
+  String get superProp =>
+      props[_$key__superProp___$GenericSuperProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSuperProps.superProp] to see the source code for this prop
   @override
   set superProp(String value) =>
@@ -43,8 +44,9 @@ abstract class _$GenericSuperPropsAccessorsMixin
 
   /// Go to [_$GenericSuperProps.superProp1] to see the source code for this prop
   @override
-  String get superProp1 => props[_$key__superProp1___$GenericSuperProps];
-
+  String get superProp1 =>
+      props[_$key__superProp1___$GenericSuperProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSuperProps.superProp1] to see the source code for this prop
   @override
   set superProp1(String value) =>
@@ -122,8 +124,9 @@ abstract class _$GenericSuperStateAccessorsMixin
 
   /// Go to [_$GenericSuperState.superState] to see the source code for this prop
   @override
-  String get superState => state[_$key__superState___$GenericSuperState];
-
+  String get superState =>
+      state[_$key__superState___$GenericSuperState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$GenericSuperState.superState] to see the source code for this prop
   @override
   set superState(String value) =>

--- a/example/builder/private_component.over_react.g.dart
+++ b/example/builder/private_component.over_react.g.dart
@@ -23,8 +23,9 @@ abstract class _$_PrivatePropsAccessorsMixin implements _$_PrivateProps {
 
   /// Go to [_$_PrivateProps.prop1] to see the source code for this prop
   @override
-  bool get prop1 => props[_$key__prop1___$_PrivateProps];
-
+  bool get prop1 =>
+      props[_$key__prop1___$_PrivateProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$_PrivateProps.prop1] to see the source code for this prop
   @override
   set prop1(bool value) => props[_$key__prop1___$_PrivateProps] = value;
@@ -83,8 +84,9 @@ abstract class _$_PrivateStateAccessorsMixin implements _$_PrivateState {
 
   /// Go to [_$_PrivateState.state1] to see the source code for this prop
   @override
-  bool get state1 => state[_$key__state1___$_PrivateState];
-
+  bool get state1 =>
+      state[_$key__state1___$_PrivateState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$_PrivateState.state1] to see the source code for this prop
   @override
   set state1(bool value) => state[_$key__state1___$_PrivateState] = value;

--- a/example/builder/private_factory_public_component.over_react.g.dart
+++ b/example/builder/private_factory_public_component.over_react.g.dart
@@ -24,8 +24,9 @@ abstract class _$FormActionInputPropsAccessorsMixin
 
   /// Go to [_$FormActionInputProps.prop1] to see the source code for this prop
   @override
-  String get prop1 => props[_$key__prop1___$FormActionInputProps];
-
+  String get prop1 =>
+      props[_$key__prop1___$FormActionInputProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$FormActionInputProps.prop1] to see the source code for this prop
   @override
   set prop1(String value) =>

--- a/example/builder/props_mixin.over_react.g.dart
+++ b/example/builder/props_mixin.over_react.g.dart
@@ -14,8 +14,9 @@ abstract class ExamplePropsMixinClass implements _$ExamplePropsMixinClass {
 
   /// Go to [_$ExamplePropsMixinClass.propMixin1] to see the source code for this prop
   @override
-  String get propMixin1 => props[_$key__propMixin1___$ExamplePropsMixinClass];
-
+  String get propMixin1 =>
+      props[_$key__propMixin1___$ExamplePropsMixinClass] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ExamplePropsMixinClass.propMixin1] to see the source code for this prop
   @override
   set propMixin1(String value) =>
@@ -49,8 +50,8 @@ abstract class MixesInOtherMixinMixin<T extends Iterable, U>
   /// Go to [_$MixesInOtherMixinMixin.otherPropMixin] to see the source code for this prop
   @override
   String get otherPropMixin =>
-      props[_$key__otherPropMixin___$MixesInOtherMixinMixin];
-
+      props[_$key__otherPropMixin___$MixesInOtherMixinMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$MixesInOtherMixinMixin.otherPropMixin] to see the source code for this prop
   @override
   set otherPropMixin(String value) =>

--- a/example/builder/state_mixin.over_react.g.dart
+++ b/example/builder/state_mixin.over_react.g.dart
@@ -14,8 +14,9 @@ abstract class ExampleStateMixinClass implements _$ExampleStateMixinClass {
 
   /// Go to [_$ExampleStateMixinClass.stateMixin1] to see the source code for this prop
   @override
-  String get stateMixin1 => state[_$key__stateMixin1___$ExampleStateMixinClass];
-
+  String get stateMixin1 =>
+      state[_$key__stateMixin1___$ExampleStateMixinClass] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ExampleStateMixinClass.stateMixin1] to see the source code for this prop
   @override
   set stateMixin1(String value) =>

--- a/example/index.dart
+++ b/example/index.dart
@@ -18,7 +18,7 @@ main() {
         (Basic()
           ..basic1 = '<basic prop>'
           ..id = 'the id of this component'
-        )(),
+        )(null, null, ['this is another child']),
         (Sub()
           ..superProp = '<superProp value>'
           ..subProp = '<subProp value>'

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -410,7 +410,7 @@ class ImplGenerator {
                 '  /// Go to [$consumerClassName.$accessorName] to see the source code for this prop\n'
                 '  @override\n'
                 '${metadataSrc.toString()}'
-                '  ${typeString}get $accessorName => $proxiedMapName[$keyConstantName];\n'
+                '  ${typeString}get $accessorName => $proxiedMapName[$keyConstantName] ?? null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;\n'
                 '  /// Go to [$consumerClassName.$accessorName] to see the source code for this prop\n'
                 '  @override\n'
                 '${metadataSrc.toString()}'

--- a/lib/src/component/abstract_transition.over_react.g.dart
+++ b/lib/src/component/abstract_transition.over_react.g.dart
@@ -35,8 +35,8 @@ abstract class _$AbstractTransitionStateAccessorsMixin
   /// Go to [_$AbstractTransitionState.transitionPhase] to see the source code for this prop
   @override
   TransitionPhase get transitionPhase =>
-      state[_$key__transitionPhase___$AbstractTransitionState];
-
+      state[_$key__transitionPhase___$AbstractTransitionState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractTransitionState.transitionPhase] to see the source code for this prop
   @override
   set transitionPhase(TransitionPhase value) =>

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -17,8 +17,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// Go to [_$TransitionPropsMixin.transitionCount] to see the source code for this prop
   @override
   int get transitionCount =>
-      props[_$key__transitionCount___$TransitionPropsMixin];
-
+      props[_$key__transitionCount___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.transitionCount] to see the source code for this prop
   @override
   set transitionCount(int value) =>
@@ -27,8 +27,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// Go to [_$TransitionPropsMixin.transitionInCount] to see the source code for this prop
   @override
   int get transitionInCount =>
-      props[_$key__transitionInCount___$TransitionPropsMixin];
-
+      props[_$key__transitionInCount___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.transitionInCount] to see the source code for this prop
   @override
   set transitionInCount(int value) =>
@@ -37,8 +37,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// Go to [_$TransitionPropsMixin.transitionOutCount] to see the source code for this prop
   @override
   int get transitionOutCount =>
-      props[_$key__transitionOutCount___$TransitionPropsMixin];
-
+      props[_$key__transitionOutCount___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.transitionOutCount] to see the source code for this prop
   @override
   set transitionOutCount(int value) =>
@@ -46,8 +46,9 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
 
   /// Go to [_$TransitionPropsMixin.onWillHide] to see the source code for this prop
   @override
-  Callback get onWillHide => props[_$key__onWillHide___$TransitionPropsMixin];
-
+  Callback get onWillHide =>
+      props[_$key__onWillHide___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.onWillHide] to see the source code for this prop
   @override
   set onWillHide(Callback value) =>
@@ -55,8 +56,9 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
 
   /// Go to [_$TransitionPropsMixin.onDidHide] to see the source code for this prop
   @override
-  Callback get onDidHide => props[_$key__onDidHide___$TransitionPropsMixin];
-
+  Callback get onDidHide =>
+      props[_$key__onDidHide___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.onDidHide] to see the source code for this prop
   @override
   set onDidHide(Callback value) =>
@@ -64,8 +66,9 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
 
   /// Go to [_$TransitionPropsMixin.onWillShow] to see the source code for this prop
   @override
-  Callback get onWillShow => props[_$key__onWillShow___$TransitionPropsMixin];
-
+  Callback get onWillShow =>
+      props[_$key__onWillShow___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.onWillShow] to see the source code for this prop
   @override
   set onWillShow(Callback value) =>
@@ -73,8 +76,9 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
 
   /// Go to [_$TransitionPropsMixin.onDidShow] to see the source code for this prop
   @override
-  Callback get onDidShow => props[_$key__onDidShow___$TransitionPropsMixin];
-
+  Callback get onDidShow =>
+      props[_$key__onDidShow___$TransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionPropsMixin.onDidShow] to see the source code for this prop
   @override
   set onDidShow(Callback value) =>

--- a/lib/src/component/aria_mixin.over_react.g.dart
+++ b/lib/src/component/aria_mixin.over_react.g.dart
@@ -16,8 +16,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   @override
   @Accessor(key: 'aria-activedescendant')
   String get activedescendant =>
-      props[_$key__activedescendant___$AriaPropsMixin];
-
+      props[_$key__activedescendant___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.activedescendant] to see the source code for this prop
   @override
   @Accessor(key: 'aria-activedescendant')
@@ -27,8 +27,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.atomic] to see the source code for this prop
   @override
   @Accessor(key: 'aria-atomic')
-  bool get atomic => props[_$key__atomic___$AriaPropsMixin];
-
+  bool get atomic =>
+      props[_$key__atomic___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.atomic] to see the source code for this prop
   @override
   @Accessor(key: 'aria-atomic')
@@ -37,8 +38,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.autocomplete] to see the source code for this prop
   @override
   @Accessor(key: 'aria-autocomplete')
-  dynamic get autocomplete => props[_$key__autocomplete___$AriaPropsMixin];
-
+  dynamic get autocomplete =>
+      props[_$key__autocomplete___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.autocomplete] to see the source code for this prop
   @override
   @Accessor(key: 'aria-autocomplete')
@@ -48,8 +50,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.busy] to see the source code for this prop
   @override
   @Accessor(key: 'aria-busy')
-  bool get busy => props[_$key__busy___$AriaPropsMixin];
-
+  bool get busy =>
+      props[_$key__busy___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.busy] to see the source code for this prop
   @override
   @Accessor(key: 'aria-busy')
@@ -58,8 +61,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.checked] to see the source code for this prop
   @override
   @Accessor(key: 'aria-checked')
-  dynamic get checked => props[_$key__checked___$AriaPropsMixin];
-
+  dynamic get checked =>
+      props[_$key__checked___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.checked] to see the source code for this prop
   @override
   @Accessor(key: 'aria-checked')
@@ -68,8 +72,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.controls] to see the source code for this prop
   @override
   @Accessor(key: 'aria-controls')
-  dynamic get controls => props[_$key__controls___$AriaPropsMixin];
-
+  dynamic get controls =>
+      props[_$key__controls___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.controls] to see the source code for this prop
   @override
   @Accessor(key: 'aria-controls')
@@ -79,8 +84,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.describedby] to see the source code for this prop
   @override
   @Accessor(key: 'aria-describedby')
-  dynamic get describedby => props[_$key__describedby___$AriaPropsMixin];
-
+  dynamic get describedby =>
+      props[_$key__describedby___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.describedby] to see the source code for this prop
   @override
   @Accessor(key: 'aria-describedby')
@@ -90,8 +96,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.disabled] to see the source code for this prop
   @override
   @Accessor(key: 'aria-disabled')
-  bool get disabled => props[_$key__disabled___$AriaPropsMixin];
-
+  bool get disabled =>
+      props[_$key__disabled___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.disabled] to see the source code for this prop
   @override
   @Accessor(key: 'aria-disabled')
@@ -100,8 +107,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.dropeffect] to see the source code for this prop
   @override
   @Accessor(key: 'aria-dropeffect')
-  dynamic get dropeffect => props[_$key__dropeffect___$AriaPropsMixin];
-
+  dynamic get dropeffect =>
+      props[_$key__dropeffect___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.dropeffect] to see the source code for this prop
   @override
   @Accessor(key: 'aria-dropeffect')
@@ -111,8 +119,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.expanded] to see the source code for this prop
   @override
   @Accessor(key: 'aria-expanded')
-  dynamic get expanded => props[_$key__expanded___$AriaPropsMixin];
-
+  dynamic get expanded =>
+      props[_$key__expanded___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.expanded] to see the source code for this prop
   @override
   @Accessor(key: 'aria-expanded')
@@ -122,8 +131,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.flowto] to see the source code for this prop
   @override
   @Accessor(key: 'aria-flowto')
-  dynamic get flowto => props[_$key__flowto___$AriaPropsMixin];
-
+  dynamic get flowto =>
+      props[_$key__flowto___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.flowto] to see the source code for this prop
   @override
   @Accessor(key: 'aria-flowto')
@@ -132,8 +142,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.grabbed] to see the source code for this prop
   @override
   @Accessor(key: 'aria-grabbed')
-  dynamic get grabbed => props[_$key__grabbed___$AriaPropsMixin];
-
+  dynamic get grabbed =>
+      props[_$key__grabbed___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.grabbed] to see the source code for this prop
   @override
   @Accessor(key: 'aria-grabbed')
@@ -142,8 +153,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.haspopup] to see the source code for this prop
   @override
   @Accessor(key: 'aria-haspopup')
-  bool get haspopup => props[_$key__haspopup___$AriaPropsMixin];
-
+  bool get haspopup =>
+      props[_$key__haspopup___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.haspopup] to see the source code for this prop
   @override
   @Accessor(key: 'aria-haspopup')
@@ -152,8 +164,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.hidden] to see the source code for this prop
   @override
   @Accessor(key: 'aria-hidden')
-  bool get hidden => props[_$key__hidden___$AriaPropsMixin];
-
+  bool get hidden =>
+      props[_$key__hidden___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.hidden] to see the source code for this prop
   @override
   @Accessor(key: 'aria-hidden')
@@ -162,8 +175,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.invalid] to see the source code for this prop
   @override
   @Accessor(key: 'aria-invalid')
-  dynamic get invalid => props[_$key__invalid___$AriaPropsMixin];
-
+  dynamic get invalid =>
+      props[_$key__invalid___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.invalid] to see the source code for this prop
   @override
   @Accessor(key: 'aria-invalid')
@@ -172,8 +186,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.label] to see the source code for this prop
   @override
   @Accessor(key: 'aria-label')
-  String get label => props[_$key__label___$AriaPropsMixin];
-
+  String get label =>
+      props[_$key__label___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.label] to see the source code for this prop
   @override
   @Accessor(key: 'aria-label')
@@ -182,8 +197,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.labelledby] to see the source code for this prop
   @override
   @Accessor(key: 'aria-labelledby')
-  dynamic get labelledby => props[_$key__labelledby___$AriaPropsMixin];
-
+  dynamic get labelledby =>
+      props[_$key__labelledby___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.labelledby] to see the source code for this prop
   @override
   @Accessor(key: 'aria-labelledby')
@@ -193,8 +209,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.level] to see the source code for this prop
   @override
   @Accessor(key: 'aria-level')
-  int get level => props[_$key__level___$AriaPropsMixin];
-
+  int get level =>
+      props[_$key__level___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.level] to see the source code for this prop
   @override
   @Accessor(key: 'aria-level')
@@ -203,8 +220,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.live] to see the source code for this prop
   @override
   @Accessor(key: 'aria-live')
-  dynamic get live => props[_$key__live___$AriaPropsMixin];
-
+  dynamic get live =>
+      props[_$key__live___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.live] to see the source code for this prop
   @override
   @Accessor(key: 'aria-live')
@@ -213,8 +231,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.multiline] to see the source code for this prop
   @override
   @Accessor(key: 'aria-multiline')
-  bool get multiline => props[_$key__multiline___$AriaPropsMixin];
-
+  bool get multiline =>
+      props[_$key__multiline___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.multiline] to see the source code for this prop
   @override
   @Accessor(key: 'aria-multiline')
@@ -224,8 +243,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.multiselectable] to see the source code for this prop
   @override
   @Accessor(key: 'aria-multiselectable')
-  bool get multiselectable => props[_$key__multiselectable___$AriaPropsMixin];
-
+  bool get multiselectable =>
+      props[_$key__multiselectable___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.multiselectable] to see the source code for this prop
   @override
   @Accessor(key: 'aria-multiselectable')
@@ -235,8 +255,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.orientation] to see the source code for this prop
   @override
   @Accessor(key: 'aria-orientation')
-  dynamic get orientation => props[_$key__orientation___$AriaPropsMixin];
-
+  dynamic get orientation =>
+      props[_$key__orientation___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.orientation] to see the source code for this prop
   @override
   @Accessor(key: 'aria-orientation')
@@ -246,8 +267,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.owns] to see the source code for this prop
   @override
   @Accessor(key: 'aria-owns')
-  dynamic get owns => props[_$key__owns___$AriaPropsMixin];
-
+  dynamic get owns =>
+      props[_$key__owns___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.owns] to see the source code for this prop
   @override
   @Accessor(key: 'aria-owns')
@@ -256,8 +278,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.posinset] to see the source code for this prop
   @override
   @Accessor(key: 'aria-posinset')
-  int get posinset => props[_$key__posinset___$AriaPropsMixin];
-
+  int get posinset =>
+      props[_$key__posinset___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.posinset] to see the source code for this prop
   @override
   @Accessor(key: 'aria-posinset')
@@ -266,8 +289,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.pressed] to see the source code for this prop
   @override
   @Accessor(key: 'aria-pressed')
-  dynamic get pressed => props[_$key__pressed___$AriaPropsMixin];
-
+  dynamic get pressed =>
+      props[_$key__pressed___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.pressed] to see the source code for this prop
   @override
   @Accessor(key: 'aria-pressed')
@@ -276,8 +300,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.readonly] to see the source code for this prop
   @override
   @Accessor(key: 'aria-readonly')
-  bool get readonly => props[_$key__readonly___$AriaPropsMixin];
-
+  bool get readonly =>
+      props[_$key__readonly___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.readonly] to see the source code for this prop
   @override
   @Accessor(key: 'aria-readonly')
@@ -286,8 +311,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.relevant] to see the source code for this prop
   @override
   @Accessor(key: 'aria-relevant')
-  dynamic get relevant => props[_$key__relevant___$AriaPropsMixin];
-
+  dynamic get relevant =>
+      props[_$key__relevant___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.relevant] to see the source code for this prop
   @override
   @Accessor(key: 'aria-relevant')
@@ -297,8 +323,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.required] to see the source code for this prop
   @override
   @Accessor(key: 'aria-required')
-  bool get required => props[_$key__required___$AriaPropsMixin];
-
+  bool get required =>
+      props[_$key__required___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.required] to see the source code for this prop
   @override
   @Accessor(key: 'aria-required')
@@ -306,8 +333,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
 
   /// Go to [_$AriaPropsMixin.role] to see the source code for this prop
   @override
-  String get role => props[_$key__role___$AriaPropsMixin];
-
+  String get role =>
+      props[_$key__role___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.role] to see the source code for this prop
   @override
   set role(String value) => props[_$key__role___$AriaPropsMixin] = value;
@@ -315,8 +343,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.selected] to see the source code for this prop
   @override
   @Accessor(key: 'aria-selected')
-  dynamic get selected => props[_$key__selected___$AriaPropsMixin];
-
+  dynamic get selected =>
+      props[_$key__selected___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.selected] to see the source code for this prop
   @override
   @Accessor(key: 'aria-selected')
@@ -326,8 +355,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.setsize] to see the source code for this prop
   @override
   @Accessor(key: 'aria-setsize')
-  int get setsize => props[_$key__setsize___$AriaPropsMixin];
-
+  int get setsize =>
+      props[_$key__setsize___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.setsize] to see the source code for this prop
   @override
   @Accessor(key: 'aria-setsize')
@@ -336,8 +366,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.sort] to see the source code for this prop
   @override
   @Accessor(key: 'aria-sort')
-  dynamic get sort => props[_$key__sort___$AriaPropsMixin];
-
+  dynamic get sort =>
+      props[_$key__sort___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.sort] to see the source code for this prop
   @override
   @Accessor(key: 'aria-sort')
@@ -346,8 +377,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.valuemax] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuemax')
-  num get valuemax => props[_$key__valuemax___$AriaPropsMixin];
-
+  num get valuemax =>
+      props[_$key__valuemax___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.valuemax] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuemax')
@@ -356,8 +388,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.valuemin] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuemin')
-  num get valuemin => props[_$key__valuemin___$AriaPropsMixin];
-
+  num get valuemin =>
+      props[_$key__valuemin___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.valuemin] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuemin')
@@ -366,8 +399,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.valuenow] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuenow')
-  num get valuenow => props[_$key__valuenow___$AriaPropsMixin];
-
+  num get valuenow =>
+      props[_$key__valuenow___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.valuenow] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuenow')
@@ -376,8 +410,9 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// Go to [_$AriaPropsMixin.valuetext] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuetext')
-  String get valuetext => props[_$key__valuetext___$AriaPropsMixin];
-
+  String get valuetext =>
+      props[_$key__valuetext___$AriaPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AriaPropsMixin.valuetext] to see the source code for this prop
   @override
   @Accessor(key: 'aria-valuetext')

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -17,16 +17,18 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
 
   /// Go to [_$ReactPropsMixin.children] to see the source code for this prop
   @override
-  List get children => props[_$key__children___$ReactPropsMixin];
-
+  List get children =>
+      props[_$key__children___$ReactPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ReactPropsMixin.children] to see the source code for this prop
   @override
   set children(List value) => props[_$key__children___$ReactPropsMixin] = value;
 
   /// Go to [_$ReactPropsMixin.ref] to see the source code for this prop
   @override
-  dynamic get ref => props[_$key__ref___$ReactPropsMixin];
-
+  dynamic get ref =>
+      props[_$key__ref___$ReactPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ReactPropsMixin.ref] to see the source code for this prop
   @override
   set ref(dynamic value) => props[_$key__ref___$ReactPropsMixin] = value;
@@ -61,48 +63,54 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.cols] to see the source code for this prop
   @override
-  int get cols => props[_$key__cols___$DomPropsMixin];
-
+  int get cols =>
+      props[_$key__cols___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.cols] to see the source code for this prop
   @override
   set cols(int value) => props[_$key__cols___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.rows] to see the source code for this prop
   @override
-  int get rows => props[_$key__rows___$DomPropsMixin];
-
+  int get rows =>
+      props[_$key__rows___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.rows] to see the source code for this prop
   @override
   set rows(int value) => props[_$key__rows___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.size] to see the source code for this prop
   @override
-  int get size => props[_$key__size___$DomPropsMixin];
-
+  int get size =>
+      props[_$key__size___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.size] to see the source code for this prop
   @override
   set size(int value) => props[_$key__size___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.span] to see the source code for this prop
   @override
-  int get span => props[_$key__span___$DomPropsMixin];
-
+  int get span =>
+      props[_$key__span___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.span] to see the source code for this prop
   @override
   set span(int value) => props[_$key__span___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.start] to see the source code for this prop
   @override
-  int get start => props[_$key__start___$DomPropsMixin];
-
+  int get start =>
+      props[_$key__start___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.start] to see the source code for this prop
   @override
   set start(int value) => props[_$key__start___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.allowFullScreen] to see the source code for this prop
   @override
-  bool get allowFullScreen => props[_$key__allowFullScreen___$DomPropsMixin];
-
+  bool get allowFullScreen =>
+      props[_$key__allowFullScreen___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.allowFullScreen] to see the source code for this prop
   @override
   set allowFullScreen(bool value) =>
@@ -110,56 +118,63 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.async] to see the source code for this prop
   @override
-  bool get async => props[_$key__async___$DomPropsMixin];
-
+  bool get async =>
+      props[_$key__async___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.async] to see the source code for this prop
   @override
   set async(bool value) => props[_$key__async___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.autoPlay] to see the source code for this prop
   @override
-  bool get autoPlay => props[_$key__autoPlay___$DomPropsMixin];
-
+  bool get autoPlay =>
+      props[_$key__autoPlay___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.autoPlay] to see the source code for this prop
   @override
   set autoPlay(bool value) => props[_$key__autoPlay___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.checked] to see the source code for this prop
   @override
-  bool get checked => props[_$key__checked___$DomPropsMixin];
-
+  bool get checked =>
+      props[_$key__checked___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.checked] to see the source code for this prop
   @override
   set checked(bool value) => props[_$key__checked___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.controls] to see the source code for this prop
   @override
-  bool get controls => props[_$key__controls___$DomPropsMixin];
-
+  bool get controls =>
+      props[_$key__controls___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.controls] to see the source code for this prop
   @override
   set controls(bool value) => props[_$key__controls___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.defer] to see the source code for this prop
   @override
-  bool get defer => props[_$key__defer___$DomPropsMixin];
-
+  bool get defer =>
+      props[_$key__defer___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.defer] to see the source code for this prop
   @override
   set defer(bool value) => props[_$key__defer___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.disabled] to see the source code for this prop
   @override
-  bool get disabled => props[_$key__disabled___$DomPropsMixin];
-
+  bool get disabled =>
+      props[_$key__disabled___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.disabled] to see the source code for this prop
   @override
   set disabled(bool value) => props[_$key__disabled___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.formNoValidate] to see the source code for this prop
   @override
-  bool get formNoValidate => props[_$key__formNoValidate___$DomPropsMixin];
-
+  bool get formNoValidate =>
+      props[_$key__formNoValidate___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.formNoValidate] to see the source code for this prop
   @override
   set formNoValidate(bool value) =>
@@ -167,40 +182,45 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.hidden] to see the source code for this prop
   @override
-  bool get hidden => props[_$key__hidden___$DomPropsMixin];
-
+  bool get hidden =>
+      props[_$key__hidden___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.hidden] to see the source code for this prop
   @override
   set hidden(bool value) => props[_$key__hidden___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.loop] to see the source code for this prop
   @override
-  bool get loop => props[_$key__loop___$DomPropsMixin];
-
+  bool get loop =>
+      props[_$key__loop___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.loop] to see the source code for this prop
   @override
   set loop(bool value) => props[_$key__loop___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.multiple] to see the source code for this prop
   @override
-  bool get multiple => props[_$key__multiple___$DomPropsMixin];
-
+  bool get multiple =>
+      props[_$key__multiple___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.multiple] to see the source code for this prop
   @override
   set multiple(bool value) => props[_$key__multiple___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.muted] to see the source code for this prop
   @override
-  bool get muted => props[_$key__muted___$DomPropsMixin];
-
+  bool get muted =>
+      props[_$key__muted___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.muted] to see the source code for this prop
   @override
   set muted(bool value) => props[_$key__muted___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.noValidate] to see the source code for this prop
   @override
-  bool get noValidate => props[_$key__noValidate___$DomPropsMixin];
-
+  bool get noValidate =>
+      props[_$key__noValidate___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.noValidate] to see the source code for this prop
   @override
   set noValidate(bool value) =>
@@ -208,40 +228,45 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.readOnly] to see the source code for this prop
   @override
-  bool get readOnly => props[_$key__readOnly___$DomPropsMixin];
-
+  bool get readOnly =>
+      props[_$key__readOnly___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.readOnly] to see the source code for this prop
   @override
   set readOnly(bool value) => props[_$key__readOnly___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.required] to see the source code for this prop
   @override
-  bool get required => props[_$key__required___$DomPropsMixin];
-
+  bool get required =>
+      props[_$key__required___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.required] to see the source code for this prop
   @override
   set required(bool value) => props[_$key__required___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.seamless] to see the source code for this prop
   @override
-  bool get seamless => props[_$key__seamless___$DomPropsMixin];
-
+  bool get seamless =>
+      props[_$key__seamless___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.seamless] to see the source code for this prop
   @override
   set seamless(bool value) => props[_$key__seamless___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.selected] to see the source code for this prop
   @override
-  bool get selected => props[_$key__selected___$DomPropsMixin];
-
+  bool get selected =>
+      props[_$key__selected___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.selected] to see the source code for this prop
   @override
   set selected(bool value) => props[_$key__selected___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.style] to see the source code for this prop
   @override
-  Map<String, dynamic> get style => props[_$key__style___$DomPropsMixin];
-
+  Map<String, dynamic> get style =>
+      props[_$key__style___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.style] to see the source code for this prop
   @override
   set style(Map<String, dynamic> value) =>
@@ -249,8 +274,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.className] to see the source code for this prop
   @override
-  String get className => props[_$key__className___$DomPropsMixin];
-
+  String get className =>
+      props[_$key__className___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.className] to see the source code for this prop
   @override
   set className(String value) =>
@@ -258,32 +284,36 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.title] to see the source code for this prop
   @override
-  String get title => props[_$key__title___$DomPropsMixin];
-
+  String get title =>
+      props[_$key__title___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.title] to see the source code for this prop
   @override
   set title(String value) => props[_$key__title___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.id] to see the source code for this prop
   @override
-  String get id => props[_$key__id___$DomPropsMixin];
-
+  String get id =>
+      props[_$key__id___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.id] to see the source code for this prop
   @override
   set id(String value) => props[_$key__id___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.accept] to see the source code for this prop
   @override
-  dynamic get accept => props[_$key__accept___$DomPropsMixin];
-
+  dynamic get accept =>
+      props[_$key__accept___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.accept] to see the source code for this prop
   @override
   set accept(dynamic value) => props[_$key__accept___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.acceptCharset] to see the source code for this prop
   @override
-  dynamic get acceptCharset => props[_$key__acceptCharset___$DomPropsMixin];
-
+  dynamic get acceptCharset =>
+      props[_$key__acceptCharset___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.acceptCharset] to see the source code for this prop
   @override
   set acceptCharset(dynamic value) =>
@@ -291,8 +321,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.accessKey] to see the source code for this prop
   @override
-  dynamic get accessKey => props[_$key__accessKey___$DomPropsMixin];
-
+  dynamic get accessKey =>
+      props[_$key__accessKey___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.accessKey] to see the source code for this prop
   @override
   set accessKey(dynamic value) =>
@@ -300,8 +331,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.action] to see the source code for this prop
   @override
-  dynamic get action => props[_$key__action___$DomPropsMixin];
-
+  dynamic get action =>
+      props[_$key__action___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.action] to see the source code for this prop
   @override
   set action(dynamic value) => props[_$key__action___$DomPropsMixin] = value;
@@ -309,8 +341,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.allowTransparency] to see the source code for this prop
   @override
   dynamic get allowTransparency =>
-      props[_$key__allowTransparency___$DomPropsMixin];
-
+      props[_$key__allowTransparency___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.allowTransparency] to see the source code for this prop
   @override
   set allowTransparency(dynamic value) =>
@@ -318,16 +350,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.alt] to see the source code for this prop
   @override
-  dynamic get alt => props[_$key__alt___$DomPropsMixin];
-
+  dynamic get alt =>
+      props[_$key__alt___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.alt] to see the source code for this prop
   @override
   set alt(dynamic value) => props[_$key__alt___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.autoComplete] to see the source code for this prop
   @override
-  dynamic get autoComplete => props[_$key__autoComplete___$DomPropsMixin];
-
+  dynamic get autoComplete =>
+      props[_$key__autoComplete___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.autoComplete] to see the source code for this prop
   @override
   set autoComplete(dynamic value) =>
@@ -335,8 +369,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.cellPadding] to see the source code for this prop
   @override
-  dynamic get cellPadding => props[_$key__cellPadding___$DomPropsMixin];
-
+  dynamic get cellPadding =>
+      props[_$key__cellPadding___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.cellPadding] to see the source code for this prop
   @override
   set cellPadding(dynamic value) =>
@@ -344,8 +379,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.cellSpacing] to see the source code for this prop
   @override
-  dynamic get cellSpacing => props[_$key__cellSpacing___$DomPropsMixin];
-
+  dynamic get cellSpacing =>
+      props[_$key__cellSpacing___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.cellSpacing] to see the source code for this prop
   @override
   set cellSpacing(dynamic value) =>
@@ -353,40 +389,45 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.charSet] to see the source code for this prop
   @override
-  dynamic get charSet => props[_$key__charSet___$DomPropsMixin];
-
+  dynamic get charSet =>
+      props[_$key__charSet___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.charSet] to see the source code for this prop
   @override
   set charSet(dynamic value) => props[_$key__charSet___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.classID] to see the source code for this prop
   @override
-  dynamic get classID => props[_$key__classID___$DomPropsMixin];
-
+  dynamic get classID =>
+      props[_$key__classID___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.classID] to see the source code for this prop
   @override
   set classID(dynamic value) => props[_$key__classID___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.colSpan] to see the source code for this prop
   @override
-  dynamic get colSpan => props[_$key__colSpan___$DomPropsMixin];
-
+  dynamic get colSpan =>
+      props[_$key__colSpan___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.colSpan] to see the source code for this prop
   @override
   set colSpan(dynamic value) => props[_$key__colSpan___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.content] to see the source code for this prop
   @override
-  dynamic get content => props[_$key__content___$DomPropsMixin];
-
+  dynamic get content =>
+      props[_$key__content___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.content] to see the source code for this prop
   @override
   set content(dynamic value) => props[_$key__content___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.contentEditable] to see the source code for this prop
   @override
-  dynamic get contentEditable => props[_$key__contentEditable___$DomPropsMixin];
-
+  dynamic get contentEditable =>
+      props[_$key__contentEditable___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.contentEditable] to see the source code for this prop
   @override
   set contentEditable(dynamic value) =>
@@ -394,8 +435,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.contextMenu] to see the source code for this prop
   @override
-  dynamic get contextMenu => props[_$key__contextMenu___$DomPropsMixin];
-
+  dynamic get contextMenu =>
+      props[_$key__contextMenu___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.contextMenu] to see the source code for this prop
   @override
   set contextMenu(dynamic value) =>
@@ -403,16 +445,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.coords] to see the source code for this prop
   @override
-  dynamic get coords => props[_$key__coords___$DomPropsMixin];
-
+  dynamic get coords =>
+      props[_$key__coords___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.coords] to see the source code for this prop
   @override
   set coords(dynamic value) => props[_$key__coords___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.crossOrigin] to see the source code for this prop
   @override
-  dynamic get crossOrigin => props[_$key__crossOrigin___$DomPropsMixin];
-
+  dynamic get crossOrigin =>
+      props[_$key__crossOrigin___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.crossOrigin] to see the source code for this prop
   @override
   set crossOrigin(dynamic value) =>
@@ -420,16 +464,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.data] to see the source code for this prop
   @override
-  dynamic get data => props[_$key__data___$DomPropsMixin];
-
+  dynamic get data =>
+      props[_$key__data___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.data] to see the source code for this prop
   @override
   set data(dynamic value) => props[_$key__data___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.dateTime] to see the source code for this prop
   @override
-  dynamic get dateTime => props[_$key__dateTime___$DomPropsMixin];
-
+  dynamic get dateTime =>
+      props[_$key__dateTime___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.dateTime] to see the source code for this prop
   @override
   set dateTime(dynamic value) =>
@@ -437,16 +483,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.dir] to see the source code for this prop
   @override
-  dynamic get dir => props[_$key__dir___$DomPropsMixin];
-
+  dynamic get dir =>
+      props[_$key__dir___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.dir] to see the source code for this prop
   @override
   set dir(dynamic value) => props[_$key__dir___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.download] to see the source code for this prop
   @override
-  dynamic get download => props[_$key__download___$DomPropsMixin];
-
+  dynamic get download =>
+      props[_$key__download___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.download] to see the source code for this prop
   @override
   set download(dynamic value) =>
@@ -454,8 +502,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.draggable] to see the source code for this prop
   @override
-  dynamic get draggable => props[_$key__draggable___$DomPropsMixin];
-
+  dynamic get draggable =>
+      props[_$key__draggable___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.draggable] to see the source code for this prop
   @override
   set draggable(dynamic value) =>
@@ -463,24 +512,27 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.encType] to see the source code for this prop
   @override
-  dynamic get encType => props[_$key__encType___$DomPropsMixin];
-
+  dynamic get encType =>
+      props[_$key__encType___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.encType] to see the source code for this prop
   @override
   set encType(dynamic value) => props[_$key__encType___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.form] to see the source code for this prop
   @override
-  dynamic get form => props[_$key__form___$DomPropsMixin];
-
+  dynamic get form =>
+      props[_$key__form___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.form] to see the source code for this prop
   @override
   set form(dynamic value) => props[_$key__form___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.frameBorder] to see the source code for this prop
   @override
-  dynamic get frameBorder => props[_$key__frameBorder___$DomPropsMixin];
-
+  dynamic get frameBorder =>
+      props[_$key__frameBorder___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.frameBorder] to see the source code for this prop
   @override
   set frameBorder(dynamic value) =>
@@ -488,24 +540,27 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.height] to see the source code for this prop
   @override
-  dynamic get height => props[_$key__height___$DomPropsMixin];
-
+  dynamic get height =>
+      props[_$key__height___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.height] to see the source code for this prop
   @override
   set height(dynamic value) => props[_$key__height___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.href] to see the source code for this prop
   @override
-  dynamic get href => props[_$key__href___$DomPropsMixin];
-
+  dynamic get href =>
+      props[_$key__href___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.href] to see the source code for this prop
   @override
   set href(dynamic value) => props[_$key__href___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.hrefLang] to see the source code for this prop
   @override
-  dynamic get hrefLang => props[_$key__hrefLang___$DomPropsMixin];
-
+  dynamic get hrefLang =>
+      props[_$key__hrefLang___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.hrefLang] to see the source code for this prop
   @override
   set hrefLang(dynamic value) =>
@@ -513,16 +568,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.htmlFor] to see the source code for this prop
   @override
-  dynamic get htmlFor => props[_$key__htmlFor___$DomPropsMixin];
-
+  dynamic get htmlFor =>
+      props[_$key__htmlFor___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.htmlFor] to see the source code for this prop
   @override
   set htmlFor(dynamic value) => props[_$key__htmlFor___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.httpEquiv] to see the source code for this prop
   @override
-  dynamic get httpEquiv => props[_$key__httpEquiv___$DomPropsMixin];
-
+  dynamic get httpEquiv =>
+      props[_$key__httpEquiv___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.httpEquiv] to see the source code for this prop
   @override
   set httpEquiv(dynamic value) =>
@@ -530,40 +587,45 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.icon] to see the source code for this prop
   @override
-  dynamic get icon => props[_$key__icon___$DomPropsMixin];
-
+  dynamic get icon =>
+      props[_$key__icon___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.icon] to see the source code for this prop
   @override
   set icon(dynamic value) => props[_$key__icon___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.label] to see the source code for this prop
   @override
-  dynamic get label => props[_$key__label___$DomPropsMixin];
-
+  dynamic get label =>
+      props[_$key__label___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.label] to see the source code for this prop
   @override
   set label(dynamic value) => props[_$key__label___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.lang] to see the source code for this prop
   @override
-  dynamic get lang => props[_$key__lang___$DomPropsMixin];
-
+  dynamic get lang =>
+      props[_$key__lang___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.lang] to see the source code for this prop
   @override
   set lang(dynamic value) => props[_$key__lang___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.list] to see the source code for this prop
   @override
-  dynamic get list => props[_$key__list___$DomPropsMixin];
-
+  dynamic get list =>
+      props[_$key__list___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.list] to see the source code for this prop
   @override
   set list(dynamic value) => props[_$key__list___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.manifest] to see the source code for this prop
   @override
-  dynamic get manifest => props[_$key__manifest___$DomPropsMixin];
-
+  dynamic get manifest =>
+      props[_$key__manifest___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.manifest] to see the source code for this prop
   @override
   set manifest(dynamic value) =>
@@ -571,16 +633,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.max] to see the source code for this prop
   @override
-  dynamic get max => props[_$key__max___$DomPropsMixin];
-
+  dynamic get max =>
+      props[_$key__max___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.max] to see the source code for this prop
   @override
   set max(dynamic value) => props[_$key__max___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.maxLength] to see the source code for this prop
   @override
-  dynamic get maxLength => props[_$key__maxLength___$DomPropsMixin];
-
+  dynamic get maxLength =>
+      props[_$key__maxLength___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.maxLength] to see the source code for this prop
   @override
   set maxLength(dynamic value) =>
@@ -588,16 +652,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.media] to see the source code for this prop
   @override
-  dynamic get media => props[_$key__media___$DomPropsMixin];
-
+  dynamic get media =>
+      props[_$key__media___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.media] to see the source code for this prop
   @override
   set media(dynamic value) => props[_$key__media___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.mediaGroup] to see the source code for this prop
   @override
-  dynamic get mediaGroup => props[_$key__mediaGroup___$DomPropsMixin];
-
+  dynamic get mediaGroup =>
+      props[_$key__mediaGroup___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.mediaGroup] to see the source code for this prop
   @override
   set mediaGroup(dynamic value) =>
@@ -605,48 +671,54 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.method] to see the source code for this prop
   @override
-  dynamic get method => props[_$key__method___$DomPropsMixin];
-
+  dynamic get method =>
+      props[_$key__method___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.method] to see the source code for this prop
   @override
   set method(dynamic value) => props[_$key__method___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.min] to see the source code for this prop
   @override
-  dynamic get min => props[_$key__min___$DomPropsMixin];
-
+  dynamic get min =>
+      props[_$key__min___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.min] to see the source code for this prop
   @override
   set min(dynamic value) => props[_$key__min___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.name] to see the source code for this prop
   @override
-  dynamic get name => props[_$key__name___$DomPropsMixin];
-
+  dynamic get name =>
+      props[_$key__name___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.name] to see the source code for this prop
   @override
   set name(dynamic value) => props[_$key__name___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.open] to see the source code for this prop
   @override
-  dynamic get open => props[_$key__open___$DomPropsMixin];
-
+  dynamic get open =>
+      props[_$key__open___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.open] to see the source code for this prop
   @override
   set open(dynamic value) => props[_$key__open___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.pattern] to see the source code for this prop
   @override
-  dynamic get pattern => props[_$key__pattern___$DomPropsMixin];
-
+  dynamic get pattern =>
+      props[_$key__pattern___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.pattern] to see the source code for this prop
   @override
   set pattern(dynamic value) => props[_$key__pattern___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.placeholder] to see the source code for this prop
   @override
-  dynamic get placeholder => props[_$key__placeholder___$DomPropsMixin];
-
+  dynamic get placeholder =>
+      props[_$key__placeholder___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.placeholder] to see the source code for this prop
   @override
   set placeholder(dynamic value) =>
@@ -654,24 +726,27 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.poster] to see the source code for this prop
   @override
-  dynamic get poster => props[_$key__poster___$DomPropsMixin];
-
+  dynamic get poster =>
+      props[_$key__poster___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.poster] to see the source code for this prop
   @override
   set poster(dynamic value) => props[_$key__poster___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.preload] to see the source code for this prop
   @override
-  dynamic get preload => props[_$key__preload___$DomPropsMixin];
-
+  dynamic get preload =>
+      props[_$key__preload___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.preload] to see the source code for this prop
   @override
   set preload(dynamic value) => props[_$key__preload___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.radioGroup] to see the source code for this prop
   @override
-  dynamic get radioGroup => props[_$key__radioGroup___$DomPropsMixin];
-
+  dynamic get radioGroup =>
+      props[_$key__radioGroup___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.radioGroup] to see the source code for this prop
   @override
   set radioGroup(dynamic value) =>
@@ -679,48 +754,54 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.rel] to see the source code for this prop
   @override
-  dynamic get rel => props[_$key__rel___$DomPropsMixin];
-
+  dynamic get rel =>
+      props[_$key__rel___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.rel] to see the source code for this prop
   @override
   set rel(dynamic value) => props[_$key__rel___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.role] to see the source code for this prop
   @override
-  dynamic get role => props[_$key__role___$DomPropsMixin];
-
+  dynamic get role =>
+      props[_$key__role___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.role] to see the source code for this prop
   @override
   set role(dynamic value) => props[_$key__role___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.rowSpan] to see the source code for this prop
   @override
-  dynamic get rowSpan => props[_$key__rowSpan___$DomPropsMixin];
-
+  dynamic get rowSpan =>
+      props[_$key__rowSpan___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.rowSpan] to see the source code for this prop
   @override
   set rowSpan(dynamic value) => props[_$key__rowSpan___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.sandbox] to see the source code for this prop
   @override
-  dynamic get sandbox => props[_$key__sandbox___$DomPropsMixin];
-
+  dynamic get sandbox =>
+      props[_$key__sandbox___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.sandbox] to see the source code for this prop
   @override
   set sandbox(dynamic value) => props[_$key__sandbox___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.scope] to see the source code for this prop
   @override
-  dynamic get scope => props[_$key__scope___$DomPropsMixin];
-
+  dynamic get scope =>
+      props[_$key__scope___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.scope] to see the source code for this prop
   @override
   set scope(dynamic value) => props[_$key__scope___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.scrolling] to see the source code for this prop
   @override
-  dynamic get scrolling => props[_$key__scrolling___$DomPropsMixin];
-
+  dynamic get scrolling =>
+      props[_$key__scrolling___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.scrolling] to see the source code for this prop
   @override
   set scrolling(dynamic value) =>
@@ -728,24 +809,27 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.shape] to see the source code for this prop
   @override
-  dynamic get shape => props[_$key__shape___$DomPropsMixin];
-
+  dynamic get shape =>
+      props[_$key__shape___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.shape] to see the source code for this prop
   @override
   set shape(dynamic value) => props[_$key__shape___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.sizes] to see the source code for this prop
   @override
-  dynamic get sizes => props[_$key__sizes___$DomPropsMixin];
-
+  dynamic get sizes =>
+      props[_$key__sizes___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.sizes] to see the source code for this prop
   @override
   set sizes(dynamic value) => props[_$key__sizes___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.spellCheck] to see the source code for this prop
   @override
-  dynamic get spellCheck => props[_$key__spellCheck___$DomPropsMixin];
-
+  dynamic get spellCheck =>
+      props[_$key__spellCheck___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.spellCheck] to see the source code for this prop
   @override
   set spellCheck(dynamic value) =>
@@ -753,40 +837,45 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.src] to see the source code for this prop
   @override
-  dynamic get src => props[_$key__src___$DomPropsMixin];
-
+  dynamic get src =>
+      props[_$key__src___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.src] to see the source code for this prop
   @override
   set src(dynamic value) => props[_$key__src___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.srcDoc] to see the source code for this prop
   @override
-  dynamic get srcDoc => props[_$key__srcDoc___$DomPropsMixin];
-
+  dynamic get srcDoc =>
+      props[_$key__srcDoc___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.srcDoc] to see the source code for this prop
   @override
   set srcDoc(dynamic value) => props[_$key__srcDoc___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.srcSet] to see the source code for this prop
   @override
-  dynamic get srcSet => props[_$key__srcSet___$DomPropsMixin];
-
+  dynamic get srcSet =>
+      props[_$key__srcSet___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.srcSet] to see the source code for this prop
   @override
   set srcSet(dynamic value) => props[_$key__srcSet___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.step] to see the source code for this prop
   @override
-  dynamic get step => props[_$key__step___$DomPropsMixin];
-
+  dynamic get step =>
+      props[_$key__step___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.step] to see the source code for this prop
   @override
   set step(dynamic value) => props[_$key__step___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.tabIndex] to see the source code for this prop
   @override
-  dynamic get tabIndex => props[_$key__tabIndex___$DomPropsMixin];
-
+  dynamic get tabIndex =>
+      props[_$key__tabIndex___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.tabIndex] to see the source code for this prop
   @override
   set tabIndex(dynamic value) =>
@@ -794,56 +883,63 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.target] to see the source code for this prop
   @override
-  dynamic get target => props[_$key__target___$DomPropsMixin];
-
+  dynamic get target =>
+      props[_$key__target___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.target] to see the source code for this prop
   @override
   set target(dynamic value) => props[_$key__target___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.type] to see the source code for this prop
   @override
-  dynamic get type => props[_$key__type___$DomPropsMixin];
-
+  dynamic get type =>
+      props[_$key__type___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.type] to see the source code for this prop
   @override
   set type(dynamic value) => props[_$key__type___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.useMap] to see the source code for this prop
   @override
-  dynamic get useMap => props[_$key__useMap___$DomPropsMixin];
-
+  dynamic get useMap =>
+      props[_$key__useMap___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.useMap] to see the source code for this prop
   @override
   set useMap(dynamic value) => props[_$key__useMap___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.value] to see the source code for this prop
   @override
-  dynamic get value => props[_$key__value___$DomPropsMixin];
-
+  dynamic get value =>
+      props[_$key__value___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.value] to see the source code for this prop
   @override
   set value(dynamic value) => props[_$key__value___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.width] to see the source code for this prop
   @override
-  dynamic get width => props[_$key__width___$DomPropsMixin];
-
+  dynamic get width =>
+      props[_$key__width___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.width] to see the source code for this prop
   @override
   set width(dynamic value) => props[_$key__width___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.wmode] to see the source code for this prop
   @override
-  dynamic get wmode => props[_$key__wmode___$DomPropsMixin];
-
+  dynamic get wmode =>
+      props[_$key__wmode___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.wmode] to see the source code for this prop
   @override
   set wmode(dynamic value) => props[_$key__wmode___$DomPropsMixin] = value;
 
   /// Go to [_$DomPropsMixin.onCopy] to see the source code for this prop
   @override
-  ClipboardEventCallback get onCopy => props[_$key__onCopy___$DomPropsMixin];
-
+  ClipboardEventCallback get onCopy =>
+      props[_$key__onCopy___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onCopy] to see the source code for this prop
   @override
   set onCopy(ClipboardEventCallback value) =>
@@ -851,8 +947,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onCut] to see the source code for this prop
   @override
-  ClipboardEventCallback get onCut => props[_$key__onCut___$DomPropsMixin];
-
+  ClipboardEventCallback get onCut =>
+      props[_$key__onCut___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onCut] to see the source code for this prop
   @override
   set onCut(ClipboardEventCallback value) =>
@@ -860,8 +957,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onPaste] to see the source code for this prop
   @override
-  ClipboardEventCallback get onPaste => props[_$key__onPaste___$DomPropsMixin];
-
+  ClipboardEventCallback get onPaste =>
+      props[_$key__onPaste___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onPaste] to see the source code for this prop
   @override
   set onPaste(ClipboardEventCallback value) =>
@@ -870,8 +968,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onKeyDown] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyDown =>
-      props[_$key__onKeyDown___$DomPropsMixin];
-
+      props[_$key__onKeyDown___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyDown] to see the source code for this prop
   @override
   set onKeyDown(KeyboardEventCallback value) =>
@@ -880,8 +978,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onKeyPress] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyPress =>
-      props[_$key__onKeyPress___$DomPropsMixin];
-
+      props[_$key__onKeyPress___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyPress] to see the source code for this prop
   @override
   set onKeyPress(KeyboardEventCallback value) =>
@@ -889,8 +987,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onKeyUp] to see the source code for this prop
   @override
-  KeyboardEventCallback get onKeyUp => props[_$key__onKeyUp___$DomPropsMixin];
-
+  KeyboardEventCallback get onKeyUp =>
+      props[_$key__onKeyUp___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyUp] to see the source code for this prop
   @override
   set onKeyUp(KeyboardEventCallback value) =>
@@ -898,8 +997,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onFocus] to see the source code for this prop
   @override
-  FocusEventCallback get onFocus => props[_$key__onFocus___$DomPropsMixin];
-
+  FocusEventCallback get onFocus =>
+      props[_$key__onFocus___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onFocus] to see the source code for this prop
   @override
   set onFocus(FocusEventCallback value) =>
@@ -907,8 +1007,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onBlur] to see the source code for this prop
   @override
-  FocusEventCallback get onBlur => props[_$key__onBlur___$DomPropsMixin];
-
+  FocusEventCallback get onBlur =>
+      props[_$key__onBlur___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onBlur] to see the source code for this prop
   @override
   set onBlur(FocusEventCallback value) =>
@@ -916,8 +1017,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onChange] to see the source code for this prop
   @override
-  FormEventCallback get onChange => props[_$key__onChange___$DomPropsMixin];
-
+  FormEventCallback get onChange =>
+      props[_$key__onChange___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onChange] to see the source code for this prop
   @override
   set onChange(FormEventCallback value) =>
@@ -925,8 +1027,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onInput] to see the source code for this prop
   @override
-  FormEventCallback get onInput => props[_$key__onInput___$DomPropsMixin];
-
+  FormEventCallback get onInput =>
+      props[_$key__onInput___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onInput] to see the source code for this prop
   @override
   set onInput(FormEventCallback value) =>
@@ -934,8 +1037,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onSubmit] to see the source code for this prop
   @override
-  FormEventCallback get onSubmit => props[_$key__onSubmit___$DomPropsMixin];
-
+  FormEventCallback get onSubmit =>
+      props[_$key__onSubmit___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onSubmit] to see the source code for this prop
   @override
   set onSubmit(FormEventCallback value) =>
@@ -943,8 +1047,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onReset] to see the source code for this prop
   @override
-  FormEventCallback get onReset => props[_$key__onReset___$DomPropsMixin];
-
+  FormEventCallback get onReset =>
+      props[_$key__onReset___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onReset] to see the source code for this prop
   @override
   set onReset(FormEventCallback value) =>
@@ -952,8 +1057,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onClick] to see the source code for this prop
   @override
-  MouseEventCallback get onClick => props[_$key__onClick___$DomPropsMixin];
-
+  MouseEventCallback get onClick =>
+      props[_$key__onClick___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onClick] to see the source code for this prop
   @override
   set onClick(MouseEventCallback value) =>
@@ -962,8 +1068,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onContextMenu] to see the source code for this prop
   @override
   MouseEventCallback get onContextMenu =>
-      props[_$key__onContextMenu___$DomPropsMixin];
-
+      props[_$key__onContextMenu___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onContextMenu] to see the source code for this prop
   @override
   set onContextMenu(MouseEventCallback value) =>
@@ -972,8 +1078,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDoubleClick] to see the source code for this prop
   @override
   MouseEventCallback get onDoubleClick =>
-      props[_$key__onDoubleClick___$DomPropsMixin];
-
+      props[_$key__onDoubleClick___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDoubleClick] to see the source code for this prop
   @override
   set onDoubleClick(MouseEventCallback value) =>
@@ -981,8 +1087,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onDrag] to see the source code for this prop
   @override
-  MouseEventCallback get onDrag => props[_$key__onDrag___$DomPropsMixin];
-
+  MouseEventCallback get onDrag =>
+      props[_$key__onDrag___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDrag] to see the source code for this prop
   @override
   set onDrag(MouseEventCallback value) =>
@@ -990,8 +1097,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onDragEnd] to see the source code for this prop
   @override
-  MouseEventCallback get onDragEnd => props[_$key__onDragEnd___$DomPropsMixin];
-
+  MouseEventCallback get onDragEnd =>
+      props[_$key__onDragEnd___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragEnd] to see the source code for this prop
   @override
   set onDragEnd(MouseEventCallback value) =>
@@ -1000,8 +1108,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragEnter] to see the source code for this prop
   @override
   MouseEventCallback get onDragEnter =>
-      props[_$key__onDragEnter___$DomPropsMixin];
-
+      props[_$key__onDragEnter___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragEnter] to see the source code for this prop
   @override
   set onDragEnter(MouseEventCallback value) =>
@@ -1010,8 +1118,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragExit] to see the source code for this prop
   @override
   MouseEventCallback get onDragExit =>
-      props[_$key__onDragExit___$DomPropsMixin];
-
+      props[_$key__onDragExit___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragExit] to see the source code for this prop
   @override
   set onDragExit(MouseEventCallback value) =>
@@ -1020,8 +1128,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragLeave] to see the source code for this prop
   @override
   MouseEventCallback get onDragLeave =>
-      props[_$key__onDragLeave___$DomPropsMixin];
-
+      props[_$key__onDragLeave___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragLeave] to see the source code for this prop
   @override
   set onDragLeave(MouseEventCallback value) =>
@@ -1030,8 +1138,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragOver] to see the source code for this prop
   @override
   MouseEventCallback get onDragOver =>
-      props[_$key__onDragOver___$DomPropsMixin];
-
+      props[_$key__onDragOver___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragOver] to see the source code for this prop
   @override
   set onDragOver(MouseEventCallback value) =>
@@ -1040,8 +1148,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragStart] to see the source code for this prop
   @override
   MouseEventCallback get onDragStart =>
-      props[_$key__onDragStart___$DomPropsMixin];
-
+      props[_$key__onDragStart___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragStart] to see the source code for this prop
   @override
   set onDragStart(MouseEventCallback value) =>
@@ -1049,8 +1157,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onDrop] to see the source code for this prop
   @override
-  MouseEventCallback get onDrop => props[_$key__onDrop___$DomPropsMixin];
-
+  MouseEventCallback get onDrop =>
+      props[_$key__onDrop___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDrop] to see the source code for this prop
   @override
   set onDrop(MouseEventCallback value) =>
@@ -1059,8 +1168,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseDown] to see the source code for this prop
   @override
   MouseEventCallback get onMouseDown =>
-      props[_$key__onMouseDown___$DomPropsMixin];
-
+      props[_$key__onMouseDown___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseDown] to see the source code for this prop
   @override
   set onMouseDown(MouseEventCallback value) =>
@@ -1069,8 +1178,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseEnter] to see the source code for this prop
   @override
   MouseEventCallback get onMouseEnter =>
-      props[_$key__onMouseEnter___$DomPropsMixin];
-
+      props[_$key__onMouseEnter___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseEnter] to see the source code for this prop
   @override
   set onMouseEnter(MouseEventCallback value) =>
@@ -1079,8 +1188,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseLeave] to see the source code for this prop
   @override
   MouseEventCallback get onMouseLeave =>
-      props[_$key__onMouseLeave___$DomPropsMixin];
-
+      props[_$key__onMouseLeave___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseLeave] to see the source code for this prop
   @override
   set onMouseLeave(MouseEventCallback value) =>
@@ -1089,8 +1198,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseMove] to see the source code for this prop
   @override
   MouseEventCallback get onMouseMove =>
-      props[_$key__onMouseMove___$DomPropsMixin];
-
+      props[_$key__onMouseMove___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseMove] to see the source code for this prop
   @override
   set onMouseMove(MouseEventCallback value) =>
@@ -1099,8 +1208,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseOut] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOut =>
-      props[_$key__onMouseOut___$DomPropsMixin];
-
+      props[_$key__onMouseOut___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseOut] to see the source code for this prop
   @override
   set onMouseOut(MouseEventCallback value) =>
@@ -1109,8 +1218,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseOver] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOver =>
-      props[_$key__onMouseOver___$DomPropsMixin];
-
+      props[_$key__onMouseOver___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseOver] to see the source code for this prop
   @override
   set onMouseOver(MouseEventCallback value) =>
@@ -1118,8 +1227,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onMouseUp] to see the source code for this prop
   @override
-  MouseEventCallback get onMouseUp => props[_$key__onMouseUp___$DomPropsMixin];
-
+  MouseEventCallback get onMouseUp =>
+      props[_$key__onMouseUp___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseUp] to see the source code for this prop
   @override
   set onMouseUp(MouseEventCallback value) =>
@@ -1128,8 +1238,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchCancel] to see the source code for this prop
   @override
   TouchEventCallback get onTouchCancel =>
-      props[_$key__onTouchCancel___$DomPropsMixin];
-
+      props[_$key__onTouchCancel___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchCancel] to see the source code for this prop
   @override
   set onTouchCancel(TouchEventCallback value) =>
@@ -1138,8 +1248,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchEnd] to see the source code for this prop
   @override
   TouchEventCallback get onTouchEnd =>
-      props[_$key__onTouchEnd___$DomPropsMixin];
-
+      props[_$key__onTouchEnd___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchEnd] to see the source code for this prop
   @override
   set onTouchEnd(TouchEventCallback value) =>
@@ -1148,8 +1258,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchMove] to see the source code for this prop
   @override
   TouchEventCallback get onTouchMove =>
-      props[_$key__onTouchMove___$DomPropsMixin];
-
+      props[_$key__onTouchMove___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchMove] to see the source code for this prop
   @override
   set onTouchMove(TouchEventCallback value) =>
@@ -1158,8 +1268,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchStart] to see the source code for this prop
   @override
   TouchEventCallback get onTouchStart =>
-      props[_$key__onTouchStart___$DomPropsMixin];
-
+      props[_$key__onTouchStart___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchStart] to see the source code for this prop
   @override
   set onTouchStart(TouchEventCallback value) =>
@@ -1167,8 +1277,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onScroll] to see the source code for this prop
   @override
-  UIEventCallback get onScroll => props[_$key__onScroll___$DomPropsMixin];
-
+  UIEventCallback get onScroll =>
+      props[_$key__onScroll___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onScroll] to see the source code for this prop
   @override
   set onScroll(UIEventCallback value) =>
@@ -1176,8 +1287,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.onWheel] to see the source code for this prop
   @override
-  WheelEventCallback get onWheel => props[_$key__onWheel___$DomPropsMixin];
-
+  WheelEventCallback get onWheel =>
+      props[_$key__onWheel___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onWheel] to see the source code for this prop
   @override
   set onWheel(WheelEventCallback value) =>
@@ -1186,8 +1298,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onCopyCapture] to see the source code for this prop
   @override
   ClipboardEventCallback get onCopyCapture =>
-      props[_$key__onCopyCapture___$DomPropsMixin];
-
+      props[_$key__onCopyCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onCopyCapture] to see the source code for this prop
   @override
   set onCopyCapture(ClipboardEventCallback value) =>
@@ -1196,8 +1308,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onCutCapture] to see the source code for this prop
   @override
   ClipboardEventCallback get onCutCapture =>
-      props[_$key__onCutCapture___$DomPropsMixin];
-
+      props[_$key__onCutCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onCutCapture] to see the source code for this prop
   @override
   set onCutCapture(ClipboardEventCallback value) =>
@@ -1206,8 +1318,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onPasteCapture] to see the source code for this prop
   @override
   ClipboardEventCallback get onPasteCapture =>
-      props[_$key__onPasteCapture___$DomPropsMixin];
-
+      props[_$key__onPasteCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onPasteCapture] to see the source code for this prop
   @override
   set onPasteCapture(ClipboardEventCallback value) =>
@@ -1216,8 +1328,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onKeyDownCapture] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyDownCapture =>
-      props[_$key__onKeyDownCapture___$DomPropsMixin];
-
+      props[_$key__onKeyDownCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyDownCapture] to see the source code for this prop
   @override
   set onKeyDownCapture(KeyboardEventCallback value) =>
@@ -1226,8 +1338,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onKeyPressCapture] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyPressCapture =>
-      props[_$key__onKeyPressCapture___$DomPropsMixin];
-
+      props[_$key__onKeyPressCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyPressCapture] to see the source code for this prop
   @override
   set onKeyPressCapture(KeyboardEventCallback value) =>
@@ -1236,8 +1348,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onKeyUpCapture] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyUpCapture =>
-      props[_$key__onKeyUpCapture___$DomPropsMixin];
-
+      props[_$key__onKeyUpCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onKeyUpCapture] to see the source code for this prop
   @override
   set onKeyUpCapture(KeyboardEventCallback value) =>
@@ -1246,8 +1358,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onFocusCapture] to see the source code for this prop
   @override
   FocusEventCallback get onFocusCapture =>
-      props[_$key__onFocusCapture___$DomPropsMixin];
-
+      props[_$key__onFocusCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onFocusCapture] to see the source code for this prop
   @override
   set onFocusCapture(FocusEventCallback value) =>
@@ -1256,8 +1368,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onBlurCapture] to see the source code for this prop
   @override
   FocusEventCallback get onBlurCapture =>
-      props[_$key__onBlurCapture___$DomPropsMixin];
-
+      props[_$key__onBlurCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onBlurCapture] to see the source code for this prop
   @override
   set onBlurCapture(FocusEventCallback value) =>
@@ -1266,8 +1378,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onChangeCapture] to see the source code for this prop
   @override
   FormEventCallback get onChangeCapture =>
-      props[_$key__onChangeCapture___$DomPropsMixin];
-
+      props[_$key__onChangeCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onChangeCapture] to see the source code for this prop
   @override
   set onChangeCapture(FormEventCallback value) =>
@@ -1276,8 +1388,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onInputCapture] to see the source code for this prop
   @override
   FormEventCallback get onInputCapture =>
-      props[_$key__onInputCapture___$DomPropsMixin];
-
+      props[_$key__onInputCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onInputCapture] to see the source code for this prop
   @override
   set onInputCapture(FormEventCallback value) =>
@@ -1286,8 +1398,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onSubmitCapture] to see the source code for this prop
   @override
   FormEventCallback get onSubmitCapture =>
-      props[_$key__onSubmitCapture___$DomPropsMixin];
-
+      props[_$key__onSubmitCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onSubmitCapture] to see the source code for this prop
   @override
   set onSubmitCapture(FormEventCallback value) =>
@@ -1296,8 +1408,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onResetCapture] to see the source code for this prop
   @override
   FormEventCallback get onResetCapture =>
-      props[_$key__onResetCapture___$DomPropsMixin];
-
+      props[_$key__onResetCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onResetCapture] to see the source code for this prop
   @override
   set onResetCapture(FormEventCallback value) =>
@@ -1306,8 +1418,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onClickCapture] to see the source code for this prop
   @override
   MouseEventCallback get onClickCapture =>
-      props[_$key__onClickCapture___$DomPropsMixin];
-
+      props[_$key__onClickCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onClickCapture] to see the source code for this prop
   @override
   set onClickCapture(MouseEventCallback value) =>
@@ -1316,8 +1428,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onContextMenuCapture] to see the source code for this prop
   @override
   MouseEventCallback get onContextMenuCapture =>
-      props[_$key__onContextMenuCapture___$DomPropsMixin];
-
+      props[_$key__onContextMenuCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onContextMenuCapture] to see the source code for this prop
   @override
   set onContextMenuCapture(MouseEventCallback value) =>
@@ -1326,8 +1438,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDoubleClickCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDoubleClickCapture =>
-      props[_$key__onDoubleClickCapture___$DomPropsMixin];
-
+      props[_$key__onDoubleClickCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDoubleClickCapture] to see the source code for this prop
   @override
   set onDoubleClickCapture(MouseEventCallback value) =>
@@ -1336,8 +1448,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragCapture =>
-      props[_$key__onDragCapture___$DomPropsMixin];
-
+      props[_$key__onDragCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragCapture] to see the source code for this prop
   @override
   set onDragCapture(MouseEventCallback value) =>
@@ -1346,8 +1458,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragEndCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragEndCapture =>
-      props[_$key__onDragEndCapture___$DomPropsMixin];
-
+      props[_$key__onDragEndCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragEndCapture] to see the source code for this prop
   @override
   set onDragEndCapture(MouseEventCallback value) =>
@@ -1356,8 +1468,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragEnterCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragEnterCapture =>
-      props[_$key__onDragEnterCapture___$DomPropsMixin];
-
+      props[_$key__onDragEnterCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragEnterCapture] to see the source code for this prop
   @override
   set onDragEnterCapture(MouseEventCallback value) =>
@@ -1366,8 +1478,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragExitCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragExitCapture =>
-      props[_$key__onDragExitCapture___$DomPropsMixin];
-
+      props[_$key__onDragExitCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragExitCapture] to see the source code for this prop
   @override
   set onDragExitCapture(MouseEventCallback value) =>
@@ -1376,8 +1488,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragLeaveCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragLeaveCapture =>
-      props[_$key__onDragLeaveCapture___$DomPropsMixin];
-
+      props[_$key__onDragLeaveCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragLeaveCapture] to see the source code for this prop
   @override
   set onDragLeaveCapture(MouseEventCallback value) =>
@@ -1386,8 +1498,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragOverCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragOverCapture =>
-      props[_$key__onDragOverCapture___$DomPropsMixin];
-
+      props[_$key__onDragOverCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragOverCapture] to see the source code for this prop
   @override
   set onDragOverCapture(MouseEventCallback value) =>
@@ -1396,8 +1508,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDragStartCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDragStartCapture =>
-      props[_$key__onDragStartCapture___$DomPropsMixin];
-
+      props[_$key__onDragStartCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDragStartCapture] to see the source code for this prop
   @override
   set onDragStartCapture(MouseEventCallback value) =>
@@ -1406,8 +1518,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onDropCapture] to see the source code for this prop
   @override
   MouseEventCallback get onDropCapture =>
-      props[_$key__onDropCapture___$DomPropsMixin];
-
+      props[_$key__onDropCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onDropCapture] to see the source code for this prop
   @override
   set onDropCapture(MouseEventCallback value) =>
@@ -1416,8 +1528,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseDownCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseDownCapture =>
-      props[_$key__onMouseDownCapture___$DomPropsMixin];
-
+      props[_$key__onMouseDownCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseDownCapture] to see the source code for this prop
   @override
   set onMouseDownCapture(MouseEventCallback value) =>
@@ -1426,8 +1538,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseEnterCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseEnterCapture =>
-      props[_$key__onMouseEnterCapture___$DomPropsMixin];
-
+      props[_$key__onMouseEnterCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseEnterCapture] to see the source code for this prop
   @override
   set onMouseEnterCapture(MouseEventCallback value) =>
@@ -1436,8 +1548,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseLeaveCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseLeaveCapture =>
-      props[_$key__onMouseLeaveCapture___$DomPropsMixin];
-
+      props[_$key__onMouseLeaveCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseLeaveCapture] to see the source code for this prop
   @override
   set onMouseLeaveCapture(MouseEventCallback value) =>
@@ -1446,8 +1558,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseMoveCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseMoveCapture =>
-      props[_$key__onMouseMoveCapture___$DomPropsMixin];
-
+      props[_$key__onMouseMoveCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseMoveCapture] to see the source code for this prop
   @override
   set onMouseMoveCapture(MouseEventCallback value) =>
@@ -1456,8 +1568,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseOutCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOutCapture =>
-      props[_$key__onMouseOutCapture___$DomPropsMixin];
-
+      props[_$key__onMouseOutCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseOutCapture] to see the source code for this prop
   @override
   set onMouseOutCapture(MouseEventCallback value) =>
@@ -1466,8 +1578,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseOverCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOverCapture =>
-      props[_$key__onMouseOverCapture___$DomPropsMixin];
-
+      props[_$key__onMouseOverCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseOverCapture] to see the source code for this prop
   @override
   set onMouseOverCapture(MouseEventCallback value) =>
@@ -1476,8 +1588,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onMouseUpCapture] to see the source code for this prop
   @override
   MouseEventCallback get onMouseUpCapture =>
-      props[_$key__onMouseUpCapture___$DomPropsMixin];
-
+      props[_$key__onMouseUpCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onMouseUpCapture] to see the source code for this prop
   @override
   set onMouseUpCapture(MouseEventCallback value) =>
@@ -1486,8 +1598,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchCancelCapture] to see the source code for this prop
   @override
   TouchEventCallback get onTouchCancelCapture =>
-      props[_$key__onTouchCancelCapture___$DomPropsMixin];
-
+      props[_$key__onTouchCancelCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchCancelCapture] to see the source code for this prop
   @override
   set onTouchCancelCapture(TouchEventCallback value) =>
@@ -1496,8 +1608,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchEndCapture] to see the source code for this prop
   @override
   TouchEventCallback get onTouchEndCapture =>
-      props[_$key__onTouchEndCapture___$DomPropsMixin];
-
+      props[_$key__onTouchEndCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchEndCapture] to see the source code for this prop
   @override
   set onTouchEndCapture(TouchEventCallback value) =>
@@ -1506,8 +1618,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchMoveCapture] to see the source code for this prop
   @override
   TouchEventCallback get onTouchMoveCapture =>
-      props[_$key__onTouchMoveCapture___$DomPropsMixin];
-
+      props[_$key__onTouchMoveCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchMoveCapture] to see the source code for this prop
   @override
   set onTouchMoveCapture(TouchEventCallback value) =>
@@ -1516,8 +1628,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onTouchStartCapture] to see the source code for this prop
   @override
   TouchEventCallback get onTouchStartCapture =>
-      props[_$key__onTouchStartCapture___$DomPropsMixin];
-
+      props[_$key__onTouchStartCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onTouchStartCapture] to see the source code for this prop
   @override
   set onTouchStartCapture(TouchEventCallback value) =>
@@ -1526,8 +1638,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onScrollCapture] to see the source code for this prop
   @override
   UIEventCallback get onScrollCapture =>
-      props[_$key__onScrollCapture___$DomPropsMixin];
-
+      props[_$key__onScrollCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onScrollCapture] to see the source code for this prop
   @override
   set onScrollCapture(UIEventCallback value) =>
@@ -1536,8 +1648,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// Go to [_$DomPropsMixin.onWheelCapture] to see the source code for this prop
   @override
   WheelEventCallback get onWheelCapture =>
-      props[_$key__onWheelCapture___$DomPropsMixin];
-
+      props[_$key__onWheelCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.onWheelCapture] to see the source code for this prop
   @override
   set onWheelCapture(WheelEventCallback value) =>
@@ -1545,8 +1657,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.defaultChecked] to see the source code for this prop
   @override
-  bool get defaultChecked => props[_$key__defaultChecked___$DomPropsMixin];
-
+  bool get defaultChecked =>
+      props[_$key__defaultChecked___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.defaultChecked] to see the source code for this prop
   @override
   set defaultChecked(bool value) =>
@@ -1554,8 +1667,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.defaultValue] to see the source code for this prop
   @override
-  dynamic get defaultValue => props[_$key__defaultValue___$DomPropsMixin];
-
+  dynamic get defaultValue =>
+      props[_$key__defaultValue___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.defaultValue] to see the source code for this prop
   @override
   set defaultValue(dynamic value) =>
@@ -1563,8 +1677,9 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// Go to [_$DomPropsMixin.autoFocus] to see the source code for this prop
   @override
-  bool get autoFocus => props[_$key__autoFocus___$DomPropsMixin];
-
+  bool get autoFocus =>
+      props[_$key__autoFocus___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DomPropsMixin.autoFocus] to see the source code for this prop
   @override
   set autoFocus(bool value) => props[_$key__autoFocus___$DomPropsMixin] = value;
@@ -2461,8 +2576,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.clipPath] to see the source code for this prop
   @override
-  dynamic get clipPath => props[_$key__clipPath___$SvgPropsMixin];
-
+  dynamic get clipPath =>
+      props[_$key__clipPath___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.clipPath] to see the source code for this prop
   @override
   set clipPath(dynamic value) =>
@@ -2470,56 +2586,63 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.cx] to see the source code for this prop
   @override
-  dynamic get cx => props[_$key__cx___$SvgPropsMixin];
-
+  dynamic get cx =>
+      props[_$key__cx___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.cx] to see the source code for this prop
   @override
   set cx(dynamic value) => props[_$key__cx___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.cy] to see the source code for this prop
   @override
-  dynamic get cy => props[_$key__cy___$SvgPropsMixin];
-
+  dynamic get cy =>
+      props[_$key__cy___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.cy] to see the source code for this prop
   @override
   set cy(dynamic value) => props[_$key__cy___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.d] to see the source code for this prop
   @override
-  dynamic get d => props[_$key__d___$SvgPropsMixin];
-
+  dynamic get d =>
+      props[_$key__d___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.d] to see the source code for this prop
   @override
   set d(dynamic value) => props[_$key__d___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.dx] to see the source code for this prop
   @override
-  dynamic get dx => props[_$key__dx___$SvgPropsMixin];
-
+  dynamic get dx =>
+      props[_$key__dx___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.dx] to see the source code for this prop
   @override
   set dx(dynamic value) => props[_$key__dx___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.dy] to see the source code for this prop
   @override
-  dynamic get dy => props[_$key__dy___$SvgPropsMixin];
-
+  dynamic get dy =>
+      props[_$key__dy___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.dy] to see the source code for this prop
   @override
   set dy(dynamic value) => props[_$key__dy___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.fill] to see the source code for this prop
   @override
-  dynamic get fill => props[_$key__fill___$SvgPropsMixin];
-
+  dynamic get fill =>
+      props[_$key__fill___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fill] to see the source code for this prop
   @override
   set fill(dynamic value) => props[_$key__fill___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.fillOpacity] to see the source code for this prop
   @override
-  dynamic get fillOpacity => props[_$key__fillOpacity___$SvgPropsMixin];
-
+  dynamic get fillOpacity =>
+      props[_$key__fillOpacity___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fillOpacity] to see the source code for this prop
   @override
   set fillOpacity(dynamic value) =>
@@ -2527,8 +2650,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.fontFamily] to see the source code for this prop
   @override
-  dynamic get fontFamily => props[_$key__fontFamily___$SvgPropsMixin];
-
+  dynamic get fontFamily =>
+      props[_$key__fontFamily___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fontFamily] to see the source code for this prop
   @override
   set fontFamily(dynamic value) =>
@@ -2536,8 +2660,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.fontSize] to see the source code for this prop
   @override
-  dynamic get fontSize => props[_$key__fontSize___$SvgPropsMixin];
-
+  dynamic get fontSize =>
+      props[_$key__fontSize___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fontSize] to see the source code for this prop
   @override
   set fontSize(dynamic value) =>
@@ -2545,16 +2670,18 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.fx] to see the source code for this prop
   @override
-  dynamic get fx => props[_$key__fx___$SvgPropsMixin];
-
+  dynamic get fx =>
+      props[_$key__fx___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fx] to see the source code for this prop
   @override
   set fx(dynamic value) => props[_$key__fx___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.fy] to see the source code for this prop
   @override
-  dynamic get fy => props[_$key__fy___$SvgPropsMixin];
-
+  dynamic get fy =>
+      props[_$key__fy___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.fy] to see the source code for this prop
   @override
   set fy(dynamic value) => props[_$key__fy___$SvgPropsMixin] = value;
@@ -2562,8 +2689,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// Go to [_$SvgPropsMixin.gradientTransform] to see the source code for this prop
   @override
   dynamic get gradientTransform =>
-      props[_$key__gradientTransform___$SvgPropsMixin];
-
+      props[_$key__gradientTransform___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.gradientTransform] to see the source code for this prop
   @override
   set gradientTransform(dynamic value) =>
@@ -2571,8 +2698,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.gradientUnits] to see the source code for this prop
   @override
-  dynamic get gradientUnits => props[_$key__gradientUnits___$SvgPropsMixin];
-
+  dynamic get gradientUnits =>
+      props[_$key__gradientUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.gradientUnits] to see the source code for this prop
   @override
   set gradientUnits(dynamic value) =>
@@ -2580,8 +2708,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.markerEnd] to see the source code for this prop
   @override
-  dynamic get markerEnd => props[_$key__markerEnd___$SvgPropsMixin];
-
+  dynamic get markerEnd =>
+      props[_$key__markerEnd___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.markerEnd] to see the source code for this prop
   @override
   set markerEnd(dynamic value) =>
@@ -2589,8 +2718,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.markerMid] to see the source code for this prop
   @override
-  dynamic get markerMid => props[_$key__markerMid___$SvgPropsMixin];
-
+  dynamic get markerMid =>
+      props[_$key__markerMid___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.markerMid] to see the source code for this prop
   @override
   set markerMid(dynamic value) =>
@@ -2598,8 +2728,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.markerStart] to see the source code for this prop
   @override
-  dynamic get markerStart => props[_$key__markerStart___$SvgPropsMixin];
-
+  dynamic get markerStart =>
+      props[_$key__markerStart___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.markerStart] to see the source code for this prop
   @override
   set markerStart(dynamic value) =>
@@ -2607,16 +2738,18 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.offset] to see the source code for this prop
   @override
-  dynamic get offset => props[_$key__offset___$SvgPropsMixin];
-
+  dynamic get offset =>
+      props[_$key__offset___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.offset] to see the source code for this prop
   @override
   set offset(dynamic value) => props[_$key__offset___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.opacity] to see the source code for this prop
   @override
-  dynamic get opacity => props[_$key__opacity___$SvgPropsMixin];
-
+  dynamic get opacity =>
+      props[_$key__opacity___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.opacity] to see the source code for this prop
   @override
   set opacity(dynamic value) => props[_$key__opacity___$SvgPropsMixin] = value;
@@ -2624,8 +2757,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// Go to [_$SvgPropsMixin.patternContentUnits] to see the source code for this prop
   @override
   dynamic get patternContentUnits =>
-      props[_$key__patternContentUnits___$SvgPropsMixin];
-
+      props[_$key__patternContentUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.patternContentUnits] to see the source code for this prop
   @override
   set patternContentUnits(dynamic value) =>
@@ -2633,8 +2766,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.patternUnits] to see the source code for this prop
   @override
-  dynamic get patternUnits => props[_$key__patternUnits___$SvgPropsMixin];
-
+  dynamic get patternUnits =>
+      props[_$key__patternUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.patternUnits] to see the source code for this prop
   @override
   set patternUnits(dynamic value) =>
@@ -2642,8 +2776,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.points] to see the source code for this prop
   @override
-  dynamic get points => props[_$key__points___$SvgPropsMixin];
-
+  dynamic get points =>
+      props[_$key__points___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.points] to see the source code for this prop
   @override
   set points(dynamic value) => props[_$key__points___$SvgPropsMixin] = value;
@@ -2651,8 +2786,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// Go to [_$SvgPropsMixin.preserveAspectRatio] to see the source code for this prop
   @override
   dynamic get preserveAspectRatio =>
-      props[_$key__preserveAspectRatio___$SvgPropsMixin];
-
+      props[_$key__preserveAspectRatio___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.preserveAspectRatio] to see the source code for this prop
   @override
   set preserveAspectRatio(dynamic value) =>
@@ -2660,32 +2795,36 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.r] to see the source code for this prop
   @override
-  dynamic get r => props[_$key__r___$SvgPropsMixin];
-
+  dynamic get r =>
+      props[_$key__r___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.r] to see the source code for this prop
   @override
   set r(dynamic value) => props[_$key__r___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.rx] to see the source code for this prop
   @override
-  dynamic get rx => props[_$key__rx___$SvgPropsMixin];
-
+  dynamic get rx =>
+      props[_$key__rx___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.rx] to see the source code for this prop
   @override
   set rx(dynamic value) => props[_$key__rx___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.ry] to see the source code for this prop
   @override
-  dynamic get ry => props[_$key__ry___$SvgPropsMixin];
-
+  dynamic get ry =>
+      props[_$key__ry___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.ry] to see the source code for this prop
   @override
   set ry(dynamic value) => props[_$key__ry___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.spreadMethod] to see the source code for this prop
   @override
-  dynamic get spreadMethod => props[_$key__spreadMethod___$SvgPropsMixin];
-
+  dynamic get spreadMethod =>
+      props[_$key__spreadMethod___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.spreadMethod] to see the source code for this prop
   @override
   set spreadMethod(dynamic value) =>
@@ -2693,8 +2832,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.stopColor] to see the source code for this prop
   @override
-  dynamic get stopColor => props[_$key__stopColor___$SvgPropsMixin];
-
+  dynamic get stopColor =>
+      props[_$key__stopColor___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.stopColor] to see the source code for this prop
   @override
   set stopColor(dynamic value) =>
@@ -2702,8 +2842,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.stopOpacity] to see the source code for this prop
   @override
-  dynamic get stopOpacity => props[_$key__stopOpacity___$SvgPropsMixin];
-
+  dynamic get stopOpacity =>
+      props[_$key__stopOpacity___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.stopOpacity] to see the source code for this prop
   @override
   set stopOpacity(dynamic value) =>
@@ -2711,16 +2852,18 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.stroke] to see the source code for this prop
   @override
-  dynamic get stroke => props[_$key__stroke___$SvgPropsMixin];
-
+  dynamic get stroke =>
+      props[_$key__stroke___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.stroke] to see the source code for this prop
   @override
   set stroke(dynamic value) => props[_$key__stroke___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.strokeDasharray] to see the source code for this prop
   @override
-  dynamic get strokeDasharray => props[_$key__strokeDasharray___$SvgPropsMixin];
-
+  dynamic get strokeDasharray =>
+      props[_$key__strokeDasharray___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.strokeDasharray] to see the source code for this prop
   @override
   set strokeDasharray(dynamic value) =>
@@ -2728,8 +2871,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.strokeLinecap] to see the source code for this prop
   @override
-  dynamic get strokeLinecap => props[_$key__strokeLinecap___$SvgPropsMixin];
-
+  dynamic get strokeLinecap =>
+      props[_$key__strokeLinecap___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.strokeLinecap] to see the source code for this prop
   @override
   set strokeLinecap(dynamic value) =>
@@ -2737,8 +2881,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.strokeOpacity] to see the source code for this prop
   @override
-  dynamic get strokeOpacity => props[_$key__strokeOpacity___$SvgPropsMixin];
-
+  dynamic get strokeOpacity =>
+      props[_$key__strokeOpacity___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.strokeOpacity] to see the source code for this prop
   @override
   set strokeOpacity(dynamic value) =>
@@ -2746,8 +2891,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.strokeWidth] to see the source code for this prop
   @override
-  dynamic get strokeWidth => props[_$key__strokeWidth___$SvgPropsMixin];
-
+  dynamic get strokeWidth =>
+      props[_$key__strokeWidth___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.strokeWidth] to see the source code for this prop
   @override
   set strokeWidth(dynamic value) =>
@@ -2755,8 +2901,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.textAnchor] to see the source code for this prop
   @override
-  dynamic get textAnchor => props[_$key__textAnchor___$SvgPropsMixin];
-
+  dynamic get textAnchor =>
+      props[_$key__textAnchor___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.textAnchor] to see the source code for this prop
   @override
   set textAnchor(dynamic value) =>
@@ -2764,8 +2911,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.transform] to see the source code for this prop
   @override
-  dynamic get transform => props[_$key__transform___$SvgPropsMixin];
-
+  dynamic get transform =>
+      props[_$key__transform___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.transform] to see the source code for this prop
   @override
   set transform(dynamic value) =>
@@ -2773,48 +2921,54 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.version] to see the source code for this prop
   @override
-  dynamic get version => props[_$key__version___$SvgPropsMixin];
-
+  dynamic get version =>
+      props[_$key__version___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.version] to see the source code for this prop
   @override
   set version(dynamic value) => props[_$key__version___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.viewBox] to see the source code for this prop
   @override
-  dynamic get viewBox => props[_$key__viewBox___$SvgPropsMixin];
-
+  dynamic get viewBox =>
+      props[_$key__viewBox___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.viewBox] to see the source code for this prop
   @override
   set viewBox(dynamic value) => props[_$key__viewBox___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.x1] to see the source code for this prop
   @override
-  dynamic get x1 => props[_$key__x1___$SvgPropsMixin];
-
+  dynamic get x1 =>
+      props[_$key__x1___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.x1] to see the source code for this prop
   @override
   set x1(dynamic value) => props[_$key__x1___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.x2] to see the source code for this prop
   @override
-  dynamic get x2 => props[_$key__x2___$SvgPropsMixin];
-
+  dynamic get x2 =>
+      props[_$key__x2___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.x2] to see the source code for this prop
   @override
   set x2(dynamic value) => props[_$key__x2___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.x] to see the source code for this prop
   @override
-  dynamic get x => props[_$key__x___$SvgPropsMixin];
-
+  dynamic get x =>
+      props[_$key__x___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.x] to see the source code for this prop
   @override
   set x(dynamic value) => props[_$key__x___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.xlinkActuate] to see the source code for this prop
   @override
-  dynamic get xlinkActuate => props[_$key__xlinkActuate___$SvgPropsMixin];
-
+  dynamic get xlinkActuate =>
+      props[_$key__xlinkActuate___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkActuate] to see the source code for this prop
   @override
   set xlinkActuate(dynamic value) =>
@@ -2822,8 +2976,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkArcrole] to see the source code for this prop
   @override
-  dynamic get xlinkArcrole => props[_$key__xlinkArcrole___$SvgPropsMixin];
-
+  dynamic get xlinkArcrole =>
+      props[_$key__xlinkArcrole___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkArcrole] to see the source code for this prop
   @override
   set xlinkArcrole(dynamic value) =>
@@ -2831,8 +2986,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkHref] to see the source code for this prop
   @override
-  dynamic get xlinkHref => props[_$key__xlinkHref___$SvgPropsMixin];
-
+  dynamic get xlinkHref =>
+      props[_$key__xlinkHref___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkHref] to see the source code for this prop
   @override
   set xlinkHref(dynamic value) =>
@@ -2840,8 +2996,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkRole] to see the source code for this prop
   @override
-  dynamic get xlinkRole => props[_$key__xlinkRole___$SvgPropsMixin];
-
+  dynamic get xlinkRole =>
+      props[_$key__xlinkRole___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkRole] to see the source code for this prop
   @override
   set xlinkRole(dynamic value) =>
@@ -2849,8 +3006,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkShow] to see the source code for this prop
   @override
-  dynamic get xlinkShow => props[_$key__xlinkShow___$SvgPropsMixin];
-
+  dynamic get xlinkShow =>
+      props[_$key__xlinkShow___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkShow] to see the source code for this prop
   @override
   set xlinkShow(dynamic value) =>
@@ -2858,8 +3016,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkTitle] to see the source code for this prop
   @override
-  dynamic get xlinkTitle => props[_$key__xlinkTitle___$SvgPropsMixin];
-
+  dynamic get xlinkTitle =>
+      props[_$key__xlinkTitle___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkTitle] to see the source code for this prop
   @override
   set xlinkTitle(dynamic value) =>
@@ -2867,8 +3026,9 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xlinkType] to see the source code for this prop
   @override
-  dynamic get xlinkType => props[_$key__xlinkType___$SvgPropsMixin];
-
+  dynamic get xlinkType =>
+      props[_$key__xlinkType___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xlinkType] to see the source code for this prop
   @override
   set xlinkType(dynamic value) =>
@@ -2876,24 +3036,27 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.xmlBase] to see the source code for this prop
   @override
-  dynamic get xmlBase => props[_$key__xmlBase___$SvgPropsMixin];
-
+  dynamic get xmlBase =>
+      props[_$key__xmlBase___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xmlBase] to see the source code for this prop
   @override
   set xmlBase(dynamic value) => props[_$key__xmlBase___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.xmlLang] to see the source code for this prop
   @override
-  dynamic get xmlLang => props[_$key__xmlLang___$SvgPropsMixin];
-
+  dynamic get xmlLang =>
+      props[_$key__xmlLang___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xmlLang] to see the source code for this prop
   @override
   set xmlLang(dynamic value) => props[_$key__xmlLang___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.xmlSpace] to see the source code for this prop
   @override
-  dynamic get xmlSpace => props[_$key__xmlSpace___$SvgPropsMixin];
-
+  dynamic get xmlSpace =>
+      props[_$key__xmlSpace___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.xmlSpace] to see the source code for this prop
   @override
   set xmlSpace(dynamic value) =>
@@ -2901,24 +3064,27 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// Go to [_$SvgPropsMixin.y1] to see the source code for this prop
   @override
-  dynamic get y1 => props[_$key__y1___$SvgPropsMixin];
-
+  dynamic get y1 =>
+      props[_$key__y1___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.y1] to see the source code for this prop
   @override
   set y1(dynamic value) => props[_$key__y1___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.y2] to see the source code for this prop
   @override
-  dynamic get y2 => props[_$key__y2___$SvgPropsMixin];
-
+  dynamic get y2 =>
+      props[_$key__y2___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.y2] to see the source code for this prop
   @override
   set y2(dynamic value) => props[_$key__y2___$SvgPropsMixin] = value;
 
   /// Go to [_$SvgPropsMixin.y] to see the source code for this prop
   @override
-  dynamic get y => props[_$key__y___$SvgPropsMixin];
-
+  dynamic get y =>
+      props[_$key__y___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SvgPropsMixin.y] to see the source code for this prop
   @override
   set y(dynamic value) => props[_$key__y___$SvgPropsMixin] = value;
@@ -3230,8 +3396,9 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
 
   /// Go to [_$UbiquitousDomPropsMixin.tabIndex] to see the source code for this prop
   @override
-  dynamic get tabIndex => props[_$key__tabIndex___$UbiquitousDomPropsMixin];
-
+  dynamic get tabIndex =>
+      props[_$key__tabIndex___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.tabIndex] to see the source code for this prop
   @override
   set tabIndex(dynamic value) =>
@@ -3239,16 +3406,18 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
 
   /// Go to [_$UbiquitousDomPropsMixin.id] to see the source code for this prop
   @override
-  String get id => props[_$key__id___$UbiquitousDomPropsMixin];
-
+  String get id =>
+      props[_$key__id___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.id] to see the source code for this prop
   @override
   set id(String value) => props[_$key__id___$UbiquitousDomPropsMixin] = value;
 
   /// Go to [_$UbiquitousDomPropsMixin.title] to see the source code for this prop
   @override
-  String get title => props[_$key__title___$UbiquitousDomPropsMixin];
-
+  String get title =>
+      props[_$key__title___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.title] to see the source code for this prop
   @override
   set title(String value) =>
@@ -3257,8 +3426,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.style] to see the source code for this prop
   @override
   Map<String, dynamic> get style =>
-      props[_$key__style___$UbiquitousDomPropsMixin];
-
+      props[_$key__style___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.style] to see the source code for this prop
   @override
   set style(Map<String, dynamic> value) =>
@@ -3267,8 +3436,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onCopy] to see the source code for this prop
   @override
   ClipboardEventCallback get onCopy =>
-      props[_$key__onCopy___$UbiquitousDomPropsMixin];
-
+      props[_$key__onCopy___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onCopy] to see the source code for this prop
   @override
   set onCopy(ClipboardEventCallback value) =>
@@ -3277,8 +3446,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onCut] to see the source code for this prop
   @override
   ClipboardEventCallback get onCut =>
-      props[_$key__onCut___$UbiquitousDomPropsMixin];
-
+      props[_$key__onCut___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onCut] to see the source code for this prop
   @override
   set onCut(ClipboardEventCallback value) =>
@@ -3287,8 +3456,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onPaste] to see the source code for this prop
   @override
   ClipboardEventCallback get onPaste =>
-      props[_$key__onPaste___$UbiquitousDomPropsMixin];
-
+      props[_$key__onPaste___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onPaste] to see the source code for this prop
   @override
   set onPaste(ClipboardEventCallback value) =>
@@ -3297,8 +3466,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onKeyDown] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyDown =>
-      props[_$key__onKeyDown___$UbiquitousDomPropsMixin];
-
+      props[_$key__onKeyDown___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onKeyDown] to see the source code for this prop
   @override
   set onKeyDown(KeyboardEventCallback value) =>
@@ -3307,8 +3476,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onKeyPress] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyPress =>
-      props[_$key__onKeyPress___$UbiquitousDomPropsMixin];
-
+      props[_$key__onKeyPress___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onKeyPress] to see the source code for this prop
   @override
   set onKeyPress(KeyboardEventCallback value) =>
@@ -3317,8 +3486,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onKeyUp] to see the source code for this prop
   @override
   KeyboardEventCallback get onKeyUp =>
-      props[_$key__onKeyUp___$UbiquitousDomPropsMixin];
-
+      props[_$key__onKeyUp___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onKeyUp] to see the source code for this prop
   @override
   set onKeyUp(KeyboardEventCallback value) =>
@@ -3327,8 +3496,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onFocus] to see the source code for this prop
   @override
   FocusEventCallback get onFocus =>
-      props[_$key__onFocus___$UbiquitousDomPropsMixin];
-
+      props[_$key__onFocus___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onFocus] to see the source code for this prop
   @override
   set onFocus(FocusEventCallback value) =>
@@ -3337,8 +3506,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onBlur] to see the source code for this prop
   @override
   FocusEventCallback get onBlur =>
-      props[_$key__onBlur___$UbiquitousDomPropsMixin];
-
+      props[_$key__onBlur___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onBlur] to see the source code for this prop
   @override
   set onBlur(FocusEventCallback value) =>
@@ -3347,8 +3516,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onChange] to see the source code for this prop
   @override
   FormEventCallback get onChange =>
-      props[_$key__onChange___$UbiquitousDomPropsMixin];
-
+      props[_$key__onChange___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onChange] to see the source code for this prop
   @override
   set onChange(FormEventCallback value) =>
@@ -3357,8 +3526,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onInput] to see the source code for this prop
   @override
   FormEventCallback get onInput =>
-      props[_$key__onInput___$UbiquitousDomPropsMixin];
-
+      props[_$key__onInput___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onInput] to see the source code for this prop
   @override
   set onInput(FormEventCallback value) =>
@@ -3367,8 +3536,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onSubmit] to see the source code for this prop
   @override
   FormEventCallback get onSubmit =>
-      props[_$key__onSubmit___$UbiquitousDomPropsMixin];
-
+      props[_$key__onSubmit___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onSubmit] to see the source code for this prop
   @override
   set onSubmit(FormEventCallback value) =>
@@ -3377,8 +3546,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onReset] to see the source code for this prop
   @override
   FormEventCallback get onReset =>
-      props[_$key__onReset___$UbiquitousDomPropsMixin];
-
+      props[_$key__onReset___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onReset] to see the source code for this prop
   @override
   set onReset(FormEventCallback value) =>
@@ -3387,8 +3556,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onClick] to see the source code for this prop
   @override
   MouseEventCallback get onClick =>
-      props[_$key__onClick___$UbiquitousDomPropsMixin];
-
+      props[_$key__onClick___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onClick] to see the source code for this prop
   @override
   set onClick(MouseEventCallback value) =>
@@ -3397,8 +3566,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onContextMenu] to see the source code for this prop
   @override
   MouseEventCallback get onContextMenu =>
-      props[_$key__onContextMenu___$UbiquitousDomPropsMixin];
-
+      props[_$key__onContextMenu___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onContextMenu] to see the source code for this prop
   @override
   set onContextMenu(MouseEventCallback value) =>
@@ -3407,8 +3576,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDoubleClick] to see the source code for this prop
   @override
   MouseEventCallback get onDoubleClick =>
-      props[_$key__onDoubleClick___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDoubleClick___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDoubleClick] to see the source code for this prop
   @override
   set onDoubleClick(MouseEventCallback value) =>
@@ -3417,8 +3586,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDrag] to see the source code for this prop
   @override
   MouseEventCallback get onDrag =>
-      props[_$key__onDrag___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDrag___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDrag] to see the source code for this prop
   @override
   set onDrag(MouseEventCallback value) =>
@@ -3427,8 +3596,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragEnd] to see the source code for this prop
   @override
   MouseEventCallback get onDragEnd =>
-      props[_$key__onDragEnd___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragEnd___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragEnd] to see the source code for this prop
   @override
   set onDragEnd(MouseEventCallback value) =>
@@ -3437,8 +3606,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragEnter] to see the source code for this prop
   @override
   MouseEventCallback get onDragEnter =>
-      props[_$key__onDragEnter___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragEnter___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragEnter] to see the source code for this prop
   @override
   set onDragEnter(MouseEventCallback value) =>
@@ -3447,8 +3616,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragExit] to see the source code for this prop
   @override
   MouseEventCallback get onDragExit =>
-      props[_$key__onDragExit___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragExit___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragExit] to see the source code for this prop
   @override
   set onDragExit(MouseEventCallback value) =>
@@ -3457,8 +3626,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragLeave] to see the source code for this prop
   @override
   MouseEventCallback get onDragLeave =>
-      props[_$key__onDragLeave___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragLeave___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragLeave] to see the source code for this prop
   @override
   set onDragLeave(MouseEventCallback value) =>
@@ -3467,8 +3636,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragOver] to see the source code for this prop
   @override
   MouseEventCallback get onDragOver =>
-      props[_$key__onDragOver___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragOver___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragOver] to see the source code for this prop
   @override
   set onDragOver(MouseEventCallback value) =>
@@ -3477,8 +3646,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDragStart] to see the source code for this prop
   @override
   MouseEventCallback get onDragStart =>
-      props[_$key__onDragStart___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDragStart___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDragStart] to see the source code for this prop
   @override
   set onDragStart(MouseEventCallback value) =>
@@ -3487,8 +3656,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onDrop] to see the source code for this prop
   @override
   MouseEventCallback get onDrop =>
-      props[_$key__onDrop___$UbiquitousDomPropsMixin];
-
+      props[_$key__onDrop___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onDrop] to see the source code for this prop
   @override
   set onDrop(MouseEventCallback value) =>
@@ -3497,8 +3666,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseDown] to see the source code for this prop
   @override
   MouseEventCallback get onMouseDown =>
-      props[_$key__onMouseDown___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseDown___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseDown] to see the source code for this prop
   @override
   set onMouseDown(MouseEventCallback value) =>
@@ -3507,8 +3676,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseEnter] to see the source code for this prop
   @override
   MouseEventCallback get onMouseEnter =>
-      props[_$key__onMouseEnter___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseEnter___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseEnter] to see the source code for this prop
   @override
   set onMouseEnter(MouseEventCallback value) =>
@@ -3517,8 +3686,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseLeave] to see the source code for this prop
   @override
   MouseEventCallback get onMouseLeave =>
-      props[_$key__onMouseLeave___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseLeave___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseLeave] to see the source code for this prop
   @override
   set onMouseLeave(MouseEventCallback value) =>
@@ -3527,8 +3696,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseMove] to see the source code for this prop
   @override
   MouseEventCallback get onMouseMove =>
-      props[_$key__onMouseMove___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseMove___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseMove] to see the source code for this prop
   @override
   set onMouseMove(MouseEventCallback value) =>
@@ -3537,8 +3706,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseOut] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOut =>
-      props[_$key__onMouseOut___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseOut___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseOut] to see the source code for this prop
   @override
   set onMouseOut(MouseEventCallback value) =>
@@ -3547,8 +3716,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseOver] to see the source code for this prop
   @override
   MouseEventCallback get onMouseOver =>
-      props[_$key__onMouseOver___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseOver___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseOver] to see the source code for this prop
   @override
   set onMouseOver(MouseEventCallback value) =>
@@ -3557,8 +3726,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onMouseUp] to see the source code for this prop
   @override
   MouseEventCallback get onMouseUp =>
-      props[_$key__onMouseUp___$UbiquitousDomPropsMixin];
-
+      props[_$key__onMouseUp___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onMouseUp] to see the source code for this prop
   @override
   set onMouseUp(MouseEventCallback value) =>
@@ -3567,8 +3736,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onTouchCancel] to see the source code for this prop
   @override
   TouchEventCallback get onTouchCancel =>
-      props[_$key__onTouchCancel___$UbiquitousDomPropsMixin];
-
+      props[_$key__onTouchCancel___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onTouchCancel] to see the source code for this prop
   @override
   set onTouchCancel(TouchEventCallback value) =>
@@ -3577,8 +3746,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onTouchEnd] to see the source code for this prop
   @override
   TouchEventCallback get onTouchEnd =>
-      props[_$key__onTouchEnd___$UbiquitousDomPropsMixin];
-
+      props[_$key__onTouchEnd___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onTouchEnd] to see the source code for this prop
   @override
   set onTouchEnd(TouchEventCallback value) =>
@@ -3587,8 +3756,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onTouchMove] to see the source code for this prop
   @override
   TouchEventCallback get onTouchMove =>
-      props[_$key__onTouchMove___$UbiquitousDomPropsMixin];
-
+      props[_$key__onTouchMove___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onTouchMove] to see the source code for this prop
   @override
   set onTouchMove(TouchEventCallback value) =>
@@ -3597,8 +3766,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onTouchStart] to see the source code for this prop
   @override
   TouchEventCallback get onTouchStart =>
-      props[_$key__onTouchStart___$UbiquitousDomPropsMixin];
-
+      props[_$key__onTouchStart___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onTouchStart] to see the source code for this prop
   @override
   set onTouchStart(TouchEventCallback value) =>
@@ -3607,8 +3776,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onScroll] to see the source code for this prop
   @override
   UIEventCallback get onScroll =>
-      props[_$key__onScroll___$UbiquitousDomPropsMixin];
-
+      props[_$key__onScroll___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onScroll] to see the source code for this prop
   @override
   set onScroll(UIEventCallback value) =>
@@ -3617,8 +3786,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// Go to [_$UbiquitousDomPropsMixin.onWheel] to see the source code for this prop
   @override
   WheelEventCallback get onWheel =>
-      props[_$key__onWheel___$UbiquitousDomPropsMixin];
-
+      props[_$key__onWheel___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$UbiquitousDomPropsMixin.onWheel] to see the source code for this prop
   @override
   set onWheel(WheelEventCallback value) =>

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -104,8 +104,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// Go to [_$ResizeSensorPropsMixin.onInitialize] to see the source code for this prop
   @override
   ResizeSensorHandler get onInitialize =>
-      props[_$key__onInitialize___$ResizeSensorPropsMixin];
-
+      props[_$key__onInitialize___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.onInitialize] to see the source code for this prop
   @override
   set onInitialize(ResizeSensorHandler value) =>
@@ -114,8 +114,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// Go to [_$ResizeSensorPropsMixin.onResize] to see the source code for this prop
   @override
   ResizeSensorHandler get onResize =>
-      props[_$key__onResize___$ResizeSensorPropsMixin];
-
+      props[_$key__onResize___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.onResize] to see the source code for this prop
   @override
   set onResize(ResizeSensorHandler value) =>
@@ -123,8 +123,9 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
 
   /// Go to [_$ResizeSensorPropsMixin.isFlexChild] to see the source code for this prop
   @override
-  bool get isFlexChild => props[_$key__isFlexChild___$ResizeSensorPropsMixin];
-
+  bool get isFlexChild =>
+      props[_$key__isFlexChild___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.isFlexChild] to see the source code for this prop
   @override
   set isFlexChild(bool value) =>
@@ -133,8 +134,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// Go to [_$ResizeSensorPropsMixin.isFlexContainer] to see the source code for this prop
   @override
   bool get isFlexContainer =>
-      props[_$key__isFlexContainer___$ResizeSensorPropsMixin];
-
+      props[_$key__isFlexContainer___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.isFlexContainer] to see the source code for this prop
   @override
   set isFlexContainer(bool value) =>
@@ -142,8 +143,9 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
 
   /// Go to [_$ResizeSensorPropsMixin.shrink] to see the source code for this prop
   @override
-  bool get shrink => props[_$key__shrink___$ResizeSensorPropsMixin];
-
+  bool get shrink =>
+      props[_$key__shrink___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.shrink] to see the source code for this prop
   @override
   set shrink(bool value) =>
@@ -151,8 +153,9 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
 
   /// Go to [_$ResizeSensorPropsMixin.quickMount] to see the source code for this prop
   @override
-  bool get quickMount => props[_$key__quickMount___$ResizeSensorPropsMixin];
-
+  bool get quickMount =>
+      props[_$key__quickMount___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.quickMount] to see the source code for this prop
   @override
   set quickMount(bool value) =>
@@ -161,8 +164,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// Go to [_$ResizeSensorPropsMixin.onDetachedMountCheck] to see the source code for this prop
   @override
   BoolCallback get onDetachedMountCheck =>
-      props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin];
-
+      props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.onDetachedMountCheck] to see the source code for this prop
   @override
   set onDetachedMountCheck(BoolCallback value) =>
@@ -171,8 +174,9 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// Go to [_$ResizeSensorPropsMixin.onDidReset] to see the source code for this prop
   @override
   @visibleForTesting
-  Callback get onDidReset => props[_$key__onDidReset___$ResizeSensorPropsMixin];
-
+  Callback get onDidReset =>
+      props[_$key__onDidReset___$ResizeSensorPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ResizeSensorPropsMixin.onDidReset] to see the source code for this prop
   @override
   @visibleForTesting

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -22,6 +22,7 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
+import 'package:over_react/src/component_declaration/util.dart';
 import 'package:over_react/src/util/test_mode.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
@@ -607,27 +608,27 @@ abstract class UiProps extends MapBase
   /// Restricted statically to 40 arguments until the dart2js fix in
   /// <https://github.com/dart-lang/sdk/pull/26032> is released.
   ///
-  ReactElement call([c1 = _notSpecified, c2 = _notSpecified, c3 = _notSpecified, c4 = _notSpecified, c5 = _notSpecified, c6 = _notSpecified, c7 = _notSpecified, c8 = _notSpecified, c9 = _notSpecified, c10 = _notSpecified, c11 = _notSpecified, c12 = _notSpecified, c13 = _notSpecified, c14 = _notSpecified, c15 = _notSpecified, c16 = _notSpecified, c17 = _notSpecified, c18 = _notSpecified, c19 = _notSpecified, c20 = _notSpecified, c21 = _notSpecified, c22 = _notSpecified, c23 = _notSpecified, c24 = _notSpecified, c25 = _notSpecified, c26 = _notSpecified, c27 = _notSpecified, c28 = _notSpecified, c29 = _notSpecified, c30 = _notSpecified, c31 = _notSpecified, c32 = _notSpecified, c33 = _notSpecified, c34 = _notSpecified, c35 = _notSpecified, c36 = _notSpecified, c37 = _notSpecified, c38 = _notSpecified, c39 = _notSpecified, c40 = _notSpecified]) {
+  ReactElement call([c1 = notSpecified, c2 = notSpecified, c3 = notSpecified, c4 = notSpecified, c5 = notSpecified, c6 = notSpecified, c7 = notSpecified, c8 = notSpecified, c9 = notSpecified, c10 = notSpecified, c11 = notSpecified, c12 = notSpecified, c13 = notSpecified, c14 = notSpecified, c15 = notSpecified, c16 = notSpecified, c17 = notSpecified, c18 = notSpecified, c19 = notSpecified, c20 = notSpecified, c21 = notSpecified, c22 = notSpecified, c23 = notSpecified, c24 = notSpecified, c25 = notSpecified, c26 = notSpecified, c27 = notSpecified, c28 = notSpecified, c29 = notSpecified, c30 = notSpecified, c31 = notSpecified, c32 = notSpecified, c33 = notSpecified, c34 = notSpecified, c35 = notSpecified, c36 = notSpecified, c37 = notSpecified, c38 = notSpecified, c39 = notSpecified, c40 = notSpecified]) {
     List childArguments;
     // Use `identical` since it compiles down to `===` in dart2js instead of calling equality helper functions,
     // and we don't want to allow any object overriding `operator==` to claim it's equal to `_notSpecified`.
-    if (identical(c1, _notSpecified)) {
+    if (identical(c1, notSpecified)) {
       childArguments = [];
-    } else if (identical(c2, _notSpecified)) {
+    } else if (identical(c2, notSpecified)) {
       childArguments = [c1];
-    } else if (identical(c3, _notSpecified)) {
+    } else if (identical(c3, notSpecified)) {
       childArguments = [c1, c2];
-    } else if (identical(c4, _notSpecified)) {
+    } else if (identical(c4, notSpecified)) {
       childArguments = [c1, c2, c3];
-    } else if (identical(c5, _notSpecified)) {
+    } else if (identical(c5, notSpecified)) {
       childArguments = [c1, c2, c3, c4];
-    } else if (identical(c6, _notSpecified)) {
+    } else if (identical(c6, notSpecified)) {
       childArguments = [c1, c2, c3, c4, c5];
-    } else if (identical(c7, _notSpecified)) {
+    } else if (identical(c7, notSpecified)) {
       childArguments = [c1, c2, c3, c4, c5, c6];
     } else {
       childArguments = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]
-        .takeWhile((child) => !identical(child, _notSpecified))
+        .takeWhile((child) => !identical(child, notSpecified))
         .toList();
     }
 
@@ -896,7 +897,3 @@ class StateMeta implements AccessorMeta<StateDescriptor> {
   const StateMeta({this.fields, this.keys});
 }
 
-const _notSpecified = const NotSpecified();
-class NotSpecified {
-  const NotSpecified();
-}

--- a/lib/src/component_declaration/util.dart
+++ b/lib/src/component_declaration/util.dart
@@ -1,0 +1,4 @@
+const notSpecified = const NotSpecified();
+class NotSpecified {
+  const NotSpecified();
+}

--- a/lib/src/util/class_names.over_react.g.dart
+++ b/lib/src/util/class_names.over_react.g.dart
@@ -14,8 +14,9 @@ abstract class CssClassPropsMixin implements _$CssClassPropsMixin {
 
   /// Go to [_$CssClassPropsMixin.className] to see the source code for this prop
   @override
-  String get className => props[_$key__className___$CssClassPropsMixin];
-
+  String get className =>
+      props[_$key__className___$CssClassPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$CssClassPropsMixin.className] to see the source code for this prop
   @override
   set className(String value) =>
@@ -24,8 +25,8 @@ abstract class CssClassPropsMixin implements _$CssClassPropsMixin {
   /// Go to [_$CssClassPropsMixin.classNameBlacklist] to see the source code for this prop
   @override
   String get classNameBlacklist =>
-      props[_$key__classNameBlacklist___$CssClassPropsMixin];
-
+      props[_$key__classNameBlacklist___$CssClassPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$CssClassPropsMixin.classNameBlacklist] to see the source code for this prop
   @override
   set classNameBlacklist(String value) =>

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 
 import 'package:over_react/component_base.dart' as component_base show UiProps;
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component_declaration/util.dart';
 import 'package:react/react_client.dart';
 
 /// A `MapView` helper that stubs in unimplemented pieces of [UiProps].
@@ -64,5 +65,5 @@ class UiPropsMapView extends MapView
       throw new UnimplementedError('@PropsMixin instances do not implement componentFactory');
 
   @override
-  ReactElement call([c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40]) => throw new UnimplementedError('@PropsMixin instances do not implement call');
+  ReactElement call([c1 = notSpecified, c2 = notSpecified, c3 = notSpecified, c4 = notSpecified, c5 = notSpecified, c6 = notSpecified, c7 = notSpecified, c8 = notSpecified, c9 = notSpecified, c10 = notSpecified, c11 = notSpecified, c12 = notSpecified, c13 = notSpecified, c14 = notSpecified, c15 = notSpecified, c16 = notSpecified, c17 = notSpecified, c18 = notSpecified, c19 = notSpecified, c20 = notSpecified, c21 = notSpecified, c22 = notSpecified, c23 = notSpecified, c24 = notSpecified, c25 = notSpecified, c26 = notSpecified, c27 = notSpecified, c28 = notSpecified, c29 = notSpecified, c30 = notSpecified, c31 = notSpecified, c32 = notSpecified, c33 = notSpecified, c34 = notSpecified, c35 = notSpecified, c36 = notSpecified, c37 = notSpecified, c38 = notSpecified, c39 = notSpecified, c40 = notSpecified]) => throw new UnimplementedError('@PropsMixin instances do not implement call');
 }

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onHandlePreShowing] to see the source code for this prop
   @override
   Callback get onHandlePreShowing =>
-      props[_$key__onHandlePreShowing___$TransitionerProps];
-
+      props[_$key__onHandlePreShowing___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onHandlePreShowing] to see the source code for this prop
   @override
   set onHandlePreShowing(Callback value) =>
@@ -35,8 +35,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onHandleShowing] to see the source code for this prop
   @override
   Callback get onHandleShowing =>
-      props[_$key__onHandleShowing___$TransitionerProps];
-
+      props[_$key__onHandleShowing___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onHandleShowing] to see the source code for this prop
   @override
   set onHandleShowing(Callback value) =>
@@ -45,8 +45,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onHandleShown] to see the source code for this prop
   @override
   Callback get onHandleShown =>
-      props[_$key__onHandleShown___$TransitionerProps];
-
+      props[_$key__onHandleShown___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onHandleShown] to see the source code for this prop
   @override
   set onHandleShown(Callback value) =>
@@ -55,8 +55,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onHandleHiding] to see the source code for this prop
   @override
   Callback get onHandleHiding =>
-      props[_$key__onHandleHiding___$TransitionerProps];
-
+      props[_$key__onHandleHiding___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onHandleHiding] to see the source code for this prop
   @override
   set onHandleHiding(Callback value) =>
@@ -65,8 +65,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onHandleHidden] to see the source code for this prop
   @override
   Callback get onHandleHidden =>
-      props[_$key__onHandleHidden___$TransitionerProps];
-
+      props[_$key__onHandleHidden___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onHandleHidden] to see the source code for this prop
   @override
   set onHandleHidden(Callback value) =>
@@ -75,8 +75,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onPrepareShow] to see the source code for this prop
   @override
   Callback get onPrepareShow =>
-      props[_$key__onPrepareShow___$TransitionerProps];
-
+      props[_$key__onPrepareShow___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onPrepareShow] to see the source code for this prop
   @override
   set onPrepareShow(Callback value) =>
@@ -85,8 +85,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.onPrepareHide] to see the source code for this prop
   @override
   Callback get onPrepareHide =>
-      props[_$key__onPrepareHide___$TransitionerProps];
-
+      props[_$key__onPrepareHide___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.onPrepareHide] to see the source code for this prop
   @override
   set onPrepareHide(Callback value) =>
@@ -94,8 +94,9 @@ abstract class _$TransitionerPropsAccessorsMixin
 
   /// Go to [_$TransitionerProps.hasTransition] to see the source code for this prop
   @override
-  bool get hasTransition => props[_$key__hasTransition___$TransitionerProps];
-
+  bool get hasTransition =>
+      props[_$key__hasTransition___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.hasTransition] to see the source code for this prop
   @override
   set hasTransition(bool value) =>
@@ -103,8 +104,9 @@ abstract class _$TransitionerPropsAccessorsMixin
 
   /// Go to [_$TransitionerProps.initiallyShown] to see the source code for this prop
   @override
-  bool get initiallyShown => props[_$key__initiallyShown___$TransitionerProps];
-
+  bool get initiallyShown =>
+      props[_$key__initiallyShown___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.initiallyShown] to see the source code for this prop
   @override
   set initiallyShown(bool value) =>
@@ -113,8 +115,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// Go to [_$TransitionerProps.transitionTimeout] to see the source code for this prop
   @override
   Duration get transitionTimeout =>
-      props[_$key__transitionTimeout___$TransitionerProps];
-
+      props[_$key__transitionTimeout___$TransitionerProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TransitionerProps.transitionTimeout] to see the source code for this prop
   @override
   set transitionTimeout(Duration value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -13,8 +13,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp___$TestAbstractProps];
-
+  String get stringProp =>
+      props[_$key__stringProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -22,8 +23,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp___$TestAbstractProps];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -31,8 +33,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$TestAbstractProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -41,8 +44,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
   /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp___$TestAbstractProps];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -53,8 +57,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestAbstractProps];
-
+      props[_$key__customNamespaceProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -65,8 +69,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps];
-
+      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -136,8 +140,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -146,8 +150,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -156,8 +160,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
   @override
   get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -167,8 +171,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -179,8 +183,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -191,9 +195,10 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp => props[
-      _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps];
-
+  get customKeyAndNamespaceProp =>
+      props[
+          _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -276,8 +281,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
   @override
-  String get stringState => state[_$key__stringState___$TestAbstractState];
-
+  String get stringState =>
+      state[_$key__stringState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -285,8 +291,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
   @override
-  dynamic get dynamicState => state[_$key__dynamicState___$TestAbstractState];
-
+  dynamic get dynamicState =>
+      state[_$key__dynamicState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -294,8 +301,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$TestAbstractState];
-
+  get untypedState =>
+      state[_$key__untypedState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -304,8 +312,9 @@ abstract class _$TestAbstractStateAccessorsMixin
   /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState => state[_$key__customKeyState___$TestAbstractState];
-
+  get customKeyState =>
+      state[_$key__customKeyState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -316,8 +325,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestAbstractState];
-
+      state[_$key__customNamespaceState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -328,8 +337,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestAbstractState];
-
+      state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -400,8 +409,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -410,8 +419,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -420,8 +429,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -431,8 +440,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -443,8 +452,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -455,9 +464,10 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceState => state[
-      _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState];
-
+  get customKeyAndNamespaceState =>
+      state[
+          _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -14,8 +14,9 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// Go to [_$TestPropsMixin.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp___$TestPropsMixin];
-
+  String get stringProp =>
+      props[_$key__stringProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -23,8 +24,9 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// Go to [_$TestPropsMixin.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp___$TestPropsMixin];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -32,8 +34,9 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// Go to [_$TestPropsMixin.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$TestPropsMixin];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) => props[_$key__untypedProp___$TestPropsMixin] = value;
@@ -41,8 +44,9 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   /// Go to [_$TestPropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp___$TestPropsMixin];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -53,8 +57,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestPropsMixin];
-
+      props[_$key__customNamespaceProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -65,8 +69,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin];
-
+      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -132,8 +136,8 @@ abstract class TestCustomNamespacePropsMixin
   /// Go to [_$TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespacePropsMixin];
-
+      props[_$key__stringProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -142,8 +146,8 @@ abstract class TestCustomNamespacePropsMixin
   /// Go to [_$TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin];
-
+      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -151,8 +155,9 @@ abstract class TestCustomNamespacePropsMixin
 
   /// Go to [_$TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$TestCustomNamespacePropsMixin];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -162,8 +167,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin];
-
+      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -174,8 +179,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin];
-
+      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -187,8 +192,9 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin];
-
+      props[
+          _$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -263,8 +269,9 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// Go to [_$TestStateMixin.stringState] to see the source code for this prop
   @override
-  String get stringState => state[_$key__stringState___$TestStateMixin];
-
+  String get stringState =>
+      state[_$key__stringState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -272,8 +279,9 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// Go to [_$TestStateMixin.dynamicState] to see the source code for this prop
   @override
-  dynamic get dynamicState => state[_$key__dynamicState___$TestStateMixin];
-
+  dynamic get dynamicState =>
+      state[_$key__dynamicState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -281,8 +289,9 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// Go to [_$TestStateMixin.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$TestStateMixin];
-
+  get untypedState =>
+      state[_$key__untypedState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -291,8 +300,9 @@ abstract class TestStateMixin implements _$TestStateMixin {
   /// Go to [_$TestStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState => state[_$key__customKeyState___$TestStateMixin];
-
+  get customKeyState =>
+      state[_$key__customKeyState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -303,8 +313,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestStateMixin];
-
+      state[_$key__customNamespaceState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -315,8 +325,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestStateMixin];
-
+      state[_$key__customKeyAndNamespaceState___$TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -383,8 +393,8 @@ abstract class TestCustomNamespaceStateMixin
   /// Go to [_$TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceStateMixin];
-
+      state[_$key__stringState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -393,8 +403,8 @@ abstract class TestCustomNamespaceStateMixin
   /// Go to [_$TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceStateMixin];
-
+      state[_$key__dynamicState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -403,8 +413,8 @@ abstract class TestCustomNamespaceStateMixin
   /// Go to [_$TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceStateMixin];
-
+      state[_$key__untypedState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -414,8 +424,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceStateMixin];
-
+      state[_$key__customKeyState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -426,8 +436,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin];
-
+      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -439,8 +449,9 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin];
-
+      state[
+          _$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
@@ -13,8 +13,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp___$TestAbstractProps];
-
+  String get stringProp =>
+      props[_$key__stringProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -22,8 +23,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp___$TestAbstractProps];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -31,8 +33,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$TestAbstractProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -41,8 +44,9 @@ abstract class _$TestAbstractPropsAccessorsMixin
   /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp___$TestAbstractProps];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -53,8 +57,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestAbstractProps];
-
+      props[_$key__customNamespaceProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -65,8 +69,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps];
-
+      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -131,8 +135,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -141,8 +145,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -151,8 +155,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
   @override
   get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -162,8 +166,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -174,8 +178,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps];
-
+      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -186,9 +190,10 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp => props[
-      _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps];
-
+  get customKeyAndNamespaceProp =>
+      props[
+          _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -265,8 +270,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
   @override
-  String get stringState => state[_$key__stringState___$TestAbstractState];
-
+  String get stringState =>
+      state[_$key__stringState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -274,8 +280,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
   @override
-  dynamic get dynamicState => state[_$key__dynamicState___$TestAbstractState];
-
+  dynamic get dynamicState =>
+      state[_$key__dynamicState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -283,8 +290,9 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$TestAbstractState];
-
+  get untypedState =>
+      state[_$key__untypedState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -293,8 +301,9 @@ abstract class _$TestAbstractStateAccessorsMixin
   /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState => state[_$key__customKeyState___$TestAbstractState];
-
+  get customKeyState =>
+      state[_$key__customKeyState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -305,8 +314,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestAbstractState];
-
+      state[_$key__customNamespaceState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -317,8 +326,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestAbstractState];
-
+      state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -384,8 +393,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -394,8 +403,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -404,8 +413,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -415,8 +424,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -427,8 +436,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState];
-
+      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -439,9 +448,10 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceState => state[
-      _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState];
-
+  get customKeyAndNamespaceState =>
+      state[
+          _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
@@ -14,8 +14,9 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// Go to [TestPropsMixin.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp__TestPropsMixin];
-
+  String get stringProp =>
+      props[_$key__stringProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -23,8 +24,9 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// Go to [TestPropsMixin.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp__TestPropsMixin];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -32,8 +34,9 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// Go to [TestPropsMixin.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp__TestPropsMixin];
-
+  get untypedProp =>
+      props[_$key__untypedProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) => props[_$key__untypedProp__TestPropsMixin] = value;
@@ -41,8 +44,9 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   /// Go to [TestPropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp__TestPropsMixin];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -52,8 +56,9 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   /// Go to [TestPropsMixin.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
-  get customNamespaceProp => props[_$key__customNamespaceProp__TestPropsMixin];
-
+  get customNamespaceProp =>
+      props[_$key__customNamespaceProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -64,8 +69,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp__TestPropsMixin];
-
+      props[_$key__customKeyAndNamespaceProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -131,8 +136,8 @@ abstract class $TestCustomNamespacePropsMixin
   /// Go to [TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp__TestCustomNamespacePropsMixin];
-
+      props[_$key__stringProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -141,8 +146,8 @@ abstract class $TestCustomNamespacePropsMixin
   /// Go to [TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp__TestCustomNamespacePropsMixin];
-
+      props[_$key__dynamicProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -150,8 +155,9 @@ abstract class $TestCustomNamespacePropsMixin
 
   /// Go to [TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp__TestCustomNamespacePropsMixin];
-
+  get untypedProp =>
+      props[_$key__untypedProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -161,8 +167,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp__TestCustomNamespacePropsMixin];
-
+      props[_$key__customKeyProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -173,8 +179,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin];
-
+      props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -185,8 +191,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp__TestCustomNamespacePropsMixin];
-
+      props[_$key__customKeyAndNamespaceProp__TestCustomNamespacePropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -260,8 +266,9 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// Go to [TestStateMixin.stringState] to see the source code for this prop
   @override
-  String get stringState => state[_$key__stringState__TestStateMixin];
-
+  String get stringState =>
+      state[_$key__stringState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -269,8 +276,9 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// Go to [TestStateMixin.dynamicState] to see the source code for this prop
   @override
-  dynamic get dynamicState => state[_$key__dynamicState__TestStateMixin];
-
+  dynamic get dynamicState =>
+      state[_$key__dynamicState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -278,8 +286,9 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// Go to [TestStateMixin.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState__TestStateMixin];
-
+  get untypedState =>
+      state[_$key__untypedState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.untypedState] to see the source code for this prop
   @override
   set untypedState(value) => state[_$key__untypedState__TestStateMixin] = value;
@@ -287,8 +296,9 @@ abstract class $TestStateMixin implements TestStateMixin {
   /// Go to [TestStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState => state[_$key__customKeyState__TestStateMixin];
-
+  get customKeyState =>
+      state[_$key__customKeyState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -299,8 +309,8 @@ abstract class $TestStateMixin implements TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState__TestStateMixin];
-
+      state[_$key__customNamespaceState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -311,8 +321,8 @@ abstract class $TestStateMixin implements TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState__TestStateMixin];
-
+      state[_$key__customKeyAndNamespaceState__TestStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -378,8 +388,8 @@ abstract class $TestCustomNamespaceStateMixin
   /// Go to [TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState__TestCustomNamespaceStateMixin];
-
+      state[_$key__stringState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -388,8 +398,8 @@ abstract class $TestCustomNamespaceStateMixin
   /// Go to [TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState__TestCustomNamespaceStateMixin];
-
+      state[_$key__dynamicState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -397,8 +407,9 @@ abstract class $TestCustomNamespaceStateMixin
 
   /// Go to [TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState__TestCustomNamespaceStateMixin];
-
+  get untypedState =>
+      state[_$key__untypedState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -408,8 +419,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState__TestCustomNamespaceStateMixin];
-
+      state[_$key__customKeyState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -420,8 +431,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState__TestCustomNamespaceStateMixin];
-
+      state[_$key__customNamespaceState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -432,8 +443,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState__TestCustomNamespaceStateMixin];
-
+      state[_$key__customKeyAndNamespaceState__TestCustomNamespaceStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -24,8 +24,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp___$ComponentTestProps];
-
+  String get stringProp =>
+      props[_$key__stringProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -33,8 +34,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp___$ComponentTestProps];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -42,8 +44,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$ComponentTestProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -52,8 +55,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp___$ComponentTestProps];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -64,8 +68,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$ComponentTestProps];
-
+      props[_$key__customNamespaceProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -76,8 +80,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps];
-
+      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @requiredProp
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @requiredProp
@@ -35,8 +36,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @nullableRequiredProp
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @nullableRequiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
   @override
   get generated1Prop =>
-      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
   @override
   set generated1Prop(value) =>
@@ -35,8 +35,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
   @override
   get generated2Prop =>
-      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
   @override
   set generated2Prop(value) =>
@@ -46,8 +46,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
-      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
   @override
   @Accessor(doNotGenerate: false)
@@ -132,8 +132,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
   @override
   get generated1State =>
-      state[_$key__generated1State___$DoNotGenerateAccessorTestState];
-
+      state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
   @override
   set generated1State(value) =>
@@ -142,8 +142,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
   @override
   get generated2State =>
-      state[_$key__generated2State___$DoNotGenerateAccessorTestState];
-
+      state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
   @override
   set generated2State(value) =>
@@ -153,8 +153,9 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
-      state[_$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState];
-
+      state[
+          _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
   @override
   @Accessor(doNotGenerate: false)

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp___$NamespacedAccessorTestProps];
-
+      props[_$key__stringProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -35,8 +35,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$NamespacedAccessorTestProps];
-
+      props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -44,8 +44,9 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
 
   /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$NamespacedAccessorTestProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -55,8 +56,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -67,8 +68,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -79,8 +80,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -185,8 +186,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$NamespacedAccessorTestState];
-
+      state[_$key__stringState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -195,8 +196,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$NamespacedAccessorTestState];
-
+      state[_$key__dynamicState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -204,8 +205,9 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
 
   /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$NamespacedAccessorTestState];
-
+  get untypedState =>
+      state[_$key__untypedState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -215,8 +217,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$NamespacedAccessorTestState];
-
+      state[_$key__customKeyState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -227,8 +229,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$NamespacedAccessorTestState];
-
+      state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -239,8 +241,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState];
-
+      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -27,8 +27,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Accessor(
@@ -42,8 +43,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isRequired: true,
       isNullable: true,
       requiredErrorMessage: 'This prop can be set to null!')
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Accessor(

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_prop_integration_tests.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_prop_integration_tests.over_react.g.dart
@@ -25,8 +25,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
@@ -35,8 +36,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -72,8 +72,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$StatefulComponentTestState];
-
+      state[_$key__stringState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -82,8 +82,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$StatefulComponentTestState];
-
+      state[_$key__dynamicState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -91,8 +91,9 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
 
   /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$StatefulComponentTestState];
-
+  get untypedState =>
+      state[_$key__untypedState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -102,8 +103,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$StatefulComponentTestState];
-
+      state[_$key__customKeyState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -114,8 +115,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$StatefulComponentTestState];
-
+      state[_$key__customNamespaceState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -126,8 +127,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState];
-
+      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
@@ -32,16 +32,6 @@ UiFactory<FooProps> Foo = _$Foo;
 class _$FooProps extends UiProps {
   String stringProp;
   String unassignedProp;
-  var untypedProp;
-
-  @Accessor(key: 'custom key!')
-  var customKeyProp;
-
-  @Accessor(keyNamespace: 'custom namespace~~')
-  var customNamespaceProp;
-
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  var customKeyAndNamespaceProp;
 }
 
 @Component()

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
@@ -1,0 +1,61 @@
+import 'package:over_react/over_react.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/test_util.dart';
+
+// ignore: uri_has_not_been_generated
+part 'unassigned_prop_integration_test.over_react.g.dart';
+
+main() {
+  test('renders all children, even with unassigned props present', () {
+    var instance = render((Foo()
+      ..stringProp = 'some string value'
+    )());
+
+    expect(instance, isNotNull); // sanity check
+
+    var node = findDomNode(instance);
+
+    // This tests a workaround added to impl_generation.dart to add ` ?? null;` to the getters
+    // for props/state members. Details: <https://github.com/dart-lang/sdk/issues/36052>
+    // without this workaround, this test would fail when compiled via DDC.
+    expect(node.text, contains('some string value'));
+  });
+}
+
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FooProps> Foo = _$Foo;
+
+@Props()
+class _$FooProps extends UiProps {
+  String stringProp;
+  String unassignedProp;
+  var untypedProp;
+
+  @Accessor(key: 'custom key!')
+  var customKeyProp;
+
+  @Accessor(keyNamespace: 'custom namespace~~')
+  var customNamespaceProp;
+
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  var customKeyAndNamespaceProp;
+}
+
+@Component()
+class FooComponent extends UiComponent<FooProps> {
+  @override
+  Map getDefaultProps() => newProps()..id = 'testId';
+
+  @override
+  render() => (Dom.div())(props.unassignedProp, props.stringProp);
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFooProps;
+}

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -38,88 +38,22 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   set unassignedProp(String value) =>
       props[_$key__unassignedProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
-  @override
-  get untypedProp =>
-      props[_$key__untypedProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
-  @override
-  set untypedProp(value) => props[_$key__untypedProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
-  @override
-  @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
-  @override
-  @Accessor(key: 'custom key!')
-  set customKeyProp(value) => props[_$key__customKeyProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~')
-  get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~')
-  set customNamespaceProp(value) =>
-      props[_$key__customNamespaceProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  set customKeyAndNamespaceProp(value) =>
-      props[_$key__customKeyAndNamespaceProp___$FooProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor _$prop__stringProp___$FooProps =
       const PropDescriptor(_$key__stringProp___$FooProps);
   static const PropDescriptor _$prop__unassignedProp___$FooProps =
       const PropDescriptor(_$key__unassignedProp___$FooProps);
-  static const PropDescriptor _$prop__untypedProp___$FooProps =
-      const PropDescriptor(_$key__untypedProp___$FooProps);
-  static const PropDescriptor _$prop__customKeyProp___$FooProps =
-      const PropDescriptor(_$key__customKeyProp___$FooProps);
-  static const PropDescriptor _$prop__customNamespaceProp___$FooProps =
-      const PropDescriptor(_$key__customNamespaceProp___$FooProps);
-  static const PropDescriptor _$prop__customKeyAndNamespaceProp___$FooProps =
-      const PropDescriptor(_$key__customKeyAndNamespaceProp___$FooProps);
   static const String _$key__stringProp___$FooProps = 'FooProps.stringProp';
   static const String _$key__unassignedProp___$FooProps =
       'FooProps.unassignedProp';
-  static const String _$key__untypedProp___$FooProps = 'FooProps.untypedProp';
-  static const String _$key__customKeyProp___$FooProps = 'FooProps.custom key!';
-  static const String _$key__customNamespaceProp___$FooProps =
-      'custom namespace~~customNamespaceProp';
-  static const String _$key__customKeyAndNamespaceProp___$FooProps =
-      'custom namespace~~custom key!';
 
   static const List<PropDescriptor> $props = const [
     _$prop__stringProp___$FooProps,
-    _$prop__unassignedProp___$FooProps,
-    _$prop__untypedProp___$FooProps,
-    _$prop__customKeyProp___$FooProps,
-    _$prop__customNamespaceProp___$FooProps,
-    _$prop__customKeyAndNamespaceProp___$FooProps
+    _$prop__unassignedProp___$FooProps
   ];
   static const List<String> $propKeys = const [
     _$key__stringProp___$FooProps,
-    _$key__unassignedProp___$FooProps,
-    _$key__untypedProp___$FooProps,
-    _$key__customKeyProp___$FooProps,
-    _$key__customNamespaceProp___$FooProps,
-    _$key__customKeyAndNamespaceProp___$FooProps
+    _$key__unassignedProp___$FooProps
   ];
 }
 

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -1,0 +1,175 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'unassigned_prop_integration_test.dart';
+
+// **************************************************************************
+// OverReactGenerator
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FooComponentFactory = registerComponent(() => new _$FooComponent(),
+    builderFactory: Foo,
+    componentClass: FooComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'Foo');
+
+abstract class _$FooPropsAccessorsMixin implements _$FooProps {
+  @override
+  Map get props;
+
+  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  @override
+  String get stringProp =>
+      props[_$key__stringProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  @override
+  set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  @override
+  String get unassignedProp =>
+      props[_$key__unassignedProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  @override
+  set unassignedProp(String value) =>
+      props[_$key__unassignedProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
+  @override
+  get untypedProp =>
+      props[_$key__untypedProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
+  @override
+  set untypedProp(value) => props[_$key__untypedProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
+  @override
+  @Accessor(key: 'custom key!')
+  get customKeyProp =>
+      props[_$key__customKeyProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
+  @override
+  @Accessor(key: 'custom key!')
+  set customKeyProp(value) => props[_$key__customKeyProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~')
+  get customNamespaceProp =>
+      props[_$key__customNamespaceProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~')
+  set customNamespaceProp(value) =>
+      props[_$key__customNamespaceProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  get customKeyAndNamespaceProp =>
+      props[_$key__customKeyAndNamespaceProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  set customKeyAndNamespaceProp(value) =>
+      props[_$key__customKeyAndNamespaceProp___$FooProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__stringProp___$FooProps =
+      const PropDescriptor(_$key__stringProp___$FooProps);
+  static const PropDescriptor _$prop__unassignedProp___$FooProps =
+      const PropDescriptor(_$key__unassignedProp___$FooProps);
+  static const PropDescriptor _$prop__untypedProp___$FooProps =
+      const PropDescriptor(_$key__untypedProp___$FooProps);
+  static const PropDescriptor _$prop__customKeyProp___$FooProps =
+      const PropDescriptor(_$key__customKeyProp___$FooProps);
+  static const PropDescriptor _$prop__customNamespaceProp___$FooProps =
+      const PropDescriptor(_$key__customNamespaceProp___$FooProps);
+  static const PropDescriptor _$prop__customKeyAndNamespaceProp___$FooProps =
+      const PropDescriptor(_$key__customKeyAndNamespaceProp___$FooProps);
+  static const String _$key__stringProp___$FooProps = 'FooProps.stringProp';
+  static const String _$key__unassignedProp___$FooProps =
+      'FooProps.unassignedProp';
+  static const String _$key__untypedProp___$FooProps = 'FooProps.untypedProp';
+  static const String _$key__customKeyProp___$FooProps = 'FooProps.custom key!';
+  static const String _$key__customNamespaceProp___$FooProps =
+      'custom namespace~~customNamespaceProp';
+  static const String _$key__customKeyAndNamespaceProp___$FooProps =
+      'custom namespace~~custom key!';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__stringProp___$FooProps,
+    _$prop__unassignedProp___$FooProps,
+    _$prop__untypedProp___$FooProps,
+    _$prop__customKeyProp___$FooProps,
+    _$prop__customNamespaceProp___$FooProps,
+    _$prop__customKeyAndNamespaceProp___$FooProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__stringProp___$FooProps,
+    _$key__unassignedProp___$FooProps,
+    _$key__untypedProp___$FooProps,
+    _$key__customKeyProp___$FooProps,
+    _$key__customNamespaceProp___$FooProps,
+    _$key__customKeyAndNamespaceProp___$FooProps
+  ];
+}
+
+const PropsMeta _$metaForFooProps = const PropsMeta(
+  fields: _$FooPropsAccessorsMixin.$props,
+  keys: _$FooPropsAccessorsMixin.$propKeys,
+);
+
+_$$FooProps _$Foo([Map backingProps]) => new _$$FooProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FooProps extends _$FooProps
+    with _$FooPropsAccessorsMixin
+    implements FooProps {
+  _$$FooProps(Map backingMap) : this._props = backingMap ?? {};
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  final Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FooProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FooComponent extends FooComponent {
+  @override
+  _$$FooProps typedPropsFactory(Map backingMap) => new _$$FooProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FooProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
+}

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -24,8 +24,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
   @override
-  String get stringProp => props[_$key__stringProp___$ComponentTestProps];
-
+  String get stringProp =>
+      props[_$key__stringProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -33,8 +34,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
   @override
-  dynamic get dynamicProp => props[_$key__dynamicProp___$ComponentTestProps];
-
+  dynamic get dynamicProp =>
+      props[_$key__dynamicProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -42,8 +44,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$ComponentTestProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -52,8 +55,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp => props[_$key__customKeyProp___$ComponentTestProps];
-
+  get customKeyProp =>
+      props[_$key__customKeyProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -64,8 +68,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$ComponentTestProps];
-
+      props[_$key__customNamespaceProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -76,8 +80,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps];
-
+      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @requiredProp
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @requiredProp
@@ -35,8 +36,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @nullableRequiredProp
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @nullableRequiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
   @override
   get generated1Prop =>
-      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
   @override
   set generated1Prop(value) =>
@@ -35,8 +35,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
   @override
   get generated2Prop =>
-      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
   @override
   set generated2Prop(value) =>
@@ -46,8 +46,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
-      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps];
-
+      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
   @override
   @Accessor(doNotGenerate: false)
@@ -137,8 +137,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
   @override
   get generated1State =>
-      state[_$key__generated1State___$DoNotGenerateAccessorTestState];
-
+      state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
   @override
   set generated1State(value) =>
@@ -147,8 +147,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
   @override
   get generated2State =>
-      state[_$key__generated2State___$DoNotGenerateAccessorTestState];
-
+      state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
   @override
   set generated2State(value) =>
@@ -158,8 +158,9 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
-      state[_$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState];
-
+      state[
+          _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
   @override
   @Accessor(doNotGenerate: false)

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
   @override
   String get stringProp =>
-      props[_$key__stringProp___$NamespacedAccessorTestProps];
-
+      props[_$key__stringProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
   @override
   set stringProp(String value) =>
@@ -35,8 +35,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$NamespacedAccessorTestProps];
-
+      props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
   @override
   set dynamicProp(dynamic value) =>
@@ -44,8 +44,9 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
 
   /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
   @override
-  get untypedProp => props[_$key__untypedProp___$NamespacedAccessorTestProps];
-
+  get untypedProp =>
+      props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
   @override
   set untypedProp(value) =>
@@ -55,8 +56,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -67,8 +68,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -79,8 +80,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps];
-
+      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -190,8 +191,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$NamespacedAccessorTestState];
-
+      state[_$key__stringState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -200,8 +201,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$NamespacedAccessorTestState];
-
+      state[_$key__dynamicState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -209,8 +210,9 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
 
   /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$NamespacedAccessorTestState];
-
+  get untypedState =>
+      state[_$key__untypedState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -220,8 +222,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$NamespacedAccessorTestState];
-
+      state[_$key__customKeyState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -232,8 +234,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$NamespacedAccessorTestState];
-
+      state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -244,8 +246,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState];
-
+      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -27,8 +27,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Accessor(
@@ -42,8 +43,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isRequired: true,
       isNullable: true,
       requiredErrorMessage: 'This prop can be set to null!')
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Accessor(

--- a/test/over_react/component_declaration/builder_integration_tests/required_prop_integration_tests.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_prop_integration_tests.over_react.g.dart
@@ -25,8 +25,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
-  get required => props[_$key__required___$ComponentTestProps];
-
+  get required =>
+      props[_$key__required___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.required] to see the source code for this prop
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
@@ -35,8 +36,9 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
-  get nullable => props[_$key__nullable___$ComponentTestProps];
-
+  get nullable =>
+      props[_$key__nullable___$ComponentTestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -77,8 +77,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
   @override
   String get stringState =>
-      state[_$key__stringState___$StatefulComponentTestState];
-
+      state[_$key__stringState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
   @override
   set stringState(String value) =>
@@ -87,8 +87,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$StatefulComponentTestState];
-
+      state[_$key__dynamicState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
   @override
   set dynamicState(dynamic value) =>
@@ -96,8 +96,9 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
 
   /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
   @override
-  get untypedState => state[_$key__untypedState___$StatefulComponentTestState];
-
+  get untypedState =>
+      state[_$key__untypedState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
   @override
   set untypedState(value) =>
@@ -107,8 +108,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$StatefulComponentTestState];
-
+      state[_$key__customKeyState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
   @override
   @Accessor(key: 'custom key!')
@@ -119,8 +120,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$StatefulComponentTestState];
-
+      state[_$key__customNamespaceState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -131,8 +132,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState];
-
+      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
@@ -30,16 +30,6 @@ UiFactory<FooProps> Foo = _$Foo;
 class _$FooProps extends UiProps {
   String stringProp;
   String unassignedProp;
-  var untypedProp;
-
-  @Accessor(key: 'custom key!')
-  var customKeyProp;
-
-  @Accessor(keyNamespace: 'custom namespace~~')
-  var customNamespaceProp;
-
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  var customKeyAndNamespaceProp;
 }
 
 @Component()

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
@@ -1,0 +1,52 @@
+import 'package:over_react/over_react.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/test_util.dart';
+
+part 'unassigned_prop_integration_test.over_react.g.dart';
+
+main() {
+  test('renders all children, even with unassigned props present', () {
+    var instance = render((Foo()
+      ..stringProp = 'some string value'
+    )());
+
+    expect(instance, isNotNull); // sanity check
+
+    var node = findDomNode(instance);
+
+    // This tests a workaround added to impl_generation.dart to add ` ?? null;` to the getters
+    // for props/state members. Details: <https://github.com/dart-lang/sdk/issues/36052>
+    // without this workaround, this test would fail when compiled via DDC.
+    expect(node.text, contains('some string value'));
+  });
+}
+
+
+@Factory()
+UiFactory<FooProps> Foo = _$Foo;
+
+@Props()
+class _$FooProps extends UiProps {
+  String stringProp;
+  String unassignedProp;
+  var untypedProp;
+
+  @Accessor(key: 'custom key!')
+  var customKeyProp;
+
+  @Accessor(keyNamespace: 'custom namespace~~')
+  var customNamespaceProp;
+
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  var customKeyAndNamespaceProp;
+}
+
+@Component()
+class FooComponent extends UiComponent<FooProps> {
+  @override
+  Map getDefaultProps() => newProps()..id = 'testId';
+
+  @override
+  render() => (Dom.div())(props.unassignedProp, props.stringProp);
+}

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -38,88 +38,22 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   set unassignedProp(String value) =>
       props[_$key__unassignedProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
-  @override
-  get untypedProp =>
-      props[_$key__untypedProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
-  @override
-  set untypedProp(value) => props[_$key__untypedProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
-  @override
-  @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
-  @override
-  @Accessor(key: 'custom key!')
-  set customKeyProp(value) => props[_$key__customKeyProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~')
-  get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~')
-  set customNamespaceProp(value) =>
-      props[_$key__customNamespaceProp___$FooProps] = value;
-
-  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
-  @override
-  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  set customKeyAndNamespaceProp(value) =>
-      props[_$key__customKeyAndNamespaceProp___$FooProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor _$prop__stringProp___$FooProps =
       const PropDescriptor(_$key__stringProp___$FooProps);
   static const PropDescriptor _$prop__unassignedProp___$FooProps =
       const PropDescriptor(_$key__unassignedProp___$FooProps);
-  static const PropDescriptor _$prop__untypedProp___$FooProps =
-      const PropDescriptor(_$key__untypedProp___$FooProps);
-  static const PropDescriptor _$prop__customKeyProp___$FooProps =
-      const PropDescriptor(_$key__customKeyProp___$FooProps);
-  static const PropDescriptor _$prop__customNamespaceProp___$FooProps =
-      const PropDescriptor(_$key__customNamespaceProp___$FooProps);
-  static const PropDescriptor _$prop__customKeyAndNamespaceProp___$FooProps =
-      const PropDescriptor(_$key__customKeyAndNamespaceProp___$FooProps);
   static const String _$key__stringProp___$FooProps = 'FooProps.stringProp';
   static const String _$key__unassignedProp___$FooProps =
       'FooProps.unassignedProp';
-  static const String _$key__untypedProp___$FooProps = 'FooProps.untypedProp';
-  static const String _$key__customKeyProp___$FooProps = 'FooProps.custom key!';
-  static const String _$key__customNamespaceProp___$FooProps =
-      'custom namespace~~customNamespaceProp';
-  static const String _$key__customKeyAndNamespaceProp___$FooProps =
-      'custom namespace~~custom key!';
 
   static const List<PropDescriptor> $props = const [
     _$prop__stringProp___$FooProps,
-    _$prop__unassignedProp___$FooProps,
-    _$prop__untypedProp___$FooProps,
-    _$prop__customKeyProp___$FooProps,
-    _$prop__customNamespaceProp___$FooProps,
-    _$prop__customKeyAndNamespaceProp___$FooProps
+    _$prop__unassignedProp___$FooProps
   ];
   static const List<String> $propKeys = const [
     _$key__stringProp___$FooProps,
-    _$key__unassignedProp___$FooProps,
-    _$key__untypedProp___$FooProps,
-    _$key__customKeyProp___$FooProps,
-    _$key__customNamespaceProp___$FooProps,
-    _$key__customKeyAndNamespaceProp___$FooProps
+    _$key__unassignedProp___$FooProps
   ];
 }
 

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -1,0 +1,179 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'unassigned_prop_integration_test.dart';
+
+// **************************************************************************
+// OverReactGenerator
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FooComponentFactory = registerComponent(() => new _$FooComponent(),
+    builderFactory: Foo,
+    componentClass: FooComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'Foo');
+
+abstract class _$FooPropsAccessorsMixin implements _$FooProps {
+  @override
+  Map get props;
+
+  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  @override
+  String get stringProp =>
+      props[_$key__stringProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  @override
+  set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  @override
+  String get unassignedProp =>
+      props[_$key__unassignedProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  @override
+  set unassignedProp(String value) =>
+      props[_$key__unassignedProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
+  @override
+  get untypedProp =>
+      props[_$key__untypedProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.untypedProp] to see the source code for this prop
+  @override
+  set untypedProp(value) => props[_$key__untypedProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
+  @override
+  @Accessor(key: 'custom key!')
+  get customKeyProp =>
+      props[_$key__customKeyProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customKeyProp] to see the source code for this prop
+  @override
+  @Accessor(key: 'custom key!')
+  set customKeyProp(value) => props[_$key__customKeyProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~')
+  get customNamespaceProp =>
+      props[_$key__customNamespaceProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~')
+  set customNamespaceProp(value) =>
+      props[_$key__customNamespaceProp___$FooProps] = value;
+
+  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  get customKeyAndNamespaceProp =>
+      props[_$key__customKeyAndNamespaceProp___$FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Go to [_$FooProps.customKeyAndNamespaceProp] to see the source code for this prop
+  @override
+  @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
+  set customKeyAndNamespaceProp(value) =>
+      props[_$key__customKeyAndNamespaceProp___$FooProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__stringProp___$FooProps =
+      const PropDescriptor(_$key__stringProp___$FooProps);
+  static const PropDescriptor _$prop__unassignedProp___$FooProps =
+      const PropDescriptor(_$key__unassignedProp___$FooProps);
+  static const PropDescriptor _$prop__untypedProp___$FooProps =
+      const PropDescriptor(_$key__untypedProp___$FooProps);
+  static const PropDescriptor _$prop__customKeyProp___$FooProps =
+      const PropDescriptor(_$key__customKeyProp___$FooProps);
+  static const PropDescriptor _$prop__customNamespaceProp___$FooProps =
+      const PropDescriptor(_$key__customNamespaceProp___$FooProps);
+  static const PropDescriptor _$prop__customKeyAndNamespaceProp___$FooProps =
+      const PropDescriptor(_$key__customKeyAndNamespaceProp___$FooProps);
+  static const String _$key__stringProp___$FooProps = 'FooProps.stringProp';
+  static const String _$key__unassignedProp___$FooProps =
+      'FooProps.unassignedProp';
+  static const String _$key__untypedProp___$FooProps = 'FooProps.untypedProp';
+  static const String _$key__customKeyProp___$FooProps = 'FooProps.custom key!';
+  static const String _$key__customNamespaceProp___$FooProps =
+      'custom namespace~~customNamespaceProp';
+  static const String _$key__customKeyAndNamespaceProp___$FooProps =
+      'custom namespace~~custom key!';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__stringProp___$FooProps,
+    _$prop__unassignedProp___$FooProps,
+    _$prop__untypedProp___$FooProps,
+    _$prop__customKeyProp___$FooProps,
+    _$prop__customNamespaceProp___$FooProps,
+    _$prop__customKeyAndNamespaceProp___$FooProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__stringProp___$FooProps,
+    _$key__unassignedProp___$FooProps,
+    _$key__untypedProp___$FooProps,
+    _$key__customKeyProp___$FooProps,
+    _$key__customNamespaceProp___$FooProps,
+    _$key__customKeyAndNamespaceProp___$FooProps
+  ];
+}
+
+const PropsMeta _$metaForFooProps = const PropsMeta(
+  fields: _$FooPropsAccessorsMixin.$props,
+  keys: _$FooPropsAccessorsMixin.$propKeys,
+);
+
+class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForFooProps;
+}
+
+_$$FooProps _$Foo([Map backingProps]) => new _$$FooProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FooProps extends _$FooProps
+    with _$FooPropsAccessorsMixin
+    implements FooProps {
+  _$$FooProps(Map backingMap) : this._props = backingMap ?? {};
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  final Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FooProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FooComponent extends FooComponent {
+  @override
+  _$$FooProps typedPropsFactory(Map backingMap) => new _$$FooProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FooProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
+}

--- a/test/over_react/component_declaration/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test.over_react.g.dart
@@ -273,8 +273,9 @@ abstract class _$TestPropValidationPropsAccessorsMixin
   /// Go to [_$TestPropValidationProps.required] to see the source code for this prop
   @override
   @requiredProp
-  String get required => props[_$key__required___$TestPropValidationProps];
-
+  String get required =>
+      props[_$key__required___$TestPropValidationProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestPropValidationProps.required] to see the source code for this prop
   @override
   @requiredProp
@@ -937,8 +938,8 @@ abstract class _$TestStatefulPropValidationPropsAccessorsMixin
   @override
   @requiredProp
   String get required =>
-      props[_$key__required___$TestStatefulPropValidationProps];
-
+      props[_$key__required___$TestStatefulPropValidationProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestStatefulPropValidationProps.required] to see the source code for this prop
   @override
   @override

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// Go to [_$TestCompositeComponentProps.onComponentDidMount] to see the source code for this prop
   @override
   Function get onComponentDidMount =>
-      props[_$key__onComponentDidMount___$TestCompositeComponentProps];
-
+      props[_$key__onComponentDidMount___$TestCompositeComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCompositeComponentProps.onComponentDidMount] to see the source code for this prop
   @override
   set onComponentDidMount(Function value) =>
@@ -35,8 +35,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// Go to [_$TestCompositeComponentProps.onComponentWillUnmount] to see the source code for this prop
   @override
   Function get onComponentWillUnmount =>
-      props[_$key__onComponentWillUnmount___$TestCompositeComponentProps];
-
+      props[_$key__onComponentWillUnmount___$TestCompositeComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCompositeComponentProps.onComponentWillUnmount] to see the source code for this prop
   @override
   set onComponentWillUnmount(Function value) =>
@@ -46,8 +46,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// Go to [_$TestCompositeComponentProps.onComponentDidUpdate] to see the source code for this prop
   @override
   Function get onComponentDidUpdate =>
-      props[_$key__onComponentDidUpdate___$TestCompositeComponentProps];
-
+      props[_$key__onComponentDidUpdate___$TestCompositeComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestCompositeComponentProps.onComponentDidUpdate] to see the source code for this prop
   @override
   set onComponentDidUpdate(Function value) =>

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -22,16 +22,18 @@ abstract class _$TestPropsAccessorsMixin implements _$TestProps {
 
   /// Go to [_$TestProps.foo] to see the source code for this prop
   @override
-  String get foo => props[_$key__foo___$TestProps];
-
+  String get foo =>
+      props[_$key__foo___$TestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestProps.foo] to see the source code for this prop
   @override
   set foo(String value) => props[_$key__foo___$TestProps] = value;
 
   /// Go to [_$TestProps.bar] to see the source code for this prop
   @override
-  String get bar => props[_$key__bar___$TestProps];
-
+  String get bar =>
+      props[_$key__bar___$TestProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TestProps.bar] to see the source code for this prop
   @override
   set bar(String value) => props[_$key__bar___$TestProps] = value;

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -37,6 +37,7 @@ import 'over_react/component_declaration/builder_integration_tests/do_not_genera
 import 'over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.dart' as namespaced_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.dart' as required_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.dart' as stateful_component_integration_test;
+import 'over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart' as unassigned_prop_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.dart' as backwards_compat_abstract_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.dart' as backwards_compat_accessor_mixin_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.dart' as backwards_compat_component_integration_test;
@@ -45,6 +46,7 @@ import 'over_react/component_declaration/builder_integration_tests/backwards_com
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.dart' as backwards_compat_namespaced_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.dart' as backwards_compat_required_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.dart' as backwards_compat_stateful_component_integration_test;
+import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart' as backwards_compat_unassigned_prop_integration_test;
 
 main() {
   setClientConfiguration();
@@ -66,6 +68,7 @@ main() {
   namespaced_accessor_integration_test.main();
   required_accessor_integration_test.main();
   stateful_component_integration_test.main();
+  unassigned_prop_integration_test.main();
 
   backwards_compat_abstract_accessor_integration_test.main();
   backwards_compat_accessor_mixin_integration_test.main();
@@ -75,4 +78,5 @@ main() {
   backwards_compat_namespaced_accessor_integration_test.main();
   backwards_compat_required_accessor_integration_test.main();
   backwards_compat_stateful_component_integration_test.main();
+  backwards_compat_unassigned_prop_integration_test.main();
 }

--- a/test/vm_tests/builder/impl_generation_test.dart
+++ b/test/vm_tests/builder/impl_generation_test.dart
@@ -162,16 +162,16 @@ main() {
 
                 group('with concrete implementations', () {
                   test('', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set someField(String value) => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className] = value'));
                   });
 
                   test('for multiple fields declared on same line', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set foo(bool value) => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set bar(bool value) => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set baz(bool value) => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className] = value'));
                   });
 
@@ -220,16 +220,16 @@ main() {
 
                 group('with concrete implementations', () {
                   test('', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField__$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField__$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set someField(String value) => ${isProps ? 'props' : 'state'}[_\$key__someField__$className] = value'));
                   });
 
                   test('for multiple fields declared on same line', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo__$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo__$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set foo(bool value) => ${isProps ? 'props' : 'state'}[_\$key__foo__$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar__$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar__$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set bar(bool value) => ${isProps ? 'props' : 'state'}[_\$key__bar__$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz__$className];\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz__$className] ?? null;'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set baz(bool value) => ${isProps ? 'props' : 'state'}[_\$key__baz__$className] = value'));
                   });
 
@@ -403,7 +403,7 @@ main() {
           test('for covariant keywords', () {
             final ors = OverReactSrc.abstractProps(backwardsCompatible: backwardsCompatible, body: 'covariant String foo;');
             generateFromSource(ors.source);
-            expect(implGenerator.outputContentsBuffer.toString(), contains('String get foo => props[_\$key__foo___\$${ors.propsClassName}];'));
+            expect(implGenerator.outputContentsBuffer.toString(), contains('String get foo => props[_\$key__foo___\$${ors.propsClassName}] ?? null;'));
             expect(implGenerator.outputContentsBuffer.toString(), contains('set foo(covariant String value) => props[_\$key__foo___\$${ors.propsClassName}] = value;'));
           });
 

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -24,8 +24,9 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp => props[_$key__basicProp___$BasicProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basicProp] to see the source code for this prop
   @override
   @deprecated
@@ -34,40 +35,45 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -24,8 +24,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
-  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
   set basicProp(String value) =>
@@ -33,8 +34,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) =>
@@ -42,8 +44,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) =>
@@ -51,8 +54,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) =>
@@ -60,8 +64,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) =>
@@ -69,8 +74,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) =>
@@ -161,8 +167,9 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
-  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
-
+  String get basicState =>
+      state[_$key__basicState___$BasicPartOfLibState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
   set basicState(String value) =>
@@ -247,8 +254,9 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
-  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
-
+  String get subProp =>
+      props[_$key__subProp___$SubPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
   set subProp(String value) =>
@@ -330,8 +338,9 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
-  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
-
+  String get superProp =>
+      props[_$key__superProp___$SuperPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
   set superProp(String value) =>

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -24,8 +24,9 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp => props[_$key__basicProp___$BasicProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basicProp] to see the source code for this prop
   @override
   @deprecated
@@ -34,40 +35,45 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -24,8 +24,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
-  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
-
+  String get basicProp =>
+      props[_$key__basicProp___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
   @override
   set basicProp(String value) =>
@@ -33,8 +34,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
-  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
-
+  String get basic1 =>
+      props[_$key__basic1___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
   @override
   set basic1(String value) =>
@@ -42,8 +44,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
-  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
-
+  String get basic2 =>
+      props[_$key__basic2___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
   @override
   set basic2(String value) =>
@@ -51,8 +54,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
-  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
-
+  String get basic3 =>
+      props[_$key__basic3___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
   @override
   set basic3(String value) =>
@@ -60,8 +64,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
-  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
-
+  String get basic4 =>
+      props[_$key__basic4___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
   @override
   set basic4(String value) =>
@@ -69,8 +74,9 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
-  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
-
+  String get basic5 =>
+      props[_$key__basic5___$BasicPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
   @override
   set basic5(String value) =>
@@ -166,8 +172,9 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
-  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
-
+  String get basicState =>
+      state[_$key__basicState___$BasicPartOfLibState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
   @override
   set basicState(String value) =>
@@ -257,8 +264,9 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
-  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
-
+  String get subProp =>
+      props[_$key__subProp___$SubPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
   @override
   set subProp(String value) =>
@@ -345,8 +353,9 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
-  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
-
+  String get superProp =>
+      props[_$key__superProp___$SuperPartOfLibProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
   @override
   set superProp(String value) =>

--- a/web/src/demo_components/button.over_react.g.dart
+++ b/web/src/demo_components/button.over_react.g.dart
@@ -22,24 +22,27 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
 
   /// Go to [_$ButtonProps.skin] to see the source code for this prop
   @override
-  ButtonSkin get skin => props[_$key__skin___$ButtonProps];
-
+  ButtonSkin get skin =>
+      props[_$key__skin___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.skin] to see the source code for this prop
   @override
   set skin(ButtonSkin value) => props[_$key__skin___$ButtonProps] = value;
 
   /// Go to [_$ButtonProps.size] to see the source code for this prop
   @override
-  ButtonSize get size => props[_$key__size___$ButtonProps];
-
+  ButtonSize get size =>
+      props[_$key__size___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.size] to see the source code for this prop
   @override
   set size(ButtonSize value) => props[_$key__size___$ButtonProps] = value;
 
   /// Go to [_$ButtonProps.isActive] to see the source code for this prop
   @override
-  bool get isActive => props[_$key__isActive___$ButtonProps];
-
+  bool get isActive =>
+      props[_$key__isActive___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.isActive] to see the source code for this prop
   @override
   set isActive(bool value) => props[_$key__isActive___$ButtonProps] = value;
@@ -47,8 +50,9 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// Go to [_$ButtonProps.isDisabled] to see the source code for this prop
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled => props[_$key__isDisabled___$ButtonProps];
-
+  bool get isDisabled =>
+      props[_$key__isDisabled___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.isDisabled] to see the source code for this prop
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
@@ -56,8 +60,9 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
 
   /// Go to [_$ButtonProps.isBlock] to see the source code for this prop
   @override
-  bool get isBlock => props[_$key__isBlock___$ButtonProps];
-
+  bool get isBlock =>
+      props[_$key__isBlock___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.isBlock] to see the source code for this prop
   @override
   set isBlock(bool value) => props[_$key__isBlock___$ButtonProps] = value;
@@ -65,8 +70,9 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// Go to [_$ButtonProps.href] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  String get href => props[_$key__href___$ButtonProps];
-
+  String get href =>
+      props[_$key__href___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.href] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -75,8 +81,9 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// Go to [_$ButtonProps.target] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  String get target => props[_$key__target___$ButtonProps];
-
+  String get target =>
+      props[_$key__target___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.target] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -84,8 +91,9 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
 
   /// Go to [_$ButtonProps.type] to see the source code for this prop
   @override
-  ButtonType get type => props[_$key__type___$ButtonProps];
-
+  ButtonType get type =>
+      props[_$key__type___$ButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonProps.type] to see the source code for this prop
   @override
   set type(ButtonType value) => props[_$key__type___$ButtonProps] = value;

--- a/web/src/demo_components/button_group.over_react.g.dart
+++ b/web/src/demo_components/button_group.over_react.g.dart
@@ -23,8 +23,9 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
 
   /// Go to [_$ButtonGroupProps.size] to see the source code for this prop
   @override
-  ButtonGroupSize get size => props[_$key__size___$ButtonGroupProps];
-
+  ButtonGroupSize get size =>
+      props[_$key__size___$ButtonGroupProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonGroupProps.size] to see the source code for this prop
   @override
   set size(ButtonGroupSize value) =>
@@ -32,16 +33,18 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
 
   /// Go to [_$ButtonGroupProps.skin] to see the source code for this prop
   @override
-  ButtonSkin get skin => props[_$key__skin___$ButtonGroupProps];
-
+  ButtonSkin get skin =>
+      props[_$key__skin___$ButtonGroupProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonGroupProps.skin] to see the source code for this prop
   @override
   set skin(ButtonSkin value) => props[_$key__skin___$ButtonGroupProps] = value;
 
   /// Go to [_$ButtonGroupProps.isVertical] to see the source code for this prop
   @override
-  bool get isVertical => props[_$key__isVertical___$ButtonGroupProps];
-
+  bool get isVertical =>
+      props[_$key__isVertical___$ButtonGroupProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ButtonGroupProps.isVertical] to see the source code for this prop
   @override
   set isVertical(bool value) =>

--- a/web/src/demo_components/list_group.over_react.g.dart
+++ b/web/src/demo_components/list_group.over_react.g.dart
@@ -24,8 +24,8 @@ abstract class _$ListGroupPropsAccessorsMixin implements _$ListGroupProps {
   /// Go to [_$ListGroupProps.elementType] to see the source code for this prop
   @override
   ListGroupElementType get elementType =>
-      props[_$key__elementType___$ListGroupProps];
-
+      props[_$key__elementType___$ListGroupProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupProps.elementType] to see the source code for this prop
   @override
   set elementType(ListGroupElementType value) =>

--- a/web/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/src/demo_components/list_group_item.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// Go to [_$ListGroupItemProps.elementType] to see the source code for this prop
   @override
   ListGroupItemElementType get elementType =>
-      props[_$key__elementType___$ListGroupItemProps];
-
+      props[_$key__elementType___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.elementType] to see the source code for this prop
   @override
   set elementType(ListGroupItemElementType value) =>
@@ -34,8 +34,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
 
   /// Go to [_$ListGroupItemProps.header] to see the source code for this prop
   @override
-  dynamic get header => props[_$key__header___$ListGroupItemProps];
-
+  dynamic get header =>
+      props[_$key__header___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.header] to see the source code for this prop
   @override
   set header(dynamic value) =>
@@ -44,8 +45,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// Go to [_$ListGroupItemProps.headerSize] to see the source code for this prop
   @override
   ListGroupItemHeaderElementSize get headerSize =>
-      props[_$key__headerSize___$ListGroupItemProps];
-
+      props[_$key__headerSize___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.headerSize] to see the source code for this prop
   @override
   set headerSize(ListGroupItemHeaderElementSize value) =>
@@ -53,8 +54,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
 
   /// Go to [_$ListGroupItemProps.headerProps] to see the source code for this prop
   @override
-  Map get headerProps => props[_$key__headerProps___$ListGroupItemProps];
-
+  Map get headerProps =>
+      props[_$key__headerProps___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.headerProps] to see the source code for this prop
   @override
   set headerProps(Map value) =>
@@ -62,8 +64,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
 
   /// Go to [_$ListGroupItemProps.skin] to see the source code for this prop
   @override
-  ListGroupItemSkin get skin => props[_$key__skin___$ListGroupItemProps];
-
+  ListGroupItemSkin get skin =>
+      props[_$key__skin___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.skin] to see the source code for this prop
   @override
   set skin(ListGroupItemSkin value) =>
@@ -71,8 +74,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
 
   /// Go to [_$ListGroupItemProps.isActive] to see the source code for this prop
   @override
-  bool get isActive => props[_$key__isActive___$ListGroupItemProps];
-
+  bool get isActive =>
+      props[_$key__isActive___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.isActive] to see the source code for this prop
   @override
   set isActive(bool value) =>
@@ -81,8 +85,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// Go to [_$ListGroupItemProps.isDisabled] to see the source code for this prop
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled => props[_$key__isDisabled___$ListGroupItemProps];
-
+  bool get isDisabled =>
+      props[_$key__isDisabled___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.isDisabled] to see the source code for this prop
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
@@ -92,8 +97,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// Go to [_$ListGroupItemProps.href] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  String get href => props[_$key__href___$ListGroupItemProps];
-
+  String get href =>
+      props[_$key__href___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.href] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -102,8 +108,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// Go to [_$ListGroupItemProps.target] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  String get target => props[_$key__target___$ListGroupItemProps];
-
+  String get target =>
+      props[_$key__target___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.target] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -112,8 +119,9 @@ abstract class _$ListGroupItemPropsAccessorsMixin
 
   /// Go to [_$ListGroupItemProps.type] to see the source code for this prop
   @override
-  ButtonType get type => props[_$key__type___$ListGroupItemProps];
-
+  ButtonType get type =>
+      props[_$key__type___$ListGroupItemProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ListGroupItemProps.type] to see the source code for this prop
   @override
   set type(ButtonType value) =>

--- a/web/src/demo_components/progress.over_react.g.dart
+++ b/web/src/demo_components/progress.over_react.g.dart
@@ -23,48 +23,54 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
 
   /// Go to [_$ProgressProps.value] to see the source code for this prop
   @override
-  double get value => props[_$key__value___$ProgressProps];
-
+  double get value =>
+      props[_$key__value___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.value] to see the source code for this prop
   @override
   set value(double value) => props[_$key__value___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.min] to see the source code for this prop
   @override
-  double get min => props[_$key__min___$ProgressProps];
-
+  double get min =>
+      props[_$key__min___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.min] to see the source code for this prop
   @override
   set min(double value) => props[_$key__min___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.max] to see the source code for this prop
   @override
-  double get max => props[_$key__max___$ProgressProps];
-
+  double get max =>
+      props[_$key__max___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.max] to see the source code for this prop
   @override
   set max(double value) => props[_$key__max___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.skin] to see the source code for this prop
   @override
-  ProgressSkin get skin => props[_$key__skin___$ProgressProps];
-
+  ProgressSkin get skin =>
+      props[_$key__skin___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.skin] to see the source code for this prop
   @override
   set skin(ProgressSkin value) => props[_$key__skin___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.isStriped] to see the source code for this prop
   @override
-  bool get isStriped => props[_$key__isStriped___$ProgressProps];
-
+  bool get isStriped =>
+      props[_$key__isStriped___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.isStriped] to see the source code for this prop
   @override
   set isStriped(bool value) => props[_$key__isStriped___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.isAnimated] to see the source code for this prop
   @override
-  bool get isAnimated => props[_$key__isAnimated___$ProgressProps];
-
+  bool get isAnimated =>
+      props[_$key__isAnimated___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.isAnimated] to see the source code for this prop
   @override
   set isAnimated(bool value) =>
@@ -72,16 +78,18 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
 
   /// Go to [_$ProgressProps.caption] to see the source code for this prop
   @override
-  String get caption => props[_$key__caption___$ProgressProps];
-
+  String get caption =>
+      props[_$key__caption___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.caption] to see the source code for this prop
   @override
   set caption(String value) => props[_$key__caption___$ProgressProps] = value;
 
   /// Go to [_$ProgressProps.captionProps] to see the source code for this prop
   @override
-  Map get captionProps => props[_$key__captionProps___$ProgressProps];
-
+  Map get captionProps =>
+      props[_$key__captionProps___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.captionProps] to see the source code for this prop
   @override
   set captionProps(Map value) =>
@@ -89,8 +97,9 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
 
   /// Go to [_$ProgressProps.showCaption] to see the source code for this prop
   @override
-  bool get showCaption => props[_$key__showCaption___$ProgressProps];
-
+  bool get showCaption =>
+      props[_$key__showCaption___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.showCaption] to see the source code for this prop
   @override
   set showCaption(bool value) =>
@@ -99,8 +108,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   /// Go to [_$ProgressProps.showPercentComplete] to see the source code for this prop
   @override
   bool get showPercentComplete =>
-      props[_$key__showPercentComplete___$ProgressProps];
-
+      props[_$key__showPercentComplete___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.showPercentComplete] to see the source code for this prop
   @override
   set showPercentComplete(bool value) =>
@@ -108,8 +117,9 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
 
   /// Go to [_$ProgressProps.rootNodeProps] to see the source code for this prop
   @override
-  Map get rootNodeProps => props[_$key__rootNodeProps___$ProgressProps];
-
+  Map get rootNodeProps =>
+      props[_$key__rootNodeProps___$ProgressProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressProps.rootNodeProps] to see the source code for this prop
   @override
   set rootNodeProps(Map value) =>
@@ -227,8 +237,9 @@ abstract class _$ProgressStateAccessorsMixin implements _$ProgressState {
 
   /// Go to [_$ProgressState.id] to see the source code for this prop
   @override
-  String get id => state[_$key__id___$ProgressState];
-
+  String get id =>
+      state[_$key__id___$ProgressState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ProgressState.id] to see the source code for this prop
   @override
   set id(String value) => state[_$key__id___$ProgressState] = value;

--- a/web/src/demo_components/tag.over_react.g.dart
+++ b/web/src/demo_components/tag.over_react.g.dart
@@ -22,16 +22,18 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
 
   /// Go to [_$TagProps.skin] to see the source code for this prop
   @override
-  TagSkin get skin => props[_$key__skin___$TagProps];
-
+  TagSkin get skin =>
+      props[_$key__skin___$TagProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TagProps.skin] to see the source code for this prop
   @override
   set skin(TagSkin value) => props[_$key__skin___$TagProps] = value;
 
   /// Go to [_$TagProps.isPill] to see the source code for this prop
   @override
-  bool get isPill => props[_$key__isPill___$TagProps];
-
+  bool get isPill =>
+      props[_$key__isPill___$TagProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$TagProps.isPill] to see the source code for this prop
   @override
   set isPill(bool value) => props[_$key__isPill___$TagProps] = value;

--- a/web/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/src/demo_components/toggle_button.over_react.g.dart
@@ -26,8 +26,9 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// Go to [_$ToggleButtonProps.autoFocus] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  bool get autoFocus => props[_$key__autoFocus___$ToggleButtonProps];
-
+  bool get autoFocus =>
+      props[_$key__autoFocus___$ToggleButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ToggleButtonProps.autoFocus] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -37,8 +38,9 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// Go to [_$ToggleButtonProps.defaultChecked] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  bool get defaultChecked => props[_$key__defaultChecked___$ToggleButtonProps];
-
+  bool get defaultChecked =>
+      props[_$key__defaultChecked___$ToggleButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ToggleButtonProps.defaultChecked] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -48,8 +50,9 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// Go to [_$ToggleButtonProps.checked] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  bool get checked => props[_$key__checked___$ToggleButtonProps];
-
+  bool get checked =>
+      props[_$key__checked___$ToggleButtonProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ToggleButtonProps.checked] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -125,8 +128,9 @@ abstract class _$ToggleButtonStateAccessorsMixin
 
   /// Go to [_$ToggleButtonState.isFocused] to see the source code for this prop
   @override
-  bool get isFocused => state[_$key__isFocused___$ToggleButtonState];
-
+  bool get isFocused =>
+      state[_$key__isFocused___$ToggleButtonState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ToggleButtonState.isFocused] to see the source code for this prop
   @override
   set isFocused(bool value) =>
@@ -134,8 +138,9 @@ abstract class _$ToggleButtonStateAccessorsMixin
 
   /// Go to [_$ToggleButtonState.isChecked] to see the source code for this prop
   @override
-  bool get isChecked => state[_$key__isChecked___$ToggleButtonState];
-
+  bool get isChecked =>
+      state[_$key__isChecked___$ToggleButtonState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$ToggleButtonState.isChecked] to see the source code for this prop
   @override
   set isChecked(bool value) =>

--- a/web/src/shared/constants.over_react.g.dart
+++ b/web/src/shared/constants.over_react.g.dart
@@ -16,8 +16,9 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// Go to [_$AbstractInputPropsMixin.name] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  String get name => props[_$key__name___$AbstractInputPropsMixin];
-
+  String get name =>
+      props[_$key__name___$AbstractInputPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractInputPropsMixin.name] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -27,8 +28,9 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// Go to [_$AbstractInputPropsMixin.value] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
-  dynamic get value => props[_$key__value___$AbstractInputPropsMixin];
-
+  dynamic get value =>
+      props[_$key__value___$AbstractInputPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractInputPropsMixin.value] to see the source code for this prop
   @override
   @Accessor(keyNamespace: '')
@@ -38,8 +40,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// Go to [_$AbstractInputPropsMixin.toggleType] to see the source code for this prop
   @override
   ToggleBehaviorType get toggleType =>
-      props[_$key__toggleType___$AbstractInputPropsMixin];
-
+      props[_$key__toggleType___$AbstractInputPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractInputPropsMixin.toggleType] to see the source code for this prop
   @override
   set toggleType(ToggleBehaviorType value) =>
@@ -81,16 +83,18 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
 
   /// Go to [_$AbstractInputStateMixin.id] to see the source code for this prop
   @override
-  String get id => state[_$key__id___$AbstractInputStateMixin];
-
+  String get id =>
+      state[_$key__id___$AbstractInputStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractInputStateMixin.id] to see the source code for this prop
   @override
   set id(String value) => state[_$key__id___$AbstractInputStateMixin] = value;
 
   /// Go to [_$AbstractInputStateMixin.name] to see the source code for this prop
   @override
-  String get name => state[_$key__name___$AbstractInputStateMixin];
-
+  String get name =>
+      state[_$key__name___$AbstractInputStateMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// Go to [_$AbstractInputStateMixin.name] to see the source code for this prop
   @override
   set name(String value) =>


### PR DESCRIPTION
## Ultimate problem:
Uninitialized key-value pairs in Maps are treated differently between dart2js compiled output and ddc compiled output. Details: https://github.com/dart-lang/sdk/issues/36052

## How it was fixed:
Add a null aware operator and explicitly return null in generated prop/state getters when the `props` or `state` map does not contain a value for the key for any prop/state member

## Testing suggestions:
* CI Passes (tests added)

## Potential areas of regression:
None
