### PR TITLE
CPLAT-5032 Add flag for possible poor state within ResizeSensor

### DIFF
--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -220,6 +220,17 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
     }
   }
 
+  @mustCallSuper
+  @override
+  void componentDidUpdate(prevProps, prevState) {
+    super.componentDidUpdate(prevProps, prevState);
+
+    if (_shouldReset) {
+      _reset();
+      _shouldReset = false;
+    }
+  }
+
   @override
   render() {
     var expandSensor = (Dom.div()
@@ -288,6 +299,8 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
       }
 
       _reset();
+    } else if (newHeight == _lastHeight && newWidth == _lastWidth) {
+      _shouldReset = true;
     }
   }
 
@@ -383,6 +396,16 @@ class ResizeSensorComponent extends UiComponent<ResizeSensorProps> with _SafeAni
 
   /// The most recently measured value for the width of the sensor.
   int _lastWidth = 0;
+
+  /// Whether or not the resize sensor should reset in the
+  /// componentDidUpdate lifecycle event.
+  ///
+  /// It was discovered (as part of CPLAT-5032) that the sensor could be
+  /// thrown off by triggering the [_handleSensorScroll] while appearing to
+  /// not change the height or width. The [_handleSensorScroll] looks for
+  /// this and uses the [_shouldReset] flag to indicate there is a
+  /// possibility the sensor is in a bad state.
+  bool _shouldReset = false;
 }
 
 /// The maximum size, in `px`, the sensor can be: 100,000.

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -42,7 +42,7 @@ class _$BaseState extends BaseState {
   @override
   final int count2;
 
-  factory _$BaseState([void updates(BaseStateBuilder b)]) =>
+  factory _$BaseState([void Function(BaseStateBuilder) updates]) =>
       (new BaseStateBuilder()..update(updates)).build();
 
   _$BaseState._({this.count1, this.count2}) : super._() {
@@ -55,7 +55,7 @@ class _$BaseState extends BaseState {
   }
 
   @override
-  BaseState rebuild(void updates(BaseStateBuilder b)) =>
+  BaseState rebuild(void Function(BaseStateBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -114,7 +114,7 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
   }
 
   @override
-  void update(void updates(BaseStateBuilder b)) {
+  void update(void Function(BaseStateBuilder) updates) {
     if (updates != null) updates(this);
   }
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
While looking for React 16 regressions within web_skin_dart, it was discovered that `AutosizeTextarea` could ignore its `maxRows` prop through persistent attempts to resize the height. The cause was that because the `AutosizeTextarea` was snapping the height down (to be smaller) and `ResizeSensor` was trying to snap the height up (to be bigger and catch up to the cursor), the caching within the `ResizeSensor` would get thrown off. When this happened, the component would skip an if statement where it otherwise would have been reset.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a flag called `_shouldReset` that is set to `true` when the unique circumstances described above are triggered.
- Add `componentDidUpdate` that checks for `_shouldReset` and resets if necessary. The `_reset()` call happens within `componentDidUpdate` because before that point in the lifecycle, the component may not be in a bad state yet. This ensures that the component will be reset at the proper time.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @aaronlademann-wf @greglittlefield-wf @tainhenning-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] Test in Firefox and Dartium (the issue is not present in Chrome)
      - [ ] Check componentry (besides `AutosizeTextarea`) reliant upon `ResizeSensor` for regressions
      - [ ] While checking componentry, including `AutosizeTextarea`, ensure performance is not reduced by adding the additional `_reset()` call and the lifecycle method.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
