### PR TITLE
CPLAT-2281 optimize copy unconsumed props

### DIFF
--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -120,8 +120,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     forwardUnconsumedProps(this.props, propsToUpdate: props, keySetsToOmit:
         consumedPropKeys, onlyCopyDomProps: true);
   }
-
-
+  
   /// Returns a copy of this component's props with React props optionally omitted, and
   /// with the specified [keysToOmit] and [keySetsToOmit] omitted.
   @override

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -87,7 +87,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    props.addProps(copyProps(keySetsToOmit: consumedPropKeys));
+    props.addEntries(copyPropsToForwardIntoMap(this.props, keySetsToOmit: consumedPropKeys));
   }
 
   /// Returns a copy of this component's props with keys found in [consumedProps] and non-DOM props omitted.
@@ -109,7 +109,8 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedDomProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    props.addProps(copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys));
+    props.addEntries(copyPropsToForwardIntoMap(this.props, keySetsToOmit:
+        consumedPropKeys, onlyCopyDomProps: true));
   }
 
 

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -87,7 +87,8 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    props.addEntries(copyPropsToForwardIntoMap(this.props, keySetsToOmit: consumedPropKeys));
+    copyPropsToForwardIntoMap(this.props, addProp: props.addProp,
+        keySetsToOmit: consumedPropKeys);
   }
 
   /// Returns a copy of this component's props with keys found in [consumedProps] and non-DOM props omitted.
@@ -109,8 +110,8 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedDomProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    props.addEntries(copyPropsToForwardIntoMap(this.props, keySetsToOmit:
-        consumedPropKeys, onlyCopyDomProps: true));
+    copyPropsToForwardIntoMap(this.props, addProp: props.addProp, keySetsToOmit:
+        consumedPropKeys, onlyCopyDomProps: true);
   }
 
 

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -84,10 +84,10 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(keySetsToOmit: consumedPropKeys);
   }
 
-  void addUnconsumedProps(UiProps props) {
+  void addUnconsumedProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    forwardUnconsumedProps(this.props, addProp: props.addProp,
+    forwardUnconsumedProps(this.props, addProp: (props as UiProps).addProp,
         keySetsToOmit: consumedPropKeys);
   }
 
@@ -108,10 +108,10 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys);
   }
 
