### PR TITLE
CPLAT-5264 CPLAT-5263 Release over_react 2.4.2+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ __Breaking Changes__
   * `getJsProps()` - use `getProps()` instead
   * `$Props` and `$PropKeys` - see the migration guide above
 
+## 1.33.2
+
+* [#292] Update `react` dependency to version `^4.7.0`, and remove references to deprecated `jsify`, `getProperty` and `setProperty` members.
+* [#294] Fix issue with `AbstractTransitionComponent` that causes ReactJS `setState` warnings to appear in the browser console.
+
+
+
 ## 1.33.1
 
 * [#272] Add `min-height: 0` to `ResizeSensor` wrapper nodes to fix issues with it not shrinking in a flexbox layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OverReact Changelog
 
+## 2.4.2
+
+> Complete `2.4.2` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.1+dart2...2.4.2+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.4.1+dart1...2.4.2+dart1)
+
+* [#288] Downgrade parse error to fine so as to not fail build unnecessarily.
+* [#292] Update `react` dependency to version `^4.7.0`, and remove references to deprecated `jsify`, `getProperty` and `setProperty` members.
+* [#294] Fix issue with `AbstractTransitionComponent` that causes ReactJS `setState` warnings to appear in the browser console.
+
 ## 2.4.1
 
 > Complete `2.4.1` Changsets:

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -310,6 +310,7 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
   void componentWillUnmount() {
     super.componentWillUnmount();
     _isUnmounted = true;
+    _cancelTransitionEndTimer();
     _cancelTransitionEventListener();
   }
 

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -50,6 +50,7 @@ void setComponentTypeMeta(ReactDartComponentFactoryProxy factory, {
     bool isWrapper,
     ReactDartComponentFactoryProxy parentType
 }) {
+  // ignore: argument_type_not_assignable
   setProperty(factory.type, _componentTypeMetaKey, new ComponentTypeMeta(isWrapper, parentType));
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.4.1+dart2
+version: 2.4.2+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -992,7 +992,7 @@ main() {
 
         test('a String', () {
           expect(() => getProps('string'), throwsArgumentError);
-        });
+        }, testOn: 'js');
 
         test('null', () {
           expect(() => getProps(null), throwsArgumentError);


### PR DESCRIPTION
Pull Requests included in release:
* Patch changes:
	* [CPLAT-5632 Downgrade parse error to fine so as to not fail build unnecessarily](https://github.com/Workiva/over_react/pull/288)
	* [CPLAT-5641 Fix js interop helper deprecations](https://github.com/Workiva/over_react/pull/292)
	* [CPLAT-1053 Fix issue with `AbstractTransitionComponent` that causes ReactJS `setState` warnings to appear in the browser console.](https://github.com/Workiva/over_react/pull/294)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/1.33.2...Workiva:release_over_react_2.4.2+dart2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/1.33.2...2.4.2+dart2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)