### PR TITLE
CPLAT-4935 Copy doc comments to generated accessors

### DIFF
--- a/example/builder/abstract_inheritance.over_react.g.dart
+++ b/example/builder/abstract_inheritance.over_react.g.dart
@@ -20,12 +20,12 @@ abstract class _$SubPropsAccessorsMixin implements _$SubProps {
   @override
   Map get props;
 
-  /// Go to [_$SubProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubProps.subProp] -->
   @override
   String get subProp =>
       props[_$key__subProp___$SubProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SubProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubProps.subProp] -->
   @override
   set subProp(String value) => props[_$key__subProp___$SubProps] = value;
   /* GENERATED CONSTANTS */
@@ -85,12 +85,12 @@ abstract class _$SubStateAccessorsMixin implements _$SubState {
   @override
   Map get state;
 
-  /// Go to [_$SubState.subState] to see the source code for this prop
+  /// <!-- Generated from [_$SubState.subState] -->
   @override
   String get subState =>
       state[_$key__subState___$SubState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SubState.subState] to see the source code for this prop
+  /// <!-- Generated from [_$SubState.subState] -->
   @override
   set subState(String value) => state[_$key__subState___$SubState] = value;
   /* GENERATED CONSTANTS */
@@ -161,12 +161,12 @@ abstract class _$SuperPropsAccessorsMixin implements _$SuperProps {
   @override
   Map get props;
 
-  /// Go to [_$SuperProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperProps.superProp] -->
   @override
   String get superProp =>
       props[_$key__superProp___$SuperProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SuperProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperProps.superProp] -->
   @override
   set superProp(String value) => props[_$key__superProp___$SuperProps] = value;
   /* GENERATED CONSTANTS */
@@ -193,12 +193,12 @@ abstract class _$SuperStateAccessorsMixin implements _$SuperState {
   @override
   Map get state;
 
-  /// Go to [_$SuperState.superState] to see the source code for this prop
+  /// <!-- Generated from [_$SuperState.superState] -->
   @override
   String get superState =>
       state[_$key__superState___$SuperState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SuperState.superState] to see the source code for this prop
+  /// <!-- Generated from [_$SuperState.superState] -->
   @override
   set superState(String value) =>
       state[_$key__superState___$SuperState] = value;

--- a/example/builder/basic.over_react.g.dart
+++ b/example/builder/basic.over_react.g.dart
@@ -20,61 +20,61 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
   /* GENERATED CONSTANTS */

--- a/example/builder/basic_library.over_react.g.dart
+++ b/example/builder/basic_library.over_react.g.dart
@@ -22,62 +22,62 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>
       props[_$key__basicProp___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
       props[_$key__basic1___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
       props[_$key__basic2___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
       props[_$key__basic3___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
       props[_$key__basic4___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
       props[_$key__basic5___$BasicPartOfLibProps] = value;
@@ -175,12 +175,12 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   String get basicState =>
       state[_$key__basicState___$BasicPartOfLibState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
       state[_$key__basicState___$BasicPartOfLibState] = value;
@@ -272,12 +272,12 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   String get subProp =>
       props[_$key__subProp___$SubPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
       props[_$key__subProp___$SubPartOfLibProps] = value;
@@ -366,12 +366,12 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   String get superProp =>
       props[_$key__superProp___$SuperPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>
       props[_$key__superProp___$SuperPartOfLibProps] = value;

--- a/example/builder/basic_with_state.over_react.g.dart
+++ b/example/builder/basic_with_state.over_react.g.dart
@@ -20,57 +20,57 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
   /* GENERATED CONSTANTS */
@@ -157,12 +157,12 @@ abstract class _$BasicStateAccessorsMixin implements _$BasicState {
   @override
   Map get state;
 
-  /// Go to [_$BasicState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicState.basicState] -->
   @override
   String get basicState =>
       state[_$key__basicState___$BasicState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicState.basicState] -->
   @override
   set basicState(String value) =>
       state[_$key__basicState___$BasicState] = value;

--- a/example/builder/basic_with_type_params.over_react.g.dart
+++ b/example/builder/basic_with_type_params.over_react.g.dart
@@ -21,22 +21,22 @@ abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
   @override
   Map get props;
 
-  /// Go to [_$BasicProps.someGenericListProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.someGenericListProp] -->
   @override
   List<T> get someGenericListProp =>
       props[_$key__someGenericListProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.someGenericListProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.someGenericListProp] -->
   @override
   set someGenericListProp(List<T> value) =>
       props[_$key__someGenericListProp___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.somePropsClass] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.somePropsClass] -->
   @override
   U get somePropsClass =>
       props[_$key__somePropsClass___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.somePropsClass] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.somePropsClass] -->
   @override
   set somePropsClass(U value) =>
       props[_$key__somePropsClass___$BasicProps] = value;

--- a/example/builder/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/generic_inheritance_sub.over_react.g.dart
@@ -21,12 +21,12 @@ abstract class _$GenericSubPropsAccessorsMixin implements _$GenericSubProps {
   @override
   Map get props;
 
-  /// Go to [_$GenericSubProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSubProps.subProp] -->
   @override
   String get subProp =>
       props[_$key__subProp___$GenericSubProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSubProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSubProps.subProp] -->
   @override
   set subProp(String value) => props[_$key__subProp___$GenericSubProps] = value;
   /* GENERATED CONSTANTS */
@@ -92,12 +92,12 @@ abstract class _$GenericSubStateAccessorsMixin implements _$GenericSubState {
   @override
   Map get state;
 
-  /// Go to [_$GenericSubState.subState] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSubState.subState] -->
   @override
   String get subState =>
       state[_$key__subState___$GenericSubState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSubState.subState] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSubState.subState] -->
   @override
   set subState(String value) =>
       state[_$key__subState___$GenericSubState] = value;

--- a/example/builder/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/generic_inheritance_super.over_react.g.dart
@@ -22,32 +22,32 @@ abstract class _$GenericSuperPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$GenericSuperProps.otherSuperProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.otherSuperProp] -->
   @override
   String get otherSuperProp =>
       props[_$key__otherSuperProp___$GenericSuperProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSuperProps.otherSuperProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.otherSuperProp] -->
   @override
   set otherSuperProp(String value) =>
       props[_$key__otherSuperProp___$GenericSuperProps] = value;
 
-  /// Go to [_$GenericSuperProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.superProp] -->
   @override
   String get superProp =>
       props[_$key__superProp___$GenericSuperProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSuperProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.superProp] -->
   @override
   set superProp(String value) =>
       props[_$key__superProp___$GenericSuperProps] = value;
 
-  /// Go to [_$GenericSuperProps.superProp1] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.superProp1] -->
   @override
   String get superProp1 =>
       props[_$key__superProp1___$GenericSuperProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSuperProps.superProp1] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperProps.superProp1] -->
   @override
   set superProp1(String value) =>
       props[_$key__superProp1___$GenericSuperProps] = value;
@@ -127,12 +127,12 @@ abstract class _$GenericSuperStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$GenericSuperState.superState] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperState.superState] -->
   @override
   String get superState =>
       state[_$key__superState___$GenericSuperState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$GenericSuperState.superState] to see the source code for this prop
+  /// <!-- Generated from [_$GenericSuperState.superState] -->
   @override
   set superState(String value) =>
       state[_$key__superState___$GenericSuperState] = value;

--- a/example/builder/private_component.over_react.g.dart
+++ b/example/builder/private_component.over_react.g.dart
@@ -21,12 +21,12 @@ abstract class _$_PrivatePropsAccessorsMixin implements _$_PrivateProps {
   @override
   Map get props;
 
-  /// Go to [_$_PrivateProps.prop1] to see the source code for this prop
+  /// <!-- Generated from [_$_PrivateProps.prop1] -->
   @override
   bool get prop1 =>
       props[_$key__prop1___$_PrivateProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$_PrivateProps.prop1] to see the source code for this prop
+  /// <!-- Generated from [_$_PrivateProps.prop1] -->
   @override
   set prop1(bool value) => props[_$key__prop1___$_PrivateProps] = value;
   /* GENERATED CONSTANTS */
@@ -87,12 +87,12 @@ abstract class _$_PrivateStateAccessorsMixin implements _$_PrivateState {
   @override
   Map get state;
 
-  /// Go to [_$_PrivateState.state1] to see the source code for this prop
+  /// <!-- Generated from [_$_PrivateState.state1] -->
   @override
   bool get state1 =>
       state[_$key__state1___$_PrivateState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$_PrivateState.state1] to see the source code for this prop
+  /// <!-- Generated from [_$_PrivateState.state1] -->
   @override
   set state1(bool value) => state[_$key__state1___$_PrivateState] = value;
   /* GENERATED CONSTANTS */

--- a/example/builder/private_factory_public_component.over_react.g.dart
+++ b/example/builder/private_factory_public_component.over_react.g.dart
@@ -22,12 +22,12 @@ abstract class _$FormActionInputPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$FormActionInputProps.prop1] to see the source code for this prop
+  /// <!-- Generated from [_$FormActionInputProps.prop1] -->
   @override
   String get prop1 =>
       props[_$key__prop1___$FormActionInputProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FormActionInputProps.prop1] to see the source code for this prop
+  /// <!-- Generated from [_$FormActionInputProps.prop1] -->
   @override
   set prop1(String value) =>
       props[_$key__prop1___$FormActionInputProps] = value;

--- a/example/builder/props_mixin.over_react.g.dart
+++ b/example/builder/props_mixin.over_react.g.dart
@@ -12,12 +12,12 @@ abstract class ExamplePropsMixinClass implements _$ExamplePropsMixinClass {
 
   static const PropsMeta meta = _$metaForExamplePropsMixinClass;
 
-  /// Go to [_$ExamplePropsMixinClass.propMixin1] to see the source code for this prop
+  /// <!-- Generated from [_$ExamplePropsMixinClass.propMixin1] -->
   @override
   String get propMixin1 =>
       props[_$key__propMixin1___$ExamplePropsMixinClass] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ExamplePropsMixinClass.propMixin1] to see the source code for this prop
+  /// <!-- Generated from [_$ExamplePropsMixinClass.propMixin1] -->
   @override
   set propMixin1(String value) =>
       props[_$key__propMixin1___$ExamplePropsMixinClass] = value;
@@ -47,12 +47,12 @@ abstract class MixesInOtherMixinMixin<T extends Iterable, U>
 
   static const PropsMeta meta = _$metaForMixesInOtherMixinMixin;
 
-  /// Go to [_$MixesInOtherMixinMixin.otherPropMixin] to see the source code for this prop
+  /// <!-- Generated from [_$MixesInOtherMixinMixin.otherPropMixin] -->
   @override
   String get otherPropMixin =>
       props[_$key__otherPropMixin___$MixesInOtherMixinMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$MixesInOtherMixinMixin.otherPropMixin] to see the source code for this prop
+  /// <!-- Generated from [_$MixesInOtherMixinMixin.otherPropMixin] -->
   @override
   set otherPropMixin(String value) =>
       props[_$key__otherPropMixin___$MixesInOtherMixinMixin] = value;

--- a/example/builder/state_mixin.over_react.g.dart
+++ b/example/builder/state_mixin.over_react.g.dart
@@ -12,12 +12,12 @@ abstract class ExampleStateMixinClass implements _$ExampleStateMixinClass {
 
   static const StateMeta meta = _$metaForExampleStateMixinClass;
 
-  /// Go to [_$ExampleStateMixinClass.stateMixin1] to see the source code for this prop
+  /// <!-- Generated from [_$ExampleStateMixinClass.stateMixin1] -->
   @override
   String get stateMixin1 =>
       state[_$key__stateMixin1___$ExampleStateMixinClass] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ExampleStateMixinClass.stateMixin1] to see the source code for this prop
+  /// <!-- Generated from [_$ExampleStateMixinClass.stateMixin1] -->
   @override
   set stateMixin1(String value) =>
       state[_$key__stateMixin1___$ExampleStateMixinClass] = value;

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -411,12 +411,33 @@ class ImplGenerator {
                 ? typeString
                 : '${field.covariantKeyword} $typeString';
 
+            // Carry over the existing doc comment since IDEs don't inherit
+            // doc comments for some reason.
+            String docComment;
+            if (variable.documentationComment == null) {
+              docComment = '';
+            } else {
+              final existingCommentSource = sourceFile.getText(
+                  variable.documentationComment.offset,
+                  variable.documentationComment.end);
+              docComment =
+                  '$existingCommentSource\n'
+                  '  ///\n';
+            }
+            // Provide a link to the original declaration:
+            // - for better UX in VS Code, since the "Dart: Go to Super Class/Method" action isn't easily discoverable
+            // - to provide a reminder to the user that they probably want to look at the original declaration
+            //
+            // Use an HTML comment so it isn't rendered to the hover/quickdoc, which clutters up the comment.
+            // Even inside comments, this link will be clickable in IDEs!
+            docComment += '  /// <!-- Generated from [$consumerClassName.$accessorName] -->';
+
             String generatedAccessor =
-                '  /// Go to [$consumerClassName.$accessorName] to see the source code for this prop\n'
+                '  $docComment\n'
                 '  @override\n'
                 '${metadataSrc.toString()}'
                 '  ${typeString}get $accessorName => $proxiedMapName[$keyConstantName] ?? null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;\n'
-                '  /// Go to [$consumerClassName.$accessorName] to see the source code for this prop\n'
+                '  $docComment\n'
                 '  @override\n'
                 '${metadataSrc.toString()}'
                 '  set $accessorName(${setterTypeString}value) => $proxiedMapName[$keyConstantName] = value;\n';

--- a/lib/src/component/abstract_transition.over_react.g.dart
+++ b/lib/src/component/abstract_transition.over_react.g.dart
@@ -32,12 +32,20 @@ abstract class _$AbstractTransitionStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$AbstractTransitionState.transitionPhase] to see the source code for this prop
+  /// The current phase of transition the [AbstractTransitionComponent] is in.
+  ///
+  /// Default:  [AbstractTransitionComponent.initiallyShown] ? [TransitionPhase.SHOWN] : [TransitionPhase.HIDDEN]
+  ///
+  /// <!-- Generated from [_$AbstractTransitionState.transitionPhase] -->
   @override
   TransitionPhase get transitionPhase =>
       state[_$key__transitionPhase___$AbstractTransitionState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractTransitionState.transitionPhase] to see the source code for this prop
+  /// The current phase of transition the [AbstractTransitionComponent] is in.
+  ///
+  /// Default:  [AbstractTransitionComponent.initiallyShown] ? [TransitionPhase.SHOWN] : [TransitionPhase.HIDDEN]
+  ///
+  /// <!-- Generated from [_$AbstractTransitionState.transitionPhase] -->
   @override
   set transitionPhase(TransitionPhase value) =>
       state[_$key__transitionPhase___$AbstractTransitionState] = value;

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -14,72 +14,124 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   static final TransitionPropsMapView defaultProps =
       new TransitionPropsMapView({})..transitionCount = 1;
 
-  /// Go to [_$TransitionPropsMixin.transitionCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is shown/hidden.
+  ///
+  /// Serves as the default for [transitionInCount]/[transitionOutCount] when they are not specified.
+  ///
+  /// Default: `1`
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionCount] -->
   @override
   int get transitionCount =>
       props[_$key__transitionCount___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.transitionCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is shown/hidden.
+  ///
+  /// Serves as the default for [transitionInCount]/[transitionOutCount] when they are not specified.
+  ///
+  /// Default: `1`
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionCount] -->
   @override
   set transitionCount(int value) =>
       props[_$key__transitionCount___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.transitionInCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is shown.
+  ///
+  /// Default: [transitionCount]
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionInCount] -->
   @override
   int get transitionInCount =>
       props[_$key__transitionInCount___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.transitionInCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is shown.
+  ///
+  /// Default: [transitionCount]
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionInCount] -->
   @override
   set transitionInCount(int value) =>
       props[_$key__transitionInCount___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.transitionOutCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is hidden.
+  ///
+  /// Default: [transitionCount]
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionOutCount] -->
   @override
   int get transitionOutCount =>
       props[_$key__transitionOutCount___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.transitionOutCount] to see the source code for this prop
+  /// The number of `transitionend` event that occur when the transition node is hidden.
+  ///
+  /// Default: [transitionCount]
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.transitionOutCount] -->
   @override
   set transitionOutCount(int value) =>
       props[_$key__transitionOutCount___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.onWillHide] to see the source code for this prop
+  /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will remain visible.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onWillHide] -->
   @override
   Callback get onWillHide =>
       props[_$key__onWillHide___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.onWillHide] to see the source code for this prop
+  /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will remain visible.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onWillHide] -->
   @override
   set onWillHide(Callback value) =>
       props[_$key__onWillHide___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.onDidHide] to see the source code for this prop
+  /// Optional callback that fires after the [AbstractTransitionComponent] is hidden.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onDidHide] -->
   @override
   Callback get onDidHide =>
       props[_$key__onDidHide___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.onDidHide] to see the source code for this prop
+  /// Optional callback that fires after the [AbstractTransitionComponent] is hidden.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onDidHide] -->
   @override
   set onDidHide(Callback value) =>
       props[_$key__onDidHide___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.onWillShow] to see the source code for this prop
+  /// Optional callback that fires before the [AbstractTransitionComponent] appears.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will not appear.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onWillShow] -->
   @override
   Callback get onWillShow =>
       props[_$key__onWillShow___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.onWillShow] to see the source code for this prop
+  /// Optional callback that fires before the [AbstractTransitionComponent] appears.
+  ///
+  /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will not appear.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onWillShow] -->
   @override
   set onWillShow(Callback value) =>
       props[_$key__onWillShow___$TransitionPropsMixin] = value;
 
-  /// Go to [_$TransitionPropsMixin.onDidShow] to see the source code for this prop
+  /// Optional callback that fires after the [AbstractTransitionComponent] appears.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onDidShow] -->
   @override
   Callback get onDidShow =>
       props[_$key__onDidShow___$TransitionPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionPropsMixin.onDidShow] to see the source code for this prop
+  /// Optional callback that fires after the [AbstractTransitionComponent] appears.
+  ///
+  /// <!-- Generated from [_$TransitionPropsMixin.onDidShow] -->
   @override
   set onDidShow(Callback value) =>
       props[_$key__onDidShow___$TransitionPropsMixin] = value;

--- a/lib/src/component/aria_mixin.over_react.g.dart
+++ b/lib/src/component/aria_mixin.over_react.g.dart
@@ -12,408 +12,1640 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
 
   static const PropsMeta meta = _$metaForAriaPropsMixin;
 
-  /// Go to [_$AriaPropsMixin.activedescendant] to see the source code for this prop
+  /// Identifies the currently active descendant of a compositewidget.
+  ///
+  /// This is used when a composite widget is responsible for managing its current active child
+  /// to reduce the overhead of having all children be focusable. Examples include: multi-level
+  /// lists, trees, and grids. In some implementations the user agent may use aria-activedescendant
+  /// to tell assistive technologies that the active descendant has focus. Authors MAY use the aria-activedescendant
+  /// attribute on the focused descendant of a composite widget; for example, on a textbox descendant
+  /// of a combo box.
+  ///
+  /// Authors SHOULD ensure that the element targeted by the aria-activedescendant attribute is
+  /// either a descendant of the container in the DOM, or is a logical descendant as indicated by
+  /// the aria-owns attribute. The user agent is not expected to validate that the active descendant
+  /// is a descendant of the container. Authors SHOULD ensure that the currently active descendant
+  /// is visible and in view (or scrolls into view) when focused.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-activedescendant>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.activedescendant] -->
   @override
   @Accessor(key: 'aria-activedescendant')
   String get activedescendant =>
       props[_$key__activedescendant___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.activedescendant] to see the source code for this prop
+  /// Identifies the currently active descendant of a compositewidget.
+  ///
+  /// This is used when a composite widget is responsible for managing its current active child
+  /// to reduce the overhead of having all children be focusable. Examples include: multi-level
+  /// lists, trees, and grids. In some implementations the user agent may use aria-activedescendant
+  /// to tell assistive technologies that the active descendant has focus. Authors MAY use the aria-activedescendant
+  /// attribute on the focused descendant of a composite widget; for example, on a textbox descendant
+  /// of a combo box.
+  ///
+  /// Authors SHOULD ensure that the element targeted by the aria-activedescendant attribute is
+  /// either a descendant of the container in the DOM, or is a logical descendant as indicated by
+  /// the aria-owns attribute. The user agent is not expected to validate that the active descendant
+  /// is a descendant of the container. Authors SHOULD ensure that the currently active descendant
+  /// is visible and in view (or scrolls into view) when focused.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-activedescendant>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.activedescendant] -->
   @override
   @Accessor(key: 'aria-activedescendant')
   set activedescendant(String value) =>
       props[_$key__activedescendant___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.atomic] to see the source code for this prop
+  /// Indicates whether assistive technologies will present all, or only parts of, the changed region
+  /// based on the change notifications defined by the aria-relevant attribute. See related aria-relevant.
+  ///
+  /// Both accessibility APIs and the Document Object Model [DOM] provide events to allow the assistive
+  /// technologies to determine changed areas of the document.
+  ///
+  /// When the content of a live region changes, user agents SHOULD examine the changed element
+  /// and traverse the ancestors to find the first element with aria-atomic set, and apply the appropriate
+  /// behavior for the cases below.
+  ///
+  /// If none of the ancestors have explicitly set aria-atomic, the default is that aria-atomic
+  /// is false, and assistive technologies will only present the changed node to the user.If aria-atomic
+  /// is explicitly set to false, assistive technologies will stop searching up the ancestor chain
+  /// and present only the changed node to the user.If aria-atomic is explicitly set to true, assistive
+  /// technologies will present the entire contents of the element.
+  ///
+  /// When aria-atomic is true, assistive technologies MAY choose to combine several changes and
+  /// present the entire changed region at once.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-atomic>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.atomic] -->
   @override
   @Accessor(key: 'aria-atomic')
   bool get atomic =>
       props[_$key__atomic___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.atomic] to see the source code for this prop
+  /// Indicates whether assistive technologies will present all, or only parts of, the changed region
+  /// based on the change notifications defined by the aria-relevant attribute. See related aria-relevant.
+  ///
+  /// Both accessibility APIs and the Document Object Model [DOM] provide events to allow the assistive
+  /// technologies to determine changed areas of the document.
+  ///
+  /// When the content of a live region changes, user agents SHOULD examine the changed element
+  /// and traverse the ancestors to find the first element with aria-atomic set, and apply the appropriate
+  /// behavior for the cases below.
+  ///
+  /// If none of the ancestors have explicitly set aria-atomic, the default is that aria-atomic
+  /// is false, and assistive technologies will only present the changed node to the user.If aria-atomic
+  /// is explicitly set to false, assistive technologies will stop searching up the ancestor chain
+  /// and present only the changed node to the user.If aria-atomic is explicitly set to true, assistive
+  /// technologies will present the entire contents of the element.
+  ///
+  /// When aria-atomic is true, assistive technologies MAY choose to combine several changes and
+  /// present the entire changed region at once.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-atomic>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.atomic] -->
   @override
   @Accessor(key: 'aria-atomic')
   set atomic(bool value) => props[_$key__atomic___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.autocomplete] to see the source code for this prop
+  /// Indicates whether user input completion suggestions are provided.
+  ///
+  /// For a textbox with the aria-autocomplete attribute set to either inline or both, authors SHOULD
+  /// ensure that any auto-completed text is selected, so the user can type over it.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.autocomplete] -->
   @override
   @Accessor(key: 'aria-autocomplete')
   dynamic get autocomplete =>
       props[_$key__autocomplete___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.autocomplete] to see the source code for this prop
+  /// Indicates whether user input completion suggestions are provided.
+  ///
+  /// For a textbox with the aria-autocomplete attribute set to either inline or both, authors SHOULD
+  /// ensure that any auto-completed text is selected, so the user can type over it.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-autocomplete>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.autocomplete] -->
   @override
   @Accessor(key: 'aria-autocomplete')
   set autocomplete(dynamic value) =>
       props[_$key__autocomplete___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.busy] to see the source code for this prop
+  /// Indicates whether an element, and its subtree, are currently being updated.
+  ///
+  /// The default is that aria-busy is false. If authors know that multiple parts of the same element
+  /// need to be loaded or modified, they can set aria-busy to true when the first part is loaded,
+  /// and then set aria-busy to false when the last part is loaded. When a widget is missing required
+  /// owned elements due to script execution or loading, authors MUST mark a containing element
+  /// with aria-busy equal to true. For example, until a page is fully initialized and complete,
+  /// an author could mark the document element as busy. If there is an error updating the element,
+  /// author MAY set the aria-invalid attribute to true.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-busy>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.busy] -->
   @override
   @Accessor(key: 'aria-busy')
   bool get busy =>
       props[_$key__busy___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.busy] to see the source code for this prop
+  /// Indicates whether an element, and its subtree, are currently being updated.
+  ///
+  /// The default is that aria-busy is false. If authors know that multiple parts of the same element
+  /// need to be loaded or modified, they can set aria-busy to true when the first part is loaded,
+  /// and then set aria-busy to false when the last part is loaded. When a widget is missing required
+  /// owned elements due to script execution or loading, authors MUST mark a containing element
+  /// with aria-busy equal to true. For example, until a page is fully initialized and complete,
+  /// an author could mark the document element as busy. If there is an error updating the element,
+  /// author MAY set the aria-invalid attribute to true.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-busy>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.busy] -->
   @override
   @Accessor(key: 'aria-busy')
   set busy(bool value) => props[_$key__busy___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.checked] to see the source code for this prop
+  /// Indicates the current "checked" state of checkboxes, radio buttons, and other widgets. See
+  /// related aria-pressed and aria-selected.
+  ///
+  /// The aria-checked attribute indicates whether the element is checked (true), unchecked (false),
+  /// or represents a group of other elements that have a mixture of checked and unchecked values
+  /// (mixed). Most inputs only support values of true and false, but the mixed value is supported
+  /// by certain tri-state inputs such as a checkbox or menuitemcheckbox.
+  ///
+  /// The mixed value is not supported on radio or menuitemradio or any element that inherits from
+  /// these in the taxonomy, and user agents MUST treat a mixed value as equivalent to false for
+  /// those roles.
+  ///
+  /// Examples using the mixed value of tri-state inputs are covered in WAI-ARIA Authoring Practices
+  /// [ARIA-PRACTICES]
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-checked>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.checked] -->
   @override
   @Accessor(key: 'aria-checked')
   dynamic get checked =>
       props[_$key__checked___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.checked] to see the source code for this prop
+  /// Indicates the current "checked" state of checkboxes, radio buttons, and other widgets. See
+  /// related aria-pressed and aria-selected.
+  ///
+  /// The aria-checked attribute indicates whether the element is checked (true), unchecked (false),
+  /// or represents a group of other elements that have a mixture of checked and unchecked values
+  /// (mixed). Most inputs only support values of true and false, but the mixed value is supported
+  /// by certain tri-state inputs such as a checkbox or menuitemcheckbox.
+  ///
+  /// The mixed value is not supported on radio or menuitemradio or any element that inherits from
+  /// these in the taxonomy, and user agents MUST treat a mixed value as equivalent to false for
+  /// those roles.
+  ///
+  /// Examples using the mixed value of tri-state inputs are covered in WAI-ARIA Authoring Practices
+  /// [ARIA-PRACTICES]
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-checked>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.checked] -->
   @override
   @Accessor(key: 'aria-checked')
   set checked(dynamic value) => props[_$key__checked___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.controls] to see the source code for this prop
+  /// Identifies the element (or elements) whose contents or presence are controlled by the current
+  /// element. See related aria-owns.
+  ///
+  /// For example:
+  ///
+  /// A table of contents tree view may control the content of a neighboring document pane.A group
+  /// of checkboxes may control what commodity prices are tracked live in a table or graph.A tab
+  /// controls the display of its associated tab panel.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-controls>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.controls] -->
   @override
   @Accessor(key: 'aria-controls')
   dynamic get controls =>
       props[_$key__controls___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.controls] to see the source code for this prop
+  /// Identifies the element (or elements) whose contents or presence are controlled by the current
+  /// element. See related aria-owns.
+  ///
+  /// For example:
+  ///
+  /// A table of contents tree view may control the content of a neighboring document pane.A group
+  /// of checkboxes may control what commodity prices are tracked live in a table or graph.A tab
+  /// controls the display of its associated tab panel.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-controls>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.controls] -->
   @override
   @Accessor(key: 'aria-controls')
   set controls(dynamic value) =>
       props[_$key__controls___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.describedby] to see the source code for this prop
+  /// Identifies the element (or elements) that describes the object. See related aria-labelledby.
+  ///
+  /// The aria-labelledby attribute is similar to aria-describedby in that both reference other
+  /// elements to calculate a text alternative, but a label should be concise, where a description
+  /// is intended to provide more verbose information.
+  ///
+  /// The element or elements referenced by the aria-describedby comprise the entire description.
+  /// Include ID references to multiple elements if necessary, or enclose a set of elements (e.g.,
+  /// paragraphs) with the element referenced by the ID.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.describedby] -->
   @override
   @Accessor(key: 'aria-describedby')
   dynamic get describedby =>
       props[_$key__describedby___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.describedby] to see the source code for this prop
+  /// Identifies the element (or elements) that describes the object. See related aria-labelledby.
+  ///
+  /// The aria-labelledby attribute is similar to aria-describedby in that both reference other
+  /// elements to calculate a text alternative, but a label should be concise, where a description
+  /// is intended to provide more verbose information.
+  ///
+  /// The element or elements referenced by the aria-describedby comprise the entire description.
+  /// Include ID references to multiple elements if necessary, or enclose a set of elements (e.g.,
+  /// paragraphs) with the element referenced by the ID.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.describedby] -->
   @override
   @Accessor(key: 'aria-describedby')
   set describedby(dynamic value) =>
       props[_$key__describedby___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.disabled] to see the source code for this prop
+  /// Indicates that the element is perceivable but disabled, so it is not editable or otherwise
+  /// operable. See related aria-hidden and aria-readonly.
+  ///
+  /// For example, irrelevant options in a radio group may be disabled. Disabled elements might
+  /// not receive focus from the tab order. For some disabled elements, applications might choose
+  /// not to support navigation to descendants. In addition to setting the aria-disabled attribute,
+  /// authors SHOULD change the appearance (grayed out, etc.) to indicate that the item has been
+  /// disabled.
+  ///
+  /// The state of being disabled applies to the current element and all focusable descendant elements
+  /// of the element on which the aria-disabled attribute is applied.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.disabled] -->
   @override
   @Accessor(key: 'aria-disabled')
   bool get disabled =>
       props[_$key__disabled___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.disabled] to see the source code for this prop
+  /// Indicates that the element is perceivable but disabled, so it is not editable or otherwise
+  /// operable. See related aria-hidden and aria-readonly.
+  ///
+  /// For example, irrelevant options in a radio group may be disabled. Disabled elements might
+  /// not receive focus from the tab order. For some disabled elements, applications might choose
+  /// not to support navigation to descendants. In addition to setting the aria-disabled attribute,
+  /// authors SHOULD change the appearance (grayed out, etc.) to indicate that the item has been
+  /// disabled.
+  ///
+  /// The state of being disabled applies to the current element and all focusable descendant elements
+  /// of the element on which the aria-disabled attribute is applied.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-disabled>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.disabled] -->
   @override
   @Accessor(key: 'aria-disabled')
   set disabled(bool value) => props[_$key__disabled___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.dropeffect] to see the source code for this prop
+  /// Indicates what functions can be performed when the dragged object is released on the drop
+  /// target. This allows assistive technologies to convey the possible drag options available to
+  /// users, including whether a pop-up menu of choices is provided by the application. Typically,
+  /// drop effect functions can only be provided once an object has been grabbed for a drag operation
+  /// as the drop effect functions available are dependent on the object being dragged.
+  ///
+  /// More than one drop effect may be supported for a given element. Therefore, the value of this
+  /// attribute is a space-delimited set of tokens indicating the possible effects, or none if there
+  /// is no supported operation. In addition to setting the aria-dropeffect attribute, authors SHOULD
+  /// show a visual indication of potential drop targets.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-dropeffect>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.dropeffect] -->
   @override
   @Accessor(key: 'aria-dropeffect')
   dynamic get dropeffect =>
       props[_$key__dropeffect___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.dropeffect] to see the source code for this prop
+  /// Indicates what functions can be performed when the dragged object is released on the drop
+  /// target. This allows assistive technologies to convey the possible drag options available to
+  /// users, including whether a pop-up menu of choices is provided by the application. Typically,
+  /// drop effect functions can only be provided once an object has been grabbed for a drag operation
+  /// as the drop effect functions available are dependent on the object being dragged.
+  ///
+  /// More than one drop effect may be supported for a given element. Therefore, the value of this
+  /// attribute is a space-delimited set of tokens indicating the possible effects, or none if there
+  /// is no supported operation. In addition to setting the aria-dropeffect attribute, authors SHOULD
+  /// show a visual indication of potential drop targets.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-dropeffect>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.dropeffect] -->
   @override
   @Accessor(key: 'aria-dropeffect')
   set dropeffect(dynamic value) =>
       props[_$key__dropeffect___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.expanded] to see the source code for this prop
+  /// Indicates whether the element, or another grouping element it controls, is currently expanded
+  /// or collapsed.
+  ///
+  /// For example, this indicates whether a portion of a tree is expanded or collapsed. In other
+  /// instances, this may be applied to page sections to mark expandable and collapsible regions
+  /// that are flexible for managing content density. Simplifying the user interface by collapsing
+  /// sections may improve usability for all, including those with cognitive or developmental disabilities.
+  ///
+  /// If the element with the aria-expanded attribute controls the expansion of another grouping
+  /// container that is not 'owned by' the element, the author SHOULD reference the container by
+  /// using the aria-controls attribute.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.expanded] -->
   @override
   @Accessor(key: 'aria-expanded')
   dynamic get expanded =>
       props[_$key__expanded___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.expanded] to see the source code for this prop
+  /// Indicates whether the element, or another grouping element it controls, is currently expanded
+  /// or collapsed.
+  ///
+  /// For example, this indicates whether a portion of a tree is expanded or collapsed. In other
+  /// instances, this may be applied to page sections to mark expandable and collapsible regions
+  /// that are flexible for managing content density. Simplifying the user interface by collapsing
+  /// sections may improve usability for all, including those with cognitive or developmental disabilities.
+  ///
+  /// If the element with the aria-expanded attribute controls the expansion of another grouping
+  /// container that is not 'owned by' the element, the author SHOULD reference the container by
+  /// using the aria-controls attribute.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.expanded] -->
   @override
   @Accessor(key: 'aria-expanded')
   set expanded(dynamic value) =>
       props[_$key__expanded___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.flowto] to see the source code for this prop
+  /// Identifies the next element (or elements) in an alternate reading order of content which,
+  /// at the user's discretion, allows assistive technology to override the general default of reading
+  /// in document source order.
+  ///
+  /// When aria-flowto has a single IDREF, it allows assistive technologies to, at the user's request,
+  /// forego normal document reading order and go to the targeted object.  However, when aria-flowto
+  /// is provided with multiple IDREFS, assistive technologies SHOULD present the referenced elements
+  /// as path choices.
+  ///
+  /// In the case of one or more IDREFS, user agents or assistive technologies SHOULD give the user
+  /// the option of navigating to any of the targeted elements. The name of the path can be determined
+  /// by the name of the target element of the aria-flowto attribute. Accessibility APIs can provide
+  /// named path relationships.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-flowto>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.flowto] -->
   @override
   @Accessor(key: 'aria-flowto')
   dynamic get flowto =>
       props[_$key__flowto___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.flowto] to see the source code for this prop
+  /// Identifies the next element (or elements) in an alternate reading order of content which,
+  /// at the user's discretion, allows assistive technology to override the general default of reading
+  /// in document source order.
+  ///
+  /// When aria-flowto has a single IDREF, it allows assistive technologies to, at the user's request,
+  /// forego normal document reading order and go to the targeted object.  However, when aria-flowto
+  /// is provided with multiple IDREFS, assistive technologies SHOULD present the referenced elements
+  /// as path choices.
+  ///
+  /// In the case of one or more IDREFS, user agents or assistive technologies SHOULD give the user
+  /// the option of navigating to any of the targeted elements. The name of the path can be determined
+  /// by the name of the target element of the aria-flowto attribute. Accessibility APIs can provide
+  /// named path relationships.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-flowto>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.flowto] -->
   @override
   @Accessor(key: 'aria-flowto')
   set flowto(dynamic value) => props[_$key__flowto___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.grabbed] to see the source code for this prop
+  /// Indicates an element's "grabbed" state in a drag-and-drop operation.
+  ///
+  /// When it is set to true it has been selected for dragging, false indicates that the element
+  /// can be grabbed for a drag-and-drop operation, but is not currently grabbed, and undefined
+  /// (or no value) indicates the element cannot be grabbed (default).
+  ///
+  /// When aria-grabbed is set to true, authors SHOULD update the aria-dropeffect attribute of all
+  /// potential drop targets. When an element is not grabbed (the value is set to false, undefined,
+  /// or the attribute is removed), authors SHOULD revert the aria-dropeffect attributes of the
+  /// associated drop targets to none.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-grabbed>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.grabbed] -->
   @override
   @Accessor(key: 'aria-grabbed')
   dynamic get grabbed =>
       props[_$key__grabbed___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.grabbed] to see the source code for this prop
+  /// Indicates an element's "grabbed" state in a drag-and-drop operation.
+  ///
+  /// When it is set to true it has been selected for dragging, false indicates that the element
+  /// can be grabbed for a drag-and-drop operation, but is not currently grabbed, and undefined
+  /// (or no value) indicates the element cannot be grabbed (default).
+  ///
+  /// When aria-grabbed is set to true, authors SHOULD update the aria-dropeffect attribute of all
+  /// potential drop targets. When an element is not grabbed (the value is set to false, undefined,
+  /// or the attribute is removed), authors SHOULD revert the aria-dropeffect attributes of the
+  /// associated drop targets to none.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-grabbed>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.grabbed] -->
   @override
   @Accessor(key: 'aria-grabbed')
   set grabbed(dynamic value) => props[_$key__grabbed___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.haspopup] to see the source code for this prop
+  /// Indicates that the element has a popup context menu or sub-level menu.
+  ///
+  /// This means that activation renders conditional content. Note that ordinary tooltips are not
+  /// considered popups in this context.
+  ///
+  /// A popup is generally presented visually as a group of items that appears to be on top of the
+  /// main page content.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.haspopup] -->
   @override
   @Accessor(key: 'aria-haspopup')
   bool get haspopup =>
       props[_$key__haspopup___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.haspopup] to see the source code for this prop
+  /// Indicates that the element has a popup context menu or sub-level menu.
+  ///
+  /// This means that activation renders conditional content. Note that ordinary tooltips are not
+  /// considered popups in this context.
+  ///
+  /// A popup is generally presented visually as a group of items that appears to be on top of the
+  /// main page content.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.haspopup] -->
   @override
   @Accessor(key: 'aria-haspopup')
   set haspopup(bool value) => props[_$key__haspopup___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.hidden] to see the source code for this prop
+  /// Indicates that the element and all of its descendants are not visible or perceivable to any
+  /// user as implemented by the author. See related aria-disabled.
+  ///
+  /// If an element is only visible after some user action, authors MUST set the aria-hidden attribute
+  /// to true. When the element is presented, authors MUST set the aria-hidden attribute to false
+  /// or remove the attribute, indicating that the element is visible. Some assistive technologies
+  /// access WAI-ARIA information directly through the DOM and not through platform accessibility
+  /// supported by the browser. Authors MUST set aria-hidden="true" on content that is not displayed,
+  /// regardless of the mechanism used to hide it. This allows assistive technologies or user agents
+  /// to properly skip hidden elements in the document.
+  ///
+  /// It is recommended that authors key visibility of elements off this attribute, rather than
+  /// change visibility and separately have to remember to update this property. CSS 2 provides
+  /// a way to select on attribute values ([CSS]). The following CSS declaration makes content visible
+  /// unless the aria-hidden attribute is true; scripts need only update the value of this attribute
+  /// to change visibility:
+  ///
+  /// [aria-hidden="true"] { visibility: hidden; }
+  ///
+  /// Note: Authors are reminded that visibility:hidden and display:none apply to all CSS media
+  /// types; therefore, use of either will hide the content from assistive technologies that access
+  /// the DOM through a rendering engine. However, in order to support assistive technologies that
+  /// access the DOM directly, or other authoring techniques to visibly hide content (for example,
+  /// opacity or off-screen positioning), authors need to ensure the aria-hidden attribute is always
+  /// updated accordingly when an element is shown or hidden, unless the intent of using off-screen
+  /// positioning is to make the content visible only to screen reader users and not others.
+  ///
+  /// Authors MAY, with caution, use aria-hidden to hide visibly rendered content from assistive
+  /// technologies only if the act of hiding this content is intended to improve the experience
+  /// for users of assistive technologies by removing redundant or extraneous content. Authors using
+  /// aria-hidden to hide visible content from screen readers MUST ensure that identical or equivalent
+  /// meaning and functionality is exposed to assistive technologies.
+  ///
+  /// Note: Authors are advised to use extreme caution and consider a wide range of disabilities
+  /// when hiding visibly rendered content from assistive technologies. For example, a sighted,
+  /// dexterity-impaired individual may use voice-controlled assistive technologies to access a
+  /// visual interface. If an author hides visible link text "Go to checkout" and exposes similar,
+  /// yet non-identical link text "Check out now" to the accessibility API, the user may be unable
+  /// to access the interface they perceive using voice control. Similar problems may also arise
+  /// for screen reader users. For example, a sighted telephone support technician may attempt to
+  /// have the blind screen reader user click the "Go to checkout" link, which they may be unable
+  /// to find using a type-ahead item search ("Go to…").
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.hidden] -->
   @override
   @Accessor(key: 'aria-hidden')
   bool get hidden =>
       props[_$key__hidden___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.hidden] to see the source code for this prop
+  /// Indicates that the element and all of its descendants are not visible or perceivable to any
+  /// user as implemented by the author. See related aria-disabled.
+  ///
+  /// If an element is only visible after some user action, authors MUST set the aria-hidden attribute
+  /// to true. When the element is presented, authors MUST set the aria-hidden attribute to false
+  /// or remove the attribute, indicating that the element is visible. Some assistive technologies
+  /// access WAI-ARIA information directly through the DOM and not through platform accessibility
+  /// supported by the browser. Authors MUST set aria-hidden="true" on content that is not displayed,
+  /// regardless of the mechanism used to hide it. This allows assistive technologies or user agents
+  /// to properly skip hidden elements in the document.
+  ///
+  /// It is recommended that authors key visibility of elements off this attribute, rather than
+  /// change visibility and separately have to remember to update this property. CSS 2 provides
+  /// a way to select on attribute values ([CSS]). The following CSS declaration makes content visible
+  /// unless the aria-hidden attribute is true; scripts need only update the value of this attribute
+  /// to change visibility:
+  ///
+  /// [aria-hidden="true"] { visibility: hidden; }
+  ///
+  /// Note: Authors are reminded that visibility:hidden and display:none apply to all CSS media
+  /// types; therefore, use of either will hide the content from assistive technologies that access
+  /// the DOM through a rendering engine. However, in order to support assistive technologies that
+  /// access the DOM directly, or other authoring techniques to visibly hide content (for example,
+  /// opacity or off-screen positioning), authors need to ensure the aria-hidden attribute is always
+  /// updated accordingly when an element is shown or hidden, unless the intent of using off-screen
+  /// positioning is to make the content visible only to screen reader users and not others.
+  ///
+  /// Authors MAY, with caution, use aria-hidden to hide visibly rendered content from assistive
+  /// technologies only if the act of hiding this content is intended to improve the experience
+  /// for users of assistive technologies by removing redundant or extraneous content. Authors using
+  /// aria-hidden to hide visible content from screen readers MUST ensure that identical or equivalent
+  /// meaning and functionality is exposed to assistive technologies.
+  ///
+  /// Note: Authors are advised to use extreme caution and consider a wide range of disabilities
+  /// when hiding visibly rendered content from assistive technologies. For example, a sighted,
+  /// dexterity-impaired individual may use voice-controlled assistive technologies to access a
+  /// visual interface. If an author hides visible link text "Go to checkout" and exposes similar,
+  /// yet non-identical link text "Check out now" to the accessibility API, the user may be unable
+  /// to access the interface they perceive using voice control. Similar problems may also arise
+  /// for screen reader users. For example, a sighted telephone support technician may attempt to
+  /// have the blind screen reader user click the "Go to checkout" link, which they may be unable
+  /// to find using a type-ahead item search ("Go to…").
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.hidden] -->
   @override
   @Accessor(key: 'aria-hidden')
   set hidden(bool value) => props[_$key__hidden___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.invalid] to see the source code for this prop