-  void addUnconsumedDomProps(UiProps props) {
+  void addUnconsumedDomProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    forwardUnconsumedProps(this.props, addProp: props.addProp, keySetsToOmit:
+    forwardUnconsumedProps(this.props, addProp: (props as UiProps).addProp, keySetsToOmit:
         consumedPropKeys, onlyCopyDomProps: true);
   }
 

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -73,9 +73,9 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// > Related [copyUnconsumedDomProps]
   ///
-  /// __Deprecated.__ Use [addUnconsumedProps] instead within
-  /// [modifyProps] (rather than [addProps]). Will be removed in the `4.0.0`
-  /// release.
+  /// __Deprecated.__ Use [addUnconsumedProps] within
+  /// [modifyProps] (rather than [addProps]) instead. Will be removed in the
+  /// `4.0.0` release.
   @override
   @Deprecated('4.0.0')
   Map copyUnconsumedProps() {
@@ -87,7 +87,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    copyPropsToForwardIntoMap(this.props, addProp: props.addProp,
+    forwardUnconsumedProps(this.props, addProp: props.addProp,
         keySetsToOmit: consumedPropKeys);
   }
 
@@ -97,8 +97,9 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// > Related [copyUnconsumedProps]
   ///
-  /// __Deprecated.__ Use [addUnconsumedDomProps] instead within
-  /// [modifyProps] (rather than [addProps]). Will be removed in the `4.0.0` release.
+  /// __Deprecated.__ Use [addUnconsumedDomProps] within
+  /// [modifyProps] (rather than [addProps]) instead. Will be removed in the
+  /// `4.0.0` release.
   @override
   @Deprecated('4.0.0')
   Map copyUnconsumedDomProps() {
@@ -110,7 +111,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedDomProps(UiProps props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    copyPropsToForwardIntoMap(this.props, addProp: props.addProp, keySetsToOmit:
+    forwardUnconsumedProps(this.props, addProp: props.addProp, keySetsToOmit:
         consumedPropKeys, onlyCopyDomProps: true);
   }
 

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -84,7 +84,18 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(keySetsToOmit: consumedPropKeys);
   }
 
-  /// Passes a reference of a component's [UiProps] to be updated with unconsumed props.
+  /// A prop modifier that passes a reference of a component's `props` to be updated with any unconsumed props.
+  ///
+  /// Call within `modifyProps` like so:
+  ///
+  ///     class SomeCompositeComponent extends UiComponent<SomeCompositeComponentProps> {
+  ///       @override
+  ///       render() {
+  ///         return (SomeOtherWidget()..modifyProps(addUnconsumedProps))(
+  ///           props.children,
+  ///         );
+  ///       }
+  ///     }
   ///
   /// > Related [addUnconsumedDomProps]
   void addUnconsumedProps(Map props) {
@@ -111,7 +122,18 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys);
   }
 
-  /// Passes a reference of a component's [UiProps] to be updated with the unconsumed DOM props.
+  /// A prop modifier that passes a reference of a component's `props` to be updated with any unconsumed `DomProps`.
+  ///
+  /// Call within `modifyProps` like so:
+  ///
+  ///     class SomeCompositeComponent extends UiComponent<SomeCompositeComponentProps> {
+  ///       @override
+  ///       render() {
+  ///         return (Dom.div()..modifyProps(addUnconsumedDomProps))(
+  ///           props.children,
+  ///         );
+  ///       }
+  ///     }
   ///
   /// > Related [addUnconsumedProps]
   void addUnconsumedDomProps(Map props) {

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -87,7 +87,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    forwardUnconsumedProps(this.props, addProp: (props as UiProps).addProp,
+    forwardUnconsumedProps(this.props, propsToUpdate: props,
         keySetsToOmit: consumedPropKeys);
   }
 
@@ -111,7 +111,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   void addUnconsumedDomProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
-    forwardUnconsumedProps(this.props, addProp: (props as UiProps).addProp, keySetsToOmit:
+    forwardUnconsumedProps(this.props, propsToUpdate: props, keySetsToOmit:
         consumedPropKeys, onlyCopyDomProps: true);
   }
 

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -88,7 +88,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// > Related [addUnconsumedDomProps]
   void addUnconsumedProps(Map props) {
-    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
+    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys);
 
     forwardUnconsumedProps(this.props, propsToUpdate: props,
         keySetsToOmit: consumedPropKeys);
@@ -115,7 +115,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// > Related [addUnconsumedProps]
   void addUnconsumedDomProps(Map props) {
-    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
+    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys);
 
     forwardUnconsumedProps(this.props, propsToUpdate: props, keySetsToOmit:
         consumedPropKeys, onlyCopyDomProps: true);

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -72,11 +72,22 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// > Should be used alongside [forwardingClassNameBuilder].
   ///
   /// > Related [copyUnconsumedDomProps]
+  ///
+  /// __Deprecated.__ Use [addUnconsumedProps] instead within
+  /// [modifyProps] (rather than [addProps]). Will be removed in the `4.0.0`
+  /// release.
   @override
+  @Deprecated('4.0.0')
   Map copyUnconsumedProps() {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
     return copyProps(keySetsToOmit: consumedPropKeys);
+  }
+
+  void addUnconsumedProps(UiProps props) {
+    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
+
+    props.addProps(copyProps(keySetsToOmit: consumedPropKeys));
   }
 
   /// Returns a copy of this component's props with keys found in [consumedProps] and non-DOM props omitted.
@@ -84,12 +95,23 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// > Should be used alongside [forwardingClassNameBuilder].
   ///
   /// > Related [copyUnconsumedProps]
+  ///
+  /// __Deprecated.__ Use [addUnconsumedDomProps] instead within
+  /// [modifyProps] (rather than [addProps]). Will be removed in the `4.0.0` release.
   @override
+  @Deprecated('4.0.0')
   Map copyUnconsumedDomProps() {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
     return copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys);
   }
+
+  void addUnconsumedDomProps(UiProps props) {
+    var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
+
+    props.addProps(copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys));
+  }
+
 
   /// Returns a copy of this component's props with React props optionally omitted, and
   /// with the specified [keysToOmit] and [keySetsToOmit] omitted.

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -74,8 +74,17 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// > Related [copyUnconsumedDomProps]
   ///
   /// __Deprecated.__ Use [addUnconsumedProps] within
-  /// [modifyProps] (rather than [addProps]) instead. Will be removed in the
-  /// `4.0.0` release.
+  /// [modifyProps] (rather than [addProps]) instead.
+  ///
+  /// Replace
+  ///
+  ///   ..addProps(copyUnconsumedProps())
+  ///
+  /// with
+  ///
+  ///   ..modifyProps(addUnconsumedProps)
+  ///
+  /// Will be removed in the `4.0.0` release.
   @override
   @Deprecated('4.0.0')
   Map copyUnconsumedProps() {
@@ -99,6 +108,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// > Related [addUnconsumedDomProps]
   void addUnconsumedProps(Map props) {
+    // TODO: cache this value to avoid unnecessary looping
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys);
 
     forwardUnconsumedProps(this.props, propsToUpdate: props,

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -84,6 +84,9 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(keySetsToOmit: consumedPropKeys);
   }
 
+  /// Passes a reference of a component's [UiProps] to be updated with unconsumed props.
+  ///
+  /// > Related [addUnconsumedDomProps]
   void addUnconsumedProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 
@@ -108,6 +111,9 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys);
   }
 
+  /// Passes a reference of a component's [UiProps] to be updated with the unconsumed DOM props.
+  ///
+  /// > Related [addUnconsumedProps]
   void addUnconsumedDomProps(Map props) {
     var consumedPropKeys = consumedProps?.map((ConsumedProps consumedProps) => consumedProps.keys) ?? const [];
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -74,19 +74,14 @@ void forwardUnconsumedProps(Map props, {
   bool onlyCopyDomProps: false,
   Iterable keysToOmit,
   Iterable<Iterable> keySetsToOmit,
-  Function addProp,
+  void addProp(key, value),
 }) {
-  props.forEach((key, value) {
+  for (String key in props.keys) {
     if (onlyCopyDomProps) {
-      bool shouldAddProp = false;
-
-      /// todo: work in a way to skip checks if a single check returns true?
-      /// we don't need to do two more checks if the first one returns true
-      if (key.startsWith('aria-')) shouldAddProp = true;
-      if (key.startsWith('data-')) shouldAddProp = true;
-      if (_validDomProps.contains(key)) shouldAddProp = true;
-      if (shouldAddProp) {
-        addProp(key, value);
+      if (key.startsWith('aria-') ||
+          key.startsWith('data-') ||
+          _validDomProps.contains(key)) {
+        addProp(key, props[key]);
       }
       return;
     }
@@ -99,10 +94,10 @@ void forwardUnconsumedProps(Map props, {
       });
     }
 
-    if (omitReactProps && ['key', 'ref', 'children'].contains(key)) return;
+    if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) return;
 
-    addProp(key, value);
-  });
+    addProp(key, props[key]);
+  }
 }
 
 
@@ -117,6 +112,6 @@ Map<String, dynamic> newStyleFromProps(Map props) {
   return existingStyle == null ? <String, dynamic>{} : new Map.from(existingStyle);
 }
 
