### PR TITLE
CPLAT-5243: Restore the dart 1 & 2 dual-release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
     - [Minimum Required Review](#minimum-required-review)
     - [Review Types](#review-types)
     - [Manual Testing Criteria](#manual-testing-criteria)
+- [__Dart 1 & Dart 2 Dual-Releases__](#dart-1--dart-2-dual-releases)
 
 ---
 
@@ -122,3 +123,76 @@ __If none of these apply, then manual testing instructions may be omitted.__
     _Examples:_
     - Test runner was updated.
     - New test suites were added.
+
+---
+
+## Dart 1 & Dart 2 Dual-Releases
+
+Long story short, we are unable to maintain a single codebase of over_react that
+is compatible with both Dart 1 and Dart 2. Transformers only work on Dart 1 and
+builders only work on Dart 2, and we can't maintain the transformer and builder
+together due to dependency conflicts.
+
+> For more information on our Dart 2 migration, [see this guide](/doc/dart2_migration.md).
+
+Fortunately, this problem can be shouldered entirely by the maintainers via a
+dual-release strategy (credit to the [dart2_constant](https://pub.dartlang.org/packages/dart2_constant)
+for the idea). The result is that consumers will depend on a version range of
+this library like they normally do and everything will _just work_.
+
+For every _version_ we want to release, we will actually release two releases -
+a Dart 1 (transformer) version and a Dart 2 (builder) version. These two
+releases will have the same semantic version, but will have unique build
+suffixes. The `pub` client will then decide which one to install based on their
+`environment.sdk` constraints and the active Dart SDK version.
+
+### Branches
+
+- `master`
+  - Dart2-only
+  - Provides a builder
+  - Environment constraint: `>=2.1.0 <3.0.0`
+
+- `master_dart1`
+  - Dart1-only
+  - Provides a transformer
+  - Environment constraint: `>=1.24.3 <2.0.0`
+
+### Release Process
+
+> Note that these steps are intended to be followed by Workiva employees, and as
+> such have some references to internal tooling.
+
+For every release, do the following:
+
+1. Ensure the next release versions exist in MARV:
+
+    Name | Branch
+    ---- | ------
+    over_react 2.x.x+dart1 | master_dart1
+    over_react 2.x.x+dart2 | master
+
+1. Trigger the `over_react 2.x.x+dart1` release first and review the PR:
+
+   - Ensure the updated `pubspec.yaml` version is correct, including the
+     `+dart1` suffix.
+
+   - Ensure the build passes.
+
+   - Merge the Dart 1 release and publish it to pub.
+
+1. Trigger the `over_react 2.x.x+dart2` release second and review the PR:
+
+   - Ensure the updated `pubspec.yaml` version is correct, including the
+     `+dart2` suffix.
+
+   - Ensure the build passes.
+
+   - **Add any necessary changelog updates to the Dart 2 version.**
+
+   - Merge the Dart 2 release and publish it to pub.
+
+1. Re-recreate the Dart 1 release in MARV (it does not get recreated
+   automatically like the default release does).
+
+1. Add the `+dart2` suffix to the automatically created release.


### PR DESCRIPTION
# [CPLAT-5243](https://jira.atl.workiva.net/browse/CPLAT-5243)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-5243)

## Motivation
The instructions for managing the dart 1 & 2 dual releases accidentally got overwritten by our recent rollout of updated contributing documentation.

## Changes
Restore them.

#### Release Notes
n/a

### QA Checklist
Docs-only change.

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