+  /// Indicates the entered value does not conform to the format expected by the application.
+  ///
+  /// If the value is computed to be invalid or out-of-range, the application author SHOULD set
+  /// this attribute to true. User agents SHOULD inform the user of the error. Application authors
+  /// SHOULD provide suggestions for corrections if they are known. Authors MAY prevent form submission
+  /// when an associated form element has its aria-invalid attribute set to true.
+  ///
+  /// When the user attempts to submit data involving a field for which aria-required is true, authors
+  /// MAY use the aria-invalid attribute to signal there is an error. However, if the user has not
+  /// attempted to submit the form, authors SHOULD NOT set the aria-invalid attribute on required
+  /// widgets simply because the user has not yet entered data.
+  ///
+  /// For future expansion, the aria-invalid attribute is an enumerated type. Any value not recognized
+  /// in the list of allowed values MUST be treated by user agents as if the value true had been
+  /// provided. If the attribute is not present, or its value is false, or its value is an empty
+  /// string, the default value of false applies.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.invalid] -->
   @override
   @Accessor(key: 'aria-invalid')
   dynamic get invalid =>
       props[_$key__invalid___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.invalid] to see the source code for this prop
+  /// Indicates the entered value does not conform to the format expected by the application.
+  ///
+  /// If the value is computed to be invalid or out-of-range, the application author SHOULD set
+  /// this attribute to true. User agents SHOULD inform the user of the error. Application authors
+  /// SHOULD provide suggestions for corrections if they are known. Authors MAY prevent form submission
+  /// when an associated form element has its aria-invalid attribute set to true.
+  ///
+  /// When the user attempts to submit data involving a field for which aria-required is true, authors
+  /// MAY use the aria-invalid attribute to signal there is an error. However, if the user has not
+  /// attempted to submit the form, authors SHOULD NOT set the aria-invalid attribute on required
+  /// widgets simply because the user has not yet entered data.
+  ///
+  /// For future expansion, the aria-invalid attribute is an enumerated type. Any value not recognized
+  /// in the list of allowed values MUST be treated by user agents as if the value true had been
+  /// provided. If the attribute is not present, or its value is false, or its value is an empty
+  /// string, the default value of false applies.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-invalid>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.invalid] -->
   @override
   @Accessor(key: 'aria-invalid')
   set invalid(dynamic value) => props[_$key__invalid___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.label] to see the source code for this prop
+  /// Defines a string value that labels the current element. See related aria-labelledby.
+  ///
+  /// The purpose of aria-label is the same as that of aria-labelledby. It provides the user with
+  /// a recognizable name of the object. The most common accessibility API mapping for a label is
+  /// the accessible name property.
+  ///
+  /// If the label text is visible on screen, authors SHOULD use aria-labelledby and SHOULD NOT
+  /// use aria-label. There may be instances where the name of an element cannot be determined programmatically
+  /// from the content of the element, and there are cases where providing a visible label is not
+  /// the desired user experience. Most host languages provide an attribute that could be used to
+  /// name the element (e.g., the title attribute in HTML [HTML]), yet this could present a browser
+  /// tooltip. In the cases where a visible label or visible tooltip is undesirable, authors MAY
+  /// set the accessible name of the element using aria-label. As required by the text alternative
+  /// computation, user agents give precedence to aria-labelledby over aria-label when computing
+  /// the accessible name property.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-label>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.label] -->
   @override
   @Accessor(key: 'aria-label')
   String get label =>
       props[_$key__label___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.label] to see the source code for this prop
+  /// Defines a string value that labels the current element. See related aria-labelledby.
+  ///
+  /// The purpose of aria-label is the same as that of aria-labelledby. It provides the user with
+  /// a recognizable name of the object. The most common accessibility API mapping for a label is
+  /// the accessible name property.
+  ///
+  /// If the label text is visible on screen, authors SHOULD use aria-labelledby and SHOULD NOT
+  /// use aria-label. There may be instances where the name of an element cannot be determined programmatically
+  /// from the content of the element, and there are cases where providing a visible label is not
+  /// the desired user experience. Most host languages provide an attribute that could be used to
+  /// name the element (e.g., the title attribute in HTML [HTML]), yet this could present a browser
+  /// tooltip. In the cases where a visible label or visible tooltip is undesirable, authors MAY
+  /// set the accessible name of the element using aria-label. As required by the text alternative
+  /// computation, user agents give precedence to aria-labelledby over aria-label when computing
+  /// the accessible name property.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-label>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.label] -->
   @override
   @Accessor(key: 'aria-label')
   set label(String value) => props[_$key__label___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.labelledby] to see the source code for this prop
+  /// Identifies the element (or elements) that labels the current element. See related aria-label
+  /// and aria-describedby.
+  ///
+  /// The purpose of aria-labelledby is the same as that of aria-label. It provides the user with
+  /// a recognizable name of the object. The most common accessibility API mapping for a label is
+  /// the accessible name property.
+  ///
+  /// If the label text is visible on screen, authors SHOULD use aria-labelledby and SHOULD NOT
+  /// use aria-label. Use aria-label only if the interface is such that it is not possible to have
+  /// a visible label on the screen. As required by the text alternative computation, user agents
+  /// give precedence to aria-labelledby over aria-label when computing the accessible name property.
+  ///
+  /// The aria-labelledby attribute is similar to aria-describedby in that both reference other
+  /// elements to calculate a text alternative, but a label should be concise, where a description
+  /// is intended to provide more verbose information.
+  ///
+  /// Note: The expected spelling of this property in U.S. English is "labeledby." However, the
+  /// accessibility API features to which this property is mapped have established the "labelledby"
+  /// spelling. This property is spelled that way to match the convention and minimize the difficulty
+  /// for developers.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.labelledby] -->
   @override
   @Accessor(key: 'aria-labelledby')
   dynamic get labelledby =>
       props[_$key__labelledby___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.labelledby] to see the source code for this prop
+  /// Identifies the element (or elements) that labels the current element. See related aria-label
+  /// and aria-describedby.
+  ///
+  /// The purpose of aria-labelledby is the same as that of aria-label. It provides the user with
+  /// a recognizable name of the object. The most common accessibility API mapping for a label is
+  /// the accessible name property.
+  ///
+  /// If the label text is visible on screen, authors SHOULD use aria-labelledby and SHOULD NOT
+  /// use aria-label. Use aria-label only if the interface is such that it is not possible to have
+  /// a visible label on the screen. As required by the text alternative computation, user agents
+  /// give precedence to aria-labelledby over aria-label when computing the accessible name property.
+  ///
+  /// The aria-labelledby attribute is similar to aria-describedby in that both reference other
+  /// elements to calculate a text alternative, but a label should be concise, where a description
+  /// is intended to provide more verbose information.
+  ///
+  /// Note: The expected spelling of this property in U.S. English is "labeledby." However, the
+  /// accessibility API features to which this property is mapped have established the "labelledby"
+  /// spelling. This property is spelled that way to match the convention and minimize the difficulty
+  /// for developers.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-labelledby>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.labelledby] -->
   @override
   @Accessor(key: 'aria-labelledby')
   set labelledby(dynamic value) =>
       props[_$key__labelledby___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.level] to see the source code for this prop
+  /// Defines the hierarchical level of an element within a structure.
+  ///
+  /// This can be applied inside trees to tree items, to headings inside a document, to nested grids,
+  /// nested tablists and to other structural items that may appear inside a container or participate
+  /// in an ownership hierarchy. The value for aria-level is an integer greater than or equal to
+  /// 1.
+  ///
+  /// Levels increase with depth. If the DOM ancestry does not accurately represent the level, authors
+  /// SHOULD explicitly define the aria-level attribute.
+  ///
+  /// This attribute is applied to elements that act as leaf nodes within the orientation of the
+  /// set, for example, on elements with role treeitem rather than elements with role group. This
+  /// means that multiple elements in a set may have the same value for this attribute. Although
+  /// it would be less repetitive to provide a single value on the container, restricting this to
+  /// leaf nodes ensures that there is a single way for assistive technologies to use the attribute.
+  ///
+  /// If the DOM ancestry accurately represents the level, the user agent can calculate the level
+  /// of an item from the document structure. This attribute can be used to provide an explicit
+  /// indication of the level when that is not possible to calculate from the document structure
+  /// or the aria-owns attribute. User agent support for automatic calculation of level may vary;
+  /// authors SHOULD test with user agents and assistive technologies to determine whether this
+  /// attribute is needed. If the author intends for the user agent to calculate the level, the
+  /// author SHOULD omit this attribute.
+  ///
+  /// Note: In the case of a treegrid, aria-level is supported on elements with the role row, not
+  /// elements with role gridcell. At first glance, this may seem inconsistent with the application
+  /// of aria-level on treeitem elements, but it is consistent in that the row acts as the leaf
+  /// node within the vertical orientation of the grid, whereas the gridcell is a leaf node within
+  /// the horizontal orientation of each row. Level is not supported on sets of cells within rows,
+  /// so the aria-level attribute is applied to the element with the role row.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-level>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.level] -->
   @override
   @Accessor(key: 'aria-level')
   int get level =>
       props[_$key__level___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.level] to see the source code for this prop
+  /// Defines the hierarchical level of an element within a structure.
+  ///
+  /// This can be applied inside trees to tree items, to headings inside a document, to nested grids,
+  /// nested tablists and to other structural items that may appear inside a container or participate
+  /// in an ownership hierarchy. The value for aria-level is an integer greater than or equal to
+  /// 1.
+  ///
+  /// Levels increase with depth. If the DOM ancestry does not accurately represent the level, authors
+  /// SHOULD explicitly define the aria-level attribute.
+  ///
+  /// This attribute is applied to elements that act as leaf nodes within the orientation of the
+  /// set, for example, on elements with role treeitem rather than elements with role group. This
+  /// means that multiple elements in a set may have the same value for this attribute. Although
+  /// it would be less repetitive to provide a single value on the container, restricting this to
+  /// leaf nodes ensures that there is a single way for assistive technologies to use the attribute.
+  ///
+  /// If the DOM ancestry accurately represents the level, the user agent can calculate the level
+  /// of an item from the document structure. This attribute can be used to provide an explicit
+  /// indication of the level when that is not possible to calculate from the document structure
+  /// or the aria-owns attribute. User agent support for automatic calculation of level may vary;
+  /// authors SHOULD test with user agents and assistive technologies to determine whether this
+  /// attribute is needed. If the author intends for the user agent to calculate the level, the
+  /// author SHOULD omit this attribute.
+  ///
+  /// Note: In the case of a treegrid, aria-level is supported on elements with the role row, not
+  /// elements with role gridcell. At first glance, this may seem inconsistent with the application
+  /// of aria-level on treeitem elements, but it is consistent in that the row acts as the leaf
+  /// node within the vertical orientation of the grid, whereas the gridcell is a leaf node within
+  /// the horizontal orientation of each row. Level is not supported on sets of cells within rows,
+  /// so the aria-level attribute is applied to the element with the role row.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-level>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.level] -->
   @override
   @Accessor(key: 'aria-level')
   set level(int value) => props[_$key__level___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.live] to see the source code for this prop
