### PR TITLE
Release over_react 1.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## 1.33.1
+
+* [#272] Add `min-height: 0` to `ResizeSensor` wrapper nodes to fix issues with it not shrinking in a flexbox layout
+
 ## 1.33.0
 
 > [Complete `1.33.0` Changeset](https://github.com/Workiva/over_react/compare/1.32.0...1.33.0)

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -463,6 +463,8 @@ const Map<String, dynamic> _wrapperStylesFlexChild = const {
   'flex': '1 1 0%',
   'msFlex': '1 1 0%',
   'display': 'block',
+  // Fix ResizeSensor not shrinking properly: https://www.chromestatus.com/feature/6736527476391936
+  'minHeight': '0',
 };
 
 final Map<String, dynamic> _wrapperStylesFlexContainer = {
@@ -470,6 +472,8 @@ final Map<String, dynamic> _wrapperStylesFlexContainer = {
   'flex': '1 1 0%',
   'msFlex': '1 1 0%',
   'display': _displayFlex,
+  // Fix ResizeSensor not shrinking properly: https://www.chromestatus.com/feature/6736527476391936
+  'minHeight': '0',
 };
 
 /// The browser-prefixed value for the CSS `display` property that enables flexbox.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.33.0
+version: 1.33.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component/resize_sensor_test.dart
+++ b/test/over_react/component/resize_sensor_test.dart
@@ -142,6 +142,7 @@ void main() {
 
         expect(renderedNode.style.position, equals('relative'));
         expect(renderedNode.style.display, equals('block'));
+        expect(renderedNode.style.minHeight, '0px');
 
         var nodeStyleDecl = renderedNode.style;
         if (browser.isInternetExplorer && browser.version.major < 11) {
@@ -157,6 +158,7 @@ void main() {
         var renderedNode = renderAndGetDom((ResizeSensor()..isFlexContainer = true)());
 
         expect(renderedNode.style.position, equals('relative'));
+        expect(renderedNode.style.minHeight, '0px');
 
         var nodeStyleDecl = renderedNode.style;
         if (browser.isInternetExplorer && browser.version.major < 11) {


### PR DESCRIPTION
## Ultimate problem:
Chrome 73 released with some changes in flexbox behavior: https://www.chromestatus.com/feature/6736527476391936

This caused ResizeSensors that were flex parents or flex children and nested in a flexbox layout to not "shrink" vertically as expected, and instead overflow their container, even with a flex-basis of 0.

## How it was fixed:
Add `min-height: 0`, which is the recommended work around.

## Testing suggestions:
- CI passes
- Smoke test in layouts that use ResizeSensor

## Potential areas of regression:
ResizeSensor


---

> __FYA:__ @greglittlefield-wf @aaronlademann-wf @kealjones-wk @evanweible-wf @maxwellpeterson-wf
