### PR TITLE
CPLAT-4217 CPLAT-4216 Release over_react 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,26 @@
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0)
 > - Dart 1 (no changes)
 
-- [#254][#254] Add IDE snippets (WebStorm/IntelliJ and VSCode) for Dart2-only
+- [#254] Add IDE snippets (WebStorm/IntelliJ and VSCode) for Dart2-only
   component boilerplate.
 
-- [#253][#253] Fix a bug that would cause a runtime exception for consumers that
-  are leveraging the backwards-compatible component boilerplate when mixing in
-  a `@PropsMixin` or `@StateMixin` from this package.
+- [#253] Fix a bug that would cause a runtime exception for consumers that are
+  leveraging the backwards-compatible component boilerplate when mixing in a
+  `@PropsMixin` or `@StateMixin` from this package.
 
-- [#256][#256] Workaround a Dart Dev Compiler bug that affects private
-  props/state members and classes.
+- [#256] Workaround a Dart Dev Compiler bug that affects private props/state
+  members and classes.
 
-- [#252][#252] Workaround the following Dart Dev Compiler bug that results in
+- [#252] Workaround the following Dart Dev Compiler bug that results in
   incorrect behavior in certain scenarios when using uninitialized props/state
   fields: [dart-lang/sdk#36052](https://github.com/dart-lang/sdk/issues/36052)
 
-- [#251][#251] Update the builder's `auto_apply` option to `dependents` instead
-  of `all_packages`. This means it will only run on packages that explicitly
+- [#251] Update the builder's `auto_apply` option to `dependents` instead of
+  `all_packages`. This means it will only run on packages that explicitly
   declare a dependency on `over_react`, which makes more sense for the purpose
   of this builder _and_ is more performant because it runs on fewer packages.
 
-- [#250][#250] Fail CI if changes are detected after running a build via
+- [#250] Fail CI if changes are detected after running a build via
   `pub run build_runner build`. This ensures that we don't forget to commit
   changes to generated files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # OverReact Changelog
 
+## 2.1.0
+
+> Complete `2.1.0` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0)
+> - Dart 1 (no changes)
+
+- [#254][#254] Add IDE snippets (WebStorm/IntelliJ and VSCode) for Dart2-only
+  component boilerplate.
+
+- [#253][#253] Fix a bug that would cause a runtime exception for consumers that
+  are leveraging the backwards-compatible component boilerplate when mixing in
+  a `@PropsMixin` or `@StateMixin` from this package.
+
+- [#256][#256] Workaround a Dart Dev Compiler bug that affects private
+  props/state members and classes.
+
+- [#252][#252] Workaround the following Dart Dev Compiler bug that results in
+  incorrect behavior in certain scenarios when using uninitialized props/state
+  fields: [dart-lang/sdk#36052](https://github.com/dart-lang/sdk/issues/36052)
+
+- [#251][#251] Update the builder's `auto_apply` option to `dependents` instead
+  of `all_packages`. This means it will only run on packages that explicitly
+  declare a dependency on `over_react`, which makes more sense for the purpose
+  of this builder _and_ is more performant because it runs on fewer packages.
+
+- [#250][#250] Fail CI if changes are detected after running a build via
+  `pub run build_runner build`. This ensures that we don't forget to commit
+  changes to generated files.
+
 ## 2.0.0
 
 > [Complete `2.0.0` Changeset](https://github.com/Workiva/over_react/compare/1.31.0...2.0.0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ For every release, do the following:
 
    - Ensure the build passes.
 
+   - Merge the Dart 1 release and publish it to pub.
+
 1. Trigger the `over_react 2.x.x` release second and review the PR:
 
    - Ensure the updated `pubspec.yaml` version is correct.
@@ -65,9 +67,7 @@ For every release, do the following:
 
    - **Add any necessary changelog updates to the Dart 2 version.**
 
-1. **Merge the Dart 1 release first and publish it to pub.**
-
-1. Merge the Dart 2 release second and publish it to pub.
+   - Merge the Dart 2 release and publish it to pub.
 
 1. Re-recreate the Dart 1 release in MARV (it does not get recreated
    automatically like the default release does).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.0.0+dart2
+version: 2.1.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-4297: Use `+dart1` suffix instead of `-dart1`](https://github.com/Workiva/over_react/pull/248)
* [CPLAT-3616 Warn consumers about props / state mutation](https://github.com/Workiva/over_react/pull/249)
* [CPLAT-4326: Check for git changes after build](https://github.com/Workiva/over_react/pull/250)
* [CPLAT-4360: Set auto_apply to dependents](https://github.com/Workiva/over_react/pull/251)
* [CPLAT-4476: Create workaround for ddc bug related to uninitialized maps](https://github.com/Workiva/over_react/pull/252)
* [CPLAT-4646: Add empty `$` prefixed props mixins for backwards compatible consumers](https://github.com/Workiva/over_react/pull/253)
* [CPLAT-4110 Add Dart 2 only IDE snippets](https://github.com/Workiva/over_react/pull/254)
* [CPLAT-4674: Add workaround for ddc bug via props/state impl constructor](https://github.com/Workiva/over_react/pull/256)


Requested by: @corwinsheahan-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.0.0...Workiva:release_over_react_2.1.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.0.0...2.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)