+  /// Indicates that an element will be updated, and describes the types of updates the user agents,
+  /// assistive technologies, and user can expect from the live region.
+  ///
+  /// The values of this attribute are expressed in degrees of importance. When regions are specified
+  /// as polite, assistive technologies will notify users of updates but generally do not interrupt
+  /// the current task, and updates take low priority. When regions are specified as assertive,
+  /// assistive technologies will immediately notify the user, and could potentially clear the speech
+  /// queue of previous updates. Please refer to Live Region Properties and How to Use Them ([ARIA-PRACTICES],
+  /// Section 5.2.1).
+  ///
+  /// Politeness levels are essentially an ordering mechanism for updates and serve as a strong
+  /// suggestion to user agents or assistive technologies. The value may be overridden by user agents,
+  /// assistive technologies, or the user. For example, if assistive technologies can determine
+  /// that a change occurred in response to a key press or a mouse click, the assistive technologies
+  /// may present that change immediately even if the value of the aria-live attribute states otherwise.
+  ///
+  /// Since different users have different needs, it is up to the user to tweak his or her assistive
+  /// technologies' response to a live region with a certain politeness level from the commonly
+  /// defined baseline. Assistive technologies may choose to implement increasing and decreasing
+  /// levels of granularity so that the user can exercise control over queues and interruptions.
+  ///
+  /// When the property is not set on an object that needs to send updates, the politeness level
+  /// is the value of the nearest ancestor that sets the aria-live attribute.
+  ///
+  /// The aria-live attribute is the primary determination for the order of presentation of changes
+  /// to live regions. Implementations will also consider the default level of politeness in a role
+  /// when the aria-live attribute is not set in the ancestor chain (e.g., log changes are polite
+  /// by default). Items which are assertive will be presented immediately, followed by polite items.
+  /// User agents or assistive technologies MAY choose to clear queued changes when an assertive
+  /// change occurs. (e.g., changes in an assertive region may remove all currently queued changes)
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-live>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.live] -->
   @override
   @Accessor(key: 'aria-live')
   dynamic get live =>
       props[_$key__live___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.live] to see the source code for this prop
+  /// Indicates that an element will be updated, and describes the types of updates the user agents,
+  /// assistive technologies, and user can expect from the live region.
+  ///
+  /// The values of this attribute are expressed in degrees of importance. When regions are specified
+  /// as polite, assistive technologies will notify users of updates but generally do not interrupt
+  /// the current task, and updates take low priority. When regions are specified as assertive,
+  /// assistive technologies will immediately notify the user, and could potentially clear the speech
+  /// queue of previous updates. Please refer to Live Region Properties and How to Use Them ([ARIA-PRACTICES],
+  /// Section 5.2.1).
+  ///
+  /// Politeness levels are essentially an ordering mechanism for updates and serve as a strong
+  /// suggestion to user agents or assistive technologies. The value may be overridden by user agents,
+  /// assistive technologies, or the user. For example, if assistive technologies can determine
+  /// that a change occurred in response to a key press or a mouse click, the assistive technologies
+  /// may present that change immediately even if the value of the aria-live attribute states otherwise.
+  ///
+  /// Since different users have different needs, it is up to the user to tweak his or her assistive
+  /// technologies' response to a live region with a certain politeness level from the commonly
+  /// defined baseline. Assistive technologies may choose to implement increasing and decreasing
+  /// levels of granularity so that the user can exercise control over queues and interruptions.
+  ///
+  /// When the property is not set on an object that needs to send updates, the politeness level
+  /// is the value of the nearest ancestor that sets the aria-live attribute.
+  ///
+  /// The aria-live attribute is the primary determination for the order of presentation of changes
+  /// to live regions. Implementations will also consider the default level of politeness in a role
+  /// when the aria-live attribute is not set in the ancestor chain (e.g., log changes are polite
+  /// by default). Items which are assertive will be presented immediately, followed by polite items.
+  /// User agents or assistive technologies MAY choose to clear queued changes when an assertive
+  /// change occurs. (e.g., changes in an assertive region may remove all currently queued changes)
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-live>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.live] -->
   @override
   @Accessor(key: 'aria-live')
   set live(dynamic value) => props[_$key__live___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.multiline] to see the source code for this prop
+  /// Indicates whether a text box accepts multiple lines of input or only a single line.
+  ///
+  /// Note: In most user agent implementations, the default behavior of the ENTER or RETURN key
+  /// is different between the single-line and multi-line text fields in HTML. When user has focus
+  /// in a single-line &lt;input type="text"&gt; element, the keystroke usually submits the form.
+  /// When user has focus in a multi-line &lt;textarea&gt; element, the keystroke inserts a line
+  /// break. The WAI-ARIA textbox role differentiates these types of boxes with the aria-multiline
+  /// attribute, so authors are advised to be aware of this distinction when designing the field.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-multiline>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.multiline] -->
   @override
   @Accessor(key: 'aria-multiline')
   bool get multiline =>
       props[_$key__multiline___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.multiline] to see the source code for this prop
+  /// Indicates whether a text box accepts multiple lines of input or only a single line.
+  ///
+  /// Note: In most user agent implementations, the default behavior of the ENTER or RETURN key
+  /// is different between the single-line and multi-line text fields in HTML. When user has focus
+  /// in a single-line &lt;input type="text"&gt; element, the keystroke usually submits the form.
+  /// When user has focus in a multi-line &lt;textarea&gt; element, the keystroke inserts a line
+  /// break. The WAI-ARIA textbox role differentiates these types of boxes with the aria-multiline
+  /// attribute, so authors are advised to be aware of this distinction when designing the field.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-multiline>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.multiline] -->
   @override
   @Accessor(key: 'aria-multiline')
   set multiline(bool value) =>
       props[_$key__multiline___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.multiselectable] to see the source code for this prop
+  /// Indicates that the user may select more than one item from the current selectable descendants.
+  ///
+  /// Authors SHOULD ensure that selected descendants have the aria-selected attribute set to true,
+  /// and selectable descendant have the aria-selected attribute set to false. Authors SHOULD NOT
+  /// use the aria-selected attribute on descendants that are not selectable.
+  ///
+  /// Note: Lists and trees are examples of roles that might allow users to select more than one
+  /// item at a time.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-multiselectable>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.multiselectable] -->
   @override
   @Accessor(key: 'aria-multiselectable')
   bool get multiselectable =>
       props[_$key__multiselectable___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.multiselectable] to see the source code for this prop
+  /// Indicates that the user may select more than one item from the current selectable descendants.
+  ///
+  /// Authors SHOULD ensure that selected descendants have the aria-selected attribute set to true,
+  /// and selectable descendant have the aria-selected attribute set to false. Authors SHOULD NOT
+  /// use the aria-selected attribute on descendants that are not selectable.
+  ///
+  /// Note: Lists and trees are examples of roles that might allow users to select more than one
+  /// item at a time.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-multiselectable>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.multiselectable] -->
   @override
   @Accessor(key: 'aria-multiselectable')
   set multiselectable(bool value) =>
       props[_$key__multiselectable___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.orientation] to see the source code for this prop
+  /// Indicates whether the element and orientation is horizontal or vertical.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-orientation>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.orientation] -->
   @override
   @Accessor(key: 'aria-orientation')
   dynamic get orientation =>
       props[_$key__orientation___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.orientation] to see the source code for this prop
+  /// Indicates whether the element and orientation is horizontal or vertical.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-orientation>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.orientation] -->
   @override
   @Accessor(key: 'aria-orientation')
   set orientation(dynamic value) =>
       props[_$key__orientation___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.owns] to see the source code for this prop
+  /// Identifies an element (or elements) in order to define a visual, functional, or contextual
+  /// parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent
+  /// the relationship. See related aria-controls.
+  ///
+  /// The value of the aria-owns attribute is a space-separated list of IDREFS that reference one
+  /// or more elements in the document by ID. The reason for adding aria-owns is to expose a parent/child
+  /// contextual relationship to assistive technologies that is otherwise impossible to infer from
+  /// the DOM.
+  ///
+  /// Authors SHOULD NOT use aria-owns as a replacement for the DOM hierarchy. If the relationship
+  /// is represented in the DOM, do not use aria-owns. Authors MUST ensure that an element's ID
+  /// is not specified in more than one other element's aria-owns attribute at any time. In other
+  /// words, an element can have only one explicit owner.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-owns>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.owns] -->
   @override
   @Accessor(key: 'aria-owns')
   dynamic get owns =>
       props[_$key__owns___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.owns] to see the source code for this prop
+  /// Identifies an element (or elements) in order to define a visual, functional, or contextual
+  /// parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent
+  /// the relationship. See related aria-controls.
+  ///
+  /// The value of the aria-owns attribute is a space-separated list of IDREFS that reference one
+  /// or more elements in the document by ID. The reason for adding aria-owns is to expose a parent/child
+  /// contextual relationship to assistive technologies that is otherwise impossible to infer from
+  /// the DOM.
+  ///
+  /// Authors SHOULD NOT use aria-owns as a replacement for the DOM hierarchy. If the relationship
+  /// is represented in the DOM, do not use aria-owns. Authors MUST ensure that an element's ID
+  /// is not specified in more than one other element's aria-owns attribute at any time. In other
+  /// words, an element can have only one explicit owner.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-owns>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.owns] -->
   @override
   @Accessor(key: 'aria-owns')
   set owns(dynamic value) => props[_$key__owns___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.posinset] to see the source code for this prop
+  /// Defines an element's number or position in the current set of listitems or treeitems. Not
+  /// required if all elements in the set are present in the DOM. See related aria-setsize.
+  ///
+  /// If all items in a set are present in the document structure, it is not necessary to set this
+  /// attribute, as the user agent can automatically calculate the set size and position for each
+  /// item. However, if only a portion of the set is present in the document structure at a given
+  /// moment, this property is needed to provide an explicit indication of an element's position.
+  ///
+  /// Authors MUST set the value for aria-posinset to an integer greater than or equal to 1, and
+  /// less than or equal to the size of the set. Authors SHOULD use aria-posinset in conjunction
+  /// with aria-setsize.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-posinset>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.posinset] -->
   @override
   @Accessor(key: 'aria-posinset')
   int get posinset =>
       props[_$key__posinset___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.posinset] to see the source code for this prop
+  /// Defines an element's number or position in the current set of listitems or treeitems. Not
+  /// required if all elements in the set are present in the DOM. See related aria-setsize.
+  ///
+  /// If all items in a set are present in the document structure, it is not necessary to set this
+  /// attribute, as the user agent can automatically calculate the set size and position for each
+  /// item. However, if only a portion of the set is present in the document structure at a given
+  /// moment, this property is needed to provide an explicit indication of an element's position.
+  ///
+  /// Authors MUST set the value for aria-posinset to an integer greater than or equal to 1, and
+  /// less than or equal to the size of the set. Authors SHOULD use aria-posinset in conjunction
+  /// with aria-setsize.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-posinset>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.posinset] -->
   @override
   @Accessor(key: 'aria-posinset')
   set posinset(int value) => props[_$key__posinset___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.pressed] to see the source code for this prop
+  /// Indicates the current "pressed" state of toggle buttons. See related aria-checked and aria-selected.
+  ///
+  /// Toggle buttons require a full press-and-release cycle to change their value. Activating it
+  /// once changes the value to true, and activating it another time changes the value back to false.
+  /// A value of mixed means that the values of more than one item controlled by the button do not
+  /// all share the same value. Examples of mixed-state buttons are described in WAI-ARIA Authoring
+  /// Practices [ARIA-PRACTICES]. If the attribute is not present, the button is not a toggle button.
+  ///
+  /// The aria-pressed attribute is similar but not identical to the aria-checked attribute. Operating
+  /// systems support pressed on buttons and checked on checkboxes.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.pressed] -->
   @override
   @Accessor(key: 'aria-pressed')
   dynamic get pressed =>
       props[_$key__pressed___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.pressed] to see the source code for this prop
+  /// Indicates the current "pressed" state of toggle buttons. See related aria-checked and aria-selected.
+  ///
+  /// Toggle buttons require a full press-and-release cycle to change their value. Activating it
+  /// once changes the value to true, and activating it another time changes the value back to false.
+  /// A value of mixed means that the values of more than one item controlled by the button do not
+  /// all share the same value. Examples of mixed-state buttons are described in WAI-ARIA Authoring
+  /// Practices [ARIA-PRACTICES]. If the attribute is not present, the button is not a toggle button.
+  ///
+  /// The aria-pressed attribute is similar but not identical to the aria-checked attribute. Operating
+  /// systems support pressed on buttons and checked on checkboxes.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-pressed>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.pressed] -->
   @override
   @Accessor(key: 'aria-pressed')
   set pressed(dynamic value) => props[_$key__pressed___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.readonly] to see the source code for this prop
+  ///  Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.
+  ///
+  /// This means the user can read but not set the value of the widget. Readonly elements are relevant
+  /// to the user, and application authors SHOULD NOT restrict navigation to the element or its
+  /// focusable descendants. Other actions such as copying the value of the element are also supported.
+  /// This is in contrast to disabled elements, to which applications might not allow user navigation
+  /// to descendants.
+  ///
+  /// Examples include:
+  ///
+  /// A form element which represents a constant.Row or column headers in a spreadsheet grid.The
+  /// result of a calculation such as a shopping cart total.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-readonly>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.readonly] -->
   @override
   @Accessor(key: 'aria-readonly')
   bool get readonly =>
       props[_$key__readonly___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.readonly] to see the source code for this prop
+  ///  Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.
+  ///
+  /// This means the user can read but not set the value of the widget. Readonly elements are relevant
+  /// to the user, and application authors SHOULD NOT restrict navigation to the element or its
+  /// focusable descendants. Other actions such as copying the value of the element are also supported.
+  /// This is in contrast to disabled elements, to which applications might not allow user navigation
+  /// to descendants.
+  ///
+  /// Examples include:
+  ///
+  /// A form element which represents a constant.Row or column headers in a spreadsheet grid.The
+  /// result of a calculation such as a shopping cart total.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-readonly>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.readonly] -->
   @override
   @Accessor(key: 'aria-readonly')
   set readonly(bool value) => props[_$key__readonly___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.relevant] to see the source code for this prop
+  /// Indicates what user agent change notifications (additions, removals, etc.) assistive technologies
+  /// will receive within a live region. See related aria-atomic.
+  ///
+  /// The attribute is represented as a space delimited list of the following values: additions,
+  /// removals, text; or a single catch-all value all.
+  ///
+  /// This is used to describe semantically meaningful changes, as opposed to merely presentational
+  /// ones. For example, nodes that are removed from the top of a log are merely removed for purposes
+  /// of creating room for other entries, and the removal of them does not have meaning. However,
+  /// in the case of a buddy list, removal of a buddy name indicates that they are no longer online,
+  /// and this is a meaningful event. In that case aria-relevant will be set to all. When the aria-relevant
+  /// attribute is not provided, the default value, additions text, indicates that text modifications
+  /// and node additions are relevant, but that node removals are irrelevant.
+  ///
+  /// Note: aria-relevant values of removals or all are to be used sparingly. Assistive technologies
+  /// only need to be informed of content removal when its removal represents an important change,
+  /// such as a buddy leaving a chat room.
+  ///
+  /// Note: Text removals should only be considered relevant if one of the specified values is 'removals'
+  /// or 'all'. For example, for a text change from 'foo' to 'bar' in a live region with a default
+  /// aria-relevant value, the text addition ('bar"') would be spoken, but the text removal ('foo')
+  /// would not.
+  ///
+  /// aria-relevant is an optional attribute of live regions. This is a suggestion to assistive
+  /// technologies, but assistive technologies are not required to present changes of all the relevant
+  /// types.
+  ///
+  /// Both accessibility APIs and Document Object Model Level 2 Events [DOM] provides events to
+  /// allow assistive technologies to determine changed areas of the document.
+  ///
+  /// When aria-relevant is not defined, an element's value is inherited from the nearest ancestor
+  /// with a defined value. Although the value is a token list, inherited values are not additive;
+  /// the value provided on a descendant element completely overrides any inherited value from an
+  /// ancestor element.
+  ///
+  /// When text changes are denoted as relevant, user agents MUST monitor any descendant node change
+  /// that affects the text alternative computation of the live region as if the accessible name
+  /// were determined from contents (nameFrom: contents). For example, a text change would be triggered
+  /// if the HTML alt attribute of a contained image changed. However, no change would be triggered
+  /// if there was a text change to a node outside the live region, even if that node was referenced
+  /// (via aria-labelledby) by an element contained in the live region.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-relevant>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.relevant] -->
   @override
   @Accessor(key: 'aria-relevant')
   dynamic get relevant =>
       props[_$key__relevant___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.relevant] to see the source code for this prop
+  /// Indicates what user agent change notifications (additions, removals, etc.) assistive technologies
+  /// will receive within a live region. See related aria-atomic.
+  ///
+  /// The attribute is represented as a space delimited list of the following values: additions,
+  /// removals, text; or a single catch-all value all.
+  ///
+  /// This is used to describe semantically meaningful changes, as opposed to merely presentational
+  /// ones. For example, nodes that are removed from the top of a log are merely removed for purposes
+  /// of creating room for other entries, and the removal of them does not have meaning. However,
+  /// in the case of a buddy list, removal of a buddy name indicates that they are no longer online,
+  /// and this is a meaningful event. In that case aria-relevant will be set to all. When the aria-relevant
+  /// attribute is not provided, the default value, additions text, indicates that text modifications
+  /// and node additions are relevant, but that node removals are irrelevant.
+  ///
+  /// Note: aria-relevant values of removals or all are to be used sparingly. Assistive technologies
+  /// only need to be informed of content removal when its removal represents an important change,
+  /// such as a buddy leaving a chat room.
+  ///
+  /// Note: Text removals should only be considered relevant if one of the specified values is 'removals'
+  /// or 'all'. For example, for a text change from 'foo' to 'bar' in a live region with a default
+  /// aria-relevant value, the text addition ('bar"') would be spoken, but the text removal ('foo')
+  /// would not.
+  ///
+  /// aria-relevant is an optional attribute of live regions. This is a suggestion to assistive
+  /// technologies, but assistive technologies are not required to present changes of all the relevant
+  /// types.
+  ///
+  /// Both accessibility APIs and Document Object Model Level 2 Events [DOM] provides events to
+  /// allow assistive technologies to determine changed areas of the document.
+  ///
+  /// When aria-relevant is not defined, an element's value is inherited from the nearest ancestor
+  /// with a defined value. Although the value is a token list, inherited values are not additive;
+  /// the value provided on a descendant element completely overrides any inherited value from an
+  /// ancestor element.
+  ///
+  /// When text changes are denoted as relevant, user agents MUST monitor any descendant node change
+  /// that affects the text alternative computation of the live region as if the accessible name
+  /// were determined from contents (nameFrom: contents). For example, a text change would be triggered
+  /// if the HTML alt attribute of a contained image changed. However, no change would be triggered
+  /// if there was a text change to a node outside the live region, even if that node was referenced
+  /// (via aria-labelledby) by an element contained in the live region.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-relevant>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.relevant] -->
   @override
   @Accessor(key: 'aria-relevant')
   set relevant(dynamic value) =>
       props[_$key__relevant___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.required] to see the source code for this prop
+  /// Indicates that user input is required on the element before a form may be submitted.
+  ///
+  /// For example, if the user needs to fill in an address field, the author will need to set the
+  /// field's aria-required attribute to true.
+  ///
+  /// Note: The fact that the element is required is often presented visually (such as a sign or
+  /// symbol after the widget). Using the aria-required attribute allows the author to explicitly
+  /// convey to assistive technologies that an element is required.
+  ///
+  /// Unless an exactly equivalent native attribute is available, host languages SHOULD allow authors
+  /// to use the aria-required attribute on host language form elements that require input or selection
+  /// by the user.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-required>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.required] -->
   @override
   @Accessor(key: 'aria-required')
   bool get required =>
       props[_$key__required___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.required] to see the source code for this prop
+  /// Indicates that user input is required on the element before a form may be submitted.
+  ///
+  /// For example, if the user needs to fill in an address field, the author will need to set the
+  /// field's aria-required attribute to true.
+  ///
+  /// Note: The fact that the element is required is often presented visually (such as a sign or
+  /// symbol after the widget). Using the aria-required attribute allows the author to explicitly
+  /// convey to assistive technologies that an element is required.
+  ///
+  /// Unless an exactly equivalent native attribute is available, host languages SHOULD allow authors
+  /// to use the aria-required attribute on host language form elements that require input or selection
+  /// by the user.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-required>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.required] -->
   @override
   @Accessor(key: 'aria-required')
   set required(bool value) => props[_$key__required___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.role] to see the source code for this prop
+  /// Specifies the the type defining a user interface element. Enriches the semantics of markup and
+  /// gives assistive technologies information about how to handle each element.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/usage#usage_intro>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.role] -->
   @override
   String get role =>
       props[_$key__role___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.role] to see the source code for this prop
+  /// Specifies the the type defining a user interface element. Enriches the semantics of markup and
+  /// gives assistive technologies information about how to handle each element.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/usage#usage_intro>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.role] -->
   @override
   set role(String value) => props[_$key__role___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.selected] to see the source code for this prop
+  /// Indicates the current "selected" state of various widgets. See related aria-checked and aria-pressed.
+  ///
+  /// This attribute is used with single-selection and multiple-selection widgets:
+  ///
+  /// Single-selection containers where the currently focused item is not selected. The selection
+  /// normally follows the focus, and is managed by the user agent.Multiple-selection containers.
+  /// Authors SHOULD ensure that any selectable descendant of a container in which the aria-multiselectable
+  /// attribute is true specifies a value of either true or false for the aria-selected attribute.
+  ///
+  /// Any explicit assignment of aria-selected takes precedence over the implicit selection based
+  /// on focus. If no DOM element in the widget is explicitly marked as selected, assistive technologies
+  /// MAY convey implicit selection which follows the keyboard focus of the managed focus widget.
+  /// If any DOM element in the widget is explicitly marked as selected, the user agent MUST NOT
+  /// convey implicit selection for the widget.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.selected] -->
   @override
   @Accessor(key: 'aria-selected')
   dynamic get selected =>
       props[_$key__selected___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.selected] to see the source code for this prop
+  /// Indicates the current "selected" state of various widgets. See related aria-checked and aria-pressed.
+  ///
+  /// This attribute is used with single-selection and multiple-selection widgets:
+  ///
+  /// Single-selection containers where the currently focused item is not selected. The selection
+  /// normally follows the focus, and is managed by the user agent.Multiple-selection containers.
+  /// Authors SHOULD ensure that any selectable descendant of a container in which the aria-multiselectable
+  /// attribute is true specifies a value of either true or false for the aria-selected attribute.
+  ///
+  /// Any explicit assignment of aria-selected takes precedence over the implicit selection based
+  /// on focus. If no DOM element in the widget is explicitly marked as selected, assistive technologies
+  /// MAY convey implicit selection which follows the keyboard focus of the managed focus widget.
+  /// If any DOM element in the widget is explicitly marked as selected, the user agent MUST NOT
+  /// convey implicit selection for the widget.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-selected>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.selected] -->
   @override
   @Accessor(key: 'aria-selected')
   set selected(dynamic value) =>
       props[_$key__selected___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.setsize] to see the source code for this prop
+  /// Defines the number of items in the current set of listitems or treeitems. Not required if
+  /// all elements in the set are present in the DOM. See related aria-posinset.
+  ///
+  /// This property is marked on the members of a set, not the container element that collects the
+  /// members of the set. To orient the user by saying an element is "item X out of Y," the assistive
+  /// technologies would use X equal to the aria-posinset attribute and Y equal to the aria-setsize
+  /// attribute.
+  ///
+  /// If all items in a set are present in the document structure, it is not necessary to set this
+  /// property, as the user agent can automatically calculate the set size and position for each
+  /// item. However, if only a portion of the set is present in the document structure at a given
+  /// moment (in order to reduce document size), this property is needed to provide an explicit
+  /// indication of set size.
+  ///
+  /// Authors SHOULD use aria-setsize in conjunction with aria-posinset.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-setsize>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.setsize] -->
   @override
   @Accessor(key: 'aria-setsize')
   int get setsize =>
       props[_$key__setsize___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.setsize] to see the source code for this prop
+  /// Defines the number of items in the current set of listitems or treeitems. Not required if
+  /// all elements in the set are present in the DOM. See related aria-posinset.
+  ///
+  /// This property is marked on the members of a set, not the container element that collects the
+  /// members of the set. To orient the user by saying an element is "item X out of Y," the assistive
+  /// technologies would use X equal to the aria-posinset attribute and Y equal to the aria-setsize
+  /// attribute.
+  ///
+  /// If all items in a set are present in the document structure, it is not necessary to set this
+  /// property, as the user agent can automatically calculate the set size and position for each
+  /// item. However, if only a portion of the set is present in the document structure at a given
+  /// moment (in order to reduce document size), this property is needed to provide an explicit
+  /// indication of set size.
+  ///
+  /// Authors SHOULD use aria-setsize in conjunction with aria-posinset.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-setsize>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.setsize] -->
   @override
   @Accessor(key: 'aria-setsize')
   set setsize(int value) => props[_$key__setsize___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.sort] to see the source code for this prop
+  /// Indicates if items in a table or grid are sorted in ascending or descending order.
+  ///
+  /// Authors SHOULD only apply this property to table headers or grid headers. If the property
+  /// is not provided, there is no defined sort order. For each table or grid, authors SHOULD apply
+  /// aria-sort to only one header at a time.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-sort>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.sort] -->
   @override
   @Accessor(key: 'aria-sort')
   dynamic get sort =>
       props[_$key__sort___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.sort] to see the source code for this prop
+  /// Indicates if items in a table or grid are sorted in ascending or descending order.
+  ///
+  /// Authors SHOULD only apply this property to table headers or grid headers. If the property
+  /// is not provided, there is no defined sort order. For each table or grid, authors SHOULD apply
+  /// aria-sort to only one header at a time.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-sort>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.sort] -->
   @override
   @Accessor(key: 'aria-sort')
   set sort(dynamic value) => props[_$key__sort___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.valuemax] to see the source code for this prop
+  /// Defines the maximum allowed value for a range widget.
+  ///
+  /// A range widget may start with a given value, which can be increased until a maximum value,
+  /// defined by this property, is reached.
+  ///
+  /// Declaring the minimum and maximum values allows alternate devices to react to arrow keys,
+  /// validate the current value, or simply let the user know the size of the range. If the aria-valuenow
+  /// has a known maximum and minimum, the author SHOULD provide properties for aria-valuemax and
+  /// aria-valuemin. Authors MUST ensure the value of aria-valuemax is greater than or equal to
+  /// the value of aria-valuemin.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuemax] -->
   @override
   @Accessor(key: 'aria-valuemax')
   num get valuemax =>
       props[_$key__valuemax___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.valuemax] to see the source code for this prop
+  /// Defines the maximum allowed value for a range widget.
+  ///
+  /// A range widget may start with a given value, which can be increased until a maximum value,
+  /// defined by this property, is reached.
+  ///
+  /// Declaring the minimum and maximum values allows alternate devices to react to arrow keys,
+  /// validate the current value, or simply let the user know the size of the range. If the aria-valuenow
+  /// has a known maximum and minimum, the author SHOULD provide properties for aria-valuemax and
+  /// aria-valuemin. Authors MUST ensure the value of aria-valuemax is greater than or equal to
+  /// the value of aria-valuemin.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemax>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuemax] -->
   @override
   @Accessor(key: 'aria-valuemax')
   set valuemax(num value) => props[_$key__valuemax___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.valuemin] to see the source code for this prop
+  /// Defines the minimum allowed value for a range widget.
+  ///
+  /// A range widget may start with a given value, which can be decreased until a minimum value,
+  /// defined by this property, is reached.
+  ///
+  /// Declaring the minimum and maximum values allows alternate devices to react to arrow keys,
+  /// validate the current value, or simply let the user know the size of the range. If the aria-valuenow
+  /// has a known maximum and minimum, the author SHOULD provide properties for aria-valuemax and
+  /// aria-valuemin.
+  ///
+  /// Authors MUST ensure the value of aria-valuemin is less than or equal to the value of aria-valuemax.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuemin] -->
   @override
   @Accessor(key: 'aria-valuemin')
   num get valuemin =>
       props[_$key__valuemin___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.valuemin] to see the source code for this prop
+  /// Defines the minimum allowed value for a range widget.
+  ///
+  /// A range widget may start with a given value, which can be decreased until a minimum value,
+  /// defined by this property, is reached.
+  ///
+  /// Declaring the minimum and maximum values allows alternate devices to react to arrow keys,
+  /// validate the current value, or simply let the user know the size of the range. If the aria-valuenow
+  /// has a known maximum and minimum, the author SHOULD provide properties for aria-valuemax and
+  /// aria-valuemin.
+  ///
+  /// Authors MUST ensure the value of aria-valuemin is less than or equal to the value of aria-valuemax.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuemin>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuemin] -->
   @override
   @Accessor(key: 'aria-valuemin')
   set valuemin(num value) => props[_$key__valuemin___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.valuenow] to see the source code for this prop
