### PR TITLE
RM-56520 Release over_react 2.5.2+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.5.2
+
+> Complete `2.5.2` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.1+dart2...2.5.2+dart2)
+> - Dart 1 (no changes)
+
+* [#333] Expand upper-bound of `quiver` dependency to `<3.0.0`
+
 ## 2.5.1
 
 > Complete `2.5.1` Changsets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.1+dart2
+version: 2.5.2+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
> Complete `2.5.2` Changsets:
>
> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.1+dart2...2.5.2+dart2)
> - Dart 1 (no changes)

* #333 Expand upper-bound of `quiver` dependency to `<3.0.0`


@greglittlefield-wf @kealjones-wk @joebingham-wk 