### PR TITLE
CPLAT-6464 Improve error message for props/state variables with initializers

### DIFF
--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -403,8 +403,8 @@ class ImplGenerator {
             keyConstants[keyConstantName] = keyValue;
             constants[constantName] = constantValue;
 
-            final type = field.fields.type?.toSource();
-            final typeString = type == null ? '' : '$type ';
+            final typeSource = field.fields.type?.toSource();
+            final typeString = typeSource == null ? '' : '$typeSource ';
             final metadataSrc = new StringBuffer();
             for (final annotation in field.metadata) {
               metadataSrc.writeln('  ${annotation.toSource()}');

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -330,7 +330,10 @@ class ImplGenerator {
           field.fields.variables.forEach((VariableDeclaration variable) {
             if (variable.initializer != null) {
               logger.severe(messageWithSpan(
-                  'Fields are stubs for generated setters/getters and should not have initializers.',
+                  'Fields are stubs for generated setters/getters and should not have initializers.\n'
+                      'Instead, initialize ${type.isProps 
+                          ? 'prop values within getDefaultProps()' 
+                          : 'state values within getInitialState()'}.',
                   span: getSpan(sourceFile, variable))
               );
             }


### PR DESCRIPTION
## Motivation
> How would one initialize a list field of a class?
>
> I have
>
> ```dart
> @State()
> class _$FooState extends UiState {
>   List<ReactElement> inputs = [];
> }
> ```
> 
> But get an error `Fields are stubs for generated setters/getters and should not have initializers.`. > If I remove the `= []`, i get errors claiming the list is null everywhere, so I’m not sure where to initialize it.

This error message could be better, and indicate how to initialize these values.

## Changes
In error message, add note on where to initialize values

#### Release Notes
Improve error message for props/state variables with initializers

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