+  /// Defines the current value for a range widget. See related aria-valuetext.
+  ///
+  /// This property is used, for example, on a range widget such as a slider or progress bar.
+  ///
+  /// If the current value is not known (for example, an indeterminate progress bar), the author
+  /// SHOULD NOT set the aria-valuenow attribute. If the aria-valuenow attribute is absent, no information
+  /// is implied about the current value. If the aria-valuenow has a known maximum and minimum,
+  /// the author SHOULD provide properties for aria-valuemax and aria-valuemin.
+  ///
+  /// The value of aria-valuenow is a decimal number. If the range is a set of numeric values, then
+  /// aria-valuenow is one of those values. For example, if the range is [0, 1], a valid aria-valuenow
+  /// is 0.5. A value outside the range, such as -2.5 or 1.1, is invalid.
+  ///
+  /// For progressbar elements and scrollbar elements, assistive technologies SHOULD render the
+  /// value to users as a percent, calculated as a position on the range from aria-valuemin to aria-valuemax
+  /// if both are defined, otherwise the actual value with a percent indicator. For elements with
+  /// role slider and spinbutton, assistive technologies SHOULD render the actual value to users.
+  ///
+  ///
+  /// When the rendered value cannot be accurately represented as a number, authors SHOULD use the
+  /// aria-valuetext attribute in conjunction with aria-valuenow to provide a user-friendly representation
+  /// of the range's current value. For example, a slider may have rendered values of small, medium,
+  /// and large. In this case, the values of aria-valuenow could range from 1 through 3, which indicate
+  /// the position of each value in the value space, but the aria-valuetext would be one of the
+  /// strings: small, medium, or large.
+  ///
+  /// Note: If aria-valuetext is specified, assistive technologies render that instead of the value
+  /// of aria-valuenow.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuenow] -->
   @override
   @Accessor(key: 'aria-valuenow')
   num get valuenow =>
       props[_$key__valuenow___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.valuenow] to see the source code for this prop
+  /// Defines the current value for a range widget. See related aria-valuetext.
+  ///
+  /// This property is used, for example, on a range widget such as a slider or progress bar.
+  ///
+  /// If the current value is not known (for example, an indeterminate progress bar), the author
+  /// SHOULD NOT set the aria-valuenow attribute. If the aria-valuenow attribute is absent, no information
+  /// is implied about the current value. If the aria-valuenow has a known maximum and minimum,
+  /// the author SHOULD provide properties for aria-valuemax and aria-valuemin.
+  ///
+  /// The value of aria-valuenow is a decimal number. If the range is a set of numeric values, then
+  /// aria-valuenow is one of those values. For example, if the range is [0, 1], a valid aria-valuenow
+  /// is 0.5. A value outside the range, such as -2.5 or 1.1, is invalid.
+  ///
+  /// For progressbar elements and scrollbar elements, assistive technologies SHOULD render the
+  /// value to users as a percent, calculated as a position on the range from aria-valuemin to aria-valuemax
+  /// if both are defined, otherwise the actual value with a percent indicator. For elements with
+  /// role slider and spinbutton, assistive technologies SHOULD render the actual value to users.
+  ///
+  ///
+  /// When the rendered value cannot be accurately represented as a number, authors SHOULD use the
+  /// aria-valuetext attribute in conjunction with aria-valuenow to provide a user-friendly representation
+  /// of the range's current value. For example, a slider may have rendered values of small, medium,
+  /// and large. In this case, the values of aria-valuenow could range from 1 through 3, which indicate
+  /// the position of each value in the value space, but the aria-valuetext would be one of the
+  /// strings: small, medium, or large.
+  ///
+  /// Note: If aria-valuetext is specified, assistive technologies render that instead of the value
+  /// of aria-valuenow.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuenow>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuenow] -->
   @override
   @Accessor(key: 'aria-valuenow')
   set valuenow(num value) => props[_$key__valuenow___$AriaPropsMixin] = value;
 
-  /// Go to [_$AriaPropsMixin.valuetext] to see the source code for this prop
+  /// Defines the human readable text alternative of aria-valuenow for a range widget.
+  ///
+  /// This property is used, for example, on a range widget such as a slider or progress bar.
+  ///
+  /// If the aria-valuetext attribute is set, authors SHOULD also set the aria-valuenow attribute,
+  /// unless that value is unknown (for example, on an indeterminate progressbar).
+  ///
+  /// Authors SHOULD only set the aria-valuetext attribute when the rendered value cannot be meaningfully
+  /// represented as a number. For example, a slider may have rendered values of small, medium,
+  /// and large. In this case, the values of aria-valuenow could range from 1 through 3, which indicate
+  /// the position of each value in the value space, but the aria-valuetext would be one of the
+  /// strings: small, medium, or large. If the aria-valuetext attribute is absent, the assistive
+  /// technologies will rely solely on the aria-valuenow attribute for the current value.
+  ///
+  /// If aria-valuetext is specified, assistive technologies SHOULD render that value instead of
+  /// the value of aria-valuenow.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuetext] -->
   @override
   @Accessor(key: 'aria-valuetext')
   String get valuetext =>
       props[_$key__valuetext___$AriaPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AriaPropsMixin.valuetext] to see the source code for this prop
+  /// Defines the human readable text alternative of aria-valuenow for a range widget.
+  ///
+  /// This property is used, for example, on a range widget such as a slider or progress bar.
+  ///
+  /// If the aria-valuetext attribute is set, authors SHOULD also set the aria-valuenow attribute,
+  /// unless that value is unknown (for example, on an indeterminate progressbar).
+  ///
+  /// Authors SHOULD only set the aria-valuetext attribute when the rendered value cannot be meaningfully
+  /// represented as a number. For example, a slider may have rendered values of small, medium,
+  /// and large. In this case, the values of aria-valuenow could range from 1 through 3, which indicate
+  /// the position of each value in the value space, but the aria-valuetext would be one of the
+  /// strings: small, medium, or large. If the aria-valuetext attribute is absent, the assistive
+  /// technologies will rely solely on the aria-valuenow attribute for the current value.
+  ///
+  /// If aria-valuetext is specified, assistive technologies SHOULD render that value instead of
+  /// the value of aria-valuenow.
+  ///
+  /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext>
+  ///
+  /// <!-- Generated from [_$AriaPropsMixin.valuetext] -->
   @override
   @Accessor(key: 'aria-valuetext')
   set valuetext(String value) =>

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -22,22 +22,66 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ErrorBoundaryProps.onComponentDidCatch] to see the source code for this prop
+  /// An optional callback that will be called with an [Error] and a `ComponentStack`
+  /// containing information about which component in the tree threw the error when
+  /// the `componentDidCatch` lifecycle method is called.
+  ///
+  /// This callback can be used to log component errors like so:
+  ///
+  ///     (ErrorBoundary()
+  ///       ..onComponentDidCatch = (error, componentStack) {
+  ///         // It is up to you to implement the service / thing that calls the service.
+  ///         logComponentStackToAService(error, componentStack);
+  ///       }
+  ///     )(
+  ///       // The rest of your component tree
+  ///     )
+  ///
+  /// > See: <https://reactjs.org/docs/react-component.html#componentdidcatch>
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.onComponentDidCatch] -->
   @override
   _ComponentDidCatchCallback get onComponentDidCatch =>
       props[_$key__onComponentDidCatch___$ErrorBoundaryProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ErrorBoundaryProps.onComponentDidCatch] to see the source code for this prop
+  /// An optional callback that will be called with an [Error] and a `ComponentStack`
+  /// containing information about which component in the tree threw the error when
+  /// the `componentDidCatch` lifecycle method is called.
+  ///
+  /// This callback can be used to log component errors like so:
+  ///
+  ///     (ErrorBoundary()
+  ///       ..onComponentDidCatch = (error, componentStack) {
+  ///         // It is up to you to implement the service / thing that calls the service.
+  ///         logComponentStackToAService(error, componentStack);
+  ///       }
+  ///     )(
+  ///       // The rest of your component tree
+  ///     )
+  ///
+  /// > See: <https://reactjs.org/docs/react-component.html#componentdidcatch>
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.onComponentDidCatch] -->
   @override
   set onComponentDidCatch(_ComponentDidCatchCallback value) =>
       props[_$key__onComponentDidCatch___$ErrorBoundaryProps] = value;
 
-  /// Go to [_$ErrorBoundaryProps.fallbackUIRenderer] to see the source code for this prop
+  /// A renderer that will be used to render "fallback" UI instead of the child
+  /// component tree that crashed.
+  ///
+  /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.fallbackUIRenderer] -->
   @override
   _FallbackUiRenderer get fallbackUIRenderer =>
       props[_$key__fallbackUIRenderer___$ErrorBoundaryProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ErrorBoundaryProps.fallbackUIRenderer] to see the source code for this prop
+  /// A renderer that will be used to render "fallback" UI instead of the child
+  /// component tree that crashed.
+  ///
+  /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.fallbackUIRenderer] -->
   @override
   set fallbackUIRenderer(_FallbackUiRenderer value) =>
       props[_$key__fallbackUIRenderer___$ErrorBoundaryProps] = value;
@@ -112,12 +156,20 @@ abstract class _$ErrorBoundaryStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$ErrorBoundaryState.hasError] to see the source code for this prop
+  /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
+  ///
+  /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->
   @override
   bool get hasError =>
       state[_$key__hasError___$ErrorBoundaryState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ErrorBoundaryState.hasError] to see the source code for this prop
+  /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
+  ///
+  /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->
   @override
   set hasError(bool value) =>
       state[_$key__hasError___$ErrorBoundaryState] = value;

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -15,21 +15,35 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
   set key(Object value) =>
       props['key'] = value == null ? null : value.toString();
 
-  /// Go to [_$ReactPropsMixin.children] to see the source code for this prop
+  /// The children that were passed in to this component when it was built.
+  ///
+  /// <!-- Generated from [_$ReactPropsMixin.children] -->
   @override
   List get children =>
       props[_$key__children___$ReactPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ReactPropsMixin.children] to see the source code for this prop
+  /// The children that were passed in to this component when it was built.
+  ///
+  /// <!-- Generated from [_$ReactPropsMixin.children] -->
   @override
   set children(List value) => props[_$key__children___$ReactPropsMixin] = value;
 
-  /// Go to [_$ReactPropsMixin.ref] to see the source code for this prop
+  /// Either a String used to retrieve the element at a later time via [react.Component.ref],
+  /// or a Function that gets called with the element when it is mounted.
+  ///
+  /// See: <https://facebook.github.io/react/docs/more-about-refs.html>.
+  ///
+  /// <!-- Generated from [_$ReactPropsMixin.ref] -->
   @override
   dynamic get ref =>
       props[_$key__ref___$ReactPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ReactPropsMixin.ref] to see the source code for this prop
+  /// Either a String used to retrieve the element at a later time via [react.Component.ref],
+  /// or a Function that gets called with the element when it is mounted.
+  ///
+  /// See: <https://facebook.github.io/react/docs/more-about-refs.html>.
+  ///
+  /// <!-- Generated from [_$ReactPropsMixin.ref] -->
   @override
   set ref(dynamic value) => props[_$key__ref___$ReactPropsMixin] = value;
   /* GENERATED CONSTANTS */
@@ -61,1626 +75,1632 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   static const PropsMeta meta = _$metaForDomPropsMixin;
 
