### PR TITLE
CPLAT-7367 Remove Implementation via the On Key Word

### DIFF
--- a/lib/component_base.dart
+++ b/lib/component_base.dart
@@ -15,4 +15,3 @@
 library over_react.component_base;
 
 export 'src/component_declaration/component_base.dart';
-export 'src/component_declaration/component_base_2.dart';

--- a/lib/component_base.dart
+++ b/lib/component_base.dart
@@ -15,3 +15,4 @@
 library over_react.component_base;
 
 export 'src/component_declaration/component_base.dart';
+export 'src/component_declaration/component_base_2.dart';

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -42,8 +42,10 @@ class GeneratedClass {
   }
 }
 
+/// Do not implement component_base.Component even though we should. This is
+/// to work around https://github.com/dart-lang/sdk/issues/38098.
 mixin _GeneratedUiComponentStubs<TProps extends UiProps>
-    on component_base.UiComponent<TProps>, GeneratedClass {
+    implements GeneratedClass {
   /// The default consumed props, taken from the keys generated in the associated @[annotations.Props] class.
   @toBeGenerated
   Iterable<component_base.ConsumedProps> get $defaultConsumedProps => throw new UngeneratedError(member: #$defaultConsumedProps);
@@ -52,7 +54,6 @@ mixin _GeneratedUiComponentStubs<TProps extends UiProps>
   ///
   /// For generated components, this defaults to the keys generated in the associated @[annotations.Props] class
   /// if this getter is not overridden.
-  @override
   Iterable<component_base.ConsumedProps> get consumedProps => $defaultConsumedProps;
 
   /// Returns a typed props object backed by the specified [propsMap].

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -42,7 +42,7 @@ class GeneratedClass {
   }
 }
 
-/// Do not implement component_base.Component even though we should. This is
+/// Do not implement component_base.Component using the `on` keyword. This is
 /// to work around https://github.com/dart-lang/sdk/issues/38098.
 mixin _GeneratedUiComponentStubs<TProps extends UiProps>
     implements GeneratedClass {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Using the `on` keyword on `_GeneratedUiComponentStubs` causes issues with the inheritance of state. This is a known issue caused by https://github.com/dart-lang/sdk/issues/38098.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Change `on` to `implements` and add a comment describing why.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @kealjones-wk @greglittlefield-wf @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
