### PR TITLE
Upgrade to quiver ^2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   w_common: ^1.13.0
   w_flux: ^2.9.5
   platform_detect: ^1.3.4
-  quiver: ">=0.25.0 <1.0.0"
+  quiver: ">=0.25.0 <3.0.0"
 dev_dependencies:
   build_resolvers: ^1.0.5
   build_runner: ^1.5.2


### PR DESCRIPTION
## Motivation
quiver is out of date, conflict with other libs, in my case, [jaguar_orm](https://pub.dev/packages/jaguar_orm)

## Changes
Change quiver version to ^2.0.0.

#### Release Notes
Change quiver version to ^2.0.0.

@Workiva/app-frameworks
