### PR TITLE
RM-55763 Release over_react 2.5.1+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.5.1
+
+> Complete `2.5.1` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.0+dart2...2.5.1+dart2)
+> - Dart 1 (no changes)
+
+* Increase Dart SDK dependency lower-bound to `2.4.0`
+
 ## 2.5.0
 
 > Complete `2.5.0` Changsets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.0+dart2
+version: 2.5.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This release bumps the Dart SDK dependency lower-bound to `2.4.0` to align with our `build_web_compilers` dev-dependency lower-bound of `^2.1.1`.

@greglittlefield-wf @kealjones-wk @joebingham-wk @evanweible-wf 