### PR TITLE
CPLAT-6510 Finalize UiComponent2 - part 1 of X

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -27,8 +27,7 @@ export 'package:react/react.dart' show
     SyntheticUIEvent,
     SyntheticWheelEvent;
 
-// FIXME 3.0.0-wip use public entrypoint
-export 'package:react/src/react_client/js_backed_map.dart' show JsBackedMap;
+export 'package:react/react_client/js_backed_map.dart' show JsBackedMap;
 
 export 'package:react/react_client.dart' show setClientConfiguration, ReactElement, ReactComponentFactoryProxy;
 export 'package:react/react_client/react_interop.dart' show ReactErrorInfo;

--- a/lib/src/component/dom_components.dart
+++ b/lib/src/component/dom_components.dart
@@ -20,7 +20,7 @@ import 'package:over_react/src/component_declaration/component_base.dart' as com
 import 'package:over_react/src/component_declaration/builder_helpers.dart' as builder_helpers;
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/src/react_client/js_backed_map.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 /// Returns a new [DomProps], optionally backed by a specified Map.
 ///

--- a/lib/src/component/fragment_component.dart
+++ b/lib/src/component/fragment_component.dart
@@ -17,7 +17,7 @@ import 'package:over_react/src/component_declaration/component_base.dart'
 import 'package:over_react/src/component_declaration/builder_helpers.dart'
     as builder_helpers;
 import 'package:react/react_client.dart';
-import 'package:react/src/react_client/js_backed_map.dart';
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react.dart' as react;
 
 class FragmentProps extends component_base.UiProps

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -15,8 +15,7 @@
 library over_react.component_declaration.builder_helpers;
 
 import 'package:react/react_client.dart';
