### PR TITLE
CPLAT-6056: Warn consumers if part directive is present but there's no generated output

### DIFF
--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -94,7 +94,9 @@ class OverReactBuilder extends Builder {
       await _writePart(buildStep, outputId, outputs);
     } else {
       if (hasOutputPartDirective()) {
-        log.warning('An over react part directive was found in ${buildStep.inputId.path}, but no code was generated.');
+        log.warning('An over_react part directive was found in ${buildStep.inputId.path}, '
+            'but no code was generated. The part directive may be unnecessary if the file '
+            'does not contain any concrete components or abstract state/props classes.');
       }
     }
   }

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -58,6 +58,17 @@ class OverReactBuilder extends Builder {
     // Generate over_react code for the input library.
     generateForFile(source, buildStep.inputId, libraryUnit);
 
+
+    final outputId = buildStep.inputId.changeExtension(outputExtension);
+    final expectedPart = p.basename(outputId.path);
+
+    bool hasOutputPartDirective() {
+      final partUris = libraryUnit.directives
+        .whereType<PartDirective>()
+        .map((p) => p.uri.stringValue);
+      return partUris.contains(expectedPart);
+    }
+
     // Generate over_react code for each part file of the input library.
     for (final part in parts) {
       final partId = new AssetId.resolve(
@@ -75,18 +86,16 @@ class OverReactBuilder extends Builder {
     }
 
     if (outputs.isNotEmpty) {
-      final outputId = buildStep.inputId.changeExtension(outputExtension);
-
       // Verify that the library file has an `.over_react.g.dart` part.
-      final expectedPart = p.basename(outputId.path);
-      final partUris = libraryUnit.directives
-        .whereType<PartDirective>()
-        .map((p) => p.uri.stringValue);
-      if (!partUris.contains(expectedPart)) {
+      if (!hasOutputPartDirective()) {
         log.warning('Missing "part \'$expectedPart\';".');
       }
 
       await _writePart(buildStep, outputId, outputs);
+    } else {
+      if (hasOutputPartDirective()) {
+        log.warning('An over react part directive was found in ${buildStep.inputId.path}, but no code was generated.');
+      }
     }
   }
 

--- a/test/vm_tests/builder/over_react_builder_test.dart
+++ b/test/vm_tests/builder/over_react_builder_test.dart
@@ -80,7 +80,7 @@ main() {
       verifyNoErrorLogs();
     });
 
-    test('warns if the .over_react.g.dart part is missing', () async {
+    test('warns if the .over_react.g.dart part directive is missing', () async {
       var libraryAsset = makeAssetId('over_react|test_fixtures/source_files/missing_over_react_g_part/library.dart');
       await runBuilder(builder, [libraryAsset], reader, writerSpy, AnalyzerResolvers(), logger: logger);
       final expectedWarning = logs.firstWhere((log) {
@@ -88,6 +88,26 @@ main() {
       }, orElse: () => null);
       expect(expectedWarning, isNotNull,
         reason: 'Expected a WARNING log for the missing over_react part.');
+    });
+
+    test('warns if .over_react.g.dart part directive is present and no delcarations are present, but no code is generated', () async {
+      var libraryAsset = makeAssetId('over_react|test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart');
+      await runBuilder(builder, [libraryAsset], reader, writerSpy, AnalyzerResolvers(), logger: logger);
+      final expectedWarning = logs.firstWhere((log) {
+        return log.level == Level.WARNING && log.message == 'An over react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart, but no code was generated.';
+      }, orElse: () => null);
+      expect(expectedWarning, isNotNull,
+        reason: 'Expected a WARNING log for a part directive being present in a file with no generated output.');
+    });
+
+    test('warns if .over_react.g.dart part directive is present and delcarations are present, but no code is generated', () async {
+      var libraryAsset = makeAssetId('over_react|test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart');
+      await runBuilder(builder, [libraryAsset], reader, writerSpy, AnalyzerResolvers(), logger: logger);
+      final expectedWarning = logs.firstWhere((log) {
+        return log.level == Level.WARNING && log.message == 'An over react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart, but no code was generated.';
+      }, orElse: () => null);
+      expect(expectedWarning, isNotNull,
+        reason: 'Expected a WARNING log for a part directive being present in a file with no generated output.');
     });
 
     group('for backwards compatible boilerplate:', () {

--- a/test/vm_tests/builder/over_react_builder_test.dart
+++ b/test/vm_tests/builder/over_react_builder_test.dart
@@ -94,7 +94,8 @@ main() {
       var libraryAsset = makeAssetId('over_react|test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart');
       await runBuilder(builder, [libraryAsset], reader, writerSpy, AnalyzerResolvers(), logger: logger);
       final expectedWarning = logs.firstWhere((log) {
-        return log.level == Level.WARNING && log.message == 'An over react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart, but no code was generated.';
+        print('log.message: ${log.message}');
+        return log.level == Level.WARNING && log.message == 'An over_react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart, but no code was generated. The part directive may be unnecessary if the file does not contain any concrete components or abstract state/props classes.';
       }, orElse: () => null);
       expect(expectedWarning, isNotNull,
         reason: 'Expected a WARNING log for a part directive being present in a file with no generated output.');
@@ -104,7 +105,7 @@ main() {
       var libraryAsset = makeAssetId('over_react|test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart');
       await runBuilder(builder, [libraryAsset], reader, writerSpy, AnalyzerResolvers(), logger: logger);
       final expectedWarning = logs.firstWhere((log) {
-        return log.level == Level.WARNING && log.message == 'An over react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart, but no code was generated.';
+        return log.level == Level.WARNING && log.message == 'An over_react part directive was found in test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart, but no code was generated. The part directive may be unnecessary if the file does not contain any concrete components or abstract state/props classes.';
       }, orElse: () => null);
       expect(expectedWarning, isNotNull,
         reason: 'Expected a WARNING log for a part directive being present in a file with no generated output.');

--- a/test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart
+++ b/test_fixtures/source_files/has_part_directive_missing_gen/no_declarations.dart
@@ -1,0 +1,2 @@
+// ignore: uri_has_not_been_generated
+part 'no_declarations.over_react.g.dart';

--- a/test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart
+++ b/test_fixtures/source_files/has_part_directive_missing_gen/with_declarations.dart
@@ -1,0 +1,7 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'with_declarations.over_react.g.dart';
+
+@AbstractComponent()
+abstract class SampleComponent<TProps extends UiProps> extends UiComponent<TProps> {}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In cases where an `.over_react.g.dart` part directive are included in a file where there are no generations, the consumer doesn't get any error or warning messages from this builder.
## Changes
  <!-- What this PR changes to fix the problem. -->
Log a warning when a part directive exists, but there is no output.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @aaronlademann-wf @seanburke-wf <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