-  /// Go to [_$DomPropsMixin.cols] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cols] -->
   @override
   int get cols =>
       props[_$key__cols___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.cols] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cols] -->
   @override
   set cols(int value) => props[_$key__cols___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.rows] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rows] -->
   @override
   int get rows =>
       props[_$key__rows___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.rows] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rows] -->
   @override
   set rows(int value) => props[_$key__rows___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.size] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.size] -->
   @override
   int get size =>
       props[_$key__size___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.size] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.size] -->
   @override
   set size(int value) => props[_$key__size___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.span] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.span] -->
   @override
   int get span =>
       props[_$key__span___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.span] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.span] -->
   @override
   set span(int value) => props[_$key__span___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.start] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.start] -->
   @override
   int get start =>
       props[_$key__start___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.start] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.start] -->
   @override
   set start(int value) => props[_$key__start___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.allowFullScreen] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.allowFullScreen] -->
   @override
   bool get allowFullScreen =>
       props[_$key__allowFullScreen___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.allowFullScreen] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.allowFullScreen] -->
   @override
   set allowFullScreen(bool value) =>
       props[_$key__allowFullScreen___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.async] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.async] -->
   @override
   bool get async =>
       props[_$key__async___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.async] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.async] -->
   @override
   set async(bool value) => props[_$key__async___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.autoPlay] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.autoPlay] -->
   @override
   bool get autoPlay =>
       props[_$key__autoPlay___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.autoPlay] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.autoPlay] -->
   @override
   set autoPlay(bool value) => props[_$key__autoPlay___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.checked] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.checked] -->
   @override
   bool get checked =>
       props[_$key__checked___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.checked] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.checked] -->
   @override
   set checked(bool value) => props[_$key__checked___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.controls] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.controls] -->
   @override
   bool get controls =>
       props[_$key__controls___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.controls] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.controls] -->
   @override
   set controls(bool value) => props[_$key__controls___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.defer] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defer] -->
   @override
   bool get defer =>
       props[_$key__defer___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.defer] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defer] -->
   @override
   set defer(bool value) => props[_$key__defer___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.disabled] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.disabled] -->
   @override
   bool get disabled =>
       props[_$key__disabled___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.disabled] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.disabled] -->
   @override
   set disabled(bool value) => props[_$key__disabled___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.formNoValidate] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.formNoValidate] -->
   @override
   bool get formNoValidate =>
       props[_$key__formNoValidate___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.formNoValidate] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.formNoValidate] -->
   @override
   set formNoValidate(bool value) =>
       props[_$key__formNoValidate___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.hidden] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.hidden] -->
   @override
   bool get hidden =>
       props[_$key__hidden___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.hidden] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.hidden] -->
   @override
   set hidden(bool value) => props[_$key__hidden___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.loop] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.loop] -->
   @override
   bool get loop =>
       props[_$key__loop___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.loop] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.loop] -->
   @override
   set loop(bool value) => props[_$key__loop___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.multiple] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.multiple] -->
   @override
   bool get multiple =>
       props[_$key__multiple___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.multiple] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.multiple] -->
   @override
   set multiple(bool value) => props[_$key__multiple___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.muted] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.muted] -->
   @override
   bool get muted =>
       props[_$key__muted___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.muted] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.muted] -->
   @override
   set muted(bool value) => props[_$key__muted___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.noValidate] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.noValidate] -->
   @override
   bool get noValidate =>
       props[_$key__noValidate___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.noValidate] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.noValidate] -->
   @override
   set noValidate(bool value) =>
       props[_$key__noValidate___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.readOnly] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.readOnly] -->
   @override
   bool get readOnly =>
       props[_$key__readOnly___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.readOnly] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.readOnly] -->
   @override
   set readOnly(bool value) => props[_$key__readOnly___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.required] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.required] -->
   @override
   bool get required =>
       props[_$key__required___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.required] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.required] -->
   @override
   set required(bool value) => props[_$key__required___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.seamless] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.seamless] -->
   @override
   bool get seamless =>
       props[_$key__seamless___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.seamless] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.seamless] -->
   @override
   set seamless(bool value) => props[_$key__seamless___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.selected] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.selected] -->
   @override
   bool get selected =>
       props[_$key__selected___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.selected] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.selected] -->
   @override
   set selected(bool value) => props[_$key__selected___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.style] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.style] -->
   @override
   Map<String, dynamic> get style =>
       props[_$key__style___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.style] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.style] -->
   @override
   set style(Map<String, dynamic> value) =>
       props[_$key__style___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.className] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.className] -->
   @override
   String get className =>
       props[_$key__className___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.className] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.className] -->
   @override
   set className(String value) =>
       props[_$key__className___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.title] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
   String get title =>
       props[_$key__title___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.title] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
   set title(String value) => props[_$key__title___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.id] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.id] -->
   @override
   String get id =>
       props[_$key__id___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.id] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.id] -->
   @override
   set id(String value) => props[_$key__id___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.accept] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
   dynamic get accept =>
       props[_$key__accept___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.accept] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
   set accept(dynamic value) => props[_$key__accept___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.acceptCharset] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
   dynamic get acceptCharset =>
       props[_$key__acceptCharset___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.acceptCharset] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
   set acceptCharset(dynamic value) =>
       props[_$key__acceptCharset___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.accessKey] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
   dynamic get accessKey =>
       props[_$key__accessKey___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.accessKey] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
   set accessKey(dynamic value) =>
       props[_$key__accessKey___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.action] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
   dynamic get action =>
       props[_$key__action___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.action] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
   set action(dynamic value) => props[_$key__action___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.allowTransparency] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.allowTransparency] -->
   @override
   dynamic get allowTransparency =>
       props[_$key__allowTransparency___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.allowTransparency] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.allowTransparency] -->
   @override
   set allowTransparency(dynamic value) =>
       props[_$key__allowTransparency___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.alt] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.alt] -->
   @override
   dynamic get alt =>
       props[_$key__alt___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.alt] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.alt] -->
   @override
   set alt(dynamic value) => props[_$key__alt___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.autoComplete] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
   @override
   dynamic get autoComplete =>
       props[_$key__autoComplete___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.autoComplete] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
   @override
   set autoComplete(dynamic value) =>
       props[_$key__autoComplete___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.cellPadding] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cellPadding] -->
   @override
   dynamic get cellPadding =>
       props[_$key__cellPadding___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.cellPadding] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cellPadding] -->
   @override
   set cellPadding(dynamic value) =>
       props[_$key__cellPadding___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.cellSpacing] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cellSpacing] -->
   @override
   dynamic get cellSpacing =>
       props[_$key__cellSpacing___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.cellSpacing] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.cellSpacing] -->
   @override
   set cellSpacing(dynamic value) =>
       props[_$key__cellSpacing___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.charSet] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
   @override
   dynamic get charSet =>
       props[_$key__charSet___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.charSet] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
   @override
   set charSet(dynamic value) => props[_$key__charSet___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.classID] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.classID] -->
   @override
   dynamic get classID =>
       props[_$key__classID___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.classID] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.classID] -->
   @override
   set classID(dynamic value) => props[_$key__classID___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.colSpan] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
   dynamic get colSpan =>
       props[_$key__colSpan___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.colSpan] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
   set colSpan(dynamic value) => props[_$key__colSpan___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.content] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.content] -->
   @override
   dynamic get content =>
       props[_$key__content___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.content] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.content] -->
   @override
   set content(dynamic value) => props[_$key__content___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.contentEditable] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.contentEditable] -->
   @override
   dynamic get contentEditable =>
       props[_$key__contentEditable___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.contentEditable] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.contentEditable] -->
   @override
   set contentEditable(dynamic value) =>
       props[_$key__contentEditable___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.contextMenu] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
   @override
   dynamic get contextMenu =>
       props[_$key__contextMenu___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.contextMenu] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
   @override
   set contextMenu(dynamic value) =>
       props[_$key__contextMenu___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.coords] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.coords] -->
   @override
   dynamic get coords =>
       props[_$key__coords___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.coords] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.coords] -->
   @override
   set coords(dynamic value) => props[_$key__coords___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.crossOrigin] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
   @override
   dynamic get crossOrigin =>
       props[_$key__crossOrigin___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.crossOrigin] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
   @override
   set crossOrigin(dynamic value) =>
       props[_$key__crossOrigin___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.data] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.data] -->
   @override
   dynamic get data =>
       props[_$key__data___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.data] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.data] -->
   @override
   set data(dynamic value) => props[_$key__data___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.dateTime] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
   @override
   dynamic get dateTime =>
       props[_$key__dateTime___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.dateTime] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
   @override
   set dateTime(dynamic value) =>
       props[_$key__dateTime___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.dir] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.dir] -->
   @override
   dynamic get dir =>
       props[_$key__dir___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.dir] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.dir] -->
   @override
   set dir(dynamic value) => props[_$key__dir___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.download] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.download] -->
   @override
   dynamic get download =>
       props[_$key__download___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.download] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.download] -->
   @override
   set download(dynamic value) =>
       props[_$key__download___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.draggable] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.draggable] -->
   @override
   dynamic get draggable =>
       props[_$key__draggable___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.draggable] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.draggable] -->
   @override
   set draggable(dynamic value) =>
       props[_$key__draggable___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.encType] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.encType] -->
   @override
   dynamic get encType =>
       props[_$key__encType___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.encType] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.encType] -->
   @override
   set encType(dynamic value) => props[_$key__encType___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.form] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.form] -->
   @override
   dynamic get form =>
       props[_$key__form___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.form] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.form] -->
   @override
   set form(dynamic value) => props[_$key__form___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.frameBorder] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.frameBorder] -->
   @override
   dynamic get frameBorder =>
       props[_$key__frameBorder___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.frameBorder] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.frameBorder] -->
   @override
   set frameBorder(dynamic value) =>
       props[_$key__frameBorder___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.height] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.height] -->
   @override
   dynamic get height =>
       props[_$key__height___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.height] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.height] -->
   @override
   set height(dynamic value) => props[_$key__height___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.href] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.href] -->
   @override
   dynamic get href =>
       props[_$key__href___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.href] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.href] -->
   @override
   set href(dynamic value) => props[_$key__href___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.hrefLang] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
   @override
   dynamic get hrefLang =>
       props[_$key__hrefLang___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.hrefLang] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
   @override
   set hrefLang(dynamic value) =>
       props[_$key__hrefLang___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.htmlFor] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
   @override
   dynamic get htmlFor =>
       props[_$key__htmlFor___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.htmlFor] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
   @override
   set htmlFor(dynamic value) => props[_$key__htmlFor___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.httpEquiv] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
   @override
   dynamic get httpEquiv =>
       props[_$key__httpEquiv___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.httpEquiv] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
   @override
   set httpEquiv(dynamic value) =>
       props[_$key__httpEquiv___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.icon] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.icon] -->
   @override
   dynamic get icon =>
       props[_$key__icon___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.icon] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.icon] -->
   @override
   set icon(dynamic value) => props[_$key__icon___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.label] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.label] -->
   @override
   dynamic get label =>
       props[_$key__label___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.label] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.label] -->
   @override
   set label(dynamic value) => props[_$key__label___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.lang] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.lang] -->
   @override
   dynamic get lang =>
       props[_$key__lang___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.lang] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.lang] -->
   @override
   set lang(dynamic value) => props[_$key__lang___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.list] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.list] -->
   @override
   dynamic get list =>
       props[_$key__list___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.list] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.list] -->
   @override
   set list(dynamic value) => props[_$key__list___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.manifest] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
   @override
   dynamic get manifest =>
       props[_$key__manifest___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.manifest] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
   @override
   set manifest(dynamic value) =>
       props[_$key__manifest___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.max] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
   dynamic get max =>
       props[_$key__max___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.max] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
   set max(dynamic value) => props[_$key__max___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.maxLength] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.maxLength] -->
   @override
   dynamic get maxLength =>
       props[_$key__maxLength___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.maxLength] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.maxLength] -->
   @override
   set maxLength(dynamic value) =>
       props[_$key__maxLength___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.media] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.media] -->
   @override
   dynamic get media =>
       props[_$key__media___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.media] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.media] -->
   @override
   set media(dynamic value) => props[_$key__media___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.mediaGroup] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
   @override
   dynamic get mediaGroup =>
       props[_$key__mediaGroup___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.mediaGroup] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
   @override
   set mediaGroup(dynamic value) =>
       props[_$key__mediaGroup___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.method] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.method] -->
   @override
   dynamic get method =>
       props[_$key__method___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.method] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.method] -->
   @override
   set method(dynamic value) => props[_$key__method___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.min] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
   dynamic get min =>
       props[_$key__min___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.min] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
   set min(dynamic value) => props[_$key__min___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.name] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.name] -->
   @override
   dynamic get name =>
       props[_$key__name___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.name] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.name] -->
   @override
   set name(dynamic value) => props[_$key__name___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.open] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.open] -->
   @override
   dynamic get open =>
       props[_$key__open___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.open] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.open] -->
   @override
   set open(dynamic value) => props[_$key__open___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.pattern] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
   @override
   dynamic get pattern =>
       props[_$key__pattern___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.pattern] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
   @override
   set pattern(dynamic value) => props[_$key__pattern___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.placeholder] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
   @override
   dynamic get placeholder =>
       props[_$key__placeholder___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.placeholder] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
   @override
   set placeholder(dynamic value) =>
       props[_$key__placeholder___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.poster] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.poster] -->
   @override
   dynamic get poster =>
       props[_$key__poster___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.poster] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.poster] -->
   @override
   set poster(dynamic value) => props[_$key__poster___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.preload] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.preload] -->
   @override
   dynamic get preload =>
       props[_$key__preload___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.preload] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.preload] -->
   @override
   set preload(dynamic value) => props[_$key__preload___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.radioGroup] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
   @override
   dynamic get radioGroup =>
       props[_$key__radioGroup___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.radioGroup] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
   @override
   set radioGroup(dynamic value) =>
       props[_$key__radioGroup___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.rel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rel] -->
   @override
   dynamic get rel =>
       props[_$key__rel___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.rel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rel] -->
   @override
   set rel(dynamic value) => props[_$key__rel___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.role] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.role] -->
   @override
   dynamic get role =>
       props[_$key__role___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.role] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.role] -->
   @override
   set role(dynamic value) => props[_$key__role___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.rowSpan] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rowSpan] -->
   @override
   dynamic get rowSpan =>
       props[_$key__rowSpan___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.rowSpan] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.rowSpan] -->
   @override
   set rowSpan(dynamic value) => props[_$key__rowSpan___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.sandbox] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
   @override
   dynamic get sandbox =>
       props[_$key__sandbox___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.sandbox] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
   @override
   set sandbox(dynamic value) => props[_$key__sandbox___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.scope] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.scope] -->
   @override
   dynamic get scope =>
       props[_$key__scope___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.scope] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.scope] -->
   @override
   set scope(dynamic value) => props[_$key__scope___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.scrolling] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
   @override
   dynamic get scrolling =>
       props[_$key__scrolling___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.scrolling] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
   @override
   set scrolling(dynamic value) =>
       props[_$key__scrolling___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.shape] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.shape] -->
   @override
   dynamic get shape =>
       props[_$key__shape___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.shape] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.shape] -->
   @override
   set shape(dynamic value) => props[_$key__shape___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.sizes] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
   @override
   dynamic get sizes =>
       props[_$key__sizes___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.sizes] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
   @override
   set sizes(dynamic value) => props[_$key__sizes___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.spellCheck] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.spellCheck] -->
   @override
   dynamic get spellCheck =>
       props[_$key__spellCheck___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.spellCheck] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.spellCheck] -->
   @override
   set spellCheck(dynamic value) =>
       props[_$key__spellCheck___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.src] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.src] -->
   @override
   dynamic get src =>
       props[_$key__src___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.src] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.src] -->
   @override
   set src(dynamic value) => props[_$key__src___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.srcDoc] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
   @override
   dynamic get srcDoc =>
       props[_$key__srcDoc___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.srcDoc] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
   @override
   set srcDoc(dynamic value) => props[_$key__srcDoc___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.srcSet] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
   @override
   dynamic get srcSet =>
       props[_$key__srcSet___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.srcSet] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
   @override
   set srcSet(dynamic value) => props[_$key__srcSet___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.step] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.step] -->
   @override
   dynamic get step =>
       props[_$key__step___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.step] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.step] -->
   @override
   set step(dynamic value) => props[_$key__step___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.tabIndex] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.tabIndex] -->
   @override
   dynamic get tabIndex =>
       props[_$key__tabIndex___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.tabIndex] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.tabIndex] -->
   @override
   set tabIndex(dynamic value) =>
       props[_$key__tabIndex___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.target] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.target] -->
   @override
   dynamic get target =>
       props[_$key__target___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.target] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.target] -->
   @override
   set target(dynamic value) => props[_$key__target___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.type] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
   dynamic get type =>
       props[_$key__type___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.type] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
   set type(dynamic value) => props[_$key__type___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.useMap] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
   @override
   dynamic get useMap =>
       props[_$key__useMap___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.useMap] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
   @override
   set useMap(dynamic value) => props[_$key__useMap___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.value] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
   dynamic get value =>
       props[_$key__value___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.value] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
   set value(dynamic value) => props[_$key__value___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.width] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.width] -->
   @override
   dynamic get width =>
       props[_$key__width___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.width] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.width] -->
   @override
   set width(dynamic value) => props[_$key__width___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.wmode] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
   @override
   dynamic get wmode =>
       props[_$key__wmode___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.wmode] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
   @override
   set wmode(dynamic value) => props[_$key__wmode___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onCopy] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCopy] -->
   @override
   ClipboardEventCallback get onCopy =>
       props[_$key__onCopy___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onCopy] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCopy] -->
   @override
   set onCopy(ClipboardEventCallback value) =>
       props[_$key__onCopy___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onCut] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCut] -->
   @override
   ClipboardEventCallback get onCut =>
       props[_$key__onCut___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onCut] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCut] -->
   @override
   set onCut(ClipboardEventCallback value) =>
       props[_$key__onCut___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onPaste] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onPaste] -->
   @override
   ClipboardEventCallback get onPaste =>
       props[_$key__onPaste___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onPaste] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onPaste] -->
   @override
   set onPaste(ClipboardEventCallback value) =>
       props[_$key__onPaste___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyDown] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyDown] -->
   @override
   KeyboardEventCallback get onKeyDown =>
       props[_$key__onKeyDown___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyDown] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyDown] -->
   @override
   set onKeyDown(KeyboardEventCallback value) =>
       props[_$key__onKeyDown___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyPress] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyPress] -->
   @override
   KeyboardEventCallback get onKeyPress =>
       props[_$key__onKeyPress___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyPress] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyPress] -->
   @override
   set onKeyPress(KeyboardEventCallback value) =>
       props[_$key__onKeyPress___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyUp] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyUp] -->
   @override
   KeyboardEventCallback get onKeyUp =>
       props[_$key__onKeyUp___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyUp] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyUp] -->
   @override
   set onKeyUp(KeyboardEventCallback value) =>
       props[_$key__onKeyUp___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onFocus] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onFocus] -->
   @override
   FocusEventCallback get onFocus =>
       props[_$key__onFocus___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onFocus] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onFocus] -->
   @override
   set onFocus(FocusEventCallback value) =>
       props[_$key__onFocus___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onBlur] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onBlur] -->
   @override
   FocusEventCallback get onBlur =>
       props[_$key__onBlur___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onBlur] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onBlur] -->
   @override
   set onBlur(FocusEventCallback value) =>
       props[_$key__onBlur___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onChange] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onChange] -->
   @override
   FormEventCallback get onChange =>
       props[_$key__onChange___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onChange] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onChange] -->
   @override
   set onChange(FormEventCallback value) =>
       props[_$key__onChange___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onInput] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onInput] -->
   @override
   FormEventCallback get onInput =>
       props[_$key__onInput___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onInput] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onInput] -->
   @override
   set onInput(FormEventCallback value) =>
       props[_$key__onInput___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onSubmit] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onSubmit] -->
   @override
   FormEventCallback get onSubmit =>
       props[_$key__onSubmit___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onSubmit] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onSubmit] -->
   @override
   set onSubmit(FormEventCallback value) =>
       props[_$key__onSubmit___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onReset] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onReset] -->
   @override
   FormEventCallback get onReset =>
       props[_$key__onReset___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onReset] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onReset] -->
   @override
   set onReset(FormEventCallback value) =>
       props[_$key__onReset___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onClick] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onClick] -->
   @override
   MouseEventCallback get onClick =>
       props[_$key__onClick___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onClick] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onClick] -->
   @override
   set onClick(MouseEventCallback value) =>
       props[_$key__onClick___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onContextMenu] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onContextMenu] -->
   @override
   MouseEventCallback get onContextMenu =>
       props[_$key__onContextMenu___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onContextMenu] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onContextMenu] -->
   @override
   set onContextMenu(MouseEventCallback value) =>
       props[_$key__onContextMenu___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDoubleClick] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDoubleClick] -->
   @override
   MouseEventCallback get onDoubleClick =>
       props[_$key__onDoubleClick___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDoubleClick] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDoubleClick] -->
   @override
   set onDoubleClick(MouseEventCallback value) =>
       props[_$key__onDoubleClick___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDrag] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDrag] -->
   @override
   MouseEventCallback get onDrag =>
       props[_$key__onDrag___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDrag] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDrag] -->
   @override
   set onDrag(MouseEventCallback value) =>
       props[_$key__onDrag___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragEnd] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnd] -->
   @override
   MouseEventCallback get onDragEnd =>
       props[_$key__onDragEnd___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragEnd] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnd] -->
   @override
   set onDragEnd(MouseEventCallback value) =>
       props[_$key__onDragEnd___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragEnter] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnter] -->
   @override
   MouseEventCallback get onDragEnter =>
       props[_$key__onDragEnter___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragEnter] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnter] -->
   @override
   set onDragEnter(MouseEventCallback value) =>
       props[_$key__onDragEnter___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragExit] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragExit] -->
   @override
   MouseEventCallback get onDragExit =>
       props[_$key__onDragExit___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragExit] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragExit] -->
   @override
   set onDragExit(MouseEventCallback value) =>
       props[_$key__onDragExit___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragLeave] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragLeave] -->
   @override
   MouseEventCallback get onDragLeave =>
       props[_$key__onDragLeave___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragLeave] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragLeave] -->
   @override
   set onDragLeave(MouseEventCallback value) =>
       props[_$key__onDragLeave___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragOver] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragOver] -->
   @override
   MouseEventCallback get onDragOver =>
       props[_$key__onDragOver___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragOver] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragOver] -->
   @override
   set onDragOver(MouseEventCallback value) =>
       props[_$key__onDragOver___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragStart] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragStart] -->
   @override
   MouseEventCallback get onDragStart =>
       props[_$key__onDragStart___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragStart] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragStart] -->
   @override
   set onDragStart(MouseEventCallback value) =>
       props[_$key__onDragStart___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDrop] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDrop] -->
   @override
   MouseEventCallback get onDrop =>
       props[_$key__onDrop___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDrop] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDrop] -->
   @override
   set onDrop(MouseEventCallback value) =>
       props[_$key__onDrop___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseDown] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseDown] -->
   @override
   MouseEventCallback get onMouseDown =>
       props[_$key__onMouseDown___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseDown] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseDown] -->
   @override
   set onMouseDown(MouseEventCallback value) =>
       props[_$key__onMouseDown___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseEnter] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseEnter] -->
   @override
   MouseEventCallback get onMouseEnter =>
       props[_$key__onMouseEnter___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseEnter] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseEnter] -->
   @override
   set onMouseEnter(MouseEventCallback value) =>
       props[_$key__onMouseEnter___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseLeave] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseLeave] -->
   @override
   MouseEventCallback get onMouseLeave =>
       props[_$key__onMouseLeave___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseLeave] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseLeave] -->
   @override
   set onMouseLeave(MouseEventCallback value) =>
       props[_$key__onMouseLeave___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseMove] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseMove] -->
   @override
   MouseEventCallback get onMouseMove =>
       props[_$key__onMouseMove___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseMove] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseMove] -->
   @override
   set onMouseMove(MouseEventCallback value) =>
       props[_$key__onMouseMove___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseOut] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOut] -->
   @override
   MouseEventCallback get onMouseOut =>
       props[_$key__onMouseOut___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseOut] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOut] -->
   @override
   set onMouseOut(MouseEventCallback value) =>
       props[_$key__onMouseOut___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseOver] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOver] -->
   @override
   MouseEventCallback get onMouseOver =>
       props[_$key__onMouseOver___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseOver] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOver] -->
   @override
   set onMouseOver(MouseEventCallback value) =>
       props[_$key__onMouseOver___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseUp] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseUp] -->
   @override
   MouseEventCallback get onMouseUp =>
       props[_$key__onMouseUp___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseUp] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseUp] -->
   @override
   set onMouseUp(MouseEventCallback value) =>
       props[_$key__onMouseUp___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchCancel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchCancel] -->
   @override
   TouchEventCallback get onTouchCancel =>
       props[_$key__onTouchCancel___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchCancel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchCancel] -->
   @override
   set onTouchCancel(TouchEventCallback value) =>
       props[_$key__onTouchCancel___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchEnd] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchEnd] -->
   @override
   TouchEventCallback get onTouchEnd =>
       props[_$key__onTouchEnd___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchEnd] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchEnd] -->
   @override
   set onTouchEnd(TouchEventCallback value) =>
       props[_$key__onTouchEnd___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchMove] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchMove] -->
   @override
   TouchEventCallback get onTouchMove =>
       props[_$key__onTouchMove___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchMove] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchMove] -->
   @override
   set onTouchMove(TouchEventCallback value) =>
       props[_$key__onTouchMove___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchStart] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchStart] -->
   @override
   TouchEventCallback get onTouchStart =>
       props[_$key__onTouchStart___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchStart] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchStart] -->
   @override
   set onTouchStart(TouchEventCallback value) =>
       props[_$key__onTouchStart___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onScroll] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onScroll] -->
   @override
   UIEventCallback get onScroll =>
       props[_$key__onScroll___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onScroll] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onScroll] -->
   @override
   set onScroll(UIEventCallback value) =>
       props[_$key__onScroll___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onWheel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onWheel] -->
   @override
   WheelEventCallback get onWheel =>
       props[_$key__onWheel___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onWheel] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onWheel] -->
   @override
   set onWheel(WheelEventCallback value) =>
       props[_$key__onWheel___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onCopyCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCopyCapture] -->
   @override
   ClipboardEventCallback get onCopyCapture =>
       props[_$key__onCopyCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onCopyCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCopyCapture] -->
   @override
   set onCopyCapture(ClipboardEventCallback value) =>
       props[_$key__onCopyCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onCutCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCutCapture] -->
   @override
   ClipboardEventCallback get onCutCapture =>
       props[_$key__onCutCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onCutCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onCutCapture] -->
   @override
   set onCutCapture(ClipboardEventCallback value) =>
       props[_$key__onCutCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onPasteCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onPasteCapture] -->
   @override
   ClipboardEventCallback get onPasteCapture =>
       props[_$key__onPasteCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onPasteCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onPasteCapture] -->
   @override
   set onPasteCapture(ClipboardEventCallback value) =>
       props[_$key__onPasteCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyDownCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyDownCapture] -->
   @override
   KeyboardEventCallback get onKeyDownCapture =>
       props[_$key__onKeyDownCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyDownCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyDownCapture] -->
   @override
   set onKeyDownCapture(KeyboardEventCallback value) =>
       props[_$key__onKeyDownCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyPressCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyPressCapture] -->
   @override
   KeyboardEventCallback get onKeyPressCapture =>
       props[_$key__onKeyPressCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyPressCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyPressCapture] -->
   @override
   set onKeyPressCapture(KeyboardEventCallback value) =>
       props[_$key__onKeyPressCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onKeyUpCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyUpCapture] -->
   @override
   KeyboardEventCallback get onKeyUpCapture =>
       props[_$key__onKeyUpCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onKeyUpCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onKeyUpCapture] -->
   @override
   set onKeyUpCapture(KeyboardEventCallback value) =>
       props[_$key__onKeyUpCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onFocusCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onFocusCapture] -->
   @override
   FocusEventCallback get onFocusCapture =>
       props[_$key__onFocusCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onFocusCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onFocusCapture] -->
   @override
   set onFocusCapture(FocusEventCallback value) =>
       props[_$key__onFocusCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onBlurCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onBlurCapture] -->
   @override
   FocusEventCallback get onBlurCapture =>
       props[_$key__onBlurCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onBlurCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onBlurCapture] -->
   @override
   set onBlurCapture(FocusEventCallback value) =>
       props[_$key__onBlurCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onChangeCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onChangeCapture] -->
   @override
   FormEventCallback get onChangeCapture =>
       props[_$key__onChangeCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onChangeCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onChangeCapture] -->
   @override
   set onChangeCapture(FormEventCallback value) =>
       props[_$key__onChangeCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onInputCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onInputCapture] -->
   @override
   FormEventCallback get onInputCapture =>
       props[_$key__onInputCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onInputCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onInputCapture] -->
   @override
   set onInputCapture(FormEventCallback value) =>
       props[_$key__onInputCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onSubmitCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onSubmitCapture] -->
   @override
   FormEventCallback get onSubmitCapture =>
       props[_$key__onSubmitCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onSubmitCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onSubmitCapture] -->
   @override
   set onSubmitCapture(FormEventCallback value) =>
       props[_$key__onSubmitCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onResetCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onResetCapture] -->
   @override
   FormEventCallback get onResetCapture =>
       props[_$key__onResetCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onResetCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onResetCapture] -->
   @override
   set onResetCapture(FormEventCallback value) =>
       props[_$key__onResetCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onClickCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onClickCapture] -->
   @override
   MouseEventCallback get onClickCapture =>
       props[_$key__onClickCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onClickCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onClickCapture] -->
   @override
   set onClickCapture(MouseEventCallback value) =>
       props[_$key__onClickCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onContextMenuCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onContextMenuCapture] -->
   @override
   MouseEventCallback get onContextMenuCapture =>
       props[_$key__onContextMenuCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onContextMenuCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onContextMenuCapture] -->
   @override
   set onContextMenuCapture(MouseEventCallback value) =>
       props[_$key__onContextMenuCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDoubleClickCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDoubleClickCapture] -->
   @override
   MouseEventCallback get onDoubleClickCapture =>
       props[_$key__onDoubleClickCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDoubleClickCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDoubleClickCapture] -->
   @override
   set onDoubleClickCapture(MouseEventCallback value) =>
       props[_$key__onDoubleClickCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragCapture] -->
   @override
   MouseEventCallback get onDragCapture =>
       props[_$key__onDragCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragCapture] -->
   @override
   set onDragCapture(MouseEventCallback value) =>
       props[_$key__onDragCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragEndCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEndCapture] -->
   @override
   MouseEventCallback get onDragEndCapture =>
       props[_$key__onDragEndCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragEndCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEndCapture] -->
   @override
   set onDragEndCapture(MouseEventCallback value) =>
       props[_$key__onDragEndCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragEnterCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnterCapture] -->
   @override
   MouseEventCallback get onDragEnterCapture =>
       props[_$key__onDragEnterCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragEnterCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragEnterCapture] -->
   @override
   set onDragEnterCapture(MouseEventCallback value) =>
       props[_$key__onDragEnterCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragExitCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragExitCapture] -->
   @override
   MouseEventCallback get onDragExitCapture =>
       props[_$key__onDragExitCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragExitCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragExitCapture] -->
   @override
   set onDragExitCapture(MouseEventCallback value) =>
       props[_$key__onDragExitCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragLeaveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragLeaveCapture] -->
   @override
   MouseEventCallback get onDragLeaveCapture =>
       props[_$key__onDragLeaveCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragLeaveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragLeaveCapture] -->
   @override
   set onDragLeaveCapture(MouseEventCallback value) =>
       props[_$key__onDragLeaveCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragOverCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragOverCapture] -->
   @override
   MouseEventCallback get onDragOverCapture =>
       props[_$key__onDragOverCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragOverCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragOverCapture] -->
   @override
   set onDragOverCapture(MouseEventCallback value) =>
       props[_$key__onDragOverCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDragStartCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragStartCapture] -->
   @override
   MouseEventCallback get onDragStartCapture =>
       props[_$key__onDragStartCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDragStartCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDragStartCapture] -->
   @override
   set onDragStartCapture(MouseEventCallback value) =>
       props[_$key__onDragStartCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onDropCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDropCapture] -->
   @override
   MouseEventCallback get onDropCapture =>
       props[_$key__onDropCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onDropCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onDropCapture] -->
   @override
   set onDropCapture(MouseEventCallback value) =>
       props[_$key__onDropCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseDownCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseDownCapture] -->
   @override
   MouseEventCallback get onMouseDownCapture =>
       props[_$key__onMouseDownCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseDownCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseDownCapture] -->
   @override
   set onMouseDownCapture(MouseEventCallback value) =>
       props[_$key__onMouseDownCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseEnterCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseEnterCapture] -->
   @override
   MouseEventCallback get onMouseEnterCapture =>
       props[_$key__onMouseEnterCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseEnterCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseEnterCapture] -->
   @override
   set onMouseEnterCapture(MouseEventCallback value) =>
       props[_$key__onMouseEnterCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseLeaveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseLeaveCapture] -->
   @override
   MouseEventCallback get onMouseLeaveCapture =>
       props[_$key__onMouseLeaveCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseLeaveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseLeaveCapture] -->
   @override
   set onMouseLeaveCapture(MouseEventCallback value) =>
       props[_$key__onMouseLeaveCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseMoveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseMoveCapture] -->
   @override
   MouseEventCallback get onMouseMoveCapture =>
       props[_$key__onMouseMoveCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseMoveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseMoveCapture] -->
   @override
   set onMouseMoveCapture(MouseEventCallback value) =>
       props[_$key__onMouseMoveCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseOutCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOutCapture] -->
   @override
   MouseEventCallback get onMouseOutCapture =>
       props[_$key__onMouseOutCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseOutCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOutCapture] -->
   @override
   set onMouseOutCapture(MouseEventCallback value) =>
       props[_$key__onMouseOutCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseOverCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOverCapture] -->
   @override
   MouseEventCallback get onMouseOverCapture =>
       props[_$key__onMouseOverCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseOverCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseOverCapture] -->
   @override
   set onMouseOverCapture(MouseEventCallback value) =>
       props[_$key__onMouseOverCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onMouseUpCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseUpCapture] -->
   @override
   MouseEventCallback get onMouseUpCapture =>
       props[_$key__onMouseUpCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onMouseUpCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onMouseUpCapture] -->
   @override
   set onMouseUpCapture(MouseEventCallback value) =>
       props[_$key__onMouseUpCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchCancelCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchCancelCapture] -->
   @override
   TouchEventCallback get onTouchCancelCapture =>
       props[_$key__onTouchCancelCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchCancelCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchCancelCapture] -->
   @override
   set onTouchCancelCapture(TouchEventCallback value) =>
       props[_$key__onTouchCancelCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchEndCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchEndCapture] -->
   @override
   TouchEventCallback get onTouchEndCapture =>
       props[_$key__onTouchEndCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchEndCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchEndCapture] -->
   @override
   set onTouchEndCapture(TouchEventCallback value) =>
       props[_$key__onTouchEndCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchMoveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchMoveCapture] -->
   @override
   TouchEventCallback get onTouchMoveCapture =>
       props[_$key__onTouchMoveCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchMoveCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchMoveCapture] -->
   @override
   set onTouchMoveCapture(TouchEventCallback value) =>
       props[_$key__onTouchMoveCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onTouchStartCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchStartCapture] -->
   @override
   TouchEventCallback get onTouchStartCapture =>
       props[_$key__onTouchStartCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onTouchStartCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onTouchStartCapture] -->
   @override
   set onTouchStartCapture(TouchEventCallback value) =>
       props[_$key__onTouchStartCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onScrollCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onScrollCapture] -->
   @override
   UIEventCallback get onScrollCapture =>
       props[_$key__onScrollCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onScrollCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onScrollCapture] -->
   @override
   set onScrollCapture(UIEventCallback value) =>
       props[_$key__onScrollCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.onWheelCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onWheelCapture] -->
   @override
   WheelEventCallback get onWheelCapture =>
       props[_$key__onWheelCapture___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.onWheelCapture] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.onWheelCapture] -->
   @override
   set onWheelCapture(WheelEventCallback value) =>
       props[_$key__onWheelCapture___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.defaultChecked] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defaultChecked] -->
   @override
   bool get defaultChecked =>
       props[_$key__defaultChecked___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.defaultChecked] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defaultChecked] -->
   @override
   set defaultChecked(bool value) =>
       props[_$key__defaultChecked___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.defaultValue] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defaultValue] -->
   @override
   dynamic get defaultValue =>
       props[_$key__defaultValue___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.defaultValue] to see the source code for this prop
+  /// <!-- Generated from [_$DomPropsMixin.defaultValue] -->
   @override
   set defaultValue(dynamic value) =>
       props[_$key__defaultValue___$DomPropsMixin] = value;
 
-  /// Go to [_$DomPropsMixin.autoFocus] to see the source code for this prop
+  /// Polyfills/normalizes the `autofocus` attribute via AutoFocusMixin
+  /// (mixed in by React DOM <input>, <textarea>, and <select>).
+  ///
+  /// <!-- Generated from [_$DomPropsMixin.autoFocus] -->
   @override
   bool get autoFocus =>
       props[_$key__autoFocus___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DomPropsMixin.autoFocus] to see the source code for this prop
+  /// Polyfills/normalizes the `autofocus` attribute via AutoFocusMixin
+  /// (mixed in by React DOM <input>, <textarea>, and <select>).
+  ///
+  /// <!-- Generated from [_$DomPropsMixin.autoFocus] -->
   @override
   set autoFocus(bool value) => props[_$key__autoFocus___$DomPropsMixin] = value;
   /* GENERATED CONSTANTS */
@@ -2574,518 +2594,518 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   static const PropsMeta meta = _$metaForSvgPropsMixin;
 
-  /// Go to [_$SvgPropsMixin.clipPath] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
   dynamic get clipPath =>
       props[_$key__clipPath___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.clipPath] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
   set clipPath(dynamic value) =>
       props[_$key__clipPath___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.cx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.cx] -->
   @override
   dynamic get cx =>
       props[_$key__cx___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.cx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.cx] -->
   @override
   set cx(dynamic value) => props[_$key__cx___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.cy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.cy] -->
   @override
   dynamic get cy =>
       props[_$key__cy___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.cy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.cy] -->
   @override
   set cy(dynamic value) => props[_$key__cy___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.d] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.d] -->
   @override
   dynamic get d =>
       props[_$key__d___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.d] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.d] -->
   @override
   set d(dynamic value) => props[_$key__d___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.dx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.dx] -->
   @override
   dynamic get dx =>
       props[_$key__dx___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.dx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.dx] -->
   @override
   set dx(dynamic value) => props[_$key__dx___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.dy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.dy] -->
   @override
   dynamic get dy =>
       props[_$key__dy___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.dy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.dy] -->
   @override
   set dy(dynamic value) => props[_$key__dy___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fill] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
   @override
   dynamic get fill =>
       props[_$key__fill___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fill] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
   @override
   set fill(dynamic value) => props[_$key__fill___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fillOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fillOpacity] -->
   @override
   dynamic get fillOpacity =>
       props[_$key__fillOpacity___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fillOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fillOpacity] -->
   @override
   set fillOpacity(dynamic value) =>
       props[_$key__fillOpacity___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fontFamily] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
   @override
   dynamic get fontFamily =>
       props[_$key__fontFamily___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fontFamily] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
   @override
   set fontFamily(dynamic value) =>
       props[_$key__fontFamily___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fontSize] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fontSize] -->
   @override
   dynamic get fontSize =>
       props[_$key__fontSize___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fontSize] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fontSize] -->
   @override
   set fontSize(dynamic value) =>
       props[_$key__fontSize___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fx] -->
   @override
   dynamic get fx =>
       props[_$key__fx___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fx] -->
   @override
   set fx(dynamic value) => props[_$key__fx___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.fy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fy] -->
   @override
   dynamic get fy =>
       props[_$key__fy___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.fy] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.fy] -->
   @override
   set fy(dynamic value) => props[_$key__fy___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.gradientTransform] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
   @override
   dynamic get gradientTransform =>
       props[_$key__gradientTransform___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.gradientTransform] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
   @override
   set gradientTransform(dynamic value) =>
       props[_$key__gradientTransform___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.gradientUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
   @override
   dynamic get gradientUnits =>
       props[_$key__gradientUnits___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.gradientUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
   @override
   set gradientUnits(dynamic value) =>
       props[_$key__gradientUnits___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.markerEnd] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
   @override
   dynamic get markerEnd =>
       props[_$key__markerEnd___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.markerEnd] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
   @override
   set markerEnd(dynamic value) =>
       props[_$key__markerEnd___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.markerMid] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
   @override
   dynamic get markerMid =>
       props[_$key__markerMid___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.markerMid] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
   @override
   set markerMid(dynamic value) =>
       props[_$key__markerMid___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.markerStart] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
   @override
   dynamic get markerStart =>
       props[_$key__markerStart___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.markerStart] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
   @override
   set markerStart(dynamic value) =>
       props[_$key__markerStart___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.offset] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.offset] -->
   @override
   dynamic get offset =>
       props[_$key__offset___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.offset] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.offset] -->
   @override
   set offset(dynamic value) => props[_$key__offset___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.opacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.opacity] -->
   @override
   dynamic get opacity =>
       props[_$key__opacity___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.opacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.opacity] -->
   @override
   set opacity(dynamic value) => props[_$key__opacity___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.patternContentUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
   @override
   dynamic get patternContentUnits =>
       props[_$key__patternContentUnits___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.patternContentUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
   @override
   set patternContentUnits(dynamic value) =>
       props[_$key__patternContentUnits___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.patternUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
   @override
   dynamic get patternUnits =>
       props[_$key__patternUnits___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.patternUnits] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
   @override
   set patternUnits(dynamic value) =>
       props[_$key__patternUnits___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.points] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.points] -->
   @override
   dynamic get points =>
       props[_$key__points___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.points] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.points] -->
   @override
   set points(dynamic value) => props[_$key__points___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.preserveAspectRatio] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
   @override
   dynamic get preserveAspectRatio =>
       props[_$key__preserveAspectRatio___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.preserveAspectRatio] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
   @override
   set preserveAspectRatio(dynamic value) =>
       props[_$key__preserveAspectRatio___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.r] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.r] -->
   @override
   dynamic get r =>
       props[_$key__r___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.r] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.r] -->
   @override
   set r(dynamic value) => props[_$key__r___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.rx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.rx] -->
   @override
   dynamic get rx =>
       props[_$key__rx___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.rx] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.rx] -->
   @override
   set rx(dynamic value) => props[_$key__rx___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.ry] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.ry] -->
   @override
   dynamic get ry =>
       props[_$key__ry___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.ry] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.ry] -->
   @override
   set ry(dynamic value) => props[_$key__ry___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.spreadMethod] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
   @override
   dynamic get spreadMethod =>
       props[_$key__spreadMethod___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.spreadMethod] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
   @override
   set spreadMethod(dynamic value) =>
       props[_$key__spreadMethod___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.stopColor] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
   @override
   dynamic get stopColor =>
       props[_$key__stopColor___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.stopColor] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
   @override
   set stopColor(dynamic value) =>
       props[_$key__stopColor___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.stopOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stopOpacity] -->
   @override
   dynamic get stopOpacity =>
       props[_$key__stopOpacity___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.stopOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stopOpacity] -->
   @override
   set stopOpacity(dynamic value) =>
       props[_$key__stopOpacity___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.stroke] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
   @override
   dynamic get stroke =>
       props[_$key__stroke___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.stroke] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
   @override
   set stroke(dynamic value) => props[_$key__stroke___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.strokeDasharray] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeDasharray] -->
   @override
   dynamic get strokeDasharray =>
       props[_$key__strokeDasharray___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.strokeDasharray] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeDasharray] -->
   @override
   set strokeDasharray(dynamic value) =>
       props[_$key__strokeDasharray___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.strokeLinecap] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
   @override
   dynamic get strokeLinecap =>
       props[_$key__strokeLinecap___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.strokeLinecap] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
   @override
   set strokeLinecap(dynamic value) =>
       props[_$key__strokeLinecap___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.strokeOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeOpacity] -->
   @override
   dynamic get strokeOpacity =>
       props[_$key__strokeOpacity___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.strokeOpacity] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeOpacity] -->
   @override
   set strokeOpacity(dynamic value) =>
       props[_$key__strokeOpacity___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.strokeWidth] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeWidth] -->
   @override
   dynamic get strokeWidth =>
       props[_$key__strokeWidth___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.strokeWidth] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.strokeWidth] -->
   @override
   set strokeWidth(dynamic value) =>
       props[_$key__strokeWidth___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.textAnchor] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
   @override
   dynamic get textAnchor =>
       props[_$key__textAnchor___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.textAnchor] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
   @override
   set textAnchor(dynamic value) =>
       props[_$key__textAnchor___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.transform] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
   @override
   dynamic get transform =>
       props[_$key__transform___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.transform] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
   @override
   set transform(dynamic value) =>
       props[_$key__transform___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.version] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.version] -->
   @override
   dynamic get version =>
       props[_$key__version___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.version] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.version] -->
   @override
   set version(dynamic value) => props[_$key__version___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.viewBox] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
   @override
   dynamic get viewBox =>
       props[_$key__viewBox___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.viewBox] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
   @override
   set viewBox(dynamic value) => props[_$key__viewBox___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.x1] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x1] -->
   @override
   dynamic get x1 =>
       props[_$key__x1___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.x1] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x1] -->
   @override
   set x1(dynamic value) => props[_$key__x1___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.x2] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x2] -->
   @override
   dynamic get x2 =>
       props[_$key__x2___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.x2] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x2] -->
   @override
   set x2(dynamic value) => props[_$key__x2___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.x] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x] -->
   @override
   dynamic get x =>
       props[_$key__x___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.x] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.x] -->
   @override
   set x(dynamic value) => props[_$key__x___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkActuate] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
   @override
   dynamic get xlinkActuate =>
       props[_$key__xlinkActuate___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkActuate] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
   @override
   set xlinkActuate(dynamic value) =>
       props[_$key__xlinkActuate___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkArcrole] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
   @override
   dynamic get xlinkArcrole =>
       props[_$key__xlinkArcrole___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkArcrole] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
   @override
   set xlinkArcrole(dynamic value) =>
       props[_$key__xlinkArcrole___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkHref] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
   @override
   dynamic get xlinkHref =>
       props[_$key__xlinkHref___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkHref] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
   @override
   set xlinkHref(dynamic value) =>
       props[_$key__xlinkHref___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkRole] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
   @override
   dynamic get xlinkRole =>
       props[_$key__xlinkRole___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkRole] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
   @override
   set xlinkRole(dynamic value) =>
       props[_$key__xlinkRole___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkShow] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
   @override
   dynamic get xlinkShow =>
       props[_$key__xlinkShow___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkShow] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
   @override
   set xlinkShow(dynamic value) =>
       props[_$key__xlinkShow___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkTitle] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
   @override
   dynamic get xlinkTitle =>
       props[_$key__xlinkTitle___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkTitle] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
   @override
   set xlinkTitle(dynamic value) =>
       props[_$key__xlinkTitle___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xlinkType] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
   @override
   dynamic get xlinkType =>
       props[_$key__xlinkType___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xlinkType] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
   @override
   set xlinkType(dynamic value) =>
       props[_$key__xlinkType___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xmlBase] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
   @override
   dynamic get xmlBase =>
       props[_$key__xmlBase___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xmlBase] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
   @override
   set xmlBase(dynamic value) => props[_$key__xmlBase___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xmlLang] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
   @override
   dynamic get xmlLang =>
       props[_$key__xmlLang___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xmlLang] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
   @override
   set xmlLang(dynamic value) => props[_$key__xmlLang___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.xmlSpace] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
   @override
   dynamic get xmlSpace =>
       props[_$key__xmlSpace___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.xmlSpace] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
   @override
   set xmlSpace(dynamic value) =>
       props[_$key__xmlSpace___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.y1] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y1] -->
   @override
   dynamic get y1 =>
       props[_$key__y1___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.y1] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y1] -->
   @override
   set y1(dynamic value) => props[_$key__y1___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.y2] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y2] -->
   @override
   dynamic get y2 =>
       props[_$key__y2___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.y2] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y2] -->
   @override
   set y2(dynamic value) => props[_$key__y2___$SvgPropsMixin] = value;
 
