### PR TITLE
CPLAT-4896, CPLAT-4897 Release over_react 2.3.1+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.3.1
+
+> Complete `2.3.1` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.3.0+dart2...2.3.1+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.3.0+dart1...2.3.1+dart1)
+
+* [#272] Add `min-height: 0` to `ResizeSensor` wrapper nodes to fix issues with it not shrinking in a flexbox layout
+
 ## 2.3.0
 
 > Complete `2.3.0` Changsets:
@@ -92,6 +101,10 @@ __Breaking Changes__
 * Removals:
   * `getJsProps()` - use `getProps()` instead
   * `$Props` and `$PropKeys` - see the migration guide above
+
+## 1.33.1
+
+* [#272] Add `min-height: 0` to `ResizeSensor` wrapper nodes to fix issues with it not shrinking in a flexbox layout
 
 ## 1.33.0
 

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -458,6 +458,8 @@ const Map<String, dynamic> _wrapperStylesFlexChild = const {
   'flex': '1 1 0%',
   'msFlex': '1 1 0%',
   'display': 'block',
+  // Fix ResizeSensor not shrinking properly: https://www.chromestatus.com/feature/6736527476391936
+  'minHeight': '0',
 };
 
 final Map<String, dynamic> _wrapperStylesFlexContainer = {
@@ -465,6 +467,8 @@ final Map<String, dynamic> _wrapperStylesFlexContainer = {
   'flex': '1 1 0%',
   'msFlex': '1 1 0%',
   'display': _displayFlex,
+  // Fix ResizeSensor not shrinking properly: https://www.chromestatus.com/feature/6736527476391936
+  'minHeight': '0',
 };
 
 /// The browser-prefixed value for the CSS `display` property that enables flexbox.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.3.0+dart2
+version: 2.3.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component/resize_sensor_test.dart
+++ b/test/over_react/component/resize_sensor_test.dart
@@ -142,6 +142,7 @@ void main() {
 
         expect(renderedNode.style.position, equals('relative'));
         expect(renderedNode.style.display, equals('block'));
+        expect(renderedNode.style.minHeight, '0px');
 
         var nodeStyleDecl = renderedNode.style;
         if (browser.isInternetExplorer && browser.version.major < 11) {
@@ -157,6 +158,7 @@ void main() {
         var renderedNode = renderAndGetDom((ResizeSensor()..isFlexContainer = true)());
 
         expect(renderedNode.style.position, equals('relative'));
+        expect(renderedNode.style.minHeight, '0px');
 
         var nodeStyleDecl = renderedNode.style;
         if (browser.isInternetExplorer && browser.version.major < 11) {


### PR DESCRIPTION
Brings #272 into the `+dart2` line-of-release.

@greglittlefield-wf