### PR TITLE
3.1.0 wip component factory setter

### DIFF
--- a/example/builder/abstract_inheritance.over_react.g.dart
+++ b/example/builder/abstract_inheritance.over_react.g.dart
@@ -71,9 +71,14 @@ class _$$SubProps extends _$SubProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $SubComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $SubComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/basic.over_react.g.dart
+++ b/example/builder/basic.over_react.g.dart
@@ -147,9 +147,14 @@ class _$$BasicProps extends _$BasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $BasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $BasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/basic_library.over_react.g.dart
+++ b/example/builder/basic_library.over_react.g.dart
@@ -159,10 +159,14 @@ class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $BasicPartOfLibComponentFactory;
+      _factoryOverride ?? $BasicPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -327,10 +331,14 @@ class _$$SubPartOfLibProps extends _$SubPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $SubPartOfLibComponentFactory;
+      _factoryOverride ?? $SubPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/basic_with_state.over_react.g.dart
+++ b/example/builder/basic_with_state.over_react.g.dart
@@ -143,9 +143,14 @@ class _$$BasicProps extends _$BasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $BasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $BasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/basic_with_type_params.over_react.g.dart
+++ b/example/builder/basic_with_type_params.over_react.g.dart
@@ -93,9 +93,14 @@ class _$$BasicProps<T, U extends UiProps> extends _$BasicProps<T, U>
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $BasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $BasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/generic_inheritance_sub.over_react.g.dart
@@ -77,10 +77,14 @@ class _$$GenericSubProps extends _$GenericSubProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $GenericSubComponentFactory;
+      _factoryOverride ?? $GenericSubComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/generic_inheritance_super.over_react.g.dart
@@ -111,10 +111,14 @@ class _$$GenericSuperProps extends _$GenericSuperProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $GenericSuperComponentFactory;
+      _factoryOverride ?? $GenericSuperComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/private_component.over_react.g.dart
+++ b/example/builder/private_component.over_react.g.dart
@@ -73,9 +73,14 @@ class _$$_PrivateProps extends _$_PrivateProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $PrivateComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $PrivateComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/builder/private_factory_public_component.over_react.g.dart
+++ b/example/builder/private_factory_public_component.over_react.g.dart
@@ -79,10 +79,14 @@ class _$$FormActionInputProps extends _$FormActionInputProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $FormActionInputComponentFactory;
+      _factoryOverride ?? $FormActionInputComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/example/index.dart
+++ b/example/index.dart
@@ -11,6 +11,7 @@ import './builder/generic_inheritance_super.dart';
 
 main() {
   setClientConfiguration();
+
   react_dom.render(
       Dom.div()(
         Dom.h3()('Components'),

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -864,9 +864,12 @@ class ImplGenerator {
     if (type.isProps) {
       buffer
         ..writeln()
+        ..writeln('  ReactComponentFactoryProxy _factoryOverride;')
         ..writeln('  /// The [ReactComponentFactory] associated with the component built by this class.')
         ..writeln('  @override')
-        ..writeln('  ReactComponentFactoryProxy get componentFactory => $componentFactoryName;')
+        ..writeln('  ReactComponentFactoryProxy get componentFactory => _factoryOverride ?? $componentFactoryName;')
+        ..writeln('  @override')
+        ..writeln('  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;')
         ..writeln()
         ..writeln('  /// The default namespace for the prop getters/setters generated for this class.')
         ..writeln('  @override')

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -120,7 +120,7 @@ class ImplGenerator {
         if (declarations.component2.meta.isErrorBoundary) {
           // Override `skipMethods` as an empty list so that
           // the `componentDidCatch` and `getDerivedStateFromError`
-          // lifecycle methods are included in the component's JS bindings. 
+          // lifecycle methods are included in the component's JS bindings.
           outputContentsBuffer
             ..writeln('    skipMethods: const [],');
         }

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -65,10 +65,14 @@ abstract class _$$ErrorBoundaryProps extends _$ErrorBoundaryProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ErrorBoundaryComponentFactory;
+      _factoryOverride ?? $ErrorBoundaryComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/lib/src/component/fragment_component.dart
+++ b/lib/src/component/fragment_component.dart
@@ -28,7 +28,7 @@ class FragmentProps extends component_base.UiProps
   FragmentProps([Map props]) : this.props = props ?? new JsBackedMap();
 
   @override
-  ReactJsComponentFactoryProxy componentFactory = react.Fragment;
+  ReactComponentFactoryProxy componentFactory = react.Fragment;
 
   @override
   final Map props;

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -62,10 +62,14 @@ class _$$ResizeSensorProps extends _$ResizeSensorProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ResizeSensorComponentFactory;
+      _factoryOverride ?? $ResizeSensorComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -194,6 +194,7 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
 
   @override @toBeGenerated Map get props                 => throw new UngeneratedError(member: #props);
   @override @toBeGenerated ReactComponentFactoryProxy get componentFactory => throw new UngeneratedError(member: #componentFactory);
+  @override @toBeGenerated set componentFactory(ReactComponentFactoryProxy v) => throw new UngeneratedError(member: #componentFactory);
 }
 
 /// A [dart.collection.MapView]-like class with strongly-typed getters/setters for React state.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -619,7 +619,7 @@ abstract class UiProps extends MapBase
     return true;
   }
 
-  covariant ReactComponentFactoryProxy componentFactory;
+  ReactComponentFactoryProxy componentFactory;
 
   /// An unmodifiable map view of the default props for this component brought
   /// in from the [componentFactory].

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -404,7 +404,7 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
     if (isProps) {
       message =
         '''
-          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior; 
+          props["$key"] was updated incorrectly. Never mutate this.props directly, as it can cause unexpected behavior;
           props must be updated only by passing in new values when re-rendering this component.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
@@ -412,7 +412,7 @@ class _WarnOnModify<K, V> extends MapView<K, V> {
     } else {
       message =
         '''
-          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior; 
+          state["$key"] was updated incorrectly. Never mutate this.state directly, as it can cause unexpected behavior;
           state must be updated only via setState.
 
           This will throw in UiComponentV2 (to be released as part of the React 16 upgrade).
@@ -619,7 +619,7 @@ abstract class UiProps extends MapBase
     return true;
   }
 
-  ReactComponentFactoryProxy get componentFactory;
+  ReactComponentFactoryProxy componentFactory;
 
   /// An unmodifiable map view of the default props for this component brought
   /// in from the [componentFactory].

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -619,7 +619,7 @@ abstract class UiProps extends MapBase
     return true;
   }
 
-  ReactComponentFactoryProxy componentFactory;
+  covariant ReactComponentFactoryProxy componentFactory;
 
   /// An unmodifiable map view of the default props for this component brought
   /// in from the [componentFactory].

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -65,5 +65,8 @@ class UiPropsMapView extends MapView
       throw new UnimplementedError('@PropsMixin instances do not implement componentFactory');
 
   @override
+  set componentFactory(ReactComponentFactoryProxy v) => throw new UnimplementedError('@PropsMixin instances do not implement componentFactory');
+
+  @override
   ReactElement call([c1 = notSpecified, c2 = notSpecified, c3 = notSpecified, c4 = notSpecified, c5 = notSpecified, c6 = notSpecified, c7 = notSpecified, c8 = notSpecified, c9 = notSpecified, c10 = notSpecified, c11 = notSpecified, c12 = notSpecified, c13 = notSpecified, c14 = notSpecified, c15 = notSpecified, c16 = notSpecified, c17 = notSpecified, c18 = notSpecified, c19 = notSpecified, c20 = notSpecified, c21 = notSpecified, c22 = notSpecified, c23 = notSpecified, c24 = notSpecified, c25 = notSpecified, c26 = notSpecified, c27 = notSpecified, c28 = notSpecified, c29 = notSpecified, c30 = notSpecified, c31 = notSpecified, c32 = notSpecified, c33 = notSpecified, c34 = notSpecified, c35 = notSpecified, c36 = notSpecified, c37 = notSpecified, c38 = notSpecified, c39 = notSpecified, c40 = notSpecified]) => throw new UnimplementedError('@PropsMixin instances do not implement call');
 }

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -223,10 +223,14 @@ class _$$TransitionerProps extends _$TransitionerProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TransitionerComponentFactory;
+      _factoryOverride ?? $TransitionerComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component/fixtures/custom_error_boundary_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/custom_error_boundary_component.over_react.g.dart
@@ -65,10 +65,14 @@ abstract class _$$CustomErrorBoundaryProps extends _$CustomErrorBoundaryProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $CustomErrorBoundaryComponentFactory;
+      _factoryOverride ?? $CustomErrorBoundaryComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -74,9 +74,14 @@ abstract class _$$DummyProps extends _$DummyProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $DummyComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $DummyComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -54,9 +54,14 @@ class _$$FlawedProps extends _$FlawedProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FlawedComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FlawedComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -163,10 +163,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -94,10 +94,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -117,10 +117,14 @@ class _$$DoNotGenerateAccessorTestProps extends _$DoNotGenerateAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $DoNotGenerateAccessorTestComponentFactory;
+      _factoryOverride ?? $DoNotGenerateAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -171,10 +171,14 @@ class _$$NamespacedAccessorTestProps extends _$NamespacedAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $NamespacedAccessorTestComponentFactory;
+      _factoryOverride ?? $NamespacedAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -68,9 +68,14 @@ class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -107,10 +107,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -57,10 +57,14 @@ class _$$StatefulComponentTestProps extends _$StatefulComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $StatefulComponentTestComponentFactory;
+      _factoryOverride ?? $StatefulComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -85,9 +85,14 @@ class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -170,10 +170,14 @@ abstract class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -308,10 +312,14 @@ abstract class _$$IsErrorBoundaryProps extends _$IsErrorBoundaryProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $IsErrorBoundaryComponentFactory;
+      _factoryOverride ?? $IsErrorBoundaryComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -445,10 +453,14 @@ abstract class _$$IsNotErrorBoundaryProps extends _$IsNotErrorBoundaryProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $IsNotErrorBoundaryComponentFactory;
+      _factoryOverride ?? $IsNotErrorBoundaryComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -101,10 +101,14 @@ abstract class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -125,10 +125,14 @@ abstract class _$$DoNotGenerateAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $DoNotGenerateAccessorTestComponentFactory;
+      _factoryOverride ?? $DoNotGenerateAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -179,10 +179,14 @@ abstract class _$$NamespacedAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $NamespacedAccessorTestComponentFactory;
+      _factoryOverride ?? $NamespacedAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -75,9 +75,14 @@ abstract class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -114,10 +114,14 @@ abstract class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -88,10 +88,14 @@ abstract class _$$StatefulComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $StatefulComponentTestComponentFactory;
+      _factoryOverride ?? $StatefulComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -92,9 +92,14 @@ abstract class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -168,10 +168,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -99,10 +99,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -122,10 +122,14 @@ class _$$DoNotGenerateAccessorTestProps extends _$DoNotGenerateAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $DoNotGenerateAccessorTestComponentFactory;
+      _factoryOverride ?? $DoNotGenerateAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -176,10 +176,14 @@ class _$$NamespacedAccessorTestProps extends _$NamespacedAccessorTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $NamespacedAccessorTestComponentFactory;
+      _factoryOverride ?? $NamespacedAccessorTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -72,9 +72,14 @@ class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -112,10 +112,14 @@ class _$$ComponentTestProps extends _$ComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ComponentTestComponentFactory;
+      _factoryOverride ?? $ComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -62,10 +62,14 @@ class _$$StatefulComponentTestProps extends _$StatefulComponentTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $StatefulComponentTestComponentFactory;
+      _factoryOverride ?? $StatefulComponentTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -89,9 +89,14 @@ class _$$FooProps extends _$FooProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FooComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FooComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
@@ -58,9 +58,14 @@ class _$$TestAProps extends _$TestAProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TestAComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TestAComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
@@ -58,9 +58,14 @@ class _$$TestBProps extends _$TestBProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TestBComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TestBComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
@@ -63,10 +63,14 @@ class _$$TestExtendtypeProps extends _$TestExtendtypeProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestExtendtypeComponentFactory;
+      _factoryOverride ?? $TestExtendtypeComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
@@ -61,10 +61,14 @@ class _$$TestParentProps extends _$TestParentProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestParentComponentFactory;
+      _factoryOverride ?? $TestParentComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
@@ -63,10 +63,14 @@ class _$$TestSubsubtypeProps extends _$TestSubsubtypeProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestSubsubtypeComponentFactory;
+      _factoryOverride ?? $TestSubsubtypeComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
@@ -62,10 +62,14 @@ class _$$TestSubtypeProps extends _$TestSubtypeProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestSubtypeComponentFactory;
+      _factoryOverride ?? $TestSubtypeComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test.over_react.g.dart
@@ -61,9 +61,14 @@ class _$$TestBasicProps extends _$TestBasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TestBasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TestBasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -147,10 +152,14 @@ class _$$TestHandlerLifecycleProps extends _$TestHandlerLifecycleProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestHandlerLifecycleComponentFactory;
+      _factoryOverride ?? $TestHandlerLifecycleComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -234,10 +243,14 @@ class _$$TestHandlerPrecedenceProps extends _$TestHandlerPrecedenceProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestHandlerPrecedenceComponentFactory;
+      _factoryOverride ?? $TestHandlerPrecedenceComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -341,10 +354,14 @@ class _$$TestPropValidationProps extends _$TestPropValidationProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestPropValidationComponentFactory;
+      _factoryOverride ?? $TestPropValidationComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -428,10 +445,14 @@ class _$$TestRedrawOnProps extends _$TestRedrawOnProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestRedrawOnComponentFactory;
+      _factoryOverride ?? $TestRedrawOnComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -515,10 +536,14 @@ class _$$TestStoreHandlersProps extends _$TestStoreHandlersProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStoreHandlersComponentFactory;
+      _factoryOverride ?? $TestStoreHandlersComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -602,10 +627,14 @@ class _$$TestStatefulBasicProps extends _$TestStatefulBasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulBasicComponentFactory;
+      _factoryOverride ?? $TestStatefulBasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -739,10 +768,14 @@ class _$$TestStatefulHandlerLifecycleProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulHandlerLifecycleComponentFactory;
+      _factoryOverride ?? $TestStatefulHandlerLifecycleComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -879,10 +912,14 @@ class _$$TestStatefulHandlerPrecedenceProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulHandlerPrecedenceComponentFactory;
+      _factoryOverride ?? $TestStatefulHandlerPrecedenceComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -1041,10 +1078,14 @@ class _$$TestStatefulPropValidationProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulPropValidationComponentFactory;
+      _factoryOverride ?? $TestStatefulPropValidationComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -1177,10 +1218,14 @@ class _$$TestStatefulRedrawOnProps extends _$TestStatefulRedrawOnProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulRedrawOnComponentFactory;
+      _factoryOverride ?? $TestStatefulRedrawOnComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -1312,10 +1357,14 @@ class _$$TestStatefulStoreHandlersProps extends _$TestStatefulStoreHandlersProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestStatefulStoreHandlersComponentFactory;
+      _factoryOverride ?? $TestStatefulStoreHandlersComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/component_declaration/redux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/redux_component_test.over_react.g.dart
@@ -61,10 +61,14 @@ class _$$TestDefaultProps extends _$TestDefaultProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestDefaultComponentFactory;
+      _factoryOverride ?? $TestDefaultComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -147,10 +151,14 @@ class _$$TestConnectProps extends _$TestConnectProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestConnectComponentFactory;
+      _factoryOverride ?? $TestConnectComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -232,9 +240,14 @@ class _$$TestPureProps extends _$TestPureProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TestPureComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TestPureComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -121,10 +121,14 @@ class _$$TestCompositeComponentProps extends _$TestCompositeComponentProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TestCompositeComponentComponentFactory;
+      _factoryOverride ?? $TestCompositeComponentComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -60,9 +60,14 @@ class _$$DomTestProps extends _$DomTestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $DomTestComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $DomTestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -87,9 +87,14 @@ class _$$TestProps extends _$TestProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TestComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TestComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/test_util/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/one_level_wrapper.over_react.g.dart
@@ -62,10 +62,14 @@ class _$$OneLevelWrapperProps extends _$OneLevelWrapperProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $OneLevelWrapperComponentFactory;
+      _factoryOverride ?? $OneLevelWrapperComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/test_util/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/two_level_wrapper.over_react.g.dart
@@ -62,10 +62,14 @@ class _$$TwoLevelWrapperProps extends _$TwoLevelWrapperProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $TwoLevelWrapperComponentFactory;
+      _factoryOverride ?? $TwoLevelWrapperComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test/vm_tests/builder/impl_generation_test.dart
+++ b/test/vm_tests/builder/impl_generation_test.dart
@@ -376,7 +376,7 @@ main() {
                 test('overrides `componentFactory` to return the correct component factory', () {
                   expect(implGenerator.outputContentsBuffer.toString(), contains(
                       '  @override\n'
-                      '  ReactComponentFactoryProxy get componentFactory => \$${ors.baseName}ComponentFactory;\n'));
+                      '  ReactComponentFactoryProxy get componentFactory => _factoryOverride ?? \$${ors.baseName}ComponentFactory;\n'));
                 });
 
                 test('sets the default prop key namespace', () {

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -147,9 +147,14 @@ class _$$BasicProps extends _$BasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $BasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $BasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -158,10 +158,14 @@ class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $BasicPartOfLibComponentFactory;
+      _factoryOverride ?? $BasicPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -316,10 +320,14 @@ class _$$SubPartOfLibProps extends _$SubPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $SubPartOfLibComponentFactory;
+      _factoryOverride ?? $SubPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -153,9 +153,14 @@ class _$$BasicProps extends _$BasicProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $BasicComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $BasicComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -163,10 +163,14 @@ class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $BasicPartOfLibComponentFactory;
+      _factoryOverride ?? $BasicPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
@@ -331,10 +335,14 @@ class _$$SubPartOfLibProps extends _$SubPartOfLibProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $SubPartOfLibComponentFactory;
+      _factoryOverride ?? $SubPartOfLibComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -277,9 +277,14 @@ class _$$ButtonProps extends _$ButtonProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ButtonComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ButtonComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -135,10 +135,14 @@ class _$$ButtonGroupProps extends _$ButtonGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ButtonGroupComponentFactory;
+      _factoryOverride ?? $ButtonGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -88,9 +88,14 @@ class _$$ListGroupProps extends _$ListGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ListGroupComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ListGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -339,10 +339,14 @@ class _$$ListGroupItemProps extends _$ListGroupItemProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ListGroupItemComponentFactory;
+      _factoryOverride ?? $ListGroupItemComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -322,9 +322,14 @@ class _$$ProgressProps extends _$ProgressProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ProgressComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ProgressComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -113,9 +113,14 @@ class _$$TagProps extends _$TagProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TagComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TagComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -177,10 +177,14 @@ class _$$ToggleButtonProps extends _$ToggleButtonProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ToggleButtonComponentFactory;
+      _factoryOverride ?? $ToggleButtonComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
@@ -63,10 +63,14 @@ class _$$ToggleButtonGroupProps extends _$ToggleButtonGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ToggleButtonGroupComponentFactory;
+      _factoryOverride ?? $ToggleButtonGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -280,9 +280,14 @@ abstract class _$$ButtonProps extends _$ButtonProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ButtonComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ButtonComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -136,10 +136,14 @@ abstract class _$$ButtonGroupProps extends _$ButtonGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ButtonGroupComponentFactory;
+      _factoryOverride ?? $ButtonGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -89,9 +89,14 @@ abstract class _$$ListGroupProps extends _$ListGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ListGroupComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ListGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -341,10 +341,14 @@ abstract class _$$ListGroupItemProps extends _$ListGroupItemProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ListGroupItemComponentFactory;
+      _factoryOverride ?? $ListGroupItemComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -323,9 +323,14 @@ abstract class _$$ProgressProps extends _$ProgressProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $ProgressComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $ProgressComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -116,9 +116,14 @@ abstract class _$$TagProps extends _$TagProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $TagComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $TagComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -178,10 +178,14 @@ abstract class _$$ToggleButtonProps extends _$ToggleButtonProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ToggleButtonComponentFactory;
+      _factoryOverride ?? $ToggleButtonComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -65,10 +65,14 @@ abstract class _$$ToggleButtonGroupProps extends _$ToggleButtonGroupProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $ToggleButtonGroupComponentFactory;
+      _factoryOverride ?? $ToggleButtonGroupComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/component2/src/demos/custom_error_boundary.over_react.g.dart
+++ b/web/component2/src/demos/custom_error_boundary.over_react.g.dart
@@ -65,10 +65,14 @@ abstract class _$$CustomErrorBoundaryProps extends _$CustomErrorBoundaryProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      $CustomErrorBoundaryComponentFactory;
+      _factoryOverride ?? $CustomErrorBoundaryComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -54,9 +54,14 @@ class _$$FaultyProps extends _$FaultyProps
   @override
   bool get $isClassGenerated => true;
 
+  ReactComponentFactoryProxy _factoryOverride;
+
   /// The [ReactComponentFactory] associated with the component built by this class.
   @override
-  ReactComponentFactoryProxy get componentFactory => $FaultyComponentFactory;
+  ReactComponentFactoryProxy get componentFactory =>
+      _factoryOverride ?? $FaultyComponentFactory;
+  @override
+  set componentFactory(ReactComponentFactoryProxy v) => _factoryOverride = v;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In order to utilize JS based HOC's such as forwardRef and connect we need the ability to set the component factory of Props on the fly.

## Changes
  <!-- What this PR changes to fix the problem. -->
changes componentFactory to a field and update generated code to include on override factory

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
