### PR TITLE
CPLAT-1053 Cancel the transitionend timer when AbstractTransitionComponent unmounts

### DIFF
--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -314,6 +314,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
   void componentWillUnmount() {
     super.componentWillUnmount();
     _isUnmounted = true;
+    _cancelTransitionEndTimer();
     _cancelTransitionEventListener();
   }
 


### PR DESCRIPTION
+ To prevent ReactJS setState warnings involving unmounted components

## Motivation
ReactJS `setState` warnings are being produced by components that extend from `AbstractTransitionComponent`.

## Changes
Cancel the `transitionend` timer in-addition-to the subscription within `componentWillUnmount`.

#### Release Notes
Fix issue that causes ReactJS `setState` warnings to appear in the browser console.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
