### PR TITLE
CPLAT-6376 Add helpful error message when `@Component()` is used with UiComponent2

### DIFF
--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -127,7 +127,10 @@ mixin _GeneratedUiComponent2Stubs<TProps extends UiProps>
   /// more efficient dart2js output.
   @override
   @toBeGenerated
-  TProps typedPropsFactoryJs(JsBackedMap propsMap) => throw new UngeneratedError(member: #typedPropsFactoryJs);
+  TProps typedPropsFactoryJs(JsBackedMap propsMap) => throw new UngeneratedError(member: #typedPropsFactoryJs, message:
+    '${#typedPropsFactoryJs}` should be implemented by code generation.\n\n'
+    'This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'
+  );
 }
 
 /// See: [component_base.UiComponent2]

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -230,7 +230,10 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   TProps get props {
     // This needs to be a concrete implementation in Dart 2 for soundness;
     // without it, you get a confusing error. See: https://github.com/dart-lang/sdk/issues/36191
-    throw new UngeneratedError();
+    throw new UngeneratedError(message:
+      '`null` should be implemented by code generation.\n\n'
+      'This error may be due to your `UiComponent2` class not being annotated with `@Component2()`'
+    );
   }
 
   /// Equivalent to setting [unwrappedProps], but needed by react-dart to effect props changes.
@@ -312,7 +315,10 @@ abstract class UiStatefulComponent2<TProps extends UiProps, TState extends UiSta
   TState get state {
     // This needs to be a concrete implementation in Dart 2 for soundness;
     // without it, you get a confusing error. See: https://github.com/dart-lang/sdk/issues/36191
-    throw new UngeneratedError();
+    throw new UngeneratedError(message:
+      '`null` should be implemented by code generation.\n\n'
+      'This error may be due to your `UiStatefulComponent2` class not being annotated with `@Component2()`'
+    );
   }
 
   /// Equivalent to setting [unwrappedState], but needed by react-dart to effect state changes.

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -231,7 +231,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     // This needs to be a concrete implementation in Dart 2 for soundness;
     // without it, you get a confusing error. See: https://github.com/dart-lang/sdk/issues/36191
     throw new UngeneratedError(message:
-      '`null` should be implemented by code generation.\n\n'
+      '`props` should be implemented by code generation.\n\n'
       'This error may be due to your `UiComponent2` class not being annotated with `@Component2()`'
     );
   }
@@ -316,7 +316,7 @@ abstract class UiStatefulComponent2<TProps extends UiProps, TState extends UiSta
     // This needs to be a concrete implementation in Dart 2 for soundness;
     // without it, you get a confusing error. See: https://github.com/dart-lang/sdk/issues/36191
     throw new UngeneratedError(message:
-      '`null` should be implemented by code generation.\n\n'
+      '`state` should be implemented by code generation.\n\n'
       'This error may be due to your `UiStatefulComponent2` class not being annotated with `@Component2()`'
     );
   }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
