### PR TITLE
Introduce `propsAreEqual` utility to allow checking props updates

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   build: ^1.0.0
   built_redux: ^7.4.2
   built_value: ^5.4.4
+  collection: ^1.14.6
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -517,6 +517,44 @@ main() {
         });
       });
 
+      group('propsAreEqual()', () {
+        test('returns true when props match', () {
+          var componentProps = {
+            'foo': 'bar',
+          };
+
+          component.unwrappedProps = componentProps;
+
+          var otherProps = component.typedPropsFactory(componentProps);
+
+          expect(component.propsAreEqual(otherProps), isTrue);
+        });
+
+        test('returns false when props differ', () {
+          component.unwrappedProps = {
+            'foo': 'bar',
+          };
+
+          var otherProps = component.typedPropsFactory({
+            'foo': 'baz',
+          });
+
+          expect(component.propsAreEqual(otherProps), isFalse);
+        });
+
+        test('does not error when props contain ReactElement', () {
+          var componentProps = {
+            'foo': TestComponent()(),
+          };
+
+          component.unwrappedProps = componentProps;
+
+          var otherProps = component.typedPropsFactory(componentProps);
+
+          expect(() => component.propsAreEqual(otherProps), returnsNormally);
+        });
+      });
+
       test('newProps() returns a new UiProps instance backed by a new Map', () {
         var newProps1 = component.newProps();
         var newProps2 = component.newProps();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
A number of components end up doing something like `!const MapEquality().equals(props, typedPropsFactory(nextProps))` in `shouldComponentUpdate`. This is repetitive and, additionally, triggers a DDC issue when `props` contains a `ReactElement`.

## Changes
  <!-- What this PR changes to fix the problem. -->
Provide a utility to simplify the above situation and avoid the DDC issue.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Introduce `propsAreEqual()` utility on `UiComponent` to compare current props against next/previous

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