-  /// Go to [_$SvgPropsMixin.y] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y] -->
   @override
   dynamic get y =>
       props[_$key__y___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SvgPropsMixin.y] to see the source code for this prop
+  /// <!-- Generated from [_$SvgPropsMixin.y] -->
   @override
   set y(dynamic value) => props[_$key__y___$SvgPropsMixin] = value;
   /* GENERATED CONSTANTS */
@@ -3394,401 +3414,581 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     return _dom;
   }
 
-  /// Go to [_$UbiquitousDomPropsMixin.tabIndex] to see the source code for this prop
+  /// Whether the element if focusable.
+  /// Must be a valid integer or String of valid integer.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.tabIndex] -->
   @override
   dynamic get tabIndex =>
       props[_$key__tabIndex___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.tabIndex] to see the source code for this prop
+  /// Whether the element if focusable.
+  /// Must be a valid integer or String of valid integer.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.tabIndex] -->
   @override
   set tabIndex(dynamic value) =>
       props[_$key__tabIndex___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.id] to see the source code for this prop
+  /// Unique identifier.
+  /// Must be unique amongst all the ids, and contain at least one character.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.id] -->
   @override
   String get id =>
       props[_$key__id___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.id] to see the source code for this prop
+  /// Unique identifier.
+  /// Must be unique amongst all the ids, and contain at least one character.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.id] -->
   @override
   set id(String value) => props[_$key__id___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.title] to see the source code for this prop
+  /// Represents advisory information about the element.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.title] -->
   @override
   String get title =>
       props[_$key__title___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.title] to see the source code for this prop
+  /// Represents advisory information about the element.
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.title] -->
   @override
   set title(String value) =>
       props[_$key__title___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.style] to see the source code for this prop
+  /// An inline CSS style for the element.
+  ///
+  ///     ..style = {
+  ///       'width': '${state.progress * 100}%',
+  ///       'display': state.isHidden ? 'none' : '',
+  ///     }
+  ///
+  /// See: <https://facebook.github.io/react/tips/inline-styles.html>
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.style] -->
   @override
   Map<String, dynamic> get style =>
       props[_$key__style___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.style] to see the source code for this prop
+  /// An inline CSS style for the element.
+  ///
+  ///     ..style = {
+  ///       'width': '${state.progress * 100}%',
+  ///       'display': state.isHidden ? 'none' : '',
+  ///     }
+  ///
+  /// See: <https://facebook.github.io/react/tips/inline-styles.html>
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.style] -->
   @override
   set style(Map<String, dynamic> value) =>
       props[_$key__style___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onCopy] to see the source code for this prop
+  /// Callback for when the user copies the content of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCopy] -->
   @override
   ClipboardEventCallback get onCopy =>
       props[_$key__onCopy___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onCopy] to see the source code for this prop
+  /// Callback for when the user copies the content of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCopy] -->
   @override
   set onCopy(ClipboardEventCallback value) =>
       props[_$key__onCopy___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onCut] to see the source code for this prop
+  /// Callback for when the user cuts the content of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCut] -->
   @override
   ClipboardEventCallback get onCut =>
       props[_$key__onCut___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onCut] to see the source code for this prop
+  /// Callback for when the user cuts the content of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCut] -->
   @override
   set onCut(ClipboardEventCallback value) =>
       props[_$key__onCut___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onPaste] to see the source code for this prop
+  /// Callback for when the user pastes some content in an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPaste] -->
   @override
   ClipboardEventCallback get onPaste =>
       props[_$key__onPaste___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onPaste] to see the source code for this prop
+  /// Callback for when the user pastes some content in an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPaste] -->
   @override
   set onPaste(ClipboardEventCallback value) =>
       props[_$key__onPaste___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyDown] to see the source code for this prop
+  /// Callback for when the user is pressing a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyDown] -->
   @override
   KeyboardEventCallback get onKeyDown =>
       props[_$key__onKeyDown___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyDown] to see the source code for this prop
+  /// Callback for when the user is pressing a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyDown] -->
   @override
   set onKeyDown(KeyboardEventCallback value) =>
       props[_$key__onKeyDown___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyPress] to see the source code for this prop
+  /// Callback for when the user presses a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyPress] -->
   @override
   KeyboardEventCallback get onKeyPress =>
       props[_$key__onKeyPress___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyPress] to see the source code for this prop
+  /// Callback for when the user presses a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyPress] -->
   @override
   set onKeyPress(KeyboardEventCallback value) =>
       props[_$key__onKeyPress___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyUp] to see the source code for this prop
+  /// Callback for when the user releases a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyUp] -->
   @override
   KeyboardEventCallback get onKeyUp =>
       props[_$key__onKeyUp___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onKeyUp] to see the source code for this prop
+  /// Callback for when the user releases a key
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyUp] -->
   @override
   set onKeyUp(KeyboardEventCallback value) =>
       props[_$key__onKeyUp___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onFocus] to see the source code for this prop
+  /// Callback for when an element gets focus
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onFocus] -->
   @override
   FocusEventCallback get onFocus =>
       props[_$key__onFocus___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onFocus] to see the source code for this prop
+  /// Callback for when an element gets focus
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onFocus] -->
   @override
   set onFocus(FocusEventCallback value) =>
       props[_$key__onFocus___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onBlur] to see the source code for this prop
+  /// Callback for when an element loses focus
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onBlur] -->
   @override
   FocusEventCallback get onBlur =>
       props[_$key__onBlur___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onBlur] to see the source code for this prop
+  /// Callback for when an element loses focus
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onBlur] -->
   @override
   set onBlur(FocusEventCallback value) =>
       props[_$key__onBlur___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onChange] to see the source code for this prop
+  /// Callback for  when the content of a form element, the selection, or the checked state have changed (for <input>,
+  /// <keygen>, <select>, and <textarea>)
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onChange] -->
   @override
   FormEventCallback get onChange =>
       props[_$key__onChange___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onChange] to see the source code for this prop
+  /// Callback for  when the content of a form element, the selection, or the checked state have changed (for <input>,
+  /// <keygen>, <select>, and <textarea>)
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onChange] -->
   @override
   set onChange(FormEventCallback value) =>
       props[_$key__onChange___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onInput] to see the source code for this prop
+  /// Callback for when an element gets user input
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onInput] -->
   @override
   FormEventCallback get onInput =>
       props[_$key__onInput___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onInput] to see the source code for this prop
+  /// Callback for when an element gets user input
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onInput] -->
   @override
   set onInput(FormEventCallback value) =>
       props[_$key__onInput___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onSubmit] to see the source code for this prop
+  /// Callback for when a form is submitted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onSubmit] -->
   @override
   FormEventCallback get onSubmit =>
       props[_$key__onSubmit___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onSubmit] to see the source code for this prop
+  /// Callback for when a form is submitted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onSubmit] -->
   @override
   set onSubmit(FormEventCallback value) =>
       props[_$key__onSubmit___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onReset] to see the source code for this prop
+  /// Callback for when a form is reset
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onReset] -->
   @override
   FormEventCallback get onReset =>
       props[_$key__onReset___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onReset] to see the source code for this prop
+  /// Callback for when a form is reset
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onReset] -->
   @override
   set onReset(FormEventCallback value) =>
       props[_$key__onReset___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onClick] to see the source code for this prop
+  /// Callback for when the user clicks on an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onClick] -->
   @override
   MouseEventCallback get onClick =>
       props[_$key__onClick___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onClick] to see the source code for this prop
+  /// Callback for when the user clicks on an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onClick] -->
   @override
   set onClick(MouseEventCallback value) =>
       props[_$key__onClick___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onContextMenu] to see the source code for this prop
+  /// Callback for when the user right-clicks on an element to open a context menu
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onContextMenu] -->
   @override
   MouseEventCallback get onContextMenu =>
       props[_$key__onContextMenu___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onContextMenu] to see the source code for this prop
+  /// Callback for when the user right-clicks on an element to open a context menu
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onContextMenu] -->
   @override
   set onContextMenu(MouseEventCallback value) =>
       props[_$key__onContextMenu___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDoubleClick] to see the source code for this prop
+  /// Callback for when the user double-clicks on an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDoubleClick] -->
   @override
   MouseEventCallback get onDoubleClick =>
       props[_$key__onDoubleClick___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDoubleClick] to see the source code for this prop
+  /// Callback for when the user double-clicks on an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDoubleClick] -->
   @override
   set onDoubleClick(MouseEventCallback value) =>
       props[_$key__onDoubleClick___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDrag] to see the source code for this prop
+  /// Callback for when an element is being dragged
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrag] -->
   @override
   MouseEventCallback get onDrag =>
       props[_$key__onDrag___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDrag] to see the source code for this prop
+  /// Callback for when an element is being dragged
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrag] -->
   @override
   set onDrag(MouseEventCallback value) =>
       props[_$key__onDrag___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragEnd] to see the source code for this prop
+  /// Callback for when the user has finished dragging an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnd] -->
   @override
   MouseEventCallback get onDragEnd =>
       props[_$key__onDragEnd___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragEnd] to see the source code for this prop
+  /// Callback for when the user has finished dragging an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnd] -->
   @override
   set onDragEnd(MouseEventCallback value) =>
       props[_$key__onDragEnd___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragEnter] to see the source code for this prop
+  /// Callback for when the dragged element enters the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnter] -->
   @override
   MouseEventCallback get onDragEnter =>
       props[_$key__onDragEnter___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragEnter] to see the source code for this prop
+  /// Callback for when the dragged element enters the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnter] -->
   @override
   set onDragEnter(MouseEventCallback value) =>
       props[_$key__onDragEnter___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragExit] to see the source code for this prop
+  /// Callback for when the dragged element exits the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragExit] -->
   @override
   MouseEventCallback get onDragExit =>
       props[_$key__onDragExit___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragExit] to see the source code for this prop
+  /// Callback for when the dragged element exits the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragExit] -->
   @override
   set onDragExit(MouseEventCallback value) =>
       props[_$key__onDragExit___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragLeave] to see the source code for this prop
+  /// Callback for when the dragged element leaves the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragLeave] -->
   @override
   MouseEventCallback get onDragLeave =>
       props[_$key__onDragLeave___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragLeave] to see the source code for this prop
+  /// Callback for when the dragged element leaves the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragLeave] -->
   @override
   set onDragLeave(MouseEventCallback value) =>
       props[_$key__onDragLeave___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragOver] to see the source code for this prop
+  /// Callback for when the dragged element is over the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragOver] -->
   @override
   MouseEventCallback get onDragOver =>
       props[_$key__onDragOver___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragOver] to see the source code for this prop
+  /// Callback for when the dragged element is over the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragOver] -->
   @override
   set onDragOver(MouseEventCallback value) =>
       props[_$key__onDragOver___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDragStart] to see the source code for this prop
+  /// Callback for when the user starts to drag an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragStart] -->
   @override
   MouseEventCallback get onDragStart =>
       props[_$key__onDragStart___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDragStart] to see the source code for this prop
+  /// Callback for when the user starts to drag an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragStart] -->
   @override
   set onDragStart(MouseEventCallback value) =>
       props[_$key__onDragStart___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onDrop] to see the source code for this prop
+  /// Callback for when the dragged element is dropped on the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrop] -->
   @override
   MouseEventCallback get onDrop =>
       props[_$key__onDrop___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onDrop] to see the source code for this prop
+  /// Callback for when the dragged element is dropped on the drop target
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrop] -->
   @override
   set onDrop(MouseEventCallback value) =>
       props[_$key__onDrop___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseDown] to see the source code for this prop
+  /// Callback for when the user presses a mouse button over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseDown] -->
   @override
   MouseEventCallback get onMouseDown =>
       props[_$key__onMouseDown___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseDown] to see the source code for this prop
+  /// Callback for when the user presses a mouse button over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseDown] -->
   @override
   set onMouseDown(MouseEventCallback value) =>
       props[_$key__onMouseDown___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseEnter] to see the source code for this prop
+  /// Callback for when the pointer is moved onto an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseEnter] -->
   @override
   MouseEventCallback get onMouseEnter =>
       props[_$key__onMouseEnter___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseEnter] to see the source code for this prop
+  /// Callback for when the pointer is moved onto an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseEnter] -->
   @override
   set onMouseEnter(MouseEventCallback value) =>
       props[_$key__onMouseEnter___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseLeave] to see the source code for this prop
+  /// Callback for when the pointer is moved out of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseLeave] -->
   @override
   MouseEventCallback get onMouseLeave =>
       props[_$key__onMouseLeave___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseLeave] to see the source code for this prop
+  /// Callback for when the pointer is moved out of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseLeave] -->
   @override
   set onMouseLeave(MouseEventCallback value) =>
       props[_$key__onMouseLeave___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseMove] to see the source code for this prop
+  /// Callback for when the pointer is moving while it is over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseMove] -->
   @override
   MouseEventCallback get onMouseMove =>
       props[_$key__onMouseMove___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseMove] to see the source code for this prop
+  /// Callback for when the pointer is moving while it is over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseMove] -->
   @override
   set onMouseMove(MouseEventCallback value) =>
       props[_$key__onMouseMove___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseOut] to see the source code for this prop
+  /// Callback for when a user moves the mouse pointer out of an element, or out of one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOut] -->
   @override
   MouseEventCallback get onMouseOut =>
       props[_$key__onMouseOut___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseOut] to see the source code for this prop
+  /// Callback for when a user moves the mouse pointer out of an element, or out of one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOut] -->
   @override
   set onMouseOut(MouseEventCallback value) =>
       props[_$key__onMouseOut___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseOver] to see the source code for this prop
+  /// Callback for when the pointer is moved onto an element, or onto one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOver] -->
   @override
   MouseEventCallback get onMouseOver =>
       props[_$key__onMouseOver___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseOver] to see the source code for this prop
+  /// Callback for when the pointer is moved onto an element, or onto one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOver] -->
   @override
   set onMouseOver(MouseEventCallback value) =>
       props[_$key__onMouseOver___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseUp] to see the source code for this prop
+  /// Callback for when a user releases a mouse button over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseUp] -->
   @override
   MouseEventCallback get onMouseUp =>
       props[_$key__onMouseUp___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onMouseUp] to see the source code for this prop
+  /// Callback for when a user releases a mouse button over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseUp] -->
   @override
   set onMouseUp(MouseEventCallback value) =>
       props[_$key__onMouseUp___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchCancel] to see the source code for this prop
+  /// Callback for when the touch is interrupted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchCancel] -->
   @override
   TouchEventCallback get onTouchCancel =>
       props[_$key__onTouchCancel___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchCancel] to see the source code for this prop
+  /// Callback for when the touch is interrupted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchCancel] -->
   @override
   set onTouchCancel(TouchEventCallback value) =>
       props[_$key__onTouchCancel___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchEnd] to see the source code for this prop
+  /// Callback for when a finger is removed from a touch screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchEnd] -->
   @override
   TouchEventCallback get onTouchEnd =>
       props[_$key__onTouchEnd___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchEnd] to see the source code for this prop
+  /// Callback for when a finger is removed from a touch screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchEnd] -->
   @override
   set onTouchEnd(TouchEventCallback value) =>
       props[_$key__onTouchEnd___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchMove] to see the source code for this prop
+  /// Callback for when a finger is dragged across the screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchMove] -->
   @override
   TouchEventCallback get onTouchMove =>
       props[_$key__onTouchMove___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchMove] to see the source code for this prop
+  /// Callback for when a finger is dragged across the screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchMove] -->
   @override
   set onTouchMove(TouchEventCallback value) =>
       props[_$key__onTouchMove___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchStart] to see the source code for this prop
+  /// Callback for when a finger is placed on a touch screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchStart] -->
   @override
   TouchEventCallback get onTouchStart =>
       props[_$key__onTouchStart___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onTouchStart] to see the source code for this prop
+  /// Callback for when a finger is placed on a touch screen
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchStart] -->
   @override
   set onTouchStart(TouchEventCallback value) =>
       props[_$key__onTouchStart___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onScroll] to see the source code for this prop
+  /// Callback for when an element's scrollbar is being scrolled
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onScroll] -->
   @override
   UIEventCallback get onScroll =>
       props[_$key__onScroll___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onScroll] to see the source code for this prop
+  /// Callback for when an element's scrollbar is being scrolled
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onScroll] -->
   @override
   set onScroll(UIEventCallback value) =>
       props[_$key__onScroll___$UbiquitousDomPropsMixin] = value;
 
-  /// Go to [_$UbiquitousDomPropsMixin.onWheel] to see the source code for this prop
+  /// Callback for when the mouse wheel rolls up or down over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onWheel] -->
   @override
   WheelEventCallback get onWheel =>
       props[_$key__onWheel___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$UbiquitousDomPropsMixin.onWheel] to see the source code for this prop
+  /// Callback for when the mouse wheel rolls up or down over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onWheel] -->
   @override
   set onWheel(WheelEventCallback value) =>
       props[_$key__onWheel___$UbiquitousDomPropsMixin] = value;

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -106,83 +106,231 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
         ..shrink = false
         ..quickMount = false;
 
-  /// Go to [_$ResizeSensorPropsMixin.onInitialize] to see the source code for this prop
+  /// A function invoked with a `ResizeSensorEvent` argument when the resize sensor is initialized.
+  ///
+  /// > Will never be called if [quickMount] is `true`.
+  ///
+  /// Related: [onResize]
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onInitialize] -->
   @override
   ResizeSensorHandler get onInitialize =>
       props[_$key__onInitialize___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.onInitialize] to see the source code for this prop
+  /// A function invoked with a `ResizeSensorEvent` argument when the resize sensor is initialized.
+  ///
+  /// > Will never be called if [quickMount] is `true`.
+  ///
+  /// Related: [onResize]
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onInitialize] -->
   @override
   set onInitialize(ResizeSensorHandler value) =>
       props[_$key__onInitialize___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.onResize] to see the source code for this prop
+  /// A function invoked with a `ResizeSensorEvent` argument when the [ResizeSensor]
+  /// resizes, either due to its parent or children resizing.
+  ///
+  /// > __If this callback is not firing when you expect it to__,
+  ///   check out [onDetachedMountCheck] for a possible workaround.
+  ///
+  /// Related: [onInitialize]
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onResize] -->
   @override
   ResizeSensorHandler get onResize =>
       props[_$key__onResize___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.onResize] to see the source code for this prop
+  /// A function invoked with a `ResizeSensorEvent` argument when the [ResizeSensor]
+  /// resizes, either due to its parent or children resizing.
+  ///
+  /// > __If this callback is not firing when you expect it to__,
+  ///   check out [onDetachedMountCheck] for a possible workaround.
+  ///
+  /// Related: [onInitialize]
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onResize] -->
   @override
   set onResize(ResizeSensorHandler value) =>
       props[_$key__onResize___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.isFlexChild] to see the source code for this prop
+  /// Whether the [ResizeSensor] is a child of a flex item. Necessary to apply the correct styling.
+  ///
+  /// See this issue for details: <https://code.google.com/p/chromium/issues/detail?id=346275>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexChild] -->
   @override
   bool get isFlexChild =>
       props[_$key__isFlexChild___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.isFlexChild] to see the source code for this prop
+  /// Whether the [ResizeSensor] is a child of a flex item. Necessary to apply the correct styling.
+  ///
+  /// See this issue for details: <https://code.google.com/p/chromium/issues/detail?id=346275>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexChild] -->
   @override
   set isFlexChild(bool value) =>
       props[_$key__isFlexChild___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.isFlexContainer] to see the source code for this prop
+  /// Whether the [ResizeSensor] is a flex container. Necessary to apply the correct styling.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexContainer] -->
   @override
   bool get isFlexContainer =>
       props[_$key__isFlexContainer___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.isFlexContainer] to see the source code for this prop
+  /// Whether the [ResizeSensor] is a flex container. Necessary to apply the correct styling.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexContainer] -->
   @override
   set isFlexContainer(bool value) =>
       props[_$key__isFlexContainer___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.shrink] to see the source code for this prop
+  /// Whether the [ResizeSensor] should shrink to the size of its child.
+  ///
+  /// __WARNING:__ If set to true there is a possibility that the [ResizeSensor] will not work due to it being too
+  /// small.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.shrink] -->
   @override
   bool get shrink =>
       props[_$key__shrink___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.shrink] to see the source code for this prop
+  /// Whether the [ResizeSensor] should shrink to the size of its child.
+  ///
+  /// __WARNING:__ If set to true there is a possibility that the [ResizeSensor] will not work due to it being too
+  /// small.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.shrink] -->
   @override
   set shrink(bool value) =>
       props[_$key__shrink___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.quickMount] to see the source code for this prop
+  /// Whether quick-mount mode is enabled, which minimizes layouts caused by accessing element dimensions
+  /// during initialization, allowing the component to mount faster.
+  ///
+  /// When enabled:
+  ///
+  /// * The initial dimensions will not be retrieved, so the first [onResize]
+  ///   event will contain `0` for the previous dimensions.
+  ///
+  ///     * [onInitialize] will never be called.
+  ///
+  /// * The sensors will be initialized/reset in the next animation frame after mount, as opposed to synchronously,
+  ///   helping to break up resulting layouts.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.quickMount] -->
   @override
   bool get quickMount =>
       props[_$key__quickMount___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.quickMount] to see the source code for this prop
+  /// Whether quick-mount mode is enabled, which minimizes layouts caused by accessing element dimensions
+  /// during initialization, allowing the component to mount faster.
+  ///
+  /// When enabled:
+  ///
+  /// * The initial dimensions will not be retrieved, so the first [onResize]
+  ///   event will contain `0` for the previous dimensions.
+  ///
+  ///     * [onInitialize] will never be called.
+  ///
+  /// * The sensors will be initialized/reset in the next animation frame after mount, as opposed to synchronously,
+  ///   helping to break up resulting layouts.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.quickMount] -->
   @override
   set quickMount(bool value) =>
       props[_$key__quickMount___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.onDetachedMountCheck] to see the source code for this prop
+  /// A callback that returns a `bool` that indicates whether the [ResizeSensor] was detached from the DOM
+  /// when it first mounted.
+  ///
+  /// ### Why would I need to set this callback? ###
+  ///
+  /// If you have a [ResizeSensor] that is not emitting its [onResize] events, then the sensor was most likely
+  /// mounted detached from the DOM. In that situation, the use of this callback is the recommended way to
+  /// repair the resize behavior via a call to [ResizeSensorComponent.forceResetDetachedSensor] at a time
+  /// when you are sure that the sensor has become attached to the DOM.
+  ///
+  /// ### What does the bool argument indicate? ###
+  ///
+  /// * A `true` argument indicates that __the [ResizeSensor] was mounted detached from the DOM__,
+  ///   and a call to [ResizeSensorComponent.forceResetDetachedSensor] will be necessary to re-initialize the sensor.
+  ///
+  ///   > __NOTE:__ The re-initialization comes at the expense of force-clamping the `scrollLeft` / `scrollTop`
+  ///     values of the expand / collapse sensor nodes to the maximum possible value - which is what forces the
+  ///     reflow / paint that makes the [onResize] callbacks begin firing when expected again.
+  ///
+  /// * A `false` argument indicates that __the [ResizeSensor] was mounted attached to the DOM__.
+  ///
+  ///   > __NOTE:__ If this happens - you most likely do not need to set this callback. If for some reason the callback
+  ///     sometimes returns `true`, and sometimes returns `false` _(unexpected)_,
+  ///     you may have other underlying issues in your implementation that should be addressed separately.
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onDetachedMountCheck] -->
   @override
   BoolCallback get onDetachedMountCheck =>
       props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.onDetachedMountCheck] to see the source code for this prop
+  /// A callback that returns a `bool` that indicates whether the [ResizeSensor] was detached from the DOM
+  /// when it first mounted.
+  ///
+  /// ### Why would I need to set this callback? ###
+  ///
+  /// If you have a [ResizeSensor] that is not emitting its [onResize] events, then the sensor was most likely
+  /// mounted detached from the DOM. In that situation, the use of this callback is the recommended way to
+  /// repair the resize behavior via a call to [ResizeSensorComponent.forceResetDetachedSensor] at a time
+  /// when you are sure that the sensor has become attached to the DOM.
+  ///
+  /// ### What does the bool argument indicate? ###
+  ///
+  /// * A `true` argument indicates that __the [ResizeSensor] was mounted detached from the DOM__,
+  ///   and a call to [ResizeSensorComponent.forceResetDetachedSensor] will be necessary to re-initialize the sensor.
+  ///
+  ///   > __NOTE:__ The re-initialization comes at the expense of force-clamping the `scrollLeft` / `scrollTop`
+  ///     values of the expand / collapse sensor nodes to the maximum possible value - which is what forces the
+  ///     reflow / paint that makes the [onResize] callbacks begin firing when expected again.
+  ///
+  /// * A `false` argument indicates that __the [ResizeSensor] was mounted attached to the DOM__.
+  ///
+  ///   > __NOTE:__ If this happens - you most likely do not need to set this callback. If for some reason the callback
+  ///     sometimes returns `true`, and sometimes returns `false` _(unexpected)_,
+  ///     you may have other underlying issues in your implementation that should be addressed separately.
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onDetachedMountCheck] -->
   @override
   set onDetachedMountCheck(BoolCallback value) =>
       props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin] = value;
 
