### PR TITLE
CPLAT-5632 Downgrade parse error to fine so as to not fail build unnecessarily

### DIFF
--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -111,7 +111,7 @@ class OverReactBuilder extends Builder {
         suppressErrors: false,
         parseFunctionBodies: true);
     } catch (error, stackTrace) {
-      log.severe('There was an error parsing the compilation unit for file: $id');
+      log.fine('There was an error parsing the compilation unit for file: $id');
       log.fine(error);
       log.fine(stackTrace);
       return null;

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -42,7 +42,7 @@ class _$BaseState extends BaseState {
   @override
   final int count2;
 
-  factory _$BaseState([void updates(BaseStateBuilder b)]) =>
+  factory _$BaseState([void Function(BaseStateBuilder) updates]) =>
       (new BaseStateBuilder()..update(updates)).build();
 
   _$BaseState._({this.count1, this.count2}) : super._() {
@@ -55,7 +55,7 @@ class _$BaseState extends BaseState {
   }
 
   @override
-  BaseState rebuild(void updates(BaseStateBuilder b)) =>
+  BaseState rebuild(void Function(BaseStateBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -114,7 +114,7 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
   }
 
   @override
-  void update(void updates(BaseStateBuilder b)) {
+  void update(void Function(BaseStateBuilder) updates) {
     if (updates != null) updates(this);
   }
 


### PR DESCRIPTION
## Motivation
Syntax errors in the `example` dir cause the OverReact builder to unexpectedly fail the build when running `pbr test`

For example:
```
$ pbr test -- test/foo_test.dart
[INFO] Generating build script completed, took 329ms
[INFO] Reading cached asset graph completed, took 548ms
[INFO] Checking for updates since last build completed, took 973ms
[INFO] Running build completed, took 404ms
[INFO] Caching finalized dependency graph completed, took 301ms
[SEVERE] over_react:overReactBuilder on example/viewport/main.dart (cached):
There was an error parsing the compilation unit for file: w_virtual_components|example/viewport/main.dart
```

## Changes
  <!-- What this PR changes to fix the problem. -->
Downgrade parse error to fine so as to not fail build unnecessarily

If they're problematic, these errors will be handled further
down the line (e.g., build_web_compilers).

This prevents syntax errors in examples from failing test
compilation.

#### Release Notes
- Avoid failing the build unnecessarily due to parse errors

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
