### PR TITLE
CPLAT-5793 CPLAT-5792 Release over_react 2.4.3+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # OverReact Changelog
 
+## 2.4.3
+
+> Complete `2.4.3` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.2+dart2...2.4.3+dart2)
+> - Dart 1 (no changes)
+
+* [#302] The builder now warns if an `.over_react.g.dart` part directive is found
+  in a file that does not need one (i.e. it does not produce any generated output).
+* [#306] The handler chaining utils (e.g. `domEventCallbacks`, `Callback1Arg`, etc.)
+  have been updated to accommodate the breaking language change in Dart 2.4
+  around covariance of type variables used in super-interfaces.
+
 ## 2.4.2
 
 > Complete `2.4.2` Changsets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.4.2+dart2
+version: 2.4.3+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-6056: Warn consumers if part directive is present but there's no generated output](https://github.com/Workiva/over_react/pull/302)
	* [CPLAT-6138: Update handler chain utils for dart 2.4 compat](https://github.com/Workiva/over_react/pull/306)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.4.3+dart1...Workiva:release_over_react_2.4.3+dart2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.4.3+dart1...2.4.3+dart2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)