### PR TITLE
CPLAT-4749 Release over_react 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OverReact Changelog
 
+## 1.32.0
+
+> [Complete `1.32.0` Changeset](https://github.com/Workiva/over_react/compare/1.31.0...1.32.0)
+
+* [#249] Warn consumers about props / state mutation 
+  * Directly mutating props and state is an antipattern and can cause unpredictable rendering.
+      Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).
+
 ## 1.31.0
 
 > [Complete `1.31.0` Changeset](https://github.com/Workiva/over_react/compare/1.30.2...1.31.0)

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -247,7 +247,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     var unwrappedProps = this.unwrappedProps;
     var typedProps = _typedPropsCache[unwrappedProps];
     if (typedProps == null) {
-      typedProps = typedPropsFactory(unwrappedProps);
+      typedProps = typedPropsFactory(WarnOnModify(unwrappedProps));
       _typedPropsCache[unwrappedProps] = typedProps;
     }
     return typedProps;
@@ -417,7 +417,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-      typedState = typedStateFactory(unwrappedState);
+      typedState = typedStateFactory(WarnOnModify(unwrappedState));
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;
@@ -446,6 +446,18 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
   // ----------------------------------------------------------------------
 }
 
+class WarnOnModify<K, V> extends MapView<K, V> {
+  WarnOnModify(Map componentData): super(componentData);
+  
+  @override
+  operator []=(K key, V value) {
+    assert(
+      super[key] != value,
+      'Mutating the state or props directly will soon be impossible without causing breakages.'
+    );
+    super[key] = value;
+  }
+}
 
 /// A `dart.collection.MapView`-like class with strongly-typed getters/setters for React state.
 ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -448,15 +448,12 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
 }
 
 class _WarnOnModify<K, V> extends MapView<K, V> {
-
   //Used to customize warning based on whether the data is props or state
   bool isProps;
 
   String message;
 
-  _WarnOnModify(Map componentData, bool isProps): super(componentData){
-    this.isProps = isProps;
-  }
+  _WarnOnModify(Map componentData, this.isProps): super(componentData);
 
   @override
   operator []=(K key, V value) {

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -248,7 +248,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
     var unwrappedProps = this.unwrappedProps;
     var typedProps = _typedPropsCache[unwrappedProps];
     if (typedProps == null) {
-      typedProps = typedPropsFactory(inReactDevMode ? _WarnOnModify(unwrappedProps, true) : unwrappedProps);
+      typedProps = typedPropsFactory(inReactDevMode ? new _WarnOnModify(unwrappedProps, true) : unwrappedProps);
       _typedPropsCache[unwrappedProps] = typedProps;
     }
     return typedProps;
@@ -418,7 +418,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-    typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedState, false) : unwrappedState);
+    typedState = typedStateFactory(inReactDevMode ? new _WarnOnModify(unwrappedState, false) : unwrappedState);
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -418,7 +418,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
     var unwrappedState = this.unwrappedState;
     var typedState = _typedStateCache[unwrappedState];
     if (typedState == null) {
-      typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedProps, false) : unwrappedProps);
+    typedState = typedStateFactory(inReactDevMode ? _WarnOnModify(unwrappedState, false) : unwrappedState);
       _typedStateCache[unwrappedState] = typedState;
     }
     return typedState;
@@ -452,6 +452,8 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
   //Used to customize warning based on whether the data is props or state
   bool isProps;
 
+  String message;
+
   _WarnOnModify(Map componentData, bool isProps): super(componentData){
     this.isProps = isProps;
   }
@@ -459,24 +461,22 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
   @override
   operator []=(K key, V value) {
     if (isProps) {
-      window.console.warn(unindent(
+      message =
         '''
           props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; props must be updated only by passing in new values when rerendering this component.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
-        '''
-      ));
+        ''';
     } else {
-      window.console.warn(unindent(
+      message =
         '''
-          state["$key"] was updated incorrectly. Never this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
+          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
-        '''
-      ));
+        ''';
     }
-
     super[key] = value;
+    ValidationUtil.warn(message);
   }
 }
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -448,7 +448,7 @@ abstract class UiStatefulComponent<TProps extends UiProps, TState extends UiStat
 
 class WarnOnModify<K, V> extends MapView<K, V> {
   WarnOnModify(Map componentData): super(componentData);
-  
+
   @override
   operator []=(K key, V value) {
     assert(

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -463,14 +463,16 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
     if (isProps) {
       message =
         '''
-          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; props must be updated only by passing in new values when rerendering this component.
+          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; 
+          props must be updated only by passing in new values when re-rendering this component.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
         ''';
     } else {
       message =
         '''
-          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; state must be updated only via setState.
+          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; 
+          state must be updated only via setState.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
         ''';

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -475,7 +475,7 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
         ''';
     }
     super[key] = value;
-    ValidationUtil.warn(message);
+    ValidationUtil.warn(unindent(message));
   }
 }
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -452,7 +452,7 @@ class WarnOnModify<K, V> extends MapView<K, V> {
   @override
   operator []=(K key, V value) {
     assert(
-      super[key] != value,
+      false,
       'Mutating the state or props directly will soon be impossible without causing breakages.'
     );
     super[key] = value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.31.0
+version: 1.32.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -125,13 +125,14 @@ main() {
       }, testOn: '!js');
 
       test('warns against setting props directly', () {
+        startRecordingValidationWarnings();
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
+        var test = () => component.props['id'] = 'test';
 
-        expect(() {
-          component.props['id'] = 'test';
-        }, throwsA(const TypeMatcher<AssertionError>()));
-      }, testOn: '!js');
+        test();
+        verifyValidationWarning(contains('Never mutate this.props directly'));
+      });
 
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
@@ -867,10 +868,11 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            expect(() {
-              statefulComponent.state['test'] = true;
-            }, throwsA(const TypeMatcher<AssertionError>()));
-          }, testOn: '!js');
+            var changeState = () => statefulComponent.state['test'] = true;
+
+            changeState();
+            verifyValidationWarning(contains('Never mutate this.state directly'));
+          });
         });
 
         group('setter:', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -129,7 +129,6 @@ main() {
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
         var changeProps = () => component.props['id'] = 'test';
-
         changeProps();
         verifyValidationWarning(contains('Never mutate this.props directly'));
         stopRecordingValidationWarnings();
@@ -871,7 +870,6 @@ main() {
           test('warns against setting state directly', () {
             startRecordingValidationWarnings();
             var changeState = () => statefulComponent.state['test'] = true;
-
             changeState();
             verifyValidationWarning(contains('Never mutate this.state directly'));
             stopRecordingValidationWarnings();

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -124,6 +124,15 @@ main() {
         _commonNonInvokedBuilderTests(Dom.div());
       }, testOn: '!js');
 
+      test('warns against setting props directly', () {
+
+        var instance = render(TestComponent()());
+        var component = getDartComponent(instance);
+        var changeProps = () => component.props['id'] = 'test';
+
+        expect(changeProps, throwsA(const TypeMatcher<AssertionError>()));
+      });
+
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
 
@@ -829,7 +838,7 @@ main() {
 
       setUp(() {
         statefulComponent = new TestStatefulComponentComponent();
-        statefulComponent.unwrappedState = {};
+        statefulComponent.unwrappedState = {'test': true};
       });
 
       group('`state`', () {
@@ -855,6 +864,12 @@ main() {
             var stateAfterChange = statefulComponent.state;
 
             expect(stateBeforeChange, isNot(same(stateAfterChange)));
+          });
+
+          test('warns against setting state directly', () {
+            var changeState = () => statefulComponent.state['test'] = true;
+
+            expect(changeState, throwsA(const TypeMatcher<AssertionError>()));
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -869,10 +869,12 @@ main() {
           });
 
           test('warns against setting state directly', () {
+            startRecordingValidationWarnings();
             var changeState = () => statefulComponent.state['test'] = true;
 
             changeState();
             verifyValidationWarning(contains('Never mutate this.state directly'));
+            stopRecordingValidationWarnings();
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -131,7 +131,7 @@ main() {
         expect(() {
           component.props['id'] = 'test';
         }, throwsA(const TypeMatcher<AssertionError>()));
-      });
+      }, testOn: '!js');
 
       group('renders a DOM component with the correct children when', () {
         _commonVariadicChildrenTests(Dom.div());
@@ -867,11 +867,11 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            
+
             expect(() {
               statefulComponent.state['test'] = true;
             }, throwsA(const TypeMatcher<AssertionError>()));
-          });
+          }, testOn: '!js');
         });
 
         group('setter:', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -125,7 +125,6 @@ main() {
       }, testOn: '!js');
 
       test('warns against setting props directly', () {
-
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
         var changeProps = () => component.props['id'] = 'test';

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -128,10 +128,11 @@ main() {
         startRecordingValidationWarnings();
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
-        var test = () => component.props['id'] = 'test';
+        var changeProps = () => component.props['id'] = 'test';
 
-        test();
+        changeProps();
         verifyValidationWarning(contains('Never mutate this.props directly'));
+        stopRecordingValidationWarnings();
       });
 
       group('renders a DOM component with the correct children when', () {

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -127,9 +127,10 @@ main() {
       test('warns against setting props directly', () {
         var instance = render(TestComponent()());
         var component = getDartComponent(instance);
-        var changeProps = () => component.props['id'] = 'test';
 
-        expect(changeProps, throwsA(const TypeMatcher<AssertionError>()));
+        expect(() {
+          component.props['id'] = 'test';
+        }, throwsA(const TypeMatcher<AssertionError>()));
       });
 
       group('renders a DOM component with the correct children when', () {
@@ -866,9 +867,10 @@ main() {
           });
 
           test('warns against setting state directly', () {
-            var changeState = () => statefulComponent.state['test'] = true;
-
-            expect(changeState, throwsA(const TypeMatcher<AssertionError>()));
+            
+            expect(() {
+              statefulComponent.state['test'] = true;
+            }, throwsA(const TypeMatcher<AssertionError>()));
           });
         });
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -867,7 +867,6 @@ main() {
           });
 
           test('warns against setting state directly', () {
-
             expect(() {
               statefulComponent.state['test'] = true;
             }, throwsA(const TypeMatcher<AssertionError>()));


### PR DESCRIPTION
Backpatch of #249 into the Dart 1.x line so that consumers get warnings without having to wait until they switch to Dart 2.

> * [#249] Warn consumers about props / state mutation 
>   * Directly mutating props and state is an antipattern and can cause unpredictable rendering.
>      Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).