-  /// Go to [_$ResizeSensorPropsMixin.onDidReset] to see the source code for this prop
+  /// A callback intended for use only within internal unit tests that is called when [ResizeSensorComponent._reset]
+  /// is called.
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onDidReset] -->
   @override
   @visibleForTesting
   Callback get onDidReset =>
       props[_$key__onDidReset___$ResizeSensorPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ResizeSensorPropsMixin.onDidReset] to see the source code for this prop
+  /// A callback intended for use only within internal unit tests that is called when [ResizeSensorComponent._reset]
+  /// is called.
+  ///
+  /// <!-- Generated from [_$ResizeSensorPropsMixin.onDidReset] -->
   @override
   @visibleForTesting
   set onDidReset(Callback value) =>

--- a/lib/src/util/class_names.over_react.g.dart
+++ b/lib/src/util/class_names.over_react.g.dart
@@ -12,22 +12,42 @@ abstract class CssClassPropsMixin implements _$CssClassPropsMixin {
 
   static const PropsMeta meta = _$metaForCssClassPropsMixin;
 
-  /// Go to [_$CssClassPropsMixin.className] to see the source code for this prop
+  /// String of space-delimited CSS classes to be added to the resultant DOM.
+  ///
+  /// All over_react components merge any added classes with this prop and the [classNameBlacklist] prop (see
+  /// [UiComponent.forwardingClassNameBuilder]).
+  ///
+  /// <!-- Generated from [_$CssClassPropsMixin.className] -->
   @override
   String get className =>
       props[_$key__className___$CssClassPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$CssClassPropsMixin.className] to see the source code for this prop
+  /// String of space-delimited CSS classes to be added to the resultant DOM.
+  ///
+  /// All over_react components merge any added classes with this prop and the [classNameBlacklist] prop (see
+  /// [UiComponent.forwardingClassNameBuilder]).
+  ///
+  /// <!-- Generated from [_$CssClassPropsMixin.className] -->
   @override
   set className(String value) =>
       props[_$key__className___$CssClassPropsMixin] = value;
 
-  /// Go to [_$CssClassPropsMixin.classNameBlacklist] to see the source code for this prop
+  /// String of space-delimited CSS classes to be blacklisted from being added to the resultant DOM.
+  ///
+  /// All over_react components merge any added classes with this prop and the [className] prop (see
+  /// [UiComponent.forwardingClassNameBuilder]).
+  ///
+  /// <!-- Generated from [_$CssClassPropsMixin.classNameBlacklist] -->
   @override
   String get classNameBlacklist =>
       props[_$key__classNameBlacklist___$CssClassPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$CssClassPropsMixin.classNameBlacklist] to see the source code for this prop
+  /// String of space-delimited CSS classes to be blacklisted from being added to the resultant DOM.
+  ///
+  /// All over_react components merge any added classes with this prop and the [className] prop (see
+  /// [UiComponent.forwardingClassNameBuilder]).
+  ///
+  /// <!-- Generated from [_$CssClassPropsMixin.classNameBlacklist] -->
   @override
   set classNameBlacklist(String value) =>
       props[_$key__classNameBlacklist___$CssClassPropsMixin] = value;

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -22,102 +22,102 @@ abstract class _$TransitionerPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TransitionerProps.onHandlePreShowing] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandlePreShowing] -->
   @override
   Callback get onHandlePreShowing =>
       props[_$key__onHandlePreShowing___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onHandlePreShowing] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandlePreShowing] -->
   @override
   set onHandlePreShowing(Callback value) =>
       props[_$key__onHandlePreShowing___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onHandleShowing] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleShowing] -->
   @override
   Callback get onHandleShowing =>
       props[_$key__onHandleShowing___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onHandleShowing] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleShowing] -->
   @override
   set onHandleShowing(Callback value) =>
       props[_$key__onHandleShowing___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onHandleShown] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleShown] -->
   @override
   Callback get onHandleShown =>
       props[_$key__onHandleShown___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onHandleShown] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleShown] -->
   @override
   set onHandleShown(Callback value) =>
       props[_$key__onHandleShown___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onHandleHiding] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleHiding] -->
   @override
   Callback get onHandleHiding =>
       props[_$key__onHandleHiding___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onHandleHiding] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleHiding] -->
   @override
   set onHandleHiding(Callback value) =>
       props[_$key__onHandleHiding___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onHandleHidden] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleHidden] -->
   @override
   Callback get onHandleHidden =>
       props[_$key__onHandleHidden___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onHandleHidden] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onHandleHidden] -->
   @override
   set onHandleHidden(Callback value) =>
       props[_$key__onHandleHidden___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onPrepareShow] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onPrepareShow] -->
   @override
   Callback get onPrepareShow =>
       props[_$key__onPrepareShow___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onPrepareShow] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onPrepareShow] -->
   @override
   set onPrepareShow(Callback value) =>
       props[_$key__onPrepareShow___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.onPrepareHide] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onPrepareHide] -->
   @override
   Callback get onPrepareHide =>
       props[_$key__onPrepareHide___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.onPrepareHide] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.onPrepareHide] -->
   @override
   set onPrepareHide(Callback value) =>
       props[_$key__onPrepareHide___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.hasTransition] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.hasTransition] -->
   @override
   bool get hasTransition =>
       props[_$key__hasTransition___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.hasTransition] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.hasTransition] -->
   @override
   set hasTransition(bool value) =>
       props[_$key__hasTransition___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.initiallyShown] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.initiallyShown] -->
   @override
   bool get initiallyShown =>
       props[_$key__initiallyShown___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.initiallyShown] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.initiallyShown] -->
   @override
   set initiallyShown(bool value) =>
       props[_$key__initiallyShown___$TransitionerProps] = value;
 
-  /// Go to [_$TransitionerProps.transitionTimeout] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.transitionTimeout] -->
   @override
   Duration get transitionTimeout =>
       props[_$key__transitionTimeout___$TransitionerProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TransitionerProps.transitionTimeout] to see the source code for this prop
+  /// <!-- Generated from [_$TransitionerProps.transitionTimeout] -->
   @override
   set transitionTimeout(Duration value) =>
       props[_$key__transitionTimeout___$TransitionerProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -11,67 +11,67 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -137,69 +137,69 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] =
           value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[
           _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) => props[
@@ -279,67 +279,67 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>
@@ -406,69 +406,69 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] =
           value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[
           _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) => state[

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -12,66 +12,66 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   static const PropsMeta meta = _$metaForTestPropsMixin;
 
-  /// Go to [_$TestPropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestPropsMixin] = value;
 
-  /// Go to [_$TestPropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestPropsMixin] = value;
 
-  /// Go to [_$TestPropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
   set untypedProp(value) => props[_$key__untypedProp___$TestPropsMixin] = value;
 
-  /// Go to [_$TestPropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestPropsMixin] = value;
 
-  /// Go to [_$TestPropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestPropsMixin] = value;
 
-  /// Go to [_$TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -133,69 +133,69 @@ abstract class TestCustomNamespacePropsMixin
 
   static const PropsMeta meta = _$metaForTestCustomNamespacePropsMixin;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin] =
           value;
 
-  /// Go to [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[
           _$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -267,67 +267,67 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   static const StateMeta meta = _$metaForTestStateMixin;
 
-  /// Go to [_$TestStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestStateMixin] = value;
 
-  /// Go to [_$TestStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestStateMixin] = value;
 
-  /// Go to [_$TestStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestStateMixin] = value;
 
-  /// Go to [_$TestStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestStateMixin] = value;
 
-  /// Go to [_$TestStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestStateMixin] = value;
 
-  /// Go to [_$TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>
@@ -390,69 +390,69 @@ abstract class TestCustomNamespaceStateMixin
 
   static const StateMeta meta = _$metaForTestCustomNamespaceStateMixin;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin] =
           value;
 
-  /// Go to [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[
           _$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) => state[

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
@@ -11,67 +11,67 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestAbstractProps] = value;
 
-  /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -132,69 +132,69 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] =
           value;
 
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[
           _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) => props[
@@ -268,67 +268,67 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestAbstractState] = value;
 