@@ -21,7 +21,7 @@ main() {
       expect(
           () => react_dom.render(AnnotationError()(), mountNode),
           throwsA(hasToStringValue(contains(
-              '1This error may be due to your `UiComponent2` class not being annotated with `@Component2()`'))));
+              'This error may be due to your `UiComponent2` class not being annotated with `@Component2()`'))));
     });
 
     test('when rendering a UiStatefulComponent2', () {
@@ -30,7 +30,7 @@ main() {
       expect(
           () => react_dom.render(AnnotationErrorStateful()(), mountNode),
           throwsA(hasToStringValue(contains(
-              '1This error may be due to your `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+              'This error may be due to your `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
     });
 
     test('when rendering a UiComponent2 with default props', () {
@@ -40,7 +40,7 @@ main() {
           () =>
               react_dom.render(AnnotationErrorDefaultProps()(), mountNode),
           throwsA(hasToStringValue(contains(
-              '1This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+              'This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
     });
 
     test('when rendering a UiComponentStateful2 with default props', () {
@@ -50,7 +50,7 @@ main() {
               () =>
               react_dom.render(AnnotationErrorStatefulDefaultProps()(), mountNode),
           throwsA(hasToStringValue(contains(
-              '1This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+              'This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
     });
   });
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
@@ -12,12 +12,19 @@ part 'component_integration_test/annotation_error_stateful_component.dart';
 part 'component_integration_test/annotation_error_stateful_default_props_component.dart';
 
 main() {
-  group(
-      '(Component2) throws a helpful error message when the @Component annotation is used:',
+  group('(Component2) throws a helpful error message if the @Component annotation is used:',
       () {
-    test('when rendering a UiComponent2', () {
-      var mountNode = new DivElement();
+    Element mountNode;
 
+    setUp(() {
+      mountNode = new DivElement();
+    });
+
+    tearDown(() {
+      mountNode = null;
+    });
+
+    test('when rendering a UiComponent2', () {
       expect(
           () => react_dom.render(AnnotationError()(), mountNode),
           throwsA(hasToStringValue(contains(
@@ -25,8 +32,6 @@ main() {
     });
 
     test('when rendering a UiStatefulComponent2', () {
-      var mountNode = new DivElement();
-
       expect(
           () => react_dom.render(AnnotationErrorStateful()(), mountNode),
           throwsA(hasToStringValue(contains(
@@ -34,8 +39,6 @@ main() {
     });
 
     test('when rendering a UiComponent2 with default props', () {
-      var mountNode = new DivElement();
-
       expect(
           () =>
               react_dom.render(AnnotationErrorDefaultProps()(), mountNode),
@@ -44,8 +47,6 @@ main() {
     });
 
     test('when rendering a UiComponentStateful2 with default props', () {
-      var mountNode = new DivElement();
-
       expect(
               () =>
               react_dom.render(AnnotationErrorStatefulDefaultProps()(), mountNode),
@@ -69,5 +70,5 @@ class AnnotationErrorDefaultPropsComponent
   Map getDefaultProps() => newProps()..id = 'testId';
 
   @override
-  render() => Dom.div()();
+  render() => props.children;
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
@@ -1,0 +1,73 @@
+import 'dart:html';
+
+import 'package:over_react/over_react.dart';
+import 'package:test/test.dart';
+import 'package:over_react/react_dom.dart' as react_dom;
+
+import '../../../../test_util/test_util.dart';
+
+part 'annotation_error_integration_test.over_react.g.dart';
+part 'component_integration_test/annotation_error_component.dart';
+part 'component_integration_test/annotation_error_stateful_component.dart';
+part 'component_integration_test/annotation_error_stateful_default_props_component.dart';
+
+main() {
+  group(
+      '(Component2) throws a helpful error message when the @Component annotation is used:',
+      () {
+    test('when rendering a UiComponent2', () {
+      var mountNode = new DivElement();
+
+      expect(
+          () => react_dom.render(AnnotationError()(), mountNode),
+          throwsA(hasToStringValue(contains(
+              '1This error may be due to your `UiComponent2` class not being annotated with `@Component2()`'))));
+    });
+
+    test('when rendering a UiStatefulComponent2', () {
+      var mountNode = new DivElement();
+
+      expect(
+          () => react_dom.render(AnnotationErrorStateful()(), mountNode),
+          throwsA(hasToStringValue(contains(
+              '1This error may be due to your `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+    });
+
+    test('when rendering a UiComponent2 with default props', () {
+      var mountNode = new DivElement();
+
+      expect(
+          () =>
+              react_dom.render(AnnotationErrorDefaultProps()(), mountNode),
+          throwsA(hasToStringValue(contains(
+              '1This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+    });
+
+    test('when rendering a UiComponentStateful2 with default props', () {
+      var mountNode = new DivElement();
+
+      expect(
+              () =>
+              react_dom.render(AnnotationErrorStatefulDefaultProps()(), mountNode),
+          throwsA(hasToStringValue(contains(
+              '1This error may be due to your `UiComponent2` or `UiStatefulComponent2` class not being annotated with `@Component2()`'))));
+    });
+  });
+}
+
+@Factory()
+UiFactory<AnnotationErrorDefaultPropsProps>
+    AnnotationErrorDefaultProps = _$AnnotationErrorDefaultProps;
+
+@Props()
+class _$AnnotationErrorDefaultPropsProps extends UiProps {}
+
+@Component()
+class AnnotationErrorDefaultPropsComponent
+    extends UiComponent2<AnnotationErrorDefaultPropsProps> {
+  @override
+  Map getDefaultProps() => newProps()..id = 'testId';
+
+  @override
+  render() => Dom.div()();
+}

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -1,0 +1,469 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'annotation_error_integration_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $AnnotationErrorDefaultPropsComponentFactory = registerComponent(
+    () => new _$AnnotationErrorDefaultPropsComponent(),
+    builderFactory: AnnotationErrorDefaultProps,
+    componentClass: AnnotationErrorDefaultPropsComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'AnnotationErrorDefaultProps');
+
+abstract class _$AnnotationErrorDefaultPropsPropsAccessorsMixin
+    implements _$AnnotationErrorDefaultPropsProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForAnnotationErrorDefaultPropsProps = const PropsMeta(
+  fields: _$AnnotationErrorDefaultPropsPropsAccessorsMixin.$props,
+  keys: _$AnnotationErrorDefaultPropsPropsAccessorsMixin.$propKeys,
+);
+
+class AnnotationErrorDefaultPropsProps
+    extends _$AnnotationErrorDefaultPropsProps
+    with _$AnnotationErrorDefaultPropsPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForAnnotationErrorDefaultPropsProps;
+}
+
+_$$AnnotationErrorDefaultPropsProps _$AnnotationErrorDefaultProps(
+        [Map backingProps]) =>
+    new _$$AnnotationErrorDefaultPropsProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$AnnotationErrorDefaultPropsProps
+    extends _$AnnotationErrorDefaultPropsProps
+    with _$AnnotationErrorDefaultPropsPropsAccessorsMixin
+    implements AnnotationErrorDefaultPropsProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorDefaultPropsProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $AnnotationErrorDefaultPropsComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'AnnotationErrorDefaultPropsProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$AnnotationErrorDefaultPropsComponent
+    extends AnnotationErrorDefaultPropsComponent {
+  @override
+  _$$AnnotationErrorDefaultPropsProps typedPropsFactory(Map backingMap) =>
+      new _$$AnnotationErrorDefaultPropsProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$AnnotationErrorDefaultPropsProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForAnnotationErrorDefaultPropsProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $AnnotationErrorComponentFactory = registerComponent(
+    () => new _$AnnotationErrorComponent(),
+    builderFactory: AnnotationError,
+    componentClass: AnnotationErrorComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'AnnotationError');
+
+abstract class _$AnnotationErrorPropsAccessorsMixin
+    implements _$AnnotationErrorProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForAnnotationErrorProps = const PropsMeta(
+  fields: _$AnnotationErrorPropsAccessorsMixin.$props,
+  keys: _$AnnotationErrorPropsAccessorsMixin.$propKeys,
+);
+
+class AnnotationErrorProps extends _$AnnotationErrorProps
+    with _$AnnotationErrorPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForAnnotationErrorProps;
+}
+
+_$$AnnotationErrorProps _$AnnotationError([Map backingProps]) =>
+    new _$$AnnotationErrorProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$AnnotationErrorProps extends _$AnnotationErrorProps
+    with _$AnnotationErrorPropsAccessorsMixin
+    implements AnnotationErrorProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $AnnotationErrorComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'AnnotationErrorProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$AnnotationErrorComponent extends AnnotationErrorComponent {
+  @override
+  _$$AnnotationErrorProps typedPropsFactory(Map backingMap) =>
+      new _$$AnnotationErrorProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$AnnotationErrorProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForAnnotationErrorProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $AnnotationErrorStatefulComponentFactory = registerComponent(
+    () => new _$AnnotationErrorStatefulComponent(),
+    builderFactory: AnnotationErrorStateful,
+    componentClass: AnnotationErrorStatefulComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'AnnotationErrorStateful');
+
+abstract class _$AnnotationErrorStatefulPropsAccessorsMixin
+    implements _$AnnotationErrorStatefulProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForAnnotationErrorStatefulProps = const PropsMeta(
+  fields: _$AnnotationErrorStatefulPropsAccessorsMixin.$props,
+  keys: _$AnnotationErrorStatefulPropsAccessorsMixin.$propKeys,
+);
+
+class AnnotationErrorStatefulProps extends _$AnnotationErrorStatefulProps
+    with _$AnnotationErrorStatefulPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForAnnotationErrorStatefulProps;
+}
+
+_$$AnnotationErrorStatefulProps _$AnnotationErrorStateful([Map backingProps]) =>
+    new _$$AnnotationErrorStatefulProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$AnnotationErrorStatefulProps extends _$AnnotationErrorStatefulProps
+    with _$AnnotationErrorStatefulPropsAccessorsMixin
+    implements AnnotationErrorStatefulProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorStatefulProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $AnnotationErrorStatefulComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'AnnotationErrorStatefulProps.';
+}
+
+abstract class _$AnnotationErrorStatefulStateAccessorsMixin
+    implements _$AnnotationErrorStatefulState {
+  @override
+  Map get state;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<StateDescriptor> $state = const [];
+  static const List<String> $stateKeys = const [];
+}
+
+const StateMeta _$metaForAnnotationErrorStatefulState = const StateMeta(
+  fields: _$AnnotationErrorStatefulStateAccessorsMixin.$state,
+  keys: _$AnnotationErrorStatefulStateAccessorsMixin.$stateKeys,
+);
+
+class AnnotationErrorStatefulState extends _$AnnotationErrorStatefulState
+    with _$AnnotationErrorStatefulStateAccessorsMixin {
+  static const StateMeta meta = _$metaForAnnotationErrorStatefulState;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$AnnotationErrorStatefulState extends _$AnnotationErrorStatefulState
+    with _$AnnotationErrorStatefulStateAccessorsMixin
+    implements AnnotationErrorStatefulState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorStatefulState(Map backingMap) : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$AnnotationErrorStatefulComponent
+    extends AnnotationErrorStatefulComponent {
+  @override
+  _$$AnnotationErrorStatefulProps typedPropsFactory(Map backingMap) =>
+      new _$$AnnotationErrorStatefulProps(backingMap);
+
+  @override
+  _$$AnnotationErrorStatefulState typedStateFactory(Map backingMap) =>
+      new _$$AnnotationErrorStatefulState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$AnnotationErrorStatefulProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForAnnotationErrorStatefulProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $AnnotationErrorStatefulDefaultPropsComponentFactory = registerComponent(
+    () => new _$AnnotationErrorStatefulDefaultPropsComponent(),
+    builderFactory: AnnotationErrorStatefulDefaultProps,
+    componentClass: AnnotationErrorStatefulDefaultPropsComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'AnnotationErrorStatefulDefaultProps');
+
+abstract class _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin
+    implements _$AnnotationErrorStatefulDefaultPropsProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForAnnotationErrorStatefulDefaultPropsProps =
+    const PropsMeta(
+  fields: _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin.$props,
+  keys: _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin.$propKeys,
+);
+
+class AnnotationErrorStatefulDefaultPropsProps
+    extends _$AnnotationErrorStatefulDefaultPropsProps
+    with _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin {
+  static const PropsMeta meta =
+      _$metaForAnnotationErrorStatefulDefaultPropsProps;
+}
+
+_$$AnnotationErrorStatefulDefaultPropsProps
+    _$AnnotationErrorStatefulDefaultProps([Map backingProps]) =>
+        new _$$AnnotationErrorStatefulDefaultPropsProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$AnnotationErrorStatefulDefaultPropsProps
+    extends _$AnnotationErrorStatefulDefaultPropsProps
+    with _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin
+    implements AnnotationErrorStatefulDefaultPropsProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorStatefulDefaultPropsProps(Map backingMap)
+      : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ??
+      $AnnotationErrorStatefulDefaultPropsComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'AnnotationErrorStatefulDefaultPropsProps.';
+}
+
+abstract class _$AnnotationErrorStatefulDefaultPropsStateAccessorsMixin
+    implements _$AnnotationErrorStatefulDefaultPropsState {
+  @override
+  Map get state;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<StateDescriptor> $state = const [];
+  static const List<String> $stateKeys = const [];
+}
+
+const StateMeta _$metaForAnnotationErrorStatefulDefaultPropsState =
+    const StateMeta(
+  fields: _$AnnotationErrorStatefulDefaultPropsStateAccessorsMixin.$state,
+  keys: _$AnnotationErrorStatefulDefaultPropsStateAccessorsMixin.$stateKeys,
+);
+
+class AnnotationErrorStatefulDefaultPropsState
+    extends _$AnnotationErrorStatefulDefaultPropsState
+    with _$AnnotationErrorStatefulDefaultPropsStateAccessorsMixin {
+  static const StateMeta meta =
+      _$metaForAnnotationErrorStatefulDefaultPropsState;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$AnnotationErrorStatefulDefaultPropsState
+    extends _$AnnotationErrorStatefulDefaultPropsState
+    with _$AnnotationErrorStatefulDefaultPropsStateAccessorsMixin
+    implements AnnotationErrorStatefulDefaultPropsState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$AnnotationErrorStatefulDefaultPropsState(Map backingMap)
+      : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$AnnotationErrorStatefulDefaultPropsComponent
+    extends AnnotationErrorStatefulDefaultPropsComponent {
+  @override
+  _$$AnnotationErrorStatefulDefaultPropsProps typedPropsFactory(
+          Map backingMap) =>
+      new _$$AnnotationErrorStatefulDefaultPropsProps(backingMap);
+
+  @override
+  _$$AnnotationErrorStatefulDefaultPropsState typedStateFactory(
+          Map backingMap) =>
+      new _$$AnnotationErrorStatefulDefaultPropsState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$AnnotationErrorStatefulDefaultPropsProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForAnnotationErrorStatefulDefaultPropsProps
+  ];
+}

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_component.dart
@@ -1,0 +1,13 @@
+part of '../annotation_error_integration_test.dart';
+
+@Factory()
+UiFactory<AnnotationErrorProps> AnnotationError = _$AnnotationError;
+
+@Props()
+class _$AnnotationErrorProps extends UiProps {}
+
+@Component()
+class AnnotationErrorComponent extends UiComponent2<AnnotationErrorProps> {
+  @override
+  render() => props.children;
+}

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_component.dart
@@ -1,0 +1,18 @@
+part of '../annotation_error_integration_test.dart';
+
+@Factory()
+UiFactory<AnnotationErrorStatefulProps> AnnotationErrorStateful =
+    _$AnnotationErrorStateful;
+
+@Props()
+class _$AnnotationErrorStatefulProps extends UiProps {}
+
+@State()
+class _$AnnotationErrorStatefulState extends UiState {}
+
+@Component()
+class AnnotationErrorStatefulComponent extends UiStatefulComponent2<
+    AnnotationErrorStatefulProps, AnnotationErrorStatefulState> {
+  @override
+  render() => props.children;
+}

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_default_props_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_default_props_component.dart
@@ -1,0 +1,22 @@
+part of '../annotation_error_integration_test.dart';
+
+@Factory()
+UiFactory<AnnotationErrorStatefulDefaultPropsProps>
+    AnnotationErrorStatefulDefaultProps = _$AnnotationErrorStatefulDefaultProps;
+
+@Props()
+class _$AnnotationErrorStatefulDefaultPropsProps extends UiProps {}
+
+@State()
+class _$AnnotationErrorStatefulDefaultPropsState extends UiState {}
+
+@Component()
+class AnnotationErrorStatefulDefaultPropsComponent extends UiStatefulComponent2<
+    AnnotationErrorStatefulDefaultPropsProps,
+    AnnotationErrorStatefulDefaultPropsState> {
+  @override
+  Map getDefaultProps() => newProps()..id = 'testId';
+
+  @override
+  render() => props.children;
+}

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -51,6 +51,7 @@ import 'over_react/component_declaration/builder_integration_tests/backwards_com
 import 'over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart' as backwards_compat_unassigned_prop_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.dart' as component2_abstract_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.dart' as component2_accessor_mixin_integration_test;
+import 'over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart' as annotation_error_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/component_integration_test.dart' as component2_component_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart' as component2_constant_required_accessor_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.dart' as component2_do_not_generate_accessor_integration_test;
@@ -96,6 +97,7 @@ main() {
 
   component2_abstract_accessor_integration_test.main();
   component2_accessor_mixin_integration_test.main();
+  annotation_error_integration_test.main();
   component2_do_not_generate_accessor_integration_test.main();
   component2_component_integration_test.main();
   component2_constant_required_accessor_integration_test.main();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Right now, accidentally using `@Component()` instead of `@Component2()` gives you an unhelpful error message.
```
require.js:143 Uncaught Error: UngeneratedError: `Symbol("typedPropsFactoryJs")` should be implemented by code generation.

Ensure that you're running a build via build_runner.
    at Object.dart.throw (dart_sdk.js:4604)
    at basic_with_state._$BasicComponent.new.typedPropsFactoryJs (component_base.ddc.js:550)
    at basic_with_state._$BasicComponent.new.newProps (component_base.ddc.js:388)
    at basic_with_state._$BasicComponent.new.getDefaultProps (abstract_inheritance.ddc.js:1973)
    at Object.react_client._registerComponent2 (react.ddc.js:864)
    at react_client._registerComponent (react.ddc.js:849)
    at Object.dart._checkAndCall (dart_sdk.js:4807)
    at Object.dart.dcall (dart_sdk.js:4812)
    at Object.src__component_declaration__component_base.registerComponent (component_base.ddc.js:3041)
    at get $BasicComponentFactory (abstract_inheritance.ddc.js:2132)
    at Object.desc.get [as $BasicComponentFactory] (dart_sdk.js:3639)
    at basic_with_state._$$BasicProps.new.get componentFactory [as componentFactory] (abstract_inheritance.ddc.js:2041)
    at basic_with_state._$$BasicProps.new.call (component_base.ddc.js:2746)
    at Object.index.main (abstract_inheritance.ddc.js:2632)
```
We need to provide a runtime error with a helpful message when this occurs.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add better messages to existing UngeneratedErrors for members that were added in UiComponent2.
    - typedPropsFactoryJs
    - UiComponent2 props getter
    - UiStatefulComponent2 state getter
- Write an integration test to check that a helpful error message is thrown when rendering a UiComponent2 with a `@Component()` annotation.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @aaronlademann-wf @greglittlefield-wf @joebingham-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
