### PR TITLE
CPLAT-5235 CPLAT-5234 Release over_react 2.4.1+dart2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.4.0+dart2
+version: 2.4.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-4003 Upgrade to analyzer ^0.35.0](https://github.com/Workiva/over_react/pull/281)
	* [CPLAT-5243: Restore the dart 1 & 2 dual-release instructions](https://github.com/Workiva/over_react/pull/284)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.4.0+dart2...Workiva:release_over_react_2.4.1+dart2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.4.0+dart2...2.4.1+dart2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)