-  /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>
@@ -390,69 +390,69 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$TestCustomNamespaceAbstractState] = value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] =
           value;
 
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[
           _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) => state[

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
@@ -12,66 +12,66 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   static const PropsMeta meta = _$metaForTestPropsMixin;
 
-  /// Go to [TestPropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp__TestPropsMixin] = value;
 
-  /// Go to [TestPropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp__TestPropsMixin] = value;
 
-  /// Go to [TestPropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.untypedProp] -->
   @override
   set untypedProp(value) => props[_$key__untypedProp__TestPropsMixin] = value;
 
-  /// Go to [TestPropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp__TestPropsMixin] = value;
 
-  /// Go to [TestPropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp__TestPropsMixin] = value;
 
-  /// Go to [TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestPropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -133,67 +133,67 @@ abstract class $TestCustomNamespacePropsMixin
 
   static const PropsMeta meta = _$metaForTestCustomNamespacePropsMixin;
 
-  /// Go to [TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.stringProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp__TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp__TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp__TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp__TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin] = value;
 
-  /// Go to [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp__TestCustomNamespacePropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -264,66 +264,66 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   static const StateMeta meta = _$metaForTestStateMixin;
 
-  /// Go to [TestStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState__TestStateMixin] = value;
 
-  /// Go to [TestStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState__TestStateMixin] = value;
 
-  /// Go to [TestStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.untypedState] -->
   @override
   set untypedState(value) => state[_$key__untypedState__TestStateMixin] = value;
 
-  /// Go to [TestStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState__TestStateMixin] = value;
 
-  /// Go to [TestStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState__TestStateMixin] = value;
 
-  /// Go to [TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState__TestStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>
@@ -385,67 +385,67 @@ abstract class $TestCustomNamespaceStateMixin
 
   static const StateMeta meta = _$metaForTestCustomNamespaceStateMixin;
 
-  /// Go to [TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.stringState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState__TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState__TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.untypedState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState__TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState__TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState__TestCustomNamespaceStateMixin] = value;
 
-  /// Go to [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState__TestCustomNamespaceStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -22,67 +22,67 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -22,24 +22,24 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
   set nullable(value) => props[_$key__nullable___$ComponentTestProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -22,33 +22,33 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   get generated1Prop =>
       props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   set generated1Prop(value) =>
       props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   get generated2Prop =>
       props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   set generated2Prop(value) =>
       props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
       props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
   set explicitlyGeneratedProp(value) =>
@@ -133,34 +133,34 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   get generated1State =>
       state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   set generated1State(value) =>
       state[_$key__generated1State___$DoNotGenerateAccessorTestState] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   get generated2State =>
       state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   set generated2State(value) =>
       state[_$key__generated2State___$DoNotGenerateAccessorTestState] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
       state[
           _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)
   set explicitlyGeneratedState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -22,67 +22,67 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -187,67 +187,67 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -20,12 +20,12 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   Map get props;
 
-  /// Go to [_$FooProps._privateProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   String get _privateProp =>
       props[_$key___privateProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps._privateProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   set _privateProp(String value) =>
       props[_$key___privateProp___$FooProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -22,7 +22,7 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
       isRequired: true,
@@ -30,14 +30,14 @@ abstract class _$ComponentTestPropsAccessorsMixin
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(
       isRequired: true,
@@ -46,7 +46,7 @@ abstract class _$ComponentTestPropsAccessorsMixin
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(
       isRequired: true,

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_prop_integration_tests.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_prop_integration_tests.over_react.g.dart
@@ -22,24 +22,24 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
   set nullable(value) => props[_$key__nullable___$ComponentTestProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -73,67 +73,67 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -20,21 +20,21 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   Map get props;
 
-  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
 
-  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   String get unassignedProp =>
       props[_$key__unassignedProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   set unassignedProp(String value) =>
       props[_$key__unassignedProp___$FooProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -22,67 +22,67 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -22,24 +22,24 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
   set nullable(value) => props[_$key__nullable___$ComponentTestProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -22,33 +22,33 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   get generated1Prop =>
       props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated1Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   set generated1Prop(value) =>
       props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   get generated2Prop =>
       props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.generated2Prop] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   set generated2Prop(value) =>
       props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
       props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
   set explicitlyGeneratedProp(value) =>
@@ -138,34 +138,34 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   get generated1State =>
       state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.generated1State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   set generated1State(value) =>
       state[_$key__generated1State___$DoNotGenerateAccessorTestState] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   get generated2State =>
       state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.generated2State] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   set generated2State(value) =>
       state[_$key__generated2State___$DoNotGenerateAccessorTestState] = value;
 
-  /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
       state[
           _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] to see the source code for this prop
+  /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)
   set explicitlyGeneratedState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -22,67 +22,67 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
       props[_$key__stringProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
       props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.dynamicProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
       props[_$key__dynamicProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   get untypedProp =>
       props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.untypedProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
       props[_$key__untypedProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
       props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customKeyProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(value) =>
       props[_$key__customKeyProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
       props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(value) =>
       props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] = value;
 
-  /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
       props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(value) =>
@@ -192,67 +192,67 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$NamespacedAccessorTestState] = value;
 
-  /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$NamespacedAccessorTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -20,12 +20,12 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   Map get props;
 
-  /// Go to [_$FooProps._privateProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   String get _privateProp =>
       props[_$key___privateProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps._privateProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   set _privateProp(String value) =>
       props[_$key___privateProp___$FooProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -22,7 +22,7 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
       isRequired: true,
@@ -30,14 +30,14 @@ abstract class _$ComponentTestPropsAccessorsMixin
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(
       isRequired: true,
@@ -46,7 +46,7 @@ abstract class _$ComponentTestPropsAccessorsMixin
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(
       isRequired: true,

--- a/test/over_react/component_declaration/builder_integration_tests/required_prop_integration_tests.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_prop_integration_tests.over_react.g.dart
@@ -22,24 +22,24 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
   get required =>
       props[_$key__required___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Required(message: 'This Prop is Required for testing purposes.')
   set required(value) => props[_$key__required___$ComponentTestProps] = value;
 
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
   get nullable =>
       props[_$key__nullable___$ComponentTestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ComponentTestProps.nullable] to see the source code for this prop
+  /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Required(isNullable: true, message: 'This prop can be set to null!')
   set nullable(value) => props[_$key__nullable___$ComponentTestProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -78,67 +78,67 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   String get stringState =>
       state[_$key__stringState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.stringState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   set stringState(String value) =>
       state[_$key__stringState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
       state[_$key__dynamicState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.dynamicState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
       state[_$key__dynamicState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   get untypedState =>
       state[_$key__untypedState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.untypedState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   set untypedState(value) =>
       state[_$key__untypedState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
       state[_$key__customKeyState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customKeyState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
   set customKeyState(value) =>
       state[_$key__customKeyState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
       state[_$key__customNamespaceState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceState(value) =>
       state[_$key__customNamespaceState___$StatefulComponentTestState] = value;
 
-  /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
       state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$StatefulComponentTestState.customKeyAndNamespaceState] to see the source code for this prop
+  /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceState(value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -20,21 +20,21 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override
   Map get props;
 
-  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   String get stringProp =>
       props[_$key__stringProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.stringProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
 
-  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   String get unassignedProp =>
       props[_$key__unassignedProp___$FooProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$FooProps.unassignedProp] to see the source code for this prop
+  /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   set unassignedProp(String value) =>
       props[_$key__unassignedProp___$FooProps] = value;

--- a/test/over_react/component_declaration/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test.over_react.g.dart
@@ -284,13 +284,13 @@ abstract class _$TestPropValidationPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestPropValidationProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
   String get required =>
       props[_$key__required___$TestPropValidationProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestPropValidationProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
   set required(String value) =>
@@ -988,14 +988,14 @@ abstract class _$TestStatefulPropValidationPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestStatefulPropValidationProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$TestStatefulPropValidationProps.required] -->
   @override
   @override
   @requiredProp
   String get required =>
       props[_$key__required___$TestStatefulPropValidationProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestStatefulPropValidationProps.required] to see the source code for this prop
+  /// <!-- Generated from [_$TestStatefulPropValidationProps.required] -->
   @override
   @override
   @requiredProp

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -22,33 +22,33 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$TestCompositeComponentProps.onComponentDidMount] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidMount] -->
   @override
   Function get onComponentDidMount =>
       props[_$key__onComponentDidMount___$TestCompositeComponentProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCompositeComponentProps.onComponentDidMount] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidMount] -->
   @override
   set onComponentDidMount(Function value) =>
       props[_$key__onComponentDidMount___$TestCompositeComponentProps] = value;
 
-  /// Go to [_$TestCompositeComponentProps.onComponentWillUnmount] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentWillUnmount] -->
   @override
   Function get onComponentWillUnmount =>
       props[_$key__onComponentWillUnmount___$TestCompositeComponentProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCompositeComponentProps.onComponentWillUnmount] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentWillUnmount] -->
   @override
   set onComponentWillUnmount(Function value) =>
       props[_$key__onComponentWillUnmount___$TestCompositeComponentProps] =
           value;
 
-  /// Go to [_$TestCompositeComponentProps.onComponentDidUpdate] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidUpdate] -->
   @override
   Function get onComponentDidUpdate =>
       props[_$key__onComponentDidUpdate___$TestCompositeComponentProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestCompositeComponentProps.onComponentDidUpdate] to see the source code for this prop
+  /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidUpdate] -->
   @override
   set onComponentDidUpdate(Function value) =>
       props[_$key__onComponentDidUpdate___$TestCompositeComponentProps] = value;

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -20,21 +20,21 @@ abstract class _$TestPropsAccessorsMixin implements _$TestProps {
   @override
   Map get props;
 
-  /// Go to [_$TestProps.foo] to see the source code for this prop
+  /// <!-- Generated from [_$TestProps.foo] -->
   @override
   String get foo =>
       props[_$key__foo___$TestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestProps.foo] to see the source code for this prop
+  /// <!-- Generated from [_$TestProps.foo] -->
   @override
   set foo(String value) => props[_$key__foo___$TestProps] = value;
 
-  /// Go to [_$TestProps.bar] to see the source code for this prop
+  /// <!-- Generated from [_$TestProps.bar] -->
   @override
   String get bar =>
       props[_$key__bar___$TestProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TestProps.bar] to see the source code for this prop
+  /// <!-- Generated from [_$TestProps.bar] -->
   @override
   set bar(String value) => props[_$key__bar___$TestProps] = value;
   /* GENERATED CONSTANTS */

--- a/test/vm_tests/builder/impl_generation_test.dart
+++ b/test/vm_tests/builder/impl_generation_test.dart
@@ -176,7 +176,7 @@ main() {
                   });
 
                   test('containing links to source', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  /// Go to [_\$$className.someField] to see the source code for this prop\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  /// <!-- Generated from [_\$$className.someField] -->\n'));
                   });
 
                   test('that carry over annotations', () {
@@ -234,7 +234,7 @@ main() {
                   });
 
                   test('containing links to source', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  /// Go to [$className.someField] to see the source code for this prop\n'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  /// <!-- Generated from [$className.someField] -->\n'));
                   });
 
                   test('that carry over annotations', () {

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -20,6 +20,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
@@ -27,6 +29,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -20,61 +20,61 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
   /* GENERATED CONSTANTS */

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -22,62 +22,62 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>
       props[_$key__basicProp___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
       props[_$key__basic1___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
       props[_$key__basic2___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
       props[_$key__basic3___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
       props[_$key__basic4___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
       props[_$key__basic5___$BasicPartOfLibProps] = value;
@@ -170,12 +170,12 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   String get basicState =>
       state[_$key__basicState___$BasicPartOfLibState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
       state[_$key__basicState___$BasicPartOfLibState] = value;
@@ -262,12 +262,12 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   String get subProp =>
       props[_$key__subProp___$SubPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
       props[_$key__subProp___$SubPartOfLibProps] = value;
@@ -351,12 +351,12 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   String get superProp =>
       props[_$key__superProp___$SuperPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>
       props[_$key__superProp___$SuperPartOfLibProps] = value;

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -22,11 +22,15 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -20,6 +20,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
@@ -27,6 +29,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -20,61 +20,61 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   Map get props;
 
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   String get basicProp =>
       props[_$key__basicProp___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
   @requiredProp
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
   /* GENERATED CONSTANTS */

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -22,62 +22,62 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basicProp] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>
       props[_$key__basicProp___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   String get basic1 =>
       props[_$key__basic1___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic1] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
       props[_$key__basic1___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   String get basic2 =>
       props[_$key__basic2___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic2] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
       props[_$key__basic2___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   String get basic3 =>
       props[_$key__basic3___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic3] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
       props[_$key__basic3___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   String get basic4 =>
       props[_$key__basic4___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic4] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
       props[_$key__basic4___$BasicPartOfLibProps] = value;
 
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   String get basic5 =>
       props[_$key__basic5___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibProps.basic5] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
       props[_$key__basic5___$BasicPartOfLibProps] = value;
@@ -175,12 +175,12 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   String get basicState =>
       state[_$key__basicState___$BasicPartOfLibState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$BasicPartOfLibState.basicState] to see the source code for this prop
+  /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
       state[_$key__basicState___$BasicPartOfLibState] = value;
@@ -272,12 +272,12 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   String get subProp =>
       props[_$key__subProp___$SubPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SubPartOfLibProps.subProp] to see the source code for this prop
+  /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
       props[_$key__subProp___$SubPartOfLibProps] = value;
@@ -366,12 +366,12 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   String get superProp =>
       props[_$key__superProp___$SuperPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$SuperPartOfLibProps.superProp] to see the source code for this prop
+  /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>
       props[_$key__superProp___$SuperPartOfLibProps] = value;

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -22,11 +22,15 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   @override
   Map get props;
 
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   String get basicProp =>
       props[_$key__basicProp___$BasicPartOfLibProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Test that doc comment is copied over.
+  ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>

--- a/test_fixtures/source_files/backwards_compatible/basic.dart
+++ b/test_fixtures/source_files/backwards_compatible/basic.dart
@@ -12,6 +12,7 @@ class BasicProps extends _$BasicProps with _$BasicPropsAccessorsMixin {
 @Props()
 //// ignore: mixin_of_non_class,undefined_class
 class _$BasicProps extends UiProps {
+  /// Test that doc comment is copied over.
   @deprecated
   @requiredProp
   String basicProp;

--- a/test_fixtures/source_files/backwards_compatible/part_of_basic_library.dart
+++ b/test_fixtures/source_files/backwards_compatible/part_of_basic_library.dart
@@ -12,6 +12,7 @@ class BasicPartOfLibProps extends _$BasicPartOfLibProps with _$BasicPartOfLibPro
 class _$BasicPartOfLibProps extends UiProps
     with  ExamplePropsMixinClass, $ExamplePropsMixinClass {
 
+  /// Test that doc comment is copied over.
   String basicProp;
   String basic1;
   String basic2;

--- a/test_fixtures/source_files/basic.dart
+++ b/test_fixtures/source_files/basic.dart
@@ -8,6 +8,7 @@ UiFactory<BasicProps> Basic = _$Basic;
 @Props()
 //// ignore: mixin_of_non_class,undefined_class
 class _$BasicProps extends UiProps {
+  /// Test that doc comment is copied over.
   @deprecated
   @requiredProp
   String basicProp;

--- a/test_fixtures/source_files/part_of_basic_library.dart
+++ b/test_fixtures/source_files/part_of_basic_library.dart
@@ -7,6 +7,7 @@ UiFactory<BasicPartOfLibProps> BasicPartOfLib = _$BasicPartOfLib;
 class _$BasicPartOfLibProps extends UiProps
     with ExamplePropsMixinClass {
 
+  /// Test that doc comment is copied over.
   String basicProp;
   String basic1;
   String basic2;

--- a/web/src/demo_components/button.over_react.g.dart
+++ b/web/src/demo_components/button.over_react.g.dart
@@ -20,81 +20,181 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   @override
   Map get props;
 
-  /// Go to [_$ButtonProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Button].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#examples>.
+  ///
+  /// Default: [ButtonSkin.PRIMARY]
+  ///
+  /// <!-- Generated from [_$ButtonProps.skin] -->
   @override
   ButtonSkin get skin =>
       props[_$key__skin___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Button].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#examples>.
+  ///
+  /// Default: [ButtonSkin.PRIMARY]
+  ///
+  /// <!-- Generated from [_$ButtonProps.skin] -->
   @override
   set skin(ButtonSkin value) => props[_$key__skin___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.size] to see the source code for this prop
+  /// The size of the [Button].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#sizes>.
+  ///
+  /// Default: [ButtonSize.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ButtonProps.size] -->
   @override
   ButtonSize get size =>
       props[_$key__size___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.size] to see the source code for this prop
+  /// The size of the [Button].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#sizes>.
+  ///
+  /// Default: [ButtonSize.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ButtonProps.size] -->
   @override
   set size(ButtonSize value) => props[_$key__size___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.isActive] to see the source code for this prop
+  /// Whether the [Button] should appear "active".
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#active-state>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isActive] -->
   @override
   bool get isActive =>
       props[_$key__isActive___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.isActive] to see the source code for this prop
+  /// Whether the [Button] should appear "active".
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#active-state>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isActive] -->
   @override
   set isActive(bool value) => props[_$key__isActive___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.isDisabled] to see the source code for this prop
+  /// Whether the [Button] is disabled.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#disabled-state>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
   bool get isDisabled =>
       props[_$key__isDisabled___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.isDisabled] to see the source code for this prop
+  /// Whether the [Button] is disabled.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#disabled-state>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
   set isDisabled(bool value) => props[_$key__isDisabled___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.isBlock] to see the source code for this prop
+  /// Whether the [Button] is a block level button -- that which spans the full
+  /// width of its parent.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isBlock] -->
   @override
   bool get isBlock =>
       props[_$key__isBlock___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.isBlock] to see the source code for this prop
+  /// Whether the [Button] is a block level button -- that which spans the full
+  /// width of its parent.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonProps.isBlock] -->
   @override
   set isBlock(bool value) => props[_$key__isBlock___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.href] to see the source code for this prop
+  /// The HTML `href` attribute value for the [Button].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.href]_
+  ///
+  /// <!-- Generated from [_$ButtonProps.href] -->
   @override
   @Accessor(keyNamespace: '')
   String get href =>
       props[_$key__href___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.href] to see the source code for this prop
+  /// The HTML `href` attribute value for the [Button].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.href]_
+  ///
+  /// <!-- Generated from [_$ButtonProps.href] -->
   @override
   @Accessor(keyNamespace: '')
   set href(String value) => props[_$key__href___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.target] to see the source code for this prop
+  /// The HTML `target` attribute value for the [Button].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.target]_
+  ///
+  /// <!-- Generated from [_$ButtonProps.target] -->
   @override
   @Accessor(keyNamespace: '')
   String get target =>
       props[_$key__target___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.target] to see the source code for this prop
+  /// The HTML `target` attribute value for the [Button].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.target]_
+  ///
+  /// <!-- Generated from [_$ButtonProps.target] -->
   @override
   @Accessor(keyNamespace: '')
   set target(String value) => props[_$key__target___$ButtonProps] = value;
 
-  /// Go to [_$ButtonProps.type] to see the source code for this prop
+  /// The HTML `type` attribute value for the [Button] when
+  /// rendered via [Dom.button].
+  ///
+  /// This will only be applied if [href] is not set.
+  ///
+  /// _Proxies [DomProps.type]_
+  ///
+  /// Default: [ButtonType.BUTTON]
+  ///
+  /// <!-- Generated from [_$ButtonProps.type] -->
   @override
   ButtonType get type =>
       props[_$key__type___$ButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonProps.type] to see the source code for this prop
+  /// The HTML `type` attribute value for the [Button] when
+  /// rendered via [Dom.button].
+  ///
+  /// This will only be applied if [href] is not set.
+  ///
+  /// _Proxies [DomProps.type]_
+  ///
+  /// Default: [ButtonType.BUTTON]
+  ///
+  /// <!-- Generated from [_$ButtonProps.type] -->
   @override
   set type(ButtonType value) => props[_$key__type___$ButtonProps] = value;
   /* GENERATED CONSTANTS */

--- a/web/src/demo_components/button_group.over_react.g.dart
+++ b/web/src/demo_components/button_group.over_react.g.dart
@@ -21,31 +21,59 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   @override
   Map get props;
 
-  /// Go to [_$ButtonGroupProps.size] to see the source code for this prop
+  /// Apply a button size variation universally to every [Button] within the [ButtonGroup].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#sizing>.
+  ///
+  /// Default: [ButtonGroupSize.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.size] -->
   @override
   ButtonGroupSize get size =>
       props[_$key__size___$ButtonGroupProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonGroupProps.size] to see the source code for this prop
+  /// Apply a button size variation universally to every [Button] within the [ButtonGroup].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#sizing>.
+  ///
+  /// Default: [ButtonGroupSize.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.size] -->
   @override
   set size(ButtonGroupSize value) =>
       props[_$key__size___$ButtonGroupProps] = value;
 
-  /// Go to [_$ButtonGroupProps.skin] to see the source code for this prop
+  /// The [ButtonSkin] variation applied to every [Button] within the [ButtonGroup].
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.skin] -->
   @override
   ButtonSkin get skin =>
       props[_$key__skin___$ButtonGroupProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonGroupProps.skin] to see the source code for this prop
+  /// The [ButtonSkin] variation applied to every [Button] within the [ButtonGroup].
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.skin] -->
   @override
   set skin(ButtonSkin value) => props[_$key__skin___$ButtonGroupProps] = value;
 
-  /// Go to [_$ButtonGroupProps.isVertical] to see the source code for this prop
+  /// Make the [Button]s within a [ButtonGroup] stack vertically.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.isVertical] -->
   @override
   bool get isVertical =>
       props[_$key__isVertical___$ButtonGroupProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ButtonGroupProps.isVertical] to see the source code for this prop
+  /// Make the [Button]s within a [ButtonGroup] stack vertically.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ButtonGroupProps.isVertical] -->
   @override
   set isVertical(bool value) =>
       props[_$key__isVertical___$ButtonGroupProps] = value;

--- a/web/src/demo_components/list_group.over_react.g.dart
+++ b/web/src/demo_components/list_group.over_react.g.dart
@@ -21,12 +21,22 @@ abstract class _$ListGroupPropsAccessorsMixin implements _$ListGroupProps {
   @override
   Map get props;
 
-  /// Go to [_$ListGroupProps.elementType] to see the source code for this prop
+  /// The HTML element type for the [ListGroup], specifying its
+  /// DOM representation when rendered.
+  ///
+  /// Default: [ListGroupElementType.DIV]
+  ///
+  /// <!-- Generated from [_$ListGroupProps.elementType] -->
   @override
   ListGroupElementType get elementType =>
       props[_$key__elementType___$ListGroupProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupProps.elementType] to see the source code for this prop
+  /// The HTML element type for the [ListGroup], specifying its
+  /// DOM representation when rendered.
+  ///
+  /// Default: [ListGroupElementType.DIV]
+  ///
+  /// <!-- Generated from [_$ListGroupProps.elementType] -->
   @override
   set elementType(ListGroupElementType value) =>
       props[_$key__elementType___$ListGroupProps] = value;

--- a/web/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/src/demo_components/list_group_item.over_react.g.dart
@@ -22,107 +22,221 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ListGroupItemProps.elementType] to see the source code for this prop
+  /// The HTML element type for the [ListGroupItem], specifying its DOM
+  /// representation when rendered.
+  ///
+  /// Will only be used if [href] and [onClick] are both `null`.
+  ///
+  /// Default: [ListGroupItemElementType.SPAN]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.elementType] -->
   @override
   ListGroupItemElementType get elementType =>
       props[_$key__elementType___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.elementType] to see the source code for this prop
+  /// The HTML element type for the [ListGroupItem], specifying its DOM
+  /// representation when rendered.
+  ///
+  /// Will only be used if [href] and [onClick] are both `null`.
+  ///
+  /// Default: [ListGroupItemElementType.SPAN]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.elementType] -->
   @override
   set elementType(ListGroupItemElementType value) =>
       props[_$key__elementType___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.header] to see the source code for this prop
+  /// Optional header text to display within the [ListGroupItem] above
+  /// the value of [children].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#custom-content>.
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.header] -->
   @override
   dynamic get header =>
       props[_$key__header___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.header] to see the source code for this prop
+  /// Optional header text to display within the [ListGroupItem] above
+  /// the value of [children].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#custom-content>.
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.header] -->
   @override
   set header(dynamic value) =>
       props[_$key__header___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.headerSize] to see the source code for this prop
+  /// The size of the [header] text you desire.
+  ///
+  /// Default: [ListGroupItemHeaderElementSize.H5]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.headerSize] -->
   @override
   ListGroupItemHeaderElementSize get headerSize =>
       props[_$key__headerSize___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.headerSize] to see the source code for this prop
+  /// The size of the [header] text you desire.
+  ///
+  /// Default: [ListGroupItemHeaderElementSize.H5]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.headerSize] -->
   @override
   set headerSize(ListGroupItemHeaderElementSize value) =>
       props[_$key__headerSize___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.headerProps] to see the source code for this prop
+  /// Additional props to be added to the [header] element _(if specified)_.
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
   @override
   Map get headerProps =>
       props[_$key__headerProps___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.headerProps] to see the source code for this prop
+  /// Additional props to be added to the [header] element _(if specified)_.
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
   @override
   set headerProps(Map value) =>
       props[_$key__headerProps___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [ListGroupItem].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#contextual-classes>.
+  ///
+  /// Default: [ListGroupItemSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.skin] -->
   @override
   ListGroupItemSkin get skin =>
       props[_$key__skin___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [ListGroupItem].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#contextual-classes>.
+  ///
+  /// Default: [ListGroupItemSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.skin] -->
   @override
   set skin(ListGroupItemSkin value) =>
       props[_$key__skin___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.isActive] to see the source code for this prop
+  /// Whether the [ListGroupItem] should appear "active".
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#anchors-and-buttons>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.isActive] -->
   @override
   bool get isActive =>
       props[_$key__isActive___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.isActive] to see the source code for this prop
+  /// Whether the [ListGroupItem] should appear "active".
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#anchors-and-buttons>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.isActive] -->
   @override
   set isActive(bool value) =>
       props[_$key__isActive___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.isDisabled] to see the source code for this prop
+  /// Whether the [ListGroupItem] is disabled.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#disabled-items>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
   bool get isDisabled =>
       props[_$key__isDisabled___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.isDisabled] to see the source code for this prop
+  /// Whether the [ListGroupItem] is disabled.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#disabled-items>
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
   set isDisabled(bool value) =>
       props[_$key__isDisabled___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.href] to see the source code for this prop
+  /// The HTML `href` attribute value for the [ListGroupItem].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.href]_
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.href] -->
   @override
   @Accessor(keyNamespace: '')
   String get href =>
       props[_$key__href___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.href] to see the source code for this prop
+  /// The HTML `href` attribute value for the [ListGroupItem].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.href]_
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.href] -->
   @override
   @Accessor(keyNamespace: '')
   set href(String value) => props[_$key__href___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.target] to see the source code for this prop
+  /// The HTML `target` attribute value for the [ListGroupItem].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.target]_
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.target] -->
   @override
   @Accessor(keyNamespace: '')
   String get target =>
       props[_$key__target___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.target] to see the source code for this prop
+  /// The HTML `target` attribute value for the [ListGroupItem].
+  ///
+  /// If set, the item will render via [Dom.a].
+  ///
+  /// _Proxies [DomProps.target]_
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.target] -->
   @override
   @Accessor(keyNamespace: '')
   set target(String value) =>
       props[_$key__target___$ListGroupItemProps] = value;
 
-  /// Go to [_$ListGroupItemProps.type] to see the source code for this prop
+  /// The HTML `type` attribute value for the [ListGroupItem] when
+  /// rendered via [Dom.button].
+  ///
+  /// This will only be applied if [onClick] is also set.
+  ///
+  /// _Proxies [DomProps.type]_
+  ///
+  /// Default: [ButtonType.BUTTON]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.type] -->
   @override
   ButtonType get type =>
       props[_$key__type___$ListGroupItemProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ListGroupItemProps.type] to see the source code for this prop
+  /// The HTML `type` attribute value for the [ListGroupItem] when
+  /// rendered via [Dom.button].
+  ///
+  /// This will only be applied if [onClick] is also set.
+  ///
+  /// _Proxies [DomProps.type]_
+  ///
+  /// Default: [ButtonType.BUTTON]
+  ///
+  /// <!-- Generated from [_$ListGroupItemProps.type] -->
   @override
   set type(ButtonType value) =>
       props[_$key__type___$ListGroupItemProps] = value;

--- a/web/src/demo_components/progress.over_react.g.dart
+++ b/web/src/demo_components/progress.over_react.g.dart
@@ -21,106 +21,202 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   @override
   Map get props;
 
-  /// Go to [_$ProgressProps.value] to see the source code for this prop
+  /// The current value of the [Progress] component.
+  ///
+  /// This value should be between the [min] and [max] values.
+  ///
+  /// Default: `0.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.value] -->
   @override
   double get value =>
       props[_$key__value___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.value] to see the source code for this prop
+  /// The current value of the [Progress] component.
+  ///
+  /// This value should be between the [min] and [max] values.
+  ///
+  /// Default: `0.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.value] -->
   @override
   set value(double value) => props[_$key__value___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.min] to see the source code for this prop
+  /// The min value of the [Progress] component.
+  ///
+  /// Default: `0.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.min] -->
   @override
   double get min =>
       props[_$key__min___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.min] to see the source code for this prop
+  /// The min value of the [Progress] component.
+  ///
+  /// Default: `0.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.min] -->
   @override
   set min(double value) => props[_$key__min___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.max] to see the source code for this prop
+  /// The max value of the [Progress] component.
+  ///
+  /// Default: `100.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.max] -->
   @override
   double get max =>
       props[_$key__max___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.max] to see the source code for this prop
+  /// The max value of the [Progress] component.
+  ///
+  /// Default: `100.0`
+  ///
+  /// <!-- Generated from [_$ProgressProps.max] -->
   @override
   set max(double value) => props[_$key__max___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Progress] component.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/progress/#contextual-alternatives>.
+  ///
+  /// Default: [ProgressSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ProgressProps.skin] -->
   @override
   ProgressSkin get skin =>
       props[_$key__skin___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Progress] component.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/progress/#contextual-alternatives>.
+  ///
+  /// Default: [ProgressSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$ProgressProps.skin] -->
   @override
   set skin(ProgressSkin value) => props[_$key__skin___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.isStriped] to see the source code for this prop
+  /// Whether to render a "Barber Pole" gradient stripe effect in the [Progress] component.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.isStriped] -->
   @override
   bool get isStriped =>
       props[_$key__isStriped___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.isStriped] to see the source code for this prop
+  /// Whether to render a "Barber Pole" gradient stripe effect in the [Progress] component.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.isStriped] -->
   @override
   set isStriped(bool value) => props[_$key__isStriped___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.isAnimated] to see the source code for this prop
+  /// Whether to animate the "Barber Pole" gradient stripe effect in the [Progress] component.
+  ///
+  /// __Note:__ Has no effect if [isStriped] is `false`.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.isAnimated] -->
   @override
   bool get isAnimated =>
       props[_$key__isAnimated___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.isAnimated] to see the source code for this prop
+  /// Whether to animate the "Barber Pole" gradient stripe effect in the [Progress] component.
+  ///
+  /// __Note:__ Has no effect if [isStriped] is `false`.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.isAnimated] -->
   @override
   set isAnimated(bool value) =>
       props[_$key__isAnimated___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.caption] to see the source code for this prop
+  /// Optionally add a caption that describes the context of the [Progress] component.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/progress/#example>.
+  ///
+  /// Default: [ProgressComponent._getPercentComplete]%
+  ///
+  /// <!-- Generated from [_$ProgressProps.caption] -->
   @override
   String get caption =>
       props[_$key__caption___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.caption] to see the source code for this prop
+  /// Optionally add a caption that describes the context of the [Progress] component.
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/progress/#example>.
+  ///
+  /// Default: [ProgressComponent._getPercentComplete]%
+  ///
+  /// <!-- Generated from [_$ProgressProps.caption] -->
   @override
   set caption(String value) => props[_$key__caption___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.captionProps] to see the source code for this prop
+  /// Additional props to be added to the [caption] element _(if specified)_.
+  ///
+  /// <!-- Generated from [_$ProgressProps.captionProps] -->
   @override
   Map get captionProps =>
       props[_$key__captionProps___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.captionProps] to see the source code for this prop
+  /// Additional props to be added to the [caption] element _(if specified)_.
+  ///
+  /// <!-- Generated from [_$ProgressProps.captionProps] -->
   @override
   set captionProps(Map value) =>
       props[_$key__captionProps___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.showCaption] to see the source code for this prop
+  /// Whether the [caption] should be visible.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.showCaption] -->
   @override
   bool get showCaption =>
       props[_$key__showCaption___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.showCaption] to see the source code for this prop
+  /// Whether the [caption] should be visible.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$ProgressProps.showCaption] -->
   @override
   set showCaption(bool value) =>
       props[_$key__showCaption___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.showPercentComplete] to see the source code for this prop
+  /// Whether the [caption] should be appended with the value of [value].
+  ///
+  /// Default: true
+  ///
+  /// <!-- Generated from [_$ProgressProps.showPercentComplete] -->
   @override
   bool get showPercentComplete =>
       props[_$key__showPercentComplete___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.showPercentComplete] to see the source code for this prop
+  /// Whether the [caption] should be appended with the value of [value].
+  ///
+  /// Default: true
+  ///
+  /// <!-- Generated from [_$ProgressProps.showPercentComplete] -->
   @override
   set showPercentComplete(bool value) =>
       props[_$key__showPercentComplete___$ProgressProps] = value;
 
-  /// Go to [_$ProgressProps.rootNodeProps] to see the source code for this prop
+  /// Additional props to be added to the [Dom.div] that wraps around the [caption] element and `<progress>` element.
+  ///
+  /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
   @override
   Map get rootNodeProps =>
       props[_$key__rootNodeProps___$ProgressProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressProps.rootNodeProps] to see the source code for this prop
+  /// Additional props to be added to the [Dom.div] that wraps around the [caption] element and `<progress>` element.
+  ///
+  /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
   @override
   set rootNodeProps(Map value) =>
       props[_$key__rootNodeProps___$ProgressProps] = value;
@@ -240,12 +336,24 @@ abstract class _$ProgressStateAccessorsMixin implements _$ProgressState {
   @override
   Map get state;
 
-  /// Go to [_$ProgressState.id] to see the source code for this prop
+  /// An autogenerated GUID, used as a fallback when [ProgressProps.id] is unspecified, and
+  /// saved on the state so it will persist across remounts.
+  ///
+  /// HTML id attributes are needed on `<progress>` elements for proper accessibility support,
+  /// so this state value ensures there's always a valid ID value to use.
+  ///
+  /// <!-- Generated from [_$ProgressState.id] -->
   @override
   String get id =>
       state[_$key__id___$ProgressState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ProgressState.id] to see the source code for this prop
+  /// An autogenerated GUID, used as a fallback when [ProgressProps.id] is unspecified, and
+  /// saved on the state so it will persist across remounts.
+  ///
+  /// HTML id attributes are needed on `<progress>` elements for proper accessibility support,
+  /// so this state value ensures there's always a valid ID value to use.
+  ///
+  /// <!-- Generated from [_$ProgressState.id] -->
   @override
   set id(String value) => state[_$key__id___$ProgressState] = value;
   /* GENERATED CONSTANTS */

--- a/web/src/demo_components/tag.over_react.g.dart
+++ b/web/src/demo_components/tag.over_react.g.dart
@@ -20,21 +20,47 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   @override
   Map get props;
 
-  /// Go to [_$TagProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Tag].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/tag/#contextual-variations>.
+  ///
+  /// Default: [TagSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$TagProps.skin] -->
   @override
   TagSkin get skin =>
       props[_$key__skin___$TagProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TagProps.skin] to see the source code for this prop
+  /// The skin / "context" for the [Tag].
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/tag/#contextual-variations>.
+  ///
+  /// Default: [TagSkin.DEFAULT]
+  ///
+  /// <!-- Generated from [_$TagProps.skin] -->
   @override
   set skin(TagSkin value) => props[_$key__skin___$TagProps] = value;
 
-  /// Go to [_$TagProps.isPill] to see the source code for this prop
+  /// Whether to render the [Tag] with rounded corners that make it look
+  /// more like a "pill" (a.k.a Bootstrap v3 "badge")
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/tag/#pill-tags>.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$TagProps.isPill] -->
   @override
   bool get isPill =>
       props[_$key__isPill___$TagProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$TagProps.isPill] to see the source code for this prop
+  /// Whether to render the [Tag] with rounded corners that make it look
+  /// more like a "pill" (a.k.a Bootstrap v3 "badge")
+  ///
+  /// See: <http://v4-alpha.getbootstrap.com/components/tag/#pill-tags>.
+  ///
+  /// Default: false
+  ///
+  /// <!-- Generated from [_$TagProps.isPill] -->
   @override
   set isPill(bool value) => props[_$key__isPill___$TagProps] = value;
   /* GENERATED CONSTANTS */

--- a/web/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/src/demo_components/toggle_button.over_react.g.dart
@@ -23,37 +23,99 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   @override
   Map get props;
 
-  /// Go to [_$ToggleButtonProps.autoFocus] to see the source code for this prop
+  /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
+  ///
+  /// _Proxies [DomProps.autoFocus]._
+  ///
+  /// Default: `false`
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.autoFocus] -->
   @override
   @Accessor(keyNamespace: '')
   bool get autoFocus =>
       props[_$key__autoFocus___$ToggleButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ToggleButtonProps.autoFocus] to see the source code for this prop
+  /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
+  ///
+  /// _Proxies [DomProps.autoFocus]._
+  ///
+  /// Default: `false`
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.autoFocus] -->
   @override
   @Accessor(keyNamespace: '')
   set autoFocus(bool value) =>
       props[_$key__autoFocus___$ToggleButtonProps] = value;
 
-  /// Go to [_$ToggleButtonProps.defaultChecked] to see the source code for this prop
+  /// Whether the [ToggleButton] is checked by default.
+  ///
+  /// Setting this without the setting the [checked] prop to will make the
+  /// [ToggleButton] _uncontrolled_; it will initially render checked or unchecked
+  /// depending on the value of this prop, and then update itself automatically
+  /// in response to user input, like a normal HTML input.
+  ///
+  /// Related: [checked]
+  ///
+  /// _Proxies [DomProps.defaultChecked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#uncontrolled-components>.
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.defaultChecked] -->
   @override
   @Accessor(keyNamespace: '')
   bool get defaultChecked =>
       props[_$key__defaultChecked___$ToggleButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ToggleButtonProps.defaultChecked] to see the source code for this prop
+  /// Whether the [ToggleButton] is checked by default.
+  ///
+  /// Setting this without the setting the [checked] prop to will make the
+  /// [ToggleButton] _uncontrolled_; it will initially render checked or unchecked
+  /// depending on the value of this prop, and then update itself automatically
+  /// in response to user input, like a normal HTML input.
+  ///
+  /// Related: [checked]
+  ///
+  /// _Proxies [DomProps.defaultChecked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#uncontrolled-components>.
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.defaultChecked] -->
   @override
   @Accessor(keyNamespace: '')
   set defaultChecked(bool value) =>
       props[_$key__defaultChecked___$ToggleButtonProps] = value;
 
-  /// Go to [_$ToggleButtonProps.checked] to see the source code for this prop
+  /// Whether the [ToggleButton] is checked.
+  ///
+  /// Setting this will make the [ToggleButton] _controlled_; it will not update
+  /// automatically in response to user input, but instead will always render
+  /// checked or unchecked depending on the value of this prop.
+  ///
+  /// Related: [defaultChecked]
+  ///
+  /// _Proxies [DomProps.checked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#controlled-components>.
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.checked] -->
   @override
   @Accessor(keyNamespace: '')
   bool get checked =>
       props[_$key__checked___$ToggleButtonProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ToggleButtonProps.checked] to see the source code for this prop
+  /// Whether the [ToggleButton] is checked.
+  ///
+  /// Setting this will make the [ToggleButton] _controlled_; it will not update
+  /// automatically in response to user input, but instead will always render
+  /// checked or unchecked depending on the value of this prop.
+  ///
+  /// Related: [defaultChecked]
+  ///
+  /// _Proxies [DomProps.checked]._
+  ///
+  /// See: <https://facebook.github.io/react/docs/forms.html#controlled-components>.
+  ///
+  /// <!-- Generated from [_$ToggleButtonProps.checked] -->
   @override
   @Accessor(keyNamespace: '')
   set checked(bool value) => props[_$key__checked___$ToggleButtonProps] = value;
@@ -131,22 +193,40 @@ abstract class _$ToggleButtonStateAccessorsMixin
   @override
   Map get state;
 
-  /// Go to [_$ToggleButtonState.isFocused] to see the source code for this prop
+  /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
+  /// class.
+  ///
+  /// Initial: [ToggleButtonProps.autoFocus]
+  ///
+  /// <!-- Generated from [_$ToggleButtonState.isFocused] -->
   @override
   bool get isFocused =>
       state[_$key__isFocused___$ToggleButtonState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ToggleButtonState.isFocused] to see the source code for this prop
+  /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
+  /// class.
+  ///
+  /// Initial: [ToggleButtonProps.autoFocus]
+  ///
+  /// <!-- Generated from [_$ToggleButtonState.isFocused] -->
   @override
   set isFocused(bool value) =>
       state[_$key__isFocused___$ToggleButtonState] = value;
 
-  /// Go to [_$ToggleButtonState.isChecked] to see the source code for this prop
+  /// Tracks if the [ToggleButton] input is `checked`. Determines whether to render with the `active` CSS class.
+  ///
+  /// Initial: [ToggleButtonProps.checked] `??` [ToggleButtonProps.defaultChecked] `?? false`
+  ///
+  /// <!-- Generated from [_$ToggleButtonState.isChecked] -->
   @override
   bool get isChecked =>
       state[_$key__isChecked___$ToggleButtonState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$ToggleButtonState.isChecked] to see the source code for this prop
+  /// Tracks if the [ToggleButton] input is `checked`. Determines whether to render with the `active` CSS class.
+  ///
+  /// Initial: [ToggleButtonProps.checked] `??` [ToggleButtonProps.defaultChecked] `?? false`
+  ///
+  /// <!-- Generated from [_$ToggleButtonState.isChecked] -->
   @override
   set isChecked(bool value) =>
       state[_$key__isChecked___$ToggleButtonState] = value;

--- a/web/src/shared/constants.over_react.g.dart
+++ b/web/src/shared/constants.over_react.g.dart
@@ -13,36 +13,76 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   static const PropsMeta meta = _$metaForAbstractInputPropsMixin;
   String get id;
 
-  /// Go to [_$AbstractInputPropsMixin.name] to see the source code for this prop
+  /// The HTML `name` attribute to be applied to `<input>`.
+  ///
+  /// If unspecified, [AbstractInputStateMixin.name] will be generated.
+  ///
+  /// _Proxies [DomProps.name]._
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.name] -->
   @override
   @Accessor(keyNamespace: '')
   String get name =>
       props[_$key__name___$AbstractInputPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractInputPropsMixin.name] to see the source code for this prop
+  /// The HTML `name` attribute to be applied to `<input>`.
+  ///
+  /// If unspecified, [AbstractInputStateMixin.name] will be generated.
+  ///
+  /// _Proxies [DomProps.name]._
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.name] -->
   @override
   @Accessor(keyNamespace: '')
   set name(String value) =>
       props[_$key__name___$AbstractInputPropsMixin] = value;
 
-  /// Go to [_$AbstractInputPropsMixin.value] to see the source code for this prop
+  /// The value of the input. Setting this will make the input's value _controlled_; it will not update automatically in
+  /// response to user input, but instead will always render the value of this prop.
+  ///
+  /// See: [React Controlled Components](https://facebook.github.io/react/docs/forms.html#controlled-components)
+  ///
+  /// _Proxies [DomProps.value]._
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.value] -->
   @override
   @Accessor(keyNamespace: '')
   dynamic get value =>
       props[_$key__value___$AbstractInputPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractInputPropsMixin.value] to see the source code for this prop
+  /// The value of the input. Setting this will make the input's value _controlled_; it will not update automatically in
+  /// response to user input, but instead will always render the value of this prop.
+  ///
+  /// See: [React Controlled Components](https://facebook.github.io/react/docs/forms.html#controlled-components)
+  ///
+  /// _Proxies [DomProps.value]._
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.value] -->
   @override
   @Accessor(keyNamespace: '')
   set value(dynamic value) =>
       props[_$key__value___$AbstractInputPropsMixin] = value;
 
-  /// Go to [_$AbstractInputPropsMixin.toggleType] to see the source code for this prop
+  /// The type of "toggle" behavior an HTML `<input>` should exhibit:
+  ///
+  /// * [ToggleBehaviorType.CHECKBOX] - More than one can be active at once.
+  /// * [ToggleBehaviorType.RADIO] - Only one can be active at once.
+  ///
+  /// Default: [ToggleBehaviorType.CHECKBOX]
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.toggleType] -->
   @override
   ToggleBehaviorType get toggleType =>
       props[_$key__toggleType___$AbstractInputPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractInputPropsMixin.toggleType] to see the source code for this prop
+  /// The type of "toggle" behavior an HTML `<input>` should exhibit:
+  ///
+  /// * [ToggleBehaviorType.CHECKBOX] - More than one can be active at once.
+  /// * [ToggleBehaviorType.RADIO] - Only one can be active at once.
+  ///
+  /// Default: [ToggleBehaviorType.CHECKBOX]
+  ///
+  /// <!-- Generated from [_$AbstractInputPropsMixin.toggleType] -->
   @override
   set toggleType(ToggleBehaviorType value) =>
       props[_$key__toggleType___$AbstractInputPropsMixin] = value;
@@ -81,21 +121,45 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
 
   static const StateMeta meta = _$metaForAbstractInputStateMixin;
 
-  /// Go to [_$AbstractInputStateMixin.id] to see the source code for this prop
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML ids are needed in inputs for proper label linking and accessibility support,
+  /// so this state value ensures there's always a valid ID value to use.
+  ///
+  /// <!-- Generated from [_$AbstractInputStateMixin.id] -->
   @override
   String get id =>
       state[_$key__id___$AbstractInputStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractInputStateMixin.id] to see the source code for this prop
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML ids are needed in inputs for proper label linking and accessibility support,
+  /// so this state value ensures there's always a valid ID value to use.
+  ///
+  /// <!-- Generated from [_$AbstractInputStateMixin.id] -->
   @override
   set id(String value) => state[_$key__id___$AbstractInputStateMixin] = value;
 
-  /// Go to [_$AbstractInputStateMixin.name] to see the source code for this prop
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.name] is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML names must be the same for anything that renders an HTML `<input type="radio">` element
+  /// so that only one can be selected at a time.
+  ///
+  /// <!-- Generated from [_$AbstractInputStateMixin.name] -->
   @override
   String get name =>
       state[_$key__name___$AbstractInputStateMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Go to [_$AbstractInputStateMixin.name] to see the source code for this prop
+  /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.name] is unspecified,
+  /// and saved on the state so it will persist across remounts.
+  ///
+  /// HTML names must be the same for anything that renders an HTML `<input type="radio">` element
+  /// so that only one can be selected at a time.
+  ///
+  /// <!-- Generated from [_$AbstractInputStateMixin.name] -->
   @override
   set name(String value) =>
       state[_$key__name___$AbstractInputStateMixin] = value;


### PR DESCRIPTION
## Ultimate problem:
With the over_react builder, doc comments on props/state aren't visible when using those fields.

All you see is the generated comments
> Go to [ButtonPropsMixin.isBlock] to see the source code for this prop

## How it was fixed:
- Copy doc comments to generated code
- Update link to source code to be less obtrusive

[Example of changes](https://github.com/Workiva/over_react/compare/builder-copy-doc-comments?expand=1#diff-a8ad26d1cebe83f7b777bbe00b4b03eeR23)

## Testing suggestions:
- CI passes
- In over_react's `web` dir, verify in an IDE that documentation appears:
    - When hovering over a prop read
    - in the autocomplete menu when setting a prop

## Potential areas of regression:
- Doc comment generation in generated code


---

> __FYA:__ @aaronlademann-wf @kealjones-wk @evanweible-wf @corwinsheahan-wf @maxwellpeterson-wf
