### PR TITLE
CPLAT-4951 Release over_react 1.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## 1.33.2
+
+* [#292] Update `react` dependency to version `^4.7.0`, and remove references to deprecated `jsify`, `getProperty` and `setProperty` members.
+* [#294] Fix issue with `AbstractTransitionComponent` that causes ReactJS `setState` warnings to appear in the browser console.
+
 ## 1.33.1
 
 * [#272] Add `min-height: 0` to `ResizeSensor` wrapper nodes to fix issues with it not shrinking in a flexbox layout

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 1.33.1
+version: 1.33.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
* #292 Update `react` dependency to version `^4.7.0`, and remove references to deprecated `jsify`, `getProperty` and `setProperty` members.
  * _Back-patched from the commits originally merged into the `2.x` line-of-release._
* #294 Fix issue with `AbstractTransitionComponent` that causes ReactJS `setState` warnings to appear in the browser console.

@greglittlefield-wf @joebingham-wk 