### PR TITLE
RM-53705 Release over react 2.4.5+dart1

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -17,6 +17,7 @@ library over_react;
 
 export 'package:react/react.dart' show
     SyntheticEvent,
+    SyntheticAnimationEvent,
     SyntheticClipboardEvent,
     SyntheticKeyboardEvent,
     SyntheticFocusEvent,
@@ -24,6 +25,7 @@ export 'package:react/react.dart' show
     SyntheticDataTransfer,
     SyntheticMouseEvent,
     SyntheticTouchEvent,
+    SyntheticTransitionEvent,
     SyntheticUIEvent,
     SyntheticWheelEvent;
 

--- a/lib/src/component/callback_typedefs.dart
+++ b/lib/src/component/callback_typedefs.dart
@@ -21,12 +21,14 @@ import 'package:react/react.dart' as react;
 
 // Callbacks for React's DOM event system
 typedef DomEventCallback(react.SyntheticEvent event);
+typedef AnimationEventCallback(react.SyntheticAnimationEvent event);
 typedef ClipboardEventCallback(react.SyntheticClipboardEvent event);
 typedef KeyboardEventCallback(react.SyntheticKeyboardEvent event);
 typedef FocusEventCallback(react.SyntheticFocusEvent event);
 typedef FormEventCallback(react.SyntheticFormEvent event);
 typedef MouseEventCallback(react.SyntheticMouseEvent event);
 typedef TouchEventCallback(react.SyntheticTouchEvent event);
+typedef TransitionEventCallback(react.SyntheticTransitionEvent event);
 typedef UIEventCallback(react.SyntheticUIEvent event);
 typedef WheelEventCallback(react.SyntheticWheelEvent event);
 

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -84,6 +84,7 @@ abstract class DomPropsMixin {
     poster, preload, radioGroup, rel, role, rowSpan, sandbox, scope, scrolling, shape, sizes, spellCheck, src, srcDoc,
     srcSet, step, tabIndex, target, type, useMap, value, width, wmode;
 
+  AnimationEventCallback onAnimationEnd, onAnimationIteration, onAnimationStart;
   ClipboardEventCallback onCopy, onCut, onPaste;
   KeyboardEventCallback onKeyDown, onKeyPress, onKeyUp;
   FocusEventCallback onFocus, onBlur;
@@ -92,6 +93,7 @@ abstract class DomPropsMixin {
     onClick, onContextMenu, onDoubleClick, onDrag, onDragEnd, onDragEnter, onDragExit, onDragLeave, onDragOver,
     onDragStart, onDrop, onMouseDown, onMouseEnter, onMouseLeave, onMouseMove, onMouseOut, onMouseOver, onMouseUp;
   TouchEventCallback onTouchCancel, onTouchEnd, onTouchMove, onTouchStart;
+  TransitionEventCallback onTransitionEnd;
   UIEventCallback onScroll;
   WheelEventCallback onWheel;
 
@@ -195,6 +197,21 @@ abstract class UbiquitousDomPropsMixin {
   /// See: <https://facebook.github.io/react/tips/inline-styles.html>
   Map<String, dynamic> style;
 
+  /// Callback for when a CSS Animation has completed.
+  ///
+  /// > Related: [onAnimationIteration], [onAnimationStart], [onTransitionEnd]
+  AnimationEventCallback onAnimationEnd;
+
+  /// Callback for when an iteration of a CSS Animation ends, and another one begins.
+  ///
+  /// > Related: [onAnimationEnd], [onAnimationStart]
+  AnimationEventCallback onAnimationIteration;
+
+  /// Callback for when a CSS animation has started.
+  ///
+  /// > Related: [onAnimationEnd], [onAnimationIteration]
+  AnimationEventCallback onAnimationStart;
+
   /// Callback for when the user copies the content of an element
   ClipboardEventCallback onCopy;
 
@@ -297,6 +314,11 @@ abstract class UbiquitousDomPropsMixin {
 
   /// Callback for when a finger is placed on a touch screen
   TouchEventCallback onTouchStart;
+
+  /// Callback for when a CSS transition has completed.
+  ///
+  /// > Related: [onAnimationEnd]
+  TransitionEventCallback onTransitionEnd;
 
   /// Callback for when an element's scrollbar is being scrolled
   UIEventCallback onScroll;

--- a/lib/src/util/handler_chain_util.dart
+++ b/lib/src/util/handler_chain_util.dart
@@ -17,12 +17,14 @@ library over_react.handler_chain_util;
 import 'package:over_react/over_react.dart' show ResizeSensorEvent;
 import 'package:react/react.dart' show
     SyntheticEvent,
+    SyntheticAnimationEvent,
     SyntheticClipboardEvent,
     SyntheticKeyboardEvent,
     SyntheticFocusEvent,
     SyntheticFormEvent,
     SyntheticMouseEvent,
     SyntheticTouchEvent,
+    SyntheticTransitionEvent,
     SyntheticUIEvent,
     SyntheticWheelEvent;
 
@@ -30,6 +32,9 @@ import '../component/callback_typedefs.dart';
 
 /// Provides chaining utilities for [DomEventCallback].
 final CallbackUtil1Arg<SyntheticEvent> domEventCallbacks                    = const CallbackUtil1Arg<SyntheticEvent>();
+
+/// Provides chaining utilities for [AnimationEventCallback].
+const animationEventCallbacks = CallbackUtil1Arg<SyntheticAnimationEvent>();
 
 /// Provides chaining utilities for [ClipboardEventCallback].
 final CallbackUtil1Arg<SyntheticClipboardEvent> clipboardEventCallbacks     = const CallbackUtil1Arg<SyntheticClipboardEvent>();
@@ -48,6 +53,9 @@ final CallbackUtil1Arg<SyntheticMouseEvent> mouseEventCallbacks             = co
 
 /// Provides chaining utilities for [TouchEventCallback].
 final CallbackUtil1Arg<SyntheticTouchEvent> touchEventCallbacks             = const CallbackUtil1Arg<SyntheticTouchEvent>();
+
+/// Provides chaining utilities for [TransitionEventCallback].
+const transitionEventCallbacks = CallbackUtil1Arg<SyntheticTransitionEvent>();
 
 /// Provides chaining utilities for [UIEventCallback].
 final CallbackUtil1Arg<SyntheticUIEvent> uiEventCallbacks                   = const CallbackUtil1Arg<SyntheticUIEvent>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^4.7.0
+  react: ^4.9.0
   source_span: ^1.4.1
   transformer_utils: ^0.1.5
   w_common: ^1.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.4.4+dart1
+version: 2.4.5+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This release incorporates the `SyntheticAnimationEvent` / `SyntheticTransitionEvent` support from #327 into the Dart 1 compatible line-of-release.

@kealjones-wk 