### PR TITLE
CPLAT-6735 Backport type loosening of DomProps.componentFactory in 3.1.0-wip

### DIFF
--- a/lib/src/component/dom_components.dart
+++ b/lib/src/component/dom_components.dart
@@ -48,7 +48,7 @@ class DomProps extends component_base.UiProps
   DomProps(this.componentFactory, [Map props]) : this.props = props ?? ({});
 
   @override
-  final ReactDomComponentFactoryProxy componentFactory;
+  ReactComponentFactoryProxy componentFactory;
 
   @override
   final Map props;
@@ -70,7 +70,7 @@ class SvgProps extends component_base.UiProps
   SvgProps(this.componentFactory, [Map props]) : this.props = props ?? ({});
 
   @override
-  final ReactDomComponentFactoryProxy componentFactory;
+  ReactComponentFactoryProxy componentFactory;
 
   @override
   final Map props;


### PR DESCRIPTION
## Motivation
In 3.1.0-wip, `DomProps.componentFactory` had its type loosened from `ReactDomComponentFactoryProxy` to `ReactComponentFactoryProxy`, which could break consumer usages that depended on members declared on that subclass.

## Changes
Perform this change in 3.0.0 so that any breakages happen only when consumers perform a major bump, and not during automatic minor bumps.

#### Release Notes
`DomProps.componentFactory`: loosen typing to `ReactComponentFactoryProxy` and make mutable to support future HOC APIs

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

Please review: @aaronlademann-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
