### PR TITLE
CPLAT-4646: Add empty `$` prefixed props mixins for backwards compatible consumers

### DIFF
--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -20,6 +20,12 @@ import 'package:over_react/over_react.dart';
 
 part 'abstract_transition_props.over_react.g.dart';
 
+
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $TransitionPropsMixin {}
+
 /// Props that mirror the implementation of [AbstractTransitionProps], made available as a mixin for components
 /// that cannot extend directly from [AbstractTransitionComponent].
 @PropsMixin()

--- a/lib/src/component/aria_mixin.dart
+++ b/lib/src/component/aria_mixin.dart
@@ -23,6 +23,11 @@ import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'aria_mixin.over_react.g.dart';
 
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $AriaPropsMixin {}
+
 /// Typed getters/setters for accessibility props.
 /// To be used as a mixin for React components and builders.
 @PropsMixin(keyNamespace: '')

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -24,6 +24,11 @@ import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'prop_mixins.over_react.g.dart';
 
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $ReactPropsMixin {}
+
 /// Typed getters/setters for reserved React props.
 /// To be used as a mixin for React components and builders.
 @PropsMixin(keyNamespace: '')
@@ -53,6 +58,11 @@ abstract class _$ReactPropsMixin {
   /// See: <https://facebook.github.io/react/docs/more-about-refs.html>.
   dynamic ref;
 }
+
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $DomPropsMixin {}
 
 /// Typed getters/setters for reserved DOM-related props.
 /// To be used as a mixin for React components and builders.
@@ -107,6 +117,11 @@ abstract class _$DomPropsMixin {
   bool autoFocus;
 }
 
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $SvgPropsMixin {}
+
 @PropsMixin(keyNamespace: '')
 abstract class _$SvgPropsMixin {
   Map get props;
@@ -117,6 +132,10 @@ abstract class _$SvgPropsMixin {
     strokeOpacity, strokeWidth, textAnchor, transform, version, viewBox, x1, x2, x, xlinkActuate, xlinkArcrole,
     xlinkHref, xlinkRole, xlinkShow, xlinkTitle, xlinkType, xmlBase, xmlLang, xmlSpace, y1, y2, y;
 }
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $UbiquitousDomPropsMixin {}
 
 /// Typed getters/setters for reserved DOM-related props that can be used by all UIP components.
 /// To be used as a mixin for React components and builders.

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -65,6 +65,11 @@ part 'resize_sensor.over_react.g.dart';
 @Factory()
 UiFactory<ResizeSensorProps> ResizeSensor = _$ResizeSensor;
 
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $ResizeSensorPropsMixin {}
+
 @PropsMixin()
 abstract class _$ResizeSensorPropsMixin {
   static final ResizeSensorPropsMixinMapView defaultProps = new ResizeSensorPropsMixinMapView({})

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -25,6 +25,12 @@ import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'class_names.over_react.g.dart';
 
+
+/// This class is only present to allow for consumers which have used the
+/// --backwards-compat flag with over_react_codemod to statically analyze:
+/// <https://github.com/Workiva/over_react_codemod/blob/71e5713ec6c256ddaf7c616ff9d6d26d77bb8f25/README.md#dart-1-to-dart-2-codemod>
+abstract class $CssClassPropsMixin {}
+
 /// Typed getters/setters for props related to CSS class manipulation.
 ///
 /// Universally available on all OverReact components via [UiProps].


### PR DESCRIPTION
## Ultimate problem:
Over react 2.x+dart2 is using the Dart 2 only compatible boilerplate, since it does not have to be Dart 1 compatible. However, consumers who have been codemodded with backwards compatible over_react boilerplate will expect `$` prefixed props/state mixins to be exported from over_react. 

## How it was fixed:
Add empty `$` prefixed mixins for Props mixin (there are no state mixins).

## Testing suggestions:
* CI Passes

## Potential areas of regression:
None

