### PR TITLE
CPLAT-5599 Add temporary JS error boundary

### DIFF
--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,14 +1,71 @@
+import 'dart:html';
+import 'dart:js_util' as js_util;
+
+import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/react_interop.dart' show React, ReactClassConfig;
 
 // ignore: uri_has_not_been_generated
 part 'error_boundary.over_react.g.dart';
 
-// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef _ComponentDidCatchCallback(Error error, /*ComponentStack*/dynamic componentStack);
+/// A __temporary, private JS component for use only by [ErrorBoundary]__ that utilizes its own lightweight
+/// JS interop to make use of the ReactJS 16 `componentDidCatch` lifecycle method to prevent consumer
+/// react component trees from unmounting as a result of child component errors being "uncaught".
+///
+/// > __Why this is here__
+/// >
+/// > In order to release react-dart 5.0.0 _(which upgrades to ReactJS 16)_
+///   without depending on Dart 2 / `Component2` (coming in react-dart 5.1.0) / `UiComponent2` (coming in over_react 3.1.0) -
+///   and all the new lifecycle methods that those expose, we need to ensure that - at a minimum - the `componentDidCatch`
+///   lifecycle method is handled by components wrapped in our [ErrorBoundary] component so that the behavior of
+///   an application when a component within a tree throws - is the same as it was when using ReactJS 15.
+/// >
+/// > Otherwise, the update to react-dart 5.0.0 / over_react 3.0.0 will result in consumer apps rendering completely
+///   "blank" screens when their trees unmount as a result of a child component throwing an error.
+///   This would be unexpected, unwanted - and since we will not add a Dart js-interop layer around `componentDidCatch`
+///   until react-dart 5.1.0 / over_react 3.1.0 - unmanageable for consumers.
+///
+/// __This will be removed in over_react 3.1.0__ once [ErrorBoundaryComponent] is extending from `UiStatefulComponent2`
+/// which will ensure that the [ErrorBoundaryComponent.componentDidCatch] lifecycle method has real js-interop bindings
+/// via react-dart 5.1.0's `Component2` base class.
+///
+/// TODO: Remove in 3.1.0
+final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponentFactory = (() {
+  var componentClass = React.createClass(jsifyAndAllowInterop({
+    'displayName': 'JsErrorBoundary',
+    'render': allowInteropCaptureThis((jsThis) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
+      return js_util.getProperty(jsProps, 'children');
+    }),
+    'componentDidCatch': allowInteropCaptureThis((jsThis, error, info) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
+      js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
+    }),
+  }));
+
+  // Despite what the ReactJS docs say about only needing _either_ componentDidCatch or getDerivedStateFromError
+  // in order to define an "error boundary" component, that is not actually the case.
+  //
+  // The tree will never get re-rendered after an error is caught unless both are defined.
+  js_util.setProperty(componentClass, 'getDerivedStateFromError', allowInterop((_) => js_util.newObject()));
+
+  var reactFactory = React.createFactory(componentClass);
+
+  return ([Map props = const {}, List children = const []]) {
+    return reactFactory(jsifyAndAllowInterop(props), listifyChildren(children));
+  };
+})();
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef ReactElement _FallbackUiRenderer(Error error, /*ComponentStack*/dynamic componentStack);
+// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
+typedef _ComponentDidCatchCallback(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
+
+// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
+// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
+typedef ReactElement _FallbackUiRenderer(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 /// A higher-order component that will catch ReactJS errors anywhere within the child component tree and
 /// display a fallback UI instead of the component tree that crashed.
@@ -93,12 +150,19 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   }
 
   @override
-  render() => state.hasError
-      ? props.fallbackUIRenderer(_error, _componentStack)
-      : props.children.single;
+  render() {
+    // TODO: 3.1.0 - Remove the `_jsErrorBoundaryComponentFactory`, and restore just the children of it once this component is extending from `UiStatefulComponent2`.
+    return _jsErrorBoundaryComponentFactory({
+      'onComponentDidCatch': props.onComponentDidCatch
+    },
+      state.hasError
+          ? [props.fallbackUIRenderer(_error, _componentStack)]
+          : props.children
+    );
+  }
 
   ReactElement _renderDefaultFallbackUI(_, __) =>
-      throw new UnimplementedError('Fallback UI will not be supported until support for ReactJS 16 is released in version 3.0.0');
+      throw new UnimplementedError('Fallback UI will not be supported until support for ReactJS 16 lifecycle methods is released in version 3.1.0');
 
   @mustCallSuper
   @override

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -47,7 +47,11 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
       try {
         throwErrorFromJS(error);
       } catch (error, stack) {
-        js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
+        final callback = js_util.getProperty(jsProps, 'onComponentDidCatch');
+
+        if (callback != null) {
+          callback(error, info);
+        }
       }
     }),
   }));

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -41,14 +41,13 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
       return js_util.getProperty(jsProps, 'children');
     }),
     'componentDidCatch': allowInteropCaptureThis((jsThis, error, info) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
       // Due to the error object being passed in from ReactJS it is a javascript object that does not get dartified.
       // To fix this we throw the error again from Dart to the JS side and catch it Dart side which re-dartifies it.
       try {
         throwErrorFromJS(error);
-      } catch (e, stack) {
-        // The Dart stack track gets lost so we manually add it to the info object for reference.
-        info['dartStackTrace'] = stack;
-        js_util.getProperty(js_util.getProperty(jsThis, 'props'), 'onComponentDidCatch')(error, info);
+      } catch (error, stack) {
+        js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
       }
     }),
   }));
@@ -68,11 +67,9 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
 })();
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
 typedef _ComponentDidCatchCallback(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
 typedef ReactElement _FallbackUiRenderer(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 /// A higher-order component that will catch ReactJS errors anywhere within the child component tree and

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -6,7 +6,7 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/js_interop_helpers.dart';
-import 'package:react/react_client/react_interop.dart' show React, ReactClassConfig;
+import 'package:react/react_client/react_interop.dart' show React, ReactClassConfig, throwErrorFromJS;
 
 // ignore: uri_has_not_been_generated
 part 'error_boundary.over_react.g.dart';
@@ -41,8 +41,15 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
       return js_util.getProperty(jsProps, 'children');
     }),
     'componentDidCatch': allowInteropCaptureThis((jsThis, error, info) {
-      final jsProps = js_util.getProperty(jsThis, 'props');
-      js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
+      // Due to the error object being passed in from ReactJS it is a javascript object that does not get dartified.
+      // To fix this we throw the error again from Dart to the JS side and catch it Dart side which re-dartifies it.
+      try {
+        throwErrorFromJS(error);
+      } catch (e, stack) {
+        // The Dart stack track gets lost so we manually add it to the info object for reference.
+        info['dartStackTrace'] = stack;
+        js_util.getProperty(js_util.getProperty(jsThis, 'props'), 'onComponentDidCatch')(error, info);
+      }
     }),
   }));
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -50,6 +50,7 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
   // in order to define an "error boundary" component, that is not actually the case.
   //
   // The tree will never get re-rendered after an error is caught unless both are defined.
+  // ignore: argument_type_not_assignable
   js_util.setProperty(componentClass, 'getDerivedStateFromError', allowInterop((_) => js_util.newObject()));
 
   var reactFactory = React.createFactory(componentClass);

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -50,6 +50,7 @@ void setComponentTypeMeta(ReactDartComponentFactoryProxy factory, {
     bool isWrapper,
     ReactDartComponentFactoryProxy parentType
 }) {
+  // ignore: argument_type_not_assignable
   setProperty(factory.type, _componentTypeMetaKey, new ComponentTypeMeta(isWrapper, parentType));
 }
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -65,7 +65,6 @@ void main() {
         jacket = mount(
           (ErrorBoundary()
             ..onComponentDidCatch = (err, info) {
-              print('onComponentDidCatch');
               calls.add({'onComponentDidCatch': [err, info]});
             }
           )(Flawed()()),
@@ -84,6 +83,8 @@ void main() {
       test('and calls `props.onComponentDidCatch`', () {
         expect(calls.single.keys, ['onComponentDidCatch']);
         final errArg = calls.single['onComponentDidCatch'][0];
+        // TODO: Figure out why a `const isInstanceOf<Error>()` doesn't work.
+        expect(errArg.toString(), contains('Instance of \'Error\''));
         expect(errArg.toString(), contains('FlawedComponent.componentWillUpdate'));
 
         final infoArg = calls.single['onComponentDidCatch'][1];
@@ -94,6 +95,13 @@ void main() {
         expect(mountNode.children, isNotEmpty,
             reason: 'rendered trees wrapped in an ErrorBoundary '
                     'should NOT get unmounted when an error is thrown within child component lifecycle methods');
+      });
+
+      test('does not throw a null exception when `props.onComponentDidCatch` is not set', () {
+        jacket = mount(ErrorBoundary()((Flawed()..addTestId('flawed'))()), mountNode: mountNode);
+        // The click causes the componentDidCatch lifecycle method to execute
+        // and we want to ensure that no Dart null error is thrown as a result of no consumer prop callback being set.
+        expect(() => jacket.getNode().click(), returnsNormally);
       });
     });
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -16,6 +16,7 @@
 library error_boundary_test;
 
 import 'dart:html';
+import 'dart:js';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
@@ -38,7 +39,7 @@ void main() {
 
     // TODO: Add tests that exercise the actual ReactJS 16 error lifecycle methods once implemented.
     group('catches component errors', () {
-      List<String> calls;
+      List<Map<String, List>> calls;
       DivElement mountNode;
 
       void verifyReact16ErrorHandlingWithoutErrorBoundary() {
@@ -63,7 +64,10 @@ void main() {
         calls = [];
         jacket = mount(
           (ErrorBoundary()
-            ..onComponentDidCatch = (_, __) { calls.add('onComponentDidCatch'); }
+            ..onComponentDidCatch = (err, info) {
+              print('onComponentDidCatch');
+              calls.add({'onComponentDidCatch': [err, info]});
+            }
           )(Flawed()()),
           mountNode: mountNode,
         );
@@ -78,7 +82,12 @@ void main() {
       });
 
       test('and calls `props.onComponentDidCatch`', () {
-        expect(calls, ['onComponentDidCatch']);
+        expect(calls.single.keys, ['onComponentDidCatch']);
+        final errArg = calls.single['onComponentDidCatch'][0];
+        expect(errArg.toString(), contains('FlawedComponent.componentWillUpdate'));
+
+        final infoArg = calls.single['onComponentDidCatch'][1];
+        expect(infoArg, isNotNull);
       });
 
       test('and re-renders the tree as a result', () {

--- a/test/over_react/component/fixtures/flawed_component.dart
+++ b/test/over_react/component/fixtures/flawed_component.dart
@@ -1,0 +1,54 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedProps> Flawed = _$Flawed;
+
+@Props()
+class _$FlawedProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedProps extends _$FlawedProps with _$FlawedPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedProps;
+}
+
+@State()
+class _$FlawedState extends UiState {
+  bool hasError;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedState extends _$FlawedState with _$FlawedStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = _$metaForFlawedState;
+}
+
+@Component()
+class FlawedComponent extends UiStatefulComponent<FlawedProps, FlawedState> {
+  @override
+  Map getInitialState() => (newState()..hasError = false);
+
+  @override
+  void componentWillUpdate(_, Map nextState) {
+    final tNextState = typedStateFactory(nextState);
+    if (tNextState.hasError && !state.hasError) {
+      throw new Error();
+    }
+  }
+
+  @override
+  render() {
+    return (Dom.button()
+      ..addTestId('flawedButton')
+      ..onClick = (_) {
+        setState(newState()..hasError = true);
+      }
+    )('oh hai');
+  }
+}

--- a/test/over_react/dom/fixtures/dummy_composite_component.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.dart
@@ -55,7 +55,7 @@ class TestCompositeComponentComponent extends UiComponent<TestCompositeComponent
 
   @override
   render() {
-    return Dom.div()('oh hai');
+    return Dom.div()('oh hai', props.children);
   }
 }
 

--- a/web/demos/demos.dart
+++ b/web/demos/demos.dart
@@ -5,6 +5,9 @@ import 'package:react/react_client.dart';
 import 'package:over_react/over_react.dart';
 import '../src/demo_components.dart';
 
+// ignore: uri_has_not_been_generated
+part 'demos.over_react.g.dart';
+
 // Parts
 part 'button/button-examples.dart';
 part 'button/button-types.dart';
@@ -13,6 +16,8 @@ part 'button/button-sizes.dart';
 part 'button/button-block.dart';
 part 'button/button-active.dart';
 part 'button/button-disabled.dart';
+
+part 'faulty-component.dart';
 
 part 'list-group/list-group-basic.dart';
 part 'list-group/list-group-tags.dart';

--- a/web/demos/faulty-component.dart
+++ b/web/demos/faulty-component.dart
@@ -1,0 +1,50 @@
+part of over_react.web.demos;
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FaultyProps> Faulty = _$Faulty;
+
+@Props()
+class _$FaultyProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FaultyProps extends _$FaultyProps with _$FaultyPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFaultyProps;
+}
+
+@State()
+class _$FaultyState extends UiState {
+  bool hasErrored;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FaultyState extends _$FaultyState with _$FaultyStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = _$metaForFaultyState;
+}
+
+@Component()
+class FaultyComponent extends UiStatefulComponent<FaultyProps, FaultyState> {
+  @override
+  Map getInitialState() => (newState()..hasErrored = false);
+
+  @override
+  void componentWillUpdate(_, Map nextState) {
+    final tNextState = typedStateFactory(nextState);
+    if (tNextState.hasErrored && !state.hasErrored) {
+      throw new Error();
+    }
+  }
+
+  @override
+  render() {
+    return (Dom.div()..className = 'btn-toolbar')(
+      (Button()..onClick = (_) {
+        setState(newState()..hasErrored = true);
+      })('Click me to throw an error'),
+    );
+  }
+}

--- a/web/index.dart
+++ b/web/index.dart
@@ -1,5 +1,6 @@
 import 'dart:html';
 
+import 'package:over_react/over_react.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart' show setClientConfiguration;
 import './demos/demos.dart';
@@ -9,20 +10,32 @@ void main() {
   setClientConfiguration();
 
   react_dom.render(
-    buttonExamplesDemo(), querySelector('$demoMountNodeSelectorPrefix--button'));
+    ErrorBoundary()(buttonExamplesDemo()), querySelector('$demoMountNodeSelectorPrefix--button'));
 
   react_dom.render(
-    listGroupBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--list-group'));
+    ErrorBoundary()(listGroupBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--list-group'));
 
   react_dom.render(
-    progressBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--progress'));
+    ErrorBoundary()(progressBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--progress'));
 
   react_dom.render(
-    tagBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--tag'));
+    ErrorBoundary()(tagBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--tag'));
 
   react_dom.render(
-    checkboxToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--checkbox-toggle'));
+    ErrorBoundary()(checkboxToggleButtonDemo()), querySelector('$demoMountNodeSelectorPrefix--checkbox-toggle'));
 
   react_dom.render(
-    radioToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--radio-toggle'));
+    ErrorBoundary()(radioToggleButtonDemo()), querySelector('$demoMountNodeSelectorPrefix--radio-toggle'));
+
+  react_dom.render(
+    (ErrorBoundary()
+      ..onComponentDidCatch = (error, info) {
+        print('Consumer props.onComponentDidCatch($error, $info)');
+      }
+    )(Faulty()()),
+    querySelector('$demoMountNodeSelectorPrefix--faulty-component'),
+  );
+
+  react_dom.render(
+    Faulty()(), querySelector('$demoMountNodeSelectorPrefix--faulty-component-without-error-boundary'));
 }

--- a/web/index.html
+++ b/web/index.html
@@ -55,6 +55,18 @@
                     around with the component rendered below.</p>
                 <div class="component-demo__mount--radio-toggle"></div>
             </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws A Caught Error</h2>
+                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--faulty-component"></div>
+            </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws an Uncaught Error</h2>
+                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--faulty-component-without-error-boundary"></div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Motivation
### Problem
We want to release [react-dart `5.0.0`](https://github.com/cleandart/react-dart/milestone/2) _(which upgrades us to ReactJS 16)_ without depending on Dart 2 / `Component2` / `UiComponent2` - and all the new lifecycle methods that those expose.

However, one of the biggest behavioral differences between ReactJS 15 and 16 is that in 16, when a component throws - the entire component tree that it is a part of - __will unmount completely__.

This means that if we just unleash ReactJS 16 within the Workiva ecosystem, if any UI component in the entire shell throws - the entire shell will unmount (blank screen).  This is an unacceptable risk / experience.

### Solution
In [CPLAT-3093](https://github.com/Workiva/over_react/pull/266), we created an `ErrorBoundary` component in over_react - and have since wrapped all critical "top level" `react_dom.render` calls within Workiva platform repos to make that `ErrorBoundary` component be the root of the tree.

We can make use of that to mitigate our problem by having it actually wrap around a new, private JS component that utilizes its own JS interop to make use of the ReactJS `componentDidCatch` / `getDerivedStateFromError` lifecycle methods to prevent the entire tree from unmounting when an error is caught.

## Changes
1. Create a new, private JS component that has interop handling for the `componentDidCatch` / `getDerivedStateFromError` lifecycle methods.
2. Update `ErrorBoundary` component to render the new private JS component, passing `props.children` through as the children of the private JS component.
    1. Proxy calls to the `props.onComponentDidCatch` callback using the JS component's `componentDidCatch` lifecycle method interop handler.
3. Write tests

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @kealjones-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
    - [ ] Serve the examples, and scroll down to the two new examples of "faulty" components that throw within a lifecycle method.
      - [ ] Click the button for the one wrapped by an `ErrorBoundary`, verify that the button is still rendered in the DOM after the error is thrown.
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
