### PR TITLE
CPLAT-4217 CPLAT-4216 Release over_react 2.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.0.0+dart2
+version: 2.1.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-4297: Use `+dart1` suffix instead of `-dart1`](https://github.com/Workiva/over_react/pull/248)
* [CPLAT-3616 Warn consumers about props / state mutation](https://github.com/Workiva/over_react/pull/249)
* [CPLAT-4326: Check for git changes after build](https://github.com/Workiva/over_react/pull/250)
* [CPLAT-4360: Set auto_apply to dependents](https://github.com/Workiva/over_react/pull/251)
* [CPLAT-4476: Create workaround for ddc bug related to uninitialized maps](https://github.com/Workiva/over_react/pull/252)
* [CPLAT-4646: Add empty `$` prefixed props mixins for backwards compatible consumers](https://github.com/Workiva/over_react/pull/253)
* [CPLAT-4110 Add Dart 2 only IDE snippets](https://github.com/Workiva/over_react/pull/254)
* [CPLAT-4674: Add workaround for ddc bug via props/state impl constructor](https://github.com/Workiva/over_react/pull/256)


Requested by: @corwinsheahan-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.0.0...Workiva:release_over_react_2.1.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.0.0...2.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)