-Set _validDomProps = new Set()
+HashSet _validDomProps = new HashSet()
   ..addAll(DomPropsMixin.meta.keys)
   ..addAll(SvgPropsMixin.meta.keys);

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -82,7 +82,7 @@ void forwardUnconsumedProps(Map props, {
       if (key.startsWith('aria-') ||
           key.startsWith('data-') ||
           _validDomProps.contains(key)) {
-        oldProps[key] = props[key];
+        propsToUpdate[key] = props[key];
       }
     }
     return;

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -99,9 +99,6 @@ void forwardUnconsumedProps(Map props, {
   }
 }
 
-
-
-
 /// Returns a copy of the [DomPropsMixin.style] map found in [props].
 ///
 /// Returns an empty map if [props] or its style map are `null`.

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -100,7 +100,7 @@ void forwardUnconsumedProps(Map props, {
         /// Consequently, this case exists to give the opportunity for the loop
         /// to continue without initiating another loop (which is less
         /// performant than `.first.contains()`).
-        if (keySetsToOmit.isNotEmpty && keySetsToOmit.first.contains(key)) continue;
+        if (keySetsToOmit.first.contains(key)) continue;
 
         if (keySetsToOmit.length > 1) {
           bool shouldContinue = false;

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -69,37 +69,40 @@ Map getPropsToForward(Map props, {
 }
 
 
-List<MapEntry> copyPropsToForwardIntoMap(Map props, {
+void copyPropsToForwardIntoMap(Map props, {
   bool omitReactProps: true,
   bool onlyCopyDomProps: false,
   Iterable keysToOmit,
-  Iterable<Iterable> keySetsToOmit
+  Iterable<Iterable> keySetsToOmit,
+  Function addProp,
 }) {
-  List<MapEntry> propsToAdd;
-
   props.forEach((key, value) {
     if (onlyCopyDomProps) {
-      if (!key.startsWith('aria-')) return;
-      if (!key.startsWith('data-')) return;
-      if (!_validDomProps.contains(key)) return;
-      propsToAdd.add(MapEntry(key, value));
+      bool shouldAddProp = false;
+
+      /// todo: work in a way to skip checks if a single check returns true?
+      /// we don't need to do two more checks if the first one returns true
+      if (key.startsWith('aria-')) shouldAddProp = true;
+      if (key.startsWith('data-')) shouldAddProp = true;
+      if (_validDomProps.contains(key)) shouldAddProp = true;
+      if (shouldAddProp) {
+        addProp(key, value);
+      }
       return;
     }
 
-    if (omitReactProps && ['key', 'ref', 'children'].contains(key)) return;
-
     if (keysToOmit != null && keysToOmit.contains(key)) return;
-    
+
     if (keySetsToOmit != null) {
       keySetsToOmit.forEach((Iterable keySets) {
         if (keySets.contains(key)) return;
       });
     }
 
-    propsToAdd.add(MapEntry(key, value));
-  });
+    if (omitReactProps && ['key', 'ref', 'children'].contains(key)) return;
 
-  return propsToAdd;
+    addProp(key, value);
+  });
 }
 
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -69,7 +69,10 @@ Map getPropsToForward(Map props, {
   return propsToForward;
 }
 
-
+/// Adds unconsumed props to a passed in map reference ([propsToUpdate]).
+///
+/// Based upon configuration, the function will overlook [props] that are not
+/// meant to be passed on, such as non-DOM props or specified values.
 void forwardUnconsumedProps(Map props, {
   bool omitReactProps: true,
   bool onlyCopyDomProps: false,
@@ -91,7 +94,26 @@ void forwardUnconsumedProps(Map props, {
   for (String key in props.keys) {
     if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
-    if (keySetsToOmit != null && keySetsToOmit.expand((i) => i).contains(key)) continue;
+    if (keySetsToOmit != null) {
+        /// If the passed in value of [keySetsToOmit] comes from
+        /// [addUnconsumedDomProps], there should only be a single index.
+        /// Consequently, this case exists to give the opportunity for the loop
+        /// to continue without initiating another loop (which is less
+        /// performant than `.first.contains()`).
+        if (keySetsToOmit.first.contains(key)) continue;
+
+        if (keySetsToOmit.length > 1) {
+          bool shouldContinue = false;
+          for (Iterable keySet in keySetsToOmit) {
+            if (keySet.contains(key)) {
+              shouldContinue = true;
+              continue;
+            }
+          }
+
+          if (shouldContinue) continue;
+        }
+    }
 
     if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -100,7 +100,7 @@ void forwardUnconsumedProps(Map props, {
         /// Consequently, this case exists to give the opportunity for the loop
         /// to continue without initiating another loop (which is less
         /// performant than `.first.contains()`).
-        if (keySetsToOmit.first.contains(key)) continue;
+        if (keySetsToOmit.isNotEmpty && keySetsToOmit.first.contains(key)) continue;
 
         if (keySetsToOmit.length > 1) {
           bool shouldContinue = false;

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -74,31 +74,31 @@ void forwardUnconsumedProps(Map props, {
   bool onlyCopyDomProps: false,
   Iterable keysToOmit,
   Iterable<Iterable> keySetsToOmit,
-  void addProp(key, value),
+  Map oldProps,
 }) {
-  for (String key in props.keys) {
-    if (onlyCopyDomProps) {
+
+  if (onlyCopyDomProps) {
+    for (String key in props.keys) {
       if (key.startsWith('aria-') ||
           key.startsWith('data-') ||
           _validDomProps.contains(key)) {
-        addProp(key, props[key]);
+        oldProps[key] = props[key];
       }
-      return;
     }
+    return;
+  }
 
-    if (keysToOmit != null && keysToOmit.contains(key)) return;
+  for (String key in props.keys) {
+    if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
-    if (keySetsToOmit != null) {
-      keySetsToOmit.forEach((Iterable keySets) {
-        if (keySets.contains(key)) return;
-      });
-    }
+    if (keySetsToOmit != null && keySetsToOmit.first.contains(key)) continue;
 
-    if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) return;
+    if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
 
-    addProp(key, props[key]);
+    oldProps[key] = props[key];
   }
 }
+
 
 
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -94,24 +94,24 @@ void forwardUnconsumedProps(Map props, {
     if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
     if (keySetsToOmit != null) {
-        /// If the passed in value of [keySetsToOmit] comes from
-        /// [addUnconsumedProps], there should only be a single index.
-        /// Consequently, this case exists to give the opportunity for the loop
-        /// to continue without initiating another loop (which is less
-        /// performant than `.first.contains()`).
-        if (keySetsToOmit.first.contains(key)) continue;
+      /// If the passed in value of [keySetsToOmit] comes from
+      /// [addUnconsumedProps], there should only be a single index.
+      /// Consequently, this case exists to give the opportunity for the loop
+      /// to continue without initiating another loop (which is less
+      /// performant than `.first.contains()`).
+      if (keySetsToOmit.first.contains(key)) continue;
 
-        if (keySetsToOmit.length > 1) {
-          bool shouldContinue = false;
-          for (Iterable keySet in keySetsToOmit) {
-            if (keySet.contains(key)) {
-              shouldContinue = true;
-              continue;
-            }
+      if (keySetsToOmit.length > 1) {
+        bool shouldContinue = false;
+        for (final keySet in keySetsToOmit) {
+          if (keySet.contains(key)) {
+            shouldContinue = true;
+            continue;
           }
-
-          if (shouldContinue) continue;
         }
+
+        if (shouldContinue) continue;
+      }
     }
 
     if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -19,7 +19,6 @@ import 'dart:collection';
 import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/prop_mixins.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
-import 'package:over_react/component_base.dart';
 
 /// Returns a copy of the specified [props] map, omitting reserved React props by default,
 /// in addition to any specified [keysToOmit] or [keySetsToOmit].

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -68,6 +68,42 @@ Map getPropsToForward(Map props, {
   return propsToForward;
 }
 
+
+List<MapEntry> copyPropsToForwardIntoMap(Map props, {
+  bool omitReactProps: true,
+  bool onlyCopyDomProps: false,
+  Iterable keysToOmit,
+  Iterable<Iterable> keySetsToOmit
+}) {
+  List<MapEntry> propsToAdd;
+
+  props.forEach((key, value) {
+    if (onlyCopyDomProps) {
+      if (!key.startsWith('aria-')) return;
+      if (!key.startsWith('data-')) return;
+      if (!_validDomProps.contains(key)) return;
+      propsToAdd.add(MapEntry(key, value));
+      return;
+    }
+
+    if (omitReactProps && ['key', 'ref', 'children'].contains(key)) return;
+
+    if (keysToOmit != null && keysToOmit.contains(key)) return;
+    
+    if (keySetsToOmit != null) {
+      keySetsToOmit.forEach((Iterable keySets) {
+        if (keySets.contains(key)) return;
+      });
+    }
+
+    propsToAdd.add(MapEntry(key, value));
+  });
+
+  return propsToAdd;
+}
+
+
+
 /// Returns a copy of the [DomPropsMixin.style] map found in [props].
 ///
 /// Returns an empty map if [props] or its style map are `null`.

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -99,6 +99,7 @@ void forwardUnconsumedProps(Map props, {
       /// Consequently, this case exists to give the opportunity for the loop
       /// to continue without initiating another loop (which is less
       /// performant than `.first.contains()`).
+      /// TODO: further optimize this by identifying the best looping / data structure
       if (keySetsToOmit.first.contains(key)) continue;
 
       if (keySetsToOmit.length > 1) {
@@ -106,7 +107,7 @@ void forwardUnconsumedProps(Map props, {
         for (final keySet in keySetsToOmit) {
           if (keySet.contains(key)) {
             shouldContinue = true;
-            continue;
+            break;
           }
         }
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -95,7 +95,7 @@ void forwardUnconsumedProps(Map props, {
 
     if (keySetsToOmit != null) {
         /// If the passed in value of [keySetsToOmit] comes from
-        /// [addUnconsumedDomProps], there should only be a single index.
+        /// [addUnconsumedProps], there should only be a single index.
         /// Consequently, this case exists to give the opportunity for the loop
         /// to continue without initiating another loop (which is less
         /// performant than `.first.contains()`).

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -74,7 +74,7 @@ void forwardUnconsumedProps(Map props, {
   bool onlyCopyDomProps: false,
   Iterable keysToOmit,
   Iterable<Iterable> keySetsToOmit,
-  Map oldProps,
+  Map propsToUpdate,
 }) {
 
   if (onlyCopyDomProps) {
@@ -95,7 +95,7 @@ void forwardUnconsumedProps(Map props, {
 
     if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
 
-    oldProps[key] = props[key];
+    propsToUpdate[key] = props[key];
   }
 }
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -19,6 +19,7 @@ import 'dart:collection';
 import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/prop_mixins.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
+import 'package:over_react/component_base.dart';
 
 /// Returns a copy of the specified [props] map, omitting reserved React props by default,
 /// in addition to any specified [keysToOmit] or [keySetsToOmit].
@@ -76,7 +77,6 @@ void forwardUnconsumedProps(Map props, {
   Iterable<Iterable> keySetsToOmit,
   Map propsToUpdate,
 }) {
-
   if (onlyCopyDomProps) {
     for (String key in props.keys) {
       if (key.startsWith('aria-') ||
@@ -91,7 +91,7 @@ void forwardUnconsumedProps(Map props, {
   for (String key in props.keys) {
     if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
-    if (keySetsToOmit != null && keySetsToOmit.first.contains(key)) continue;
+    if (keySetsToOmit != null && keySetsToOmit.expand((i) => i).contains(key)) continue;
 
     if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -69,7 +69,7 @@ Map getPropsToForward(Map props, {
   return propsToForward;
 }
 
-/// Adds unconsumed props to a passed in map reference ([propsToUpdate]).
+/// Adds unconsumed props to a passed in [Map] reference ([propsToUpdate]).
 ///
 /// Based upon configuration, the function will overlook [props] that are not
 /// meant to be passed on, such as non-DOM props or specified values.

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -69,7 +69,7 @@ Map getPropsToForward(Map props, {
 }
 
 
-void copyPropsToForwardIntoMap(Map props, {
+void forwardUnconsumedProps(Map props, {
   bool omitReactProps: true,
   bool onlyCopyDomProps: false,
   Iterable keysToOmit,

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -78,6 +78,6 @@ Map<String, dynamic> newStyleFromProps(Map props) {
   return existingStyle == null ? <String, dynamic>{} : new Map.from(existingStyle);
 }
 
-SplayTreeSet _validDomProps = new SplayTreeSet()
+Set _validDomProps = new Set()
   ..addAll(DomPropsMixin.meta.keys)
   ..addAll(SvgPropsMixin.meta.keys);

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.dart
@@ -170,7 +170,7 @@ class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
 
   @override
   render() => (Dom.div()
-    ..addProps(copyUnconsumedProps())
+    ..modifyProps(addUnconsumedProps)
     ..addProp('data-prop-string-prop', props.stringProp)
     ..addProp('data-prop-dynamic-prop', props.dynamicProp)
     ..addProp('data-prop-untyped-prop', props.untypedProp)

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -806,11 +806,88 @@ main() {
       }, timeout: new Timeout(const Duration(milliseconds: 250)));
     });
 
-
     group('UiComponent2', () {
       TestComponent2Component component2;
 
       group('copyUnconsumedProps()', () {
+        test('copies props, omitting keys from `consumedProps`, as well as reserved react props', () {
+          component2 = new TestComponent2Component(testConsumedProps: [
+            const ConsumedProps(const [], const ['consumed1', 'consumed2'])
+          ]);
+
+          component2.props = new JsBackedMap.from({
+            'key': 'testKey',
+            'ref': 'testRef',
+            'children': [],
+            'consumed1': true,
+            'consumed2': true,
+            'unconsumed1': true,
+            'unconsumed2': true,
+          });
+
+          expect(component2.copyUnconsumedProps(), equals({
+            'unconsumed1': true,
+            'unconsumed2': true,
+          }));
+        });
+
+        test('copies all props when `consumedProps` is null', () {
+          component2 = new TestComponent2Component(testConsumedProps: null);
+
+          component2.props = new JsBackedMap.from({
+            'prop1': true,
+            'prop2': true,
+          });
+
+          expect(component2.copyUnconsumedProps(), equals({
+            'prop1': true,
+            'prop2': true,
+          }));
+        });
+      });
+
+      group('copyUnconsumedDomProps()', () {
+        test('copies props, omitting keys from `consumedPropKeys`, as well as reserved react props', () {
+          component2 = new TestComponent2Component(testConsumedProps: [
+            const ConsumedProps(const [], const ['consumed1', 'consumed2'])
+          ]);
+
+          component2.props = new JsBackedMap.from({
+            'key': 'testKey',
+            'ref': 'testRef',
+            'children': [],
+            'consumed1': true,
+            'consumed2': true,
+            'unconsumed1': true,
+            'unconsumed2': true,
+            'tabIndex': true,
+            'className': true,
+          });
+
+          expect(component2.copyUnconsumedDomProps(), equals({
+            'tabIndex': true,
+            'className': true,
+          }));
+        });
+
+        test('copies all props when `consumedPropKeys` is null', () {
+          component2 = new TestComponent2Component(testConsumedProps: null);
+
+          component2.props = new JsBackedMap.from({
+            'prop1': true,
+            'prop2': true,
+            'tabIndex': true,
+            'className': true,
+          });
+
+          expect(component2.copyUnconsumedDomProps(), equals({
+            'tabIndex': true,
+            'className': true,
+          }));
+        });
+      });
+
+      group('addUnconsumedProps()', () {
         test('copies props, omitting keys from `consumedProps`, as well as reserved react props', () {
           component2 = new TestComponent2Component(testConsumedProps: [
             const ConsumedProps(const [], const ['consumed1', 'consumed2'])
@@ -853,7 +930,7 @@ main() {
         });
       });
 
-      group('copyUnconsumedDomProps()', () {
+      group('addUnconsumedDomProps()', () {
         test('copies props, omitting keys from `consumedPropKeys`, as well as reserved react props', () {
           component2 = new TestComponent2Component(testConsumedProps: [
             const ConsumedProps(const [], const ['consumed1', 'consumed2'])

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart' show Dom, DummyComponent, ValidationUtil;
+import 'package:over_react/over_react.dart' show Component2, Dom, DummyComponent, Factory, Props, ValidationUtil;
 import 'package:over_react_test/over_react_test.dart';
 import 'package:over_react/src/component_declaration/component_base.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
@@ -28,6 +28,7 @@ import 'package:w_common/disposable.dart';
 
 import '../../test_util/test_util.dart';
 import '../shared/map_proxy_tests.dart';
+
 
 main() {
   void _commonNonInvokedBuilderTests(UiProps builder) {
@@ -806,6 +807,101 @@ main() {
       }, timeout: new Timeout(const Duration(milliseconds: 250)));
     });
 
+
+    group('UiComponent2', () {
+      TestComponent2Component component2;
+
+      group('copyUnconsumedProps()', () {
+        test('copies props, omitting keys from `consumedProps`, as well as reserved react props', () {
+          component2 = new TestComponent2Component(testConsumedProps: [
+            const ConsumedProps(const [], const ['consumed1', 'consumed2'])
+          ]);
+
+          component2.props = new JsBackedMap.from({
+            'key': 'testKey',
+            'ref': 'testRef',
+            'children': [],
+            'consumed1': true,
+            'consumed2': true,
+            'unconsumed1': true,
+            'unconsumed2': true,
+          });
+
+          Map test = {};
+          component2.addUnconsumedProps(test);
+
+          expect(test, equals({
+            'unconsumed1': true,
+            'unconsumed2': true,
+          }));
+        });
+
+        test('copies all props when `consumedProps` is null', () {
+          component2 = new TestComponent2Component(testConsumedProps: null);
+
+          component2.props = new JsBackedMap.from({
+            'prop1': true,
+            'prop2': true,
+          });
+
+          Map test = {};
+          component2.addUnconsumedProps(test);
+
+          expect(test, equals({
+            'prop1': true,
+            'prop2': true,
+          }));
+        });
+      });
+
+      group('copyUnconsumedDomProps()', () {
+        test('copies props, omitting keys from `consumedPropKeys`, as well as reserved react props', () {
+          component2 = new TestComponent2Component(testConsumedProps: [
+            const ConsumedProps(const [], const ['consumed1', 'consumed2'])
+          ]);
+
+          component2.props = JsBackedMap.from({
+            'key': 'testKey',
+            'ref': 'testRef',
+            'children': [],
+            'consumed1': true,
+            'consumed2': true,
+            'unconsumed1': true,
+            'unconsumed2': true,
+            'tabIndex': true,
+            'className': true,
+          });
+
+          Map test = {};
+          component2.addUnconsumedDomProps(test);
+
+          expect(test, equals({
+            'tabIndex': true,
+            'className': true,
+          }));
+        });
+
+        test('copies all props when `consumedPropKeys` is null', () {
+          component2 = new TestComponent2Component(testConsumedProps: null);
+
+          component2.props = JsBackedMap.from({
+            'prop1': true,
+            'prop2': true,
+            'tabIndex': true,
+            'className': true,
+          });
+
+          Map test = {};
+          component2.addUnconsumedDomProps(test);
+
+          expect(test, equals({
+            'tabIndex': true,
+            'className': true,
+          }));
+        });
+      });
+    });
+
     group('UiStatefulComponent', () {
       TestStatefulComponentComponent statefulComponent;
 
@@ -996,6 +1092,41 @@ class TestComponentComponent extends UiComponent<TestComponentProps> {
   }
 }
 
+class TestComponent2Props extends UiProps {
+  @override final ReactComponentFactoryProxy componentFactory = _TestComponentComponentFactory;
+  TestComponent2Props(JsBackedMap backingMap)
+      : this._props = new JsBackedMap() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+class TestComponent2Component extends UiComponent2<TestComponent2Props> {
+
+  @override
+  final List<ConsumedProps> consumedProps;
+
+  @override
+  TestComponent2Props get props => typedPropsFactory(unwrappedProps);
+
+  TestComponent2Component({List<ConsumedProps> testConsumedProps}) :
+        consumedProps = testConsumedProps;
+
+  @override
+  render() => (Dom.div()..ref = 'foo')();
+
+  @override
+  TestComponent2Props typedPropsFactory(Map propsMap) => new
+  TestComponent2Props(propsMap);
+
+  @override
+  TestComponent2Props typedPropsFactoryJs(Map propsMap) => new
+  TestComponent2Props(propsMap);
+
+}
 
 UiFactory<TestStatefulComponentProps> TestStatefulComponent = ([Map props]) => new TestStatefulComponentProps(props);
 

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart' show Component2, Dom, DummyComponent, Factory, Props, ValidationUtil;
+import 'package:over_react/over_react.dart' show Dom, DummyComponent, ValidationUtil;
 import 'package:over_react_test/over_react_test.dart';
 import 'package:over_react/src/component_declaration/component_base.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
@@ -827,10 +827,10 @@ main() {
             'unconsumed2': true,
           });
 
-          Map test = {};
-          component2.addUnconsumedProps(test);
+          Map newProps = {};
+          component2.addUnconsumedProps(newProps);
 
-          expect(test, equals({
+          expect(newProps, equals({
             'unconsumed1': true,
             'unconsumed2': true,
           }));
@@ -844,10 +844,10 @@ main() {
             'prop2': true,
           });
 
-          Map test = {};
-          component2.addUnconsumedProps(test);
+          Map newProps = {};
+          component2.addUnconsumedProps(newProps);
 
-          expect(test, equals({
+          expect(newProps, equals({
             'prop1': true,
             'prop2': true,
           }));
@@ -872,10 +872,10 @@ main() {
             'className': true,
           });
 
-          Map test = {};
-          component2.addUnconsumedDomProps(test);
+          Map newProps = {};
+          component2.addUnconsumedDomProps(newProps);
 
-          expect(test, equals({
+          expect(newProps, equals({
             'tabIndex': true,
             'className': true,
           }));
@@ -891,10 +891,10 @@ main() {
             'className': true,
           });
 
-          Map test = {};
-          component2.addUnconsumedDomProps(test);
+          Map newProps = {};
+          component2.addUnconsumedDomProps(newProps);
 
-          expect(test, equals({
+          expect(newProps, equals({
             'tabIndex': true,
             'className': true,
           }));

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -1124,7 +1124,6 @@ class TestComponent2Component extends UiComponent2<TestComponent2Props> {
   @override
   TestComponent2Props typedPropsFactoryJs(Map propsMap) => new
   TestComponent2Props(propsMap);
-
 }
 
 UiFactory<TestStatefulComponentProps> TestStatefulComponent = ([Map props]) => new TestStatefulComponentProps(props);

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -29,7 +29,6 @@ import 'package:w_common/disposable.dart';
 import '../../test_util/test_util.dart';
 import '../shared/map_proxy_tests.dart';
 
-
 main() {
   void _commonNonInvokedBuilderTests(UiProps builder) {
     bool warningsWereEnabled;

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -122,7 +122,7 @@ main() {
       });
     });
 
-    group('forwardUnconsumedProps() returns a copy of the specified props', () {
+    group('forwardUnconsumedProps() modifies a passed in props reference', () {
       group('with React props', () {
         test('omitted out by default', () {
           Map startingProps = {

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -125,13 +125,13 @@ main() {
     group('forwardUnconsumedProps() returns a copy of the specified props', () {
       group('with React props', () {
         test('omitted out by default', () {
-         Map startingProps = {
+          Map startingProps = {
             'key': 'my key',
             'ref': 'my ref',
             'other prop': 'my other prop'
           };
 
-         Map actual = {};
+          Map actual = {};
 
           forwardUnconsumedProps(startingProps, propsToUpdate: actual);
 

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -122,6 +122,120 @@ main() {
       });
     });
 
+    group('forwardUnconsumedProps() returns a copy of the specified props', () {
+      group('with React props', () {
+        test('omitted out by default', () {
+         Map startingProps = {
+            'key': 'my key',
+            'ref': 'my ref',
+            'other prop': 'my other prop'
+          };
+
+         Map actual = {};
+
+          forwardUnconsumedProps(startingProps, propsToUpdate: actual);
+
+          var expected = {'other prop': 'my other prop'};
+
+          expect(actual, equals(expected));
+        });
+
+        test('not omitted when specified', () {
+          var actual = {};
+
+          forwardUnconsumedProps({
+            'key': 'my key',
+            'ref': 'my ref',
+            'other prop': 'my other prop'
+          }, omitReactProps: false, propsToUpdate: actual);
+
+          var expected = {
+            'key': 'my key',
+            'ref': 'my ref',
+            'other prop': 'my other prop'
+          };
+
+          expect(actual, equals(expected));
+        });
+      });
+
+      test('with the specified keys omitted', () {
+        var actual = {};
+
+        forwardUnconsumedProps({
+          'prop 1': 'my prop #1',
+          'prop 2': 'my prop #2',
+          'prop 3': 'my prop #3',
+          'prop 4': 'my prop #4',
+        }, keysToOmit: [
+          'prop 2',
+          'prop 4'
+        ], propsToUpdate: actual);
+
+        var expected = {
+          'prop 1': 'my prop #1',
+          'prop 3': 'my prop #3',
+        };
+
+        expect(actual, equals(expected));
+      });
+
+      test('with the specified sets of keys omitted', () {
+        var actual = {};
+
+        forwardUnconsumedProps({
+          'prop 1': 'my prop #1',
+          'prop 2': 'my prop #2',
+          'prop 3': 'my prop #3',
+          'prop 4': 'my prop #4',
+          'prop 5': 'my prop #5',
+          'prop 6': 'my prop #6',
+        }, keySetsToOmit: [
+          [
+            'prop 1',
+            'prop 3'
+          ],
+          [
+            'prop 4',
+            'prop 5'
+          ],
+        ], propsToUpdate: actual);
+
+        var expected = {
+          'prop 2': 'my prop #2',
+          'prop 6': 'my prop #6',
+        };
+
+        expect(actual, equals(expected));
+      });
+
+      test('with only valid DOM/SVG props', () {
+        var actual = {};
+
+        forwardUnconsumedProps({
+          'tabIndex': '0',
+          'className': 'my classname',
+          'cx': '0',
+          'stroke': 'red',
+          'data-test-prop': 'my data attr',
+          'aria-test-prop': 'my aria attr',
+          'classNameBlacklist': 'my classname blacklist',
+          'custom prop': 'my custom prop',
+        }, onlyCopyDomProps: true, propsToUpdate: actual);
+
+        var expected = {
+          'tabIndex': '0',
+          'className': 'my classname',
+          'cx': '0',
+          'stroke': 'red',
+          'data-test-prop': 'my data attr',
+          'aria-test-prop': 'my aria attr',
+        };
+
+        expect(actual, equals(expected));
+      });
+    });
+
     group('newStyleFromProps() returns', () {
       test('a copy of the style map found in the specified props', () {
         var styles = {'color': 'red', 'width': '10rem'};


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
To increase the performance of forwarding props, we are adding the `addUnconsumedProps` and `addUnconsumedDomProps` methods.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add the `addUnconsumedProps` and `addUnconsumedDomProps` methods
- Deprecate the `copyUnconsumedProps` and `copyUnconsumedDomProps` methods
- Change `_validDomProps` from a `SplayTree` to a `Set`
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
