### PR TITLE
RM-53250 RM-53249 Release over_react 2.4.4+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.4.4
+
+> Complete `2.4.4` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.3+dart2...2.4.4+dart2)
+> - Dart 1 (no changes)
+
+* [#310] Upgrade to dart 2.4, analyzer 0.36.x, and build_web_compilers 2.x
+
 ## 2.4.3
 
 > Complete `2.4.3` Changsets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.4.3+dart2
+version: 2.4.4+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-6244: DO NOT MERGE: Upgrade to analyzer 0.36.x and build_web_compilers 2.x](https://github.com/Workiva/over_react/pull/310)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/2.4.4+dart1...Workiva:release_over_react_2.4.4+dart2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/2.4.4+dart1...2.4.4+dart2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)