### PR TITLE
CPLAT 6157 Add pointer event callbacks to prop mixins

### DIFF
--- a/lib/src/component/callback_typedefs.dart
+++ b/lib/src/component/callback_typedefs.dart
@@ -26,6 +26,7 @@ typedef KeyboardEventCallback(react.SyntheticKeyboardEvent event);
 typedef FocusEventCallback(react.SyntheticFocusEvent event);
 typedef FormEventCallback(react.SyntheticFormEvent event);
 typedef MouseEventCallback(react.SyntheticMouseEvent event);
+typedef PointerEventCallback(react.SyntheticPointerEvent event);
 typedef TouchEventCallback(react.SyntheticTouchEvent event);
 typedef UIEventCallback(react.SyntheticUIEvent event);
 typedef WheelEventCallback(react.SyntheticWheelEvent event);

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -93,6 +93,7 @@ abstract class _$DomPropsMixin {
   MouseEventCallback
     onClick, onContextMenu, onDoubleClick, onDrag, onDragEnd, onDragEnter, onDragExit, onDragLeave, onDragOver,
     onDragStart, onDrop, onMouseDown, onMouseEnter, onMouseLeave, onMouseMove, onMouseOut, onMouseOver, onMouseUp;
+  PointerEventCallback onPointerCancel, onPointerDown, onPointerEnter, onPointerLeave, onPointerMove, onPointerOver, onPointerOut, onPointerUp;
   TouchEventCallback onTouchCancel, onTouchEnd, onTouchMove, onTouchStart;
   UIEventCallback onScroll;
   WheelEventCallback onWheel;
@@ -104,6 +105,7 @@ abstract class _$DomPropsMixin {
   MouseEventCallback
     onClickCapture, onContextMenuCapture, onDoubleClickCapture, onDragCapture, onDragEndCapture, onDragEnterCapture, onDragExitCapture, onDragLeaveCapture, onDragOverCapture,
     onDragStartCapture, onDropCapture, onMouseDownCapture, onMouseEnterCapture, onMouseLeaveCapture, onMouseMoveCapture, onMouseOutCapture, onMouseOverCapture, onMouseUpCapture;
+  PointerEventCallback onGotPointerCapture, onLostPointerCapture;
   TouchEventCallback onTouchCancelCapture, onTouchEndCapture, onTouchMoveCapture, onTouchStartCapture;
   UIEventCallback onScrollCapture;
   WheelEventCallback onWheelCapture;
@@ -286,6 +288,30 @@ abstract class _$UbiquitousDomPropsMixin {
 
   /// Callback for when a user releases a mouse button over an element
   MouseEventCallback onMouseUp;
+
+  /// Callback for when the pointing device is interrupted
+  PointerEventCallback onPointerCancel;
+
+  /// Callback for when the pointer becomes active over an element
+  PointerEventCallback onPointerDown;
+
+  /// Callback for when the pointer is moved onto an element
+  PointerEventCallback onPointerEnter;
+
+  /// Callback for when the pointer is moved out of an element
+  PointerEventCallback onPointerLeave;
+
+  /// Callback for when the pointer is moving while it is over an element
+  PointerEventCallback onPointerMove;
+
+  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  PointerEventCallback onPointerOver;
+
+  /// Callback for when the pointer is moved out of an element, or out of one of its children
+  PointerEventCallback onPointerOut;
+
+  /// Callback for when the pointer becomes inactive over an element
+  PointerEventCallback onPointerUp;
 
   /// Callback for when the touch is interrupted
   TouchEventCallback onTouchCancel;

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -304,7 +304,7 @@ abstract class _$UbiquitousDomPropsMixin {
   /// Callback for when the pointer is moving while it is over an element
   PointerEventCallback onPointerMove;
 
-  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  /// Callback for when the pointer is moved onto an element, or onto one of its children
   PointerEventCallback onPointerOver;
 
   /// Callback for when the pointer is moved out of an element, or out of one of its children

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -4132,14 +4132,14 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   set onPointerMove(PointerEventCallback value) =>
       props[_$key__onPointerMove___$UbiquitousDomPropsMixin] = value;
 
-  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  /// Callback for when the pointer is moved onto an element, or onto one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
   @override
   PointerEventCallback get onPointerOver =>
       props[_$key__onPointerOver___$UbiquitousDomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  /// Callback for when the pointer is moved onto an element, or onto one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
   @override

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -1249,6 +1249,86 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set onMouseUp(MouseEventCallback value) =>
       props[_$key__onMouseUp___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.onPointerCancel] -->
+  @override
+  PointerEventCallback get onPointerCancel =>
+      props[_$key__onPointerCancel___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerCancel] -->
+  @override
+  set onPointerCancel(PointerEventCallback value) =>
+      props[_$key__onPointerCancel___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerDown] -->
+  @override
+  PointerEventCallback get onPointerDown =>
+      props[_$key__onPointerDown___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerDown] -->
+  @override
+  set onPointerDown(PointerEventCallback value) =>
+      props[_$key__onPointerDown___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerEnter] -->
+  @override
+  PointerEventCallback get onPointerEnter =>
+      props[_$key__onPointerEnter___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerEnter] -->
+  @override
+  set onPointerEnter(PointerEventCallback value) =>
+      props[_$key__onPointerEnter___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerLeave] -->
+  @override
+  PointerEventCallback get onPointerLeave =>
+      props[_$key__onPointerLeave___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerLeave] -->
+  @override
+  set onPointerLeave(PointerEventCallback value) =>
+      props[_$key__onPointerLeave___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerMove] -->
+  @override
+  PointerEventCallback get onPointerMove =>
+      props[_$key__onPointerMove___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerMove] -->
+  @override
+  set onPointerMove(PointerEventCallback value) =>
+      props[_$key__onPointerMove___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerOver] -->
+  @override
+  PointerEventCallback get onPointerOver =>
+      props[_$key__onPointerOver___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerOver] -->
+  @override
+  set onPointerOver(PointerEventCallback value) =>
+      props[_$key__onPointerOver___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerOut] -->
+  @override
+  PointerEventCallback get onPointerOut =>
+      props[_$key__onPointerOut___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerOut] -->
+  @override
+  set onPointerOut(PointerEventCallback value) =>
+      props[_$key__onPointerOut___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onPointerUp] -->
+  @override
+  PointerEventCallback get onPointerUp =>
+      props[_$key__onPointerUp___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onPointerUp] -->
+  @override
+  set onPointerUp(PointerEventCallback value) =>
+      props[_$key__onPointerUp___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancel] -->
   @override
   TouchEventCallback get onTouchCancel =>
@@ -1609,6 +1689,26 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set onMouseUpCapture(MouseEventCallback value) =>
       props[_$key__onMouseUpCapture___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.onGotPointerCapture] -->
+  @override
+  PointerEventCallback get onGotPointerCapture =>
+      props[_$key__onGotPointerCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onGotPointerCapture] -->
+  @override
+  set onGotPointerCapture(PointerEventCallback value) =>
+      props[_$key__onGotPointerCapture___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.onLostPointerCapture] -->
+  @override
+  PointerEventCallback get onLostPointerCapture =>
+      props[_$key__onLostPointerCapture___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.onLostPointerCapture] -->
+  @override
+  set onLostPointerCapture(PointerEventCallback value) =>
+      props[_$key__onLostPointerCapture___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancelCapture] -->
   @override
   TouchEventCallback get onTouchCancelCapture =>
@@ -1952,6 +2052,22 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__onMouseOver___$DomPropsMixin);
   static const PropDescriptor _$prop__onMouseUp___$DomPropsMixin =
       const PropDescriptor(_$key__onMouseUp___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerCancel___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerCancel___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerDown___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerDown___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerEnter___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerEnter___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerLeave___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerLeave___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerMove___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerMove___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerOver___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerOver___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerOut___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerOut___$DomPropsMixin);
+  static const PropDescriptor _$prop__onPointerUp___$DomPropsMixin =
+      const PropDescriptor(_$key__onPointerUp___$DomPropsMixin);
   static const PropDescriptor _$prop__onTouchCancel___$DomPropsMixin =
       const PropDescriptor(_$key__onTouchCancel___$DomPropsMixin);
   static const PropDescriptor _$prop__onTouchEnd___$DomPropsMixin =
@@ -2024,6 +2140,10 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__onMouseOverCapture___$DomPropsMixin);
   static const PropDescriptor _$prop__onMouseUpCapture___$DomPropsMixin =
       const PropDescriptor(_$key__onMouseUpCapture___$DomPropsMixin);
+  static const PropDescriptor _$prop__onGotPointerCapture___$DomPropsMixin =
+      const PropDescriptor(_$key__onGotPointerCapture___$DomPropsMixin);
+  static const PropDescriptor _$prop__onLostPointerCapture___$DomPropsMixin =
+      const PropDescriptor(_$key__onLostPointerCapture___$DomPropsMixin);
   static const PropDescriptor _$prop__onTouchCancelCapture___$DomPropsMixin =
       const PropDescriptor(_$key__onTouchCancelCapture___$DomPropsMixin);
   static const PropDescriptor _$prop__onTouchEndCapture___$DomPropsMixin =
@@ -2169,6 +2289,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__onMouseOut___$DomPropsMixin = 'onMouseOut';
   static const String _$key__onMouseOver___$DomPropsMixin = 'onMouseOver';
   static const String _$key__onMouseUp___$DomPropsMixin = 'onMouseUp';
+  static const String _$key__onPointerCancel___$DomPropsMixin =
+      'onPointerCancel';
+  static const String _$key__onPointerDown___$DomPropsMixin = 'onPointerDown';
+  static const String _$key__onPointerEnter___$DomPropsMixin = 'onPointerEnter';
+  static const String _$key__onPointerLeave___$DomPropsMixin = 'onPointerLeave';
+  static const String _$key__onPointerMove___$DomPropsMixin = 'onPointerMove';
+  static const String _$key__onPointerOver___$DomPropsMixin = 'onPointerOver';
+  static const String _$key__onPointerOut___$DomPropsMixin = 'onPointerOut';
+  static const String _$key__onPointerUp___$DomPropsMixin = 'onPointerUp';
   static const String _$key__onTouchCancel___$DomPropsMixin = 'onTouchCancel';
   static const String _$key__onTouchEnd___$DomPropsMixin = 'onTouchEnd';
   static const String _$key__onTouchMove___$DomPropsMixin = 'onTouchMove';
@@ -2224,6 +2353,10 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       'onMouseOverCapture';
   static const String _$key__onMouseUpCapture___$DomPropsMixin =
       'onMouseUpCapture';
+  static const String _$key__onGotPointerCapture___$DomPropsMixin =
+      'onGotPointerCapture';
+  static const String _$key__onLostPointerCapture___$DomPropsMixin =
+      'onLostPointerCapture';
   static const String _$key__onTouchCancelCapture___$DomPropsMixin =
       'onTouchCancelCapture';
   static const String _$key__onTouchEndCapture___$DomPropsMixin =
@@ -2364,6 +2497,14 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__onMouseOut___$DomPropsMixin,
     _$prop__onMouseOver___$DomPropsMixin,
     _$prop__onMouseUp___$DomPropsMixin,
+    _$prop__onPointerCancel___$DomPropsMixin,
+    _$prop__onPointerDown___$DomPropsMixin,
+    _$prop__onPointerEnter___$DomPropsMixin,
+    _$prop__onPointerLeave___$DomPropsMixin,
+    _$prop__onPointerMove___$DomPropsMixin,
+    _$prop__onPointerOver___$DomPropsMixin,
+    _$prop__onPointerOut___$DomPropsMixin,
+    _$prop__onPointerUp___$DomPropsMixin,
     _$prop__onTouchCancel___$DomPropsMixin,
     _$prop__onTouchEnd___$DomPropsMixin,
     _$prop__onTouchMove___$DomPropsMixin,
@@ -2400,6 +2541,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__onMouseOutCapture___$DomPropsMixin,
     _$prop__onMouseOverCapture___$DomPropsMixin,
     _$prop__onMouseUpCapture___$DomPropsMixin,
+    _$prop__onGotPointerCapture___$DomPropsMixin,
+    _$prop__onLostPointerCapture___$DomPropsMixin,
     _$prop__onTouchCancelCapture___$DomPropsMixin,
     _$prop__onTouchEndCapture___$DomPropsMixin,
     _$prop__onTouchMoveCapture___$DomPropsMixin,
@@ -2535,6 +2678,14 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__onMouseOut___$DomPropsMixin,
     _$key__onMouseOver___$DomPropsMixin,
     _$key__onMouseUp___$DomPropsMixin,
+    _$key__onPointerCancel___$DomPropsMixin,
+    _$key__onPointerDown___$DomPropsMixin,
+    _$key__onPointerEnter___$DomPropsMixin,
+    _$key__onPointerLeave___$DomPropsMixin,
+    _$key__onPointerMove___$DomPropsMixin,
+    _$key__onPointerOver___$DomPropsMixin,
+    _$key__onPointerOut___$DomPropsMixin,
+    _$key__onPointerUp___$DomPropsMixin,
     _$key__onTouchCancel___$DomPropsMixin,
     _$key__onTouchEnd___$DomPropsMixin,
     _$key__onTouchMove___$DomPropsMixin,
@@ -2571,6 +2722,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__onMouseOutCapture___$DomPropsMixin,
     _$key__onMouseOverCapture___$DomPropsMixin,
     _$key__onMouseUpCapture___$DomPropsMixin,
+    _$key__onGotPointerCapture___$DomPropsMixin,
+    _$key__onLostPointerCapture___$DomPropsMixin,
     _$key__onTouchCancelCapture___$DomPropsMixin,
     _$key__onTouchEndCapture___$DomPropsMixin,
     _$key__onTouchMoveCapture___$DomPropsMixin,
@@ -3909,6 +4062,118 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   set onMouseUp(MouseEventCallback value) =>
       props[_$key__onMouseUp___$UbiquitousDomPropsMixin] = value;
 
+  /// Callback for when the pointing device is interrupted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerCancel] -->
+  @override
+  PointerEventCallback get onPointerCancel =>
+      props[_$key__onPointerCancel___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointing device is interrupted
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerCancel] -->
+  @override
+  set onPointerCancel(PointerEventCallback value) =>
+      props[_$key__onPointerCancel___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer becomes active over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerDown] -->
+  @override
+  PointerEventCallback get onPointerDown =>
+      props[_$key__onPointerDown___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer becomes active over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerDown] -->
+  @override
+  set onPointerDown(PointerEventCallback value) =>
+      props[_$key__onPointerDown___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer is moved onto an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerEnter] -->
+  @override
+  PointerEventCallback get onPointerEnter =>
+      props[_$key__onPointerEnter___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer is moved onto an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerEnter] -->
+  @override
+  set onPointerEnter(PointerEventCallback value) =>
+      props[_$key__onPointerEnter___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer is moved out of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerLeave] -->
+  @override
+  PointerEventCallback get onPointerLeave =>
+      props[_$key__onPointerLeave___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer is moved out of an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerLeave] -->
+  @override
+  set onPointerLeave(PointerEventCallback value) =>
+      props[_$key__onPointerLeave___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer is moving while it is over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerMove] -->
+  @override
+  PointerEventCallback get onPointerMove =>
+      props[_$key__onPointerMove___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer is moving while it is over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerMove] -->
+  @override
+  set onPointerMove(PointerEventCallback value) =>
+      props[_$key__onPointerMove___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
+  @override
+  PointerEventCallback get onPointerOver =>
+      props[_$key__onPointerOver___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointing device is moved onto an element, or onto one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
+  @override
+  set onPointerOver(PointerEventCallback value) =>
+      props[_$key__onPointerOver___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer is moved out of an element, or out of one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOut] -->
+  @override
+  PointerEventCallback get onPointerOut =>
+      props[_$key__onPointerOut___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer is moved out of an element, or out of one of its children
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOut] -->
+  @override
+  set onPointerOut(PointerEventCallback value) =>
+      props[_$key__onPointerOut___$UbiquitousDomPropsMixin] = value;
+
+  /// Callback for when the pointer becomes inactive over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerUp] -->
+  @override
+  PointerEventCallback get onPointerUp =>
+      props[_$key__onPointerUp___$UbiquitousDomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Callback for when the pointer becomes inactive over an element
+  ///
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerUp] -->
+  @override
+  set onPointerUp(PointerEventCallback value) =>
+      props[_$key__onPointerUp___$UbiquitousDomPropsMixin] = value;
+
   /// Callback for when the touch is interrupted
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchCancel] -->
@@ -4061,6 +4326,25 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
       const PropDescriptor(_$key__onMouseOver___$UbiquitousDomPropsMixin);
   static const PropDescriptor _$prop__onMouseUp___$UbiquitousDomPropsMixin =
       const PropDescriptor(_$key__onMouseUp___$UbiquitousDomPropsMixin);
+  static const PropDescriptor
+      _$prop__onPointerCancel___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerCancel___$UbiquitousDomPropsMixin);
+  static const PropDescriptor _$prop__onPointerDown___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerDown___$UbiquitousDomPropsMixin);
+  static const PropDescriptor
+      _$prop__onPointerEnter___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerEnter___$UbiquitousDomPropsMixin);
+  static const PropDescriptor
+      _$prop__onPointerLeave___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerLeave___$UbiquitousDomPropsMixin);
+  static const PropDescriptor _$prop__onPointerMove___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerMove___$UbiquitousDomPropsMixin);
+  static const PropDescriptor _$prop__onPointerOver___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerOver___$UbiquitousDomPropsMixin);
+  static const PropDescriptor _$prop__onPointerOut___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerOut___$UbiquitousDomPropsMixin);
+  static const PropDescriptor _$prop__onPointerUp___$UbiquitousDomPropsMixin =
+      const PropDescriptor(_$key__onPointerUp___$UbiquitousDomPropsMixin);
   static const PropDescriptor _$prop__onTouchCancel___$UbiquitousDomPropsMixin =
       const PropDescriptor(_$key__onTouchCancel___$UbiquitousDomPropsMixin);
   static const PropDescriptor _$prop__onTouchEnd___$UbiquitousDomPropsMixin =
@@ -4121,6 +4405,22 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   static const String _$key__onMouseOver___$UbiquitousDomPropsMixin =
       'onMouseOver';
   static const String _$key__onMouseUp___$UbiquitousDomPropsMixin = 'onMouseUp';
+  static const String _$key__onPointerCancel___$UbiquitousDomPropsMixin =
+      'onPointerCancel';
+  static const String _$key__onPointerDown___$UbiquitousDomPropsMixin =
+      'onPointerDown';
+  static const String _$key__onPointerEnter___$UbiquitousDomPropsMixin =
+      'onPointerEnter';
+  static const String _$key__onPointerLeave___$UbiquitousDomPropsMixin =
+      'onPointerLeave';
+  static const String _$key__onPointerMove___$UbiquitousDomPropsMixin =
+      'onPointerMove';
+  static const String _$key__onPointerOver___$UbiquitousDomPropsMixin =
+      'onPointerOver';
+  static const String _$key__onPointerOut___$UbiquitousDomPropsMixin =
+      'onPointerOut';
+  static const String _$key__onPointerUp___$UbiquitousDomPropsMixin =
+      'onPointerUp';
   static const String _$key__onTouchCancel___$UbiquitousDomPropsMixin =
       'onTouchCancel';
   static const String _$key__onTouchEnd___$UbiquitousDomPropsMixin =