-// FIXME 3.0.0-wip use public entrypoint
-import 'package:react/src/react_client/js_backed_map.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 import './component_base.dart' as component_base;
 import './annotations.dart' as annotations;

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -77,8 +77,9 @@ ReactDartComponentFactoryProxy registerComponent(react.Component dartComponentFa
 class UiComponent2BridgeImpl extends Component2BridgeImpl {
   UiComponent2BridgeImpl(UiComponent2 component) : super(component);
 
+  // Tighten this type
   @override
-  UiComponent2 get component => component;
+  UiComponent2 get component => super.component;
 
   static UiComponent2BridgeImpl bridgeFactory(react.Component2 component) =>
       UiComponent2BridgeImpl(component as UiComponent2);

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -88,6 +88,25 @@ class UiComponent2BridgeImpl extends Component2BridgeImpl {
   JsMap jsifyPropTypes(Map propTypes) {
     // todo implement jsifyPropTypes
   }
+
+  /// A version of [setStateWithTypedUpdater] whose updater is passed typed views
+  /// into the `prevState` and `props` arguments, allowing them to be typed automatically
+  /// within [UiStatefulComponent2.setStateWithTypedUpdater].
+  void setStateWithTypedUpdater<TState extends UiState, TProps extends UiProps>(
+    Map Function(TState prevState, TProps props) updater,
+    Function() callback,
+  ) {
+    // This should only be called from UiStatefulComponent2
+    final component = this.component as UiStatefulComponent2<TProps, TState>;
+
+    Map typedUpdater(Map prevState, Map props) {
+      return updater(
+        component.typedStateFactory(prevState),
+        component.typedPropsFactory(props),
+      );
+    }
+    setStateWithUpdater(typedUpdater, callback);
+  }
 }
 
 /// Helper function that wraps react.registerComponent2, and allows attachment of additional

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -25,8 +25,9 @@ import 'package:over_react/src/component_declaration/util.dart';
 import 'package:over_react/src/util/test_mode.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/bridge.dart';
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart';
-import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:w_common/disposable.dart';
 
 export 'package:over_react/src/component_declaration/component_type_checking.dart' show isComponentOfType, isValidElementOfType;
@@ -70,6 +71,9 @@ ReactDartComponentFactoryProxy registerComponent(react.Component dartComponentFa
   return reactComponentFactory;
 }
 
+/// A bridge implementation that adds typing for [UiComponent2] props/state maps.
+///
+/// See [Component2Bridge] for more info.
 class UiComponent2BridgeImpl extends Component2BridgeImpl {
   UiComponent2BridgeImpl(UiComponent2 component) : super(component);
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -75,17 +75,18 @@ ReactDartComponentFactoryProxy registerComponent(react.Component dartComponentFa
 ///
 /// See [Component2Bridge] for more info.
 class UiComponent2BridgeImpl extends Component2BridgeImpl {
-  UiComponent2BridgeImpl(UiComponent2 component) : super(component);
+  const UiComponent2BridgeImpl();
 
-  // Tighten this type
+  /// Returns a const bridge instance suitable for use with any [UiComponent2].
+  ///
+  /// See [Component2BridgeFactory] for more info.
+  static UiComponent2BridgeImpl bridgeFactory(react.Component2 component) {
+    assert(component is UiComponent2, 'should not be used with non-UiComponent2 components');
+    return const UiComponent2BridgeImpl();
+  }
+
   @override
-  UiComponent2 get component => super.component;
-
-  static UiComponent2BridgeImpl bridgeFactory(react.Component2 component) =>
-      UiComponent2BridgeImpl(component as UiComponent2);
-
-  @override
-  JsMap jsifyPropTypes(Map propTypes) {
+  JsMap jsifyPropTypes(covariant UiComponent2 component, Map propTypes) {
     // todo implement jsifyPropTypes
   }
 
@@ -93,19 +94,17 @@ class UiComponent2BridgeImpl extends Component2BridgeImpl {
   /// into the `prevState` and `props` arguments, allowing them to be typed automatically
   /// within [UiStatefulComponent2.setStateWithTypedUpdater].
   void setStateWithTypedUpdater<TState extends UiState, TProps extends UiProps>(
+    UiStatefulComponent2<TProps, TState> component,
     Map Function(TState prevState, TProps props) updater,
     Function() callback,
   ) {
-    // This should only be called from UiStatefulComponent2
-    final component = this.component as UiStatefulComponent2<TProps, TState>;
-
     Map typedUpdater(Map prevState, Map props) {
       return updater(
         component.typedStateFactory(prevState),
         component.typedPropsFactory(props),
       );
     }
-    setStateWithUpdater(typedUpdater, callback);
+    setStateWithUpdater(component, typedUpdater, callback);
   }
 }
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -25,6 +25,7 @@ import 'package:over_react/src/component_declaration/util.dart';
 import 'package:over_react/src/util/test_mode.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/react_interop.dart';
 import 'package:react/src/react_client/js_backed_map.dart';
 import 'package:w_common/disposable.dart';
 
@@ -69,6 +70,21 @@ ReactDartComponentFactoryProxy registerComponent(react.Component dartComponentFa
   return reactComponentFactory;
 }
 
+class UiComponent2BridgeImpl extends Component2BridgeImpl {
+  UiComponent2BridgeImpl(UiComponent2 component) : super(component);
+
+  @override
+  UiComponent2 get component => component;
+
+  static UiComponent2BridgeImpl bridgeFactory(react.Component2 component) =>
+      UiComponent2BridgeImpl(component as UiComponent2);
+
+  @override
+  JsMap jsifyPropTypes(Map propTypes) {
+    // todo implement jsifyPropTypes
+  }
+}
+
 /// Helper function that wraps react.registerComponent2, and allows attachment of additional
 /// component factory metadata.
 ///
@@ -87,7 +103,11 @@ ReactDartComponentFactoryProxy2 registerComponent2(react.Component2 dartComponen
     String displayName,
     Iterable<String> skipMethods = const ['getDerivedStateFromError', 'componentDidCatch'],
 }) {
-  ReactDartComponentFactoryProxy2 reactComponentFactory = react.registerComponent(dartComponentFactory, skipMethods);
+  final reactComponentFactory = react.registerComponent2(
+    dartComponentFactory,
+    skipMethods: skipMethods,
+    bridgeFactory: UiComponent2BridgeImpl.bridgeFactory,
+  );
 
   if (displayName != null) {
     reactComponentFactory.reactClass.displayName = displayName;

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -100,8 +100,8 @@ class UiComponent2BridgeImpl extends Component2BridgeImpl {
   ) {
     Map typedUpdater(Map prevState, Map props) {
       return updater(
-        component.typedStateFactory(prevState),
-        component.typedPropsFactory(props),
+        component.typedStateFactoryJs(prevState as JsBackedMap),
+        component.typedPropsFactoryJs(props as JsBackedMap),
       );
     }
     setStateWithUpdater(component, typedUpdater, callback);

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -348,7 +348,7 @@ abstract class UiStatefulComponent2<TProps extends UiProps, TState extends UiSta
   @override
   void setStateWithUpdater(covariant Map Function(TState prevState, TProps props) updater, [Function() callback]) {
     final bridge = Component2Bridge.forComponent(this) as UiComponent2BridgeImpl;
-    bridge.setStateWithTypedUpdater(updater, callback);
+    bridge.setStateWithTypedUpdater(this, updater, callback);
   }
 
   //

--- a/lib/src/component_declaration/component_base/component_base_2.dart
+++ b/lib/src/component_declaration/component_base/component_base_2.dart
@@ -345,6 +345,12 @@ abstract class UiStatefulComponent2<TProps extends UiProps, TState extends UiSta
   @override
   TState newState() => typedStateFactoryJs(new JsBackedMap());
 
+  @override
+  void setStateWithUpdater(covariant Map Function(TState prevState, TProps props) updater, [Function() callback]) {
+    final bridge = Component2Bridge.forComponent(this) as UiComponent2BridgeImpl;
+    bridge.setStateWithTypedUpdater(updater, callback);
+  }
+
   //
   //   END Typed state helpers
   // ----------------------------------------------------------------------

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -18,7 +18,7 @@ import 'dart:collection';
 
 import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/prop_mixins.dart';
-import 'package:react/src/react_client/js_backed_map.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 /// Returns a copy of the specified [props] map, omitting reserved React props by default,
 /// in addition to any specified [keysToOmit] or [keySetsToOmit].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,4 +42,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: finalize-component2-api/dev
+      ref: 5.1.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,5 +41,5 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: https://github.com/cleandart/react-dart.git
-      ref: 5.1.0-wip
+      url: git@github.com:cleandart/react-dart.git
+      ref: finalize-component2-api/dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,5 +41,5 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:cleandart/react-dart.git
+      url: https://github.com/cleandart/react-dart.git
       ref: finalize-component2-api/dev

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart' show Dom, DummyComponent, ValidationUtil;
+import 'package:over_react/over_react.dart' show Dom, DummyComponent, JsBackedMap, ValidationUtil;
 import 'package:over_react_test/over_react_test.dart';
 import 'package:over_react/src/component_declaration/component_base.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';


### PR DESCRIPTION
# Depends on https://github.com/cleandart/react-dart/pull/195

## Motivation
Component2 was implemented via a large number of PRs, and has some parts that need to be cleaned up before release.

## Changes
- Update imports to use new top-level entrypoints and not src/ files
- Stub in a custom UiComponent bridge for use in prop validation PR
- Add automatic typing to `UiStatefulComponent.setStateWithUpdater` callbacks:
    ```dart
    setStateWithUpdater((prevState, props) {
      // prevState is statically typed as TState
      // props is statically typed as TProps
    });
    ```


## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

Please review: @aaronlademann-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_

[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
