### PR TITLE
CPLAT-5641 Fix js interop helper deprecations

### DIFF
--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -15,11 +15,12 @@
 /// Provides utilities around component type-checking.
 library over_react.component_declaration.component_type_checking;
 
+import 'dart:js_util';
+
 import 'package:over_react/src/component_declaration/component_base.dart' show UiFactory;
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations show Component;
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 
 // ----------------------------------------------------------------------

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,6 +24,7 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 
@@ -204,9 +205,9 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newC
         // are properly converted.
         Map convertedProps = new Map.from(newProps);
         ReactDomComponentFactoryProxy.convertProps(convertedProps);
-        propsChangeset = jsify(convertedProps);
+        propsChangeset = jsifyAndAllowInterop(convertedProps);
       } else {
-        propsChangeset = jsify(newProps);
+        propsChangeset = jsifyAndAllowInterop(newProps);
       }
     }
   } else {

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -17,13 +17,13 @@ library over_react.react_wrappers;
 
 import 'dart:collection';
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,7 +24,7 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^4.6.0
+  react: ^4.7.0
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -16,12 +16,12 @@
 library react_wrappers_test;
 
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
@@ -350,7 +350,7 @@ main() {
         });
 
         test('a plain JS object', () {
-          expect(isValidElement(new EmptyObject()), isFalse);
+          expect(isValidElement(newObject()), isFalse);
         });
 
         test('a ReactElement', () {
@@ -987,7 +987,7 @@ main() {
         });
 
         test('an empty JS object', () {
-          expect(() => getProps(new EmptyObject()), throwsArgumentError);
+          expect(() => getProps(newObject()), throwsArgumentError);
         });
 
         test('a String', () {


### PR DESCRIPTION
## Motivation
react-dart 4.7.0 added some deprecations.

## Changes
Remove references to deprecated jsify, getProperty, setProperty

#### Release Notes
Fix deprecation warnings from react-dart

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify there are no deprecation warnings coming from jsify/getProperty/setProperty usage
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