@@ -4167,6 +4467,14 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     _$prop__onMouseOut___$UbiquitousDomPropsMixin,
     _$prop__onMouseOver___$UbiquitousDomPropsMixin,
     _$prop__onMouseUp___$UbiquitousDomPropsMixin,
+    _$prop__onPointerCancel___$UbiquitousDomPropsMixin,
+    _$prop__onPointerDown___$UbiquitousDomPropsMixin,
+    _$prop__onPointerEnter___$UbiquitousDomPropsMixin,
+    _$prop__onPointerLeave___$UbiquitousDomPropsMixin,
+    _$prop__onPointerMove___$UbiquitousDomPropsMixin,
+    _$prop__onPointerOver___$UbiquitousDomPropsMixin,
+    _$prop__onPointerOut___$UbiquitousDomPropsMixin,
+    _$prop__onPointerUp___$UbiquitousDomPropsMixin,
     _$prop__onTouchCancel___$UbiquitousDomPropsMixin,
     _$prop__onTouchEnd___$UbiquitousDomPropsMixin,
     _$prop__onTouchMove___$UbiquitousDomPropsMixin,
@@ -4209,6 +4517,14 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     _$key__onMouseOut___$UbiquitousDomPropsMixin,
     _$key__onMouseOver___$UbiquitousDomPropsMixin,
     _$key__onMouseUp___$UbiquitousDomPropsMixin,
+    _$key__onPointerCancel___$UbiquitousDomPropsMixin,
+    _$key__onPointerDown___$UbiquitousDomPropsMixin,
+    _$key__onPointerEnter___$UbiquitousDomPropsMixin,
+    _$key__onPointerLeave___$UbiquitousDomPropsMixin,
+    _$key__onPointerMove___$UbiquitousDomPropsMixin,
+    _$key__onPointerOver___$UbiquitousDomPropsMixin,
+    _$key__onPointerOut___$UbiquitousDomPropsMixin,
+    _$key__onPointerUp___$UbiquitousDomPropsMixin,
     _$key__onTouchCancel___$UbiquitousDomPropsMixin,
     _$key__onTouchEnd___$UbiquitousDomPropsMixin,
     _$key__onTouchMove___$UbiquitousDomPropsMixin,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # analyzer >= 0.33.0 breaks the builder, and analyzer < 0.32.4 is Dart 2 incompatible. Wdesk currently resolves to
   # 0.30.x, so we need the lower bound
   analyzer: any
-  build: ^1.0.0
+  build: any
   built_redux: ^7.4.2
   built_value: '>=5.4.4 <7.0.0'
   dart_style: '>=0.1.7 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   # analyzer >= 0.33.0 breaks the builder, and analyzer < 0.32.4 is Dart 2 incompatible. Wdesk currently resolves to
   # 0.30.x, so we need the lower bound
-  analyzer: ^0.35.0
+  analyzer: any
   build: ^1.0.0
   built_redux: ^7.4.2
   built_value: '>=5.4.4 <7.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: any
 
 dependencies:
   # analyzer >= 0.33.0 breaks the builder, and analyzer < 0.32.4 is Dart 2 incompatible. Wdesk currently resolves to
@@ -22,7 +22,7 @@ dependencies:
   path: ^1.5.1
   react: ^4.7.0
   source_span: ^1.4.1
-  transformer_utils: ^0.2.0
+  transformer_utils: any
   w_common: ^1.13.0
   w_flux: ^2.9.5
   platform_detect: ^1.3.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,13 @@ authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: any
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   # analyzer >= 0.33.0 breaks the builder, and analyzer < 0.32.4 is Dart 2 incompatible. Wdesk currently resolves to
   # 0.30.x, so we need the lower bound
-  analyzer: any
-  build: any
+  analyzer: ^0.35.0
+  build: ^1.0.0
   built_redux: ^7.4.2
   built_value: '>=5.4.4 <7.0.0'
   dart_style: '>=0.1.7 <2.0.0'
@@ -22,7 +22,7 @@ dependencies:
   path: ^1.5.1
   react: ^4.7.0
   source_span: ^1.4.1
-  transformer_utils: any
+  transformer_utils: ^0.2.0
   w_common: ^1.13.0
   w_flux: ^2.9.5
   platform_detect: ^1.3.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,13 @@ authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: any
 
 dependencies:
   # analyzer >= 0.33.0 breaks the builder, and analyzer < 0.32.4 is Dart 2 incompatible. Wdesk currently resolves to
   # 0.30.x, so we need the lower bound
-  analyzer: ^0.35.0
-  build: ^1.0.0
+  analyzer: any
+  build: any
   built_redux: ^7.4.2
   built_value: '>=5.4.4 <7.0.0'
   dart_style: '>=0.1.7 <2.0.0'
@@ -22,7 +22,7 @@ dependencies:
   path: ^1.5.1
   react: ^4.7.0
   source_span: ^1.4.1
-  transformer_utils: ^0.2.0
+  transformer_utils: any
   w_common: ^1.13.0
   w_flux: ^2.9.5
   platform_detect: ^1.3.4


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In order to set up `_EventSimulatorAlias`s for react 16 / react.dart 5.0.0 pointer events, we must add the pointer event callbacks to `over_react` prop mixins.
## Changes
  <!-- What this PR changes to fix the problem. -->
Added pointer event callbacks to prop mixins.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @aaronlademann-wf @greglittlefield-wf @joebingham-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
