### PR TITLE
CPLAT-4739 CPLAT-4738 Release over_react 2.2.0+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,27 @@
 # OverReact Changelog
 
+## 2.2.0
+
+> Complete `2.2.0` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.1.0+dart2...2.2.0+dart1)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.1.0+dart1...2.2.0+dart1)
+
+- [#249] Warn consumers about props / state mutation 
+  - Directly mutating props and state is an antipattern and can cause unpredictable rendering.
+      Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).
+
+- [#255] Update for future compatibility with `react` 5.0.0
 ## 2.1.0
 
 > Complete `2.1.0` Changsets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0)
 > - Dart 1 (no changes)
+
+- [#249] Warn consumers about props / state mutation 
+  - Directly mutating props and state is an antipattern and can cause unpredictable rendering.
+      Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).
 
 - [#254] Add IDE snippets (WebStorm/IntelliJ and VSCode) for Dart2-only
   component boilerplate.
@@ -65,6 +81,14 @@ __Breaking Changes__
 * Removals:
   * `getJsProps()` - use `getProps()` instead
   * `$Props` and `$PropKeys` - see the migration guide above
+
+## 1.32.0
+
+> [Complete `1.32.0` Changeset](https://github.com/Workiva/over_react/compare/1.31.0...1.32.0)
+
+* [#249] Warn consumers about props / state mutation 
+  * Directly mutating props and state is an antipattern and can cause unpredictable rendering.
+      Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).
 
 ## 1.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > Complete `2.2.0` Changsets:
 >
-> - [Dart 2](https://github.com/Workiva/over_react/compare/2.1.0+dart2...2.2.0+dart1)
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.1.0+dart2...2.2.0+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.1.0+dart1...2.2.0+dart1)
 
 - [#249] Warn consumers about props / state mutation 
@@ -12,11 +12,12 @@
       Avoiding this will be especially important for components to behave correctly in React 16's [concurrent mode](https://reactjs.org/blog/2018/11/27/react-16-roadmap.html#react-16x-q2-2019-the-one-with-concurrent-mode).
 
 - [#255] Update for future compatibility with `react` 5.0.0
+
 ## 2.1.0
 
 > Complete `2.1.0` Changsets:
 >
-> - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0)
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0+dart2)
 > - Dart 1 (no changes)
 
 - [#249] Warn consumers about props / state mutation 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.1.0+dart2
+version: 2.2.0+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-4460: Make compatible for use with react.dart 5.0.0-wip](https://github.com/Workiva/over_react/pull/255)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.2.0+dart1...Workiva:release_over_react_2.2.0+dart2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.2.0+dart1...2.2.0+dart2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)