### PR TITLE
CPLAT-7460 Component2 utilities coverage, fix getProps, createRef chaining

### DIFF
--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:react/react_client.dart' hide forwardRef, createRef;
-import 'package:react/react_client.dart' as react_client show forwardRef, createRef;
+import 'package:react/react_client/react_interop.dart' as react_interop;
+import 'package:react/react_client.dart';
 import 'package:over_react/component_base.dart';
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.
@@ -47,7 +47,7 @@ import 'package:over_react/component_base.dart';
 ///
 /// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
 Ref<CurrentType> createRef<CurrentType>() {
-  return react_client.createRef<CurrentType>();
+  return react_interop.createRef<CurrentType>();
 }
 
 /// Automatically passes a [Ref] through a component to one of its children.
@@ -97,7 +97,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
     Object wrapProps(Map props, Ref ref) {
       return wrapperFunction(factory(props), ref);
     }
-    ReactComponentFactoryProxy hoc = react_client.forwardRef(wrapProps);
+    ReactComponentFactoryProxy hoc = react_interop.forwardRef(wrapProps);
 
     TProps forwardedFactory([Map props]) {
       return factory(props)..componentFactory = hoc;

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -46,8 +46,8 @@ import 'package:over_react/component_base.dart';
 ///     }
 ///
 /// Learn more: <https://reactjs.org/docs/refs-and-the-dom.html#creating-refs>.
-Ref<CurrentType> createRef<CurrentType>() {
-  return react_interop.createRef<CurrentType>();
+Ref<T> createRef<T>() {
+  return react_interop.createRef<T>();
 }
 
 /// Automatically passes a [Ref] through a component to one of its children.

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -68,18 +68,6 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
   return _getDartComponentVersionFromInstance(instance) != null;
 }
 
-/// Returns [ReactClass.dartComponentVersion] if [type] is the [ReactClass] for a Dart component
-/// (a react-dart [ReactElement] or [ReactComponent]), and null otherwise.
-String _getDartComponentVersionFromType(dynamic type) {
-  // This check doesn't do much since it's an anonymous object, but it lets
-  // us safely cast to ReactClass.
-  if (type is ReactClass) {
-    return type.dartComponentVersion;
-  }
-
-  return null;
-}
-
 /// Returns [ReactClass.dartComponentVersion] if [instance] is a Dart component
 /// (react-dart [ReactElement] or [ReactComponent]), and null for other types of components.
 ///
@@ -96,7 +84,8 @@ String _getDartComponentVersionFromInstance(/* ReactElement|ReactComponent|Eleme
 
   // We need `type` if it's a ReactElement, or `constructor` if it's a `ReactComponent`.
   final type = getProperty(instance, 'type') ?? getProperty(instance, 'constructor');
-  return _getDartComponentVersionFromType(type);
+  // ignore: invalid_use_of_protected_member
+  return ReactDartComponentVersion.fromType(type);
 }
 
 /// Whether [Expando]s can be used on [ReactElement]s.
@@ -171,9 +160,9 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers:
     Map rawPropsOrCopy;
 
     final dartComponentVersion = _getDartComponentVersionFromInstance(instance);
-    if (dartComponentVersion == '1') {
+    if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
       rawPropsOrCopy = _getExtendedProps(instance);
-    } else if (dartComponentVersion == '2') {
+    } else if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
       // TODO Since JS props are frozen don't wrap in UnmodifiableMapView once https://github.com/dart-lang/sdk/issues/15432 is fixed
       rawPropsOrCopy = JsBackedMap.backedBy(instance.props);
     } else {
@@ -242,10 +231,10 @@ bool _isCompositeComponent(dynamic instance) {
 ///   If these values might contain event handlers
 dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newChildren]) {
   final type = element.type;
-  final dartComponentVersion = _getDartComponentVersionFromType(type);
+  final dartComponentVersion = ReactDartComponentVersion.fromType(type); // ignore: invalid_use_of_protected_member
 
   // react.Component
-  if (dartComponentVersion == '1') {
+  if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
     Map oldExtendedProps = _getInternal(element).props;
 
     Map extendedProps = new Map.from(oldExtendedProps);
@@ -265,7 +254,7 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newC
   }
 
   // react.Component2
-  if (dartComponentVersion == '2') {
+  if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
     return ReactDartComponentFactoryProxy2.generateExtendedJsProps(newProps);
   }
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -25,7 +25,7 @@ import 'package:over_react/src/component_declaration/component_type_checking.dar
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
 import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
-import 'package:react/react_client/react_interop.dart' hide createRef;
+import 'package:react/react_client/react_interop.dart' hide createRef, forwardRef;
 import 'package:react/react_dom.dart' as react_dom;
 
 // Notes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,4 +44,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 5.1.0-wip
+      ref: test-coverage-take-2

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -1286,7 +1286,7 @@ main() {
 }
 
 /// Helper component for testing a Dart (react-dart) React component with cloneElement.
-final TestComponentFactory = registerComponent(() => new TestComponent()); // ignore: deprecated_member_use_from_same_package
+final TestComponentFactory = react.registerComponent(() => new TestComponent()) as ReactDartComponentFactoryProxy; // ignore: deprecated_member_use
 // ignore: deprecated_member_use
 class TestComponent extends react.Component {
   @override
@@ -1294,7 +1294,7 @@ class TestComponent extends react.Component {
 }
 
 /// Helper component for testing a Dart (react-dart) React component (version 2) with cloneElement.
-final TestComponent2Factory = registerComponent2(() => new TestComponent2());
+final TestComponent2Factory = react.registerComponent2(() => new TestComponent2());
 
 class TestComponent2 extends react.Component2 {
   @override
@@ -1314,7 +1314,7 @@ class PlainObjectStyleMap {
 }
 
 /// Helper component that renders whatever you tell it to. Necessary for rendering components with the 'ref' prop.
-final RenderingContainerComponentFactory = registerComponent(() => new RenderingContainerComponent()); // ignore: deprecated_member_use_from_same_package
+final RenderingContainerComponentFactory = react.registerComponent(() => new RenderingContainerComponent()) as ReactDartComponentFactoryProxy; // ignore: deprecated_member_use
 
 // ignore: deprecated_member_use
 class RenderingContainerComponent extends react.Component {

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -23,7 +23,7 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/react_interop.dart' hide createRef;
+import 'package:react/react_client/react_interop.dart' hide createRef, forwardRef;
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 import 'package:test/test.dart';

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -933,8 +933,6 @@ main() {
               final oneLevelWrapperFactory = isComponent2 ? OneLevelWrapper : OneLevelWrapper2;
               final twoLevelWrapperFactory = isComponent2 ? TwoLevelWrapper : TwoLevelWrapper2;
 
-              dynamic getArg(ReactElement instance) => isRendered ? render(instance) : instance;
-
               group('Dart ${isComponent2 ? 'Component2' : 'Component'} ${isRendered ? 'ReactComponent' : 'ReactElement'}', () {
                 test('', () {
                   final instance = oneLevelWrapperFactory()(
@@ -944,7 +942,8 @@ main() {
                     }, testChildren),
                   );
 
-                  expect(getProps(getArg(instance), traverseWrappers: true), {
+                  final getPropsArg = isRendered ? render(instance) : instance;
+                  expect(getProps(getPropsArg, traverseWrappers: true), {
                     'dartProp': 'dart',
                     'style': testStyle,
                     'children': testChildren
@@ -961,7 +960,8 @@ main() {
                     ),
                   );
 
-                  expect(getProps(getArg(instance), traverseWrappers: true), {
+                  final getPropsArg = isRendered ? render(instance) : instance;
+                  expect(getProps(getPropsArg, traverseWrappers: true), {
                     'dartProp': 'dart',
                     'style': testStyle,
                     'children': testChildren
@@ -974,7 +974,8 @@ main() {
                     'style': testStyle,
                   }, testChildren);
 
-                  expect(getProps(getArg(instance), traverseWrappers: true), {
+                  final getPropsArg = isRendered ? render(instance) : instance;
+                  expect(getProps(getPropsArg, traverseWrappers: true), {
                     'dartProp': 'dart',
                     'style': testStyle,
                     'children': testChildren
@@ -989,8 +990,39 @@ main() {
                     }, testChildren)
                   );
 
-                  expect(getProps(getArg(instance)), {'children': anything});
+                  final getPropsArg = isRendered ? render(instance) : instance;
+                  expect(getProps(getPropsArg), {'children': anything});
                 });
+
+                if (isRendered) {
+                  test('even when props change', () {
+                    final jacket = mount(oneLevelWrapperFactory()(
+                      testComponentFactory({
+                        'dartProp': 'dart',
+                        'style': testStyle,
+                      }, testChildren)
+                    ));
+
+                    expect(getProps(jacket.getInstance(), traverseWrappers: true), {
+                      'dartProp': 'dart',
+                      'style': testStyle,
+                      'children': testChildren
+                    });
+
+                    jacket.rerender(oneLevelWrapperFactory()(
+                      testComponentFactory({
+                        'dartProp': 'other dart',
+                        'style': testStyle,
+                      }, testChildren)
+                    ));
+
+                    expect(getProps(jacket.getInstance(), traverseWrappers: true), {
+                      'dartProp': 'other dart',
+                      'style': testStyle,
+                      'children': testChildren
+                    });
+                  });
+                }
               });
             }
 

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -403,8 +403,8 @@ main() {
           var renderedClone = render(clone);
 
           // Verify that children are overridden according to React
-          Map cloneProps = getJsChildren(renderedClone);
-          expect(cloneProps['children'], testOverrideChildren);
+          var clonePropsChildren = getJsChildren(renderedClone);
+          expect(clonePropsChildren, testOverrideChildren);
 
           // Verify that children are overridden according to the Dart component.
           Map cloneDartProps = getDartComponent(renderedClone).props;

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -61,7 +61,7 @@ main() {
           expect(cloneProps, originalProps);
         });
 
-        test('for a Dart component', () {
+        test('for a Dart Component', () {
           var original = TestComponentFactory(testProps, testChildren);
           var clone = cloneElement(original);
 
@@ -90,7 +90,7 @@ main() {
           expect(dartRenderedClone.props, dartRendered.props);
         });
 
-        test('for a Dart component version 2', () {
+        test('for a Dart Component2', () {
           var original = TestComponent2Factory(testProps, testChildren);
           var clone = cloneElement(original);
 
@@ -137,7 +137,7 @@ main() {
           expect(cloneProps, expectedPropsMerge);
         });
 
-        test('for a Dart component', () {
+        test('for a Dart Component', () {
           var original = TestComponentFactory(testProps, testChildren);
           var clone = cloneElement(original, testPropsToAdd);
 
@@ -148,7 +148,7 @@ main() {
           expect(cloneDartProps, expectedPropsMerge);
         });
 
-        test('for a Dart component version 2', () {
+        test('for a Dart Component2', () {
           var original = TestComponent2Factory(testProps, testChildren);
           var clone = cloneElement(original, testPropsToAdd);
 
@@ -188,7 +188,7 @@ main() {
           });
 
           group(', except', () {
-            test('for Dart components', () {
+            test('for a Dart Component', () {
               var original = TestComponentFactory(testProps, testChildren);
               var clone = cloneElement(original, testPropsToAdd);
 
@@ -199,7 +199,7 @@ main() {
               expect(style, same(testPropsToAdd['style']), reason: 'style should be the same object passed in, unaltered');
             });
 
-            test('for Dart components version 2', () {
+            test('for a Dart Component2', () {
               var original = TestComponent2Factory(testProps, testChildren);
               var clone = cloneElement(original, testPropsToAdd);
 
@@ -255,7 +255,7 @@ main() {
               expect(onClickWasCalled, isTrue, reason: 'event handler that was added via cloning was not called');
             });
 
-            test('for Dart components', () {
+            test('for a Dart Component', () {
               var original = TestComponentFactory(testProps, testChildren);
               var clone = cloneElement(original, testPropsToAdd);
 
@@ -272,7 +272,7 @@ main() {
               expect(onClickWasCalled, isTrue, reason: 'event handler that was added via cloning was not called');
             });
 
-            test('for Dart components version 2', () {
+            test('for a Dart Component2', () {
               var original = TestComponent2Factory(testProps, testChildren);
               var clone = cloneElement(original, testPropsToAdd);
 
@@ -318,7 +318,7 @@ main() {
           expect(clone.ref, equals(overrideKeyRefProps['ref']));
         });
 
-        test('for a Dart component', () {
+        test('for a Dart Component', () {
           ReactElement original;
           ReactElement clone;
 
@@ -345,7 +345,7 @@ main() {
               reason: '"key" and "ref" should not be visible to the rendered cloned component');
         });
 
-        test('for a Dart component version 2', () {
+        test('for a Dart Component2', () {
           ReactElement original;
           ReactElement clone;
 
@@ -379,7 +379,7 @@ main() {
           expect(cloneProps['children'], testOverrideChildren);
         });
 
-        test('for a Dart component', () {
+        test('for a Dart Component', () {
           var original = TestComponentFactory(testProps, testChildren);
           var clone = cloneElement(original, null, testOverrideChildren);
 
@@ -394,7 +394,7 @@ main() {
           expect(cloneDartProps['children'], testOverrideChildren);
         });
 
-        test('for a Dart component version 2', () {
+        test('for a Dart Component2', () {
           var original = TestComponent2Factory(testProps, testChildren);
           var clone = cloneElement(original, null, testOverrideChildren);
 
@@ -927,7 +927,7 @@ main() {
           });
 
           {
-            void sharedTests({@required bool isComponent2, @required bool isRendered}) {
+            void sharedGetPropsWrapperTests({@required bool isComponent2, @required bool isRendered}) {
               final testComponentFactory = isComponent2 ? TestComponentFactory : TestComponent2Factory;
               final oneLevelWrapperFactory = isComponent2 ? OneLevelWrapper : OneLevelWrapper2;
               final twoLevelWrapperFactory = isComponent2 ? TwoLevelWrapper : TwoLevelWrapper2;
@@ -993,16 +993,16 @@ main() {
               });
             }
 
-            sharedTests(isComponent2: false, isRendered: false);
-            sharedTests(isComponent2: false, isRendered: true);
-            sharedTests(isComponent2: true, isRendered: false);
-            sharedTests(isComponent2: true, isRendered: true);
+            sharedGetPropsWrapperTests(isComponent2: false, isRendered: false);
+            sharedGetPropsWrapperTests(isComponent2: false, isRendered: true);
+            sharedGetPropsWrapperTests(isComponent2: true, isRendered: false);
+            sharedGetPropsWrapperTests(isComponent2: true, isRendered: true);
           }
         });
       });
 
       {
-        void sharedTests(factory, {Matcher modificationThrowsMatcher = throwsUnsupportedError}) {
+        void sharedGetPropsUnmodifiableTests(factory, {Matcher modificationThrowsMatcher = throwsUnsupportedError}) {
           test('returns props as an unmodifiable map', () {
             ReactComponent renderedInstance = render(factory({
               'dartProp': 'dart'
@@ -1044,16 +1044,16 @@ main() {
           });
         }
 
-        group('for JS component', () {
-          sharedTests(testJsComponentFactory);
+        group('for a JS component', () {
+          sharedGetPropsUnmodifiableTests(testJsComponentFactory);
         });
 
-        group('for Dart Component', () {
-          sharedTests(TestComponentFactory);
+        group('for a Dart Component', () {
+          sharedGetPropsUnmodifiableTests(TestComponentFactory);
         });
 
-        group('for Dart Component2', () {
-          sharedTests(
+        group('for a Dart Component2', () {
+          sharedGetPropsUnmodifiableTests(
             TestComponent2Factory,
             // TODO uncomment once https://github.com/dart-lang/sdk/issues/15432 is fixed and we don't need an UnmodifiableMapView
             // modificationThrowsMatcher: throwsA(hasToStringValue(contains('object is not extensible'))),

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -480,11 +480,11 @@ main() {
           expect(isDomElement(Dom.div()()), isTrue);
         });
 
-        test('a Dart component', () {
+        test('a Dart Component', () {
           expect(isDomElement(TestComponentFactory({})), isFalse);
         });
 
-        test('a Dart component version 2', () {
+        test('a Dart Component2', () {
           expect(isDomElement(TestComponent2Factory({})), isFalse);
         });
 

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -1178,7 +1178,6 @@ main() {
               runExpectations();
             });
 
-            // TODO: 3.0.0 this is failing on Dart 2 dart2js tests only.
             test('a JS composite component', () {
               var instanceWithRef = testJsComponentFactoryProxy({'ref': ref});
               var chainedRef = chainRef(instanceWithRef, (ref) {
@@ -1191,7 +1190,6 @@ main() {
               runExpectations();
             });
 
-            // TODO: 3.0.0 this is failing on Dart 2 dart2js tests only.
             test('a DOM component', () {
               var instanceWithRef = (Dom.div()..ref = ref)();
               var chainedRef = chainRef(instanceWithRef, (ref) {

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -675,101 +675,64 @@ main() {
         });
       });
 
-      test('returns props for a Dart Component ReactElement', () {
-        ReactElement instance = TestComponentFactory({
-          'dartProp': 'dart',
-          'style': testStyle,
-        }, testChildren);
+      {
+        void sharedGetPropsTests({@required bool isComponent2}) {
+          final factory = isComponent2 ? TestComponent2Factory : TestComponentFactory;
 
-        expect(getProps(instance), {
-          'dartProp': 'dart',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
+          group('returns props for a Dart ${isComponent2 ? 'Component2' : 'Component'}', () {
+            test('ReactElement', () {
+              ReactElement instance = factory({
+                'dartProp': 'dart',
+                'style': testStyle,
+              }, testChildren);
 
-      test('returns props for a Dart Component2 ReactElement', () {
-        ReactElement instance = TestComponent2Factory({
-          'dartProp': 'dart',
-          'style': testStyle,
-        }, testChildren);
+              expect(getProps(instance), {
+                'dartProp': 'dart',
+                'style': testStyle,
+                'children': testChildren
+              });
+            });
 
-        expect(getProps(instance), {
-          'dartProp': 'dart',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
+            test('ReactComponent', () {
+              ReactComponent renderedInstance = render(factory({
+                'dartProp': 'dart',
+                'style': testStyle,
+              }, testChildren));
 
-      test('returns props for a Dart Component ReactComponent', () {
-        ReactComponent renderedInstance = render(TestComponentFactory({
-          'dartProp': 'dart',
-          'style': testStyle,
-        }, testChildren));
+              expect(getProps(renderedInstance), {
+                'dartProp': 'dart',
+                'style': testStyle,
+                'children': testChildren
+              });
+            });
 
-        expect(getProps(renderedInstance), {
-          'dartProp': 'dart',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
+            test('ReactComponent, even when the props change', () {
+              final jacket = mount(factory({
+                'jsProp': 'js',
+                'style': testStyle,
+              }, testChildren));
+              expect(getProps(jacket.getInstance()), {
+                'jsProp': 'js',
+                'style': testStyle,
+                'children': testChildren
+              });
 
-      test('returns props for a Dart Component2 ReactComponent', () {
-        ReactComponent renderedInstance = render(TestComponent2Factory({
-          'dartProp': 'dart',
-          'style': testStyle,
-        }, testChildren));
+              jacket.rerender(factory({
+                'jsProp': 'other js',
+                'style': testStyle,
+              }, testChildren));
+              expect(getProps(jacket.getInstance()), {
+                'jsProp': 'other js',
+                'style': testStyle,
+                'children': testChildren
+              });
+            });
+          });
+        }
 
-        expect(getProps(renderedInstance), {
-          'dartProp': 'dart',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
-
-      test('returns props for a Dart component ReactComponent, even when the props change', () {
-        final jacket = mount(TestComponentFactory({
-          'jsProp': 'js',
-          'style': testStyle,
-        }, testChildren));
-        expect(getProps(jacket.getInstance()), {
-          'jsProp': 'js',
-          'style': testStyle,
-          'children': testChildren
-        });
-
-        jacket.rerender(TestComponentFactory({
-          'jsProp': 'other js',
-          'style': testStyle,
-        }, testChildren));
-        expect(getProps(jacket.getInstance()), {
-          'jsProp': 'other js',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
-
-      test('returns props for a Dart component ReactComponent, even when the props change', () {
-        final jacket = mount(TestComponent2Factory({
-          'jsProp': 'js',
-          'style': testStyle,
-        }, testChildren));
-        expect(getProps(jacket.getInstance()), {
-          'jsProp': 'js',
-          'style': testStyle,
-          'children': testChildren
-        });
-
-        jacket.rerender(TestComponent2Factory({
-          'jsProp': 'other js',
-          'style': testStyle,
-        }, testChildren));
-        expect(getProps(jacket.getInstance()), {
-          'jsProp': 'other js',
-          'style': testStyle,
-          'children': testChildren
-        });
-      });
+        sharedGetPropsTests(isComponent2: false);
+        sharedGetPropsTests(isComponent2: true);
+      }
 
       group('traverses children of Wrapper components', () {
         group('and returns props for a', () {

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -533,17 +533,17 @@ main() {
         expect(isDartComponent(instance), isFalse);
       });
 
-      test('returns true for an mounted instance (ReactComponent) of a Dart Component', () {
+      test('returns true for a mounted instance (ReactComponent) of a Dart Component', () {
         var renderedInstance = render(TestComponentFactory({}));
         expect(isDartComponent(renderedInstance), isTrue);
       });
 
-      test('returns true for an mounted instance (ReactComponent) of a Dart Component2', () {
+      test('returns true for a mounted instance (ReactComponent) of a Dart Component2', () {
         var renderedInstance = render(TestComponent2Factory({}));
         expect(isDartComponent(renderedInstance), isTrue);
       });
 
-      test('returns false for an mounted instance (ReactComponent) of a JS composite component', () {
+      test('returns false for a mounted instance (ReactComponent) of a JS composite component', () {
         var renderedInstance = render(testJsComponentFactory({}));
         expect(isDartComponent(renderedInstance), isFalse);
       });

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -33,7 +33,6 @@ import '../../test_util/component2/two_level_wrapper.dart';
 import '../../test_util/one_level_wrapper.dart';
 import '../../test_util/test_util.dart';
 import '../../test_util/two_level_wrapper.dart';
-import '../component_declaration/component_base_test.dart';
 
 /// Main entry point for react wrappers testing
 main() {
@@ -79,8 +78,8 @@ main() {
           expect(originalShallowProps, clonePropsShallowProps);
 
           // Verify react-dart internal props are equal.
-          ReactDartComponentInternal originalInternal = originalProps['internal'];
-          ReactDartComponentInternal clonePropsInternal = cloneProps['internal'];
+          ReactDartComponentInternal originalInternal = originalProps['internal']; // ignore: deprecated_member_use
+          ReactDartComponentInternal clonePropsInternal = cloneProps['internal']; // ignore: deprecated_member_use
           expect(originalInternal.props, clonePropsInternal.props);
 
           var dartRendered = getDartComponent(render(original));
@@ -337,6 +336,7 @@ main() {
           // Verify that "key" and "ref" are overridden according to React
           expect(clone.key, overrideKeyRefProps['key']);
           expect(cloneRefCalled, isTrue);
+          expect(originalRefCalled, isFalse);
 
           var renderedClone = react_test_utils.findRenderedComponentWithTypeV2(renderedHolder, TestComponentFactory);
 
@@ -364,6 +364,7 @@ main() {
           // Verify that "key" and "ref" are overridden according to React
           expect(clone.key, overrideKeyRefProps['key']);
           expect(cloneRefCalled, isTrue);
+          expect(originalRefCalled, isFalse);
         });
       });
 
@@ -1253,7 +1254,7 @@ main() {
 }
 
 /// Helper component for testing a Dart (react-dart) React component with cloneElement.
-final TestComponentFactory = react.registerComponent(() => new TestComponent());
+final TestComponentFactory = registerComponent(() => new TestComponent()); // ignore: deprecated_member_use_from_same_package
 // ignore: deprecated_member_use
 class TestComponent extends react.Component {
   @override
@@ -1261,7 +1262,7 @@ class TestComponent extends react.Component {
 }
 
 /// Helper component for testing a Dart (react-dart) React component (version 2) with cloneElement.
-final TestComponent2Factory = react.registerComponent2(() => new TestComponent2());
+final TestComponent2Factory = registerComponent2(() => new TestComponent2());
 
 class TestComponent2 extends react.Component2 {
   @override
@@ -1281,7 +1282,7 @@ class PlainObjectStyleMap {
 }
 
 /// Helper component that renders whatever you tell it to. Necessary for rendering components with the 'ref' prop.
-final RenderingContainerComponentFactory = react.registerComponent(() => new RenderingContainerComponent());
+final RenderingContainerComponentFactory = registerComponent(() => new RenderingContainerComponent()); // ignore: deprecated_member_use_from_same_package
 
 // ignore: deprecated_member_use
 class RenderingContainerComponent extends react.Component {
@@ -1291,6 +1292,7 @@ class RenderingContainerComponent extends react.Component {
 
 // TODO update over_react_test's testJsComponentFactory with this implementation
 /// A factory for a JS composite component, for use in testing.
+// ignore: deprecated_member_use
 final testJsComponentFactoryProxy = ReactJsComponentFactoryProxy(React.createClass(ReactClassConfig(
   displayName: 'testJsComponent',
   render: allowInterop(() => Dom.div()('test js component')),

--- a/test/test_util/component2/one_level_wrapper.dart
+++ b/test/test_util/component2/one_level_wrapper.dart
@@ -1,0 +1,30 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+part 'one_level_wrapper.over_react.g.dart';
+
+@Factory()
+UiFactory<OneLevelWrapper2Props> OneLevelWrapper2 = _$OneLevelWrapper2;
+
+@Props()
+class _$OneLevelWrapper2Props extends UiProps {}
+
+@Component(isWrapper: true)
+class OneLevelWrapper2Component extends UiComponent<OneLevelWrapper2Props> {
+  @override
+  render() => Dom.div()(props.children.single);
+}
+

--- a/test/test_util/component2/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/component2/one_level_wrapper.over_react.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'one_level_wrapper.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $OneLevelWrapper2ComponentFactory = registerComponent(
+    () => new _$OneLevelWrapper2Component(),
+    builderFactory: OneLevelWrapper2,
+    componentClass: OneLevelWrapper2Component,
+    isWrapper: true,
+    parentType: null,
+    displayName: 'OneLevelWrapper2');
+
+abstract class _$OneLevelWrapper2PropsAccessorsMixin
+    implements _$OneLevelWrapper2Props {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForOneLevelWrapper2Props = const PropsMeta(
+  fields: _$OneLevelWrapper2PropsAccessorsMixin.$props,
+  keys: _$OneLevelWrapper2PropsAccessorsMixin.$propKeys,
+);
+
+class OneLevelWrapper2Props extends _$OneLevelWrapper2Props
+    with _$OneLevelWrapper2PropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForOneLevelWrapper2Props;
+}
+
+_$$OneLevelWrapper2Props _$OneLevelWrapper2([Map backingProps]) =>
+    new _$$OneLevelWrapper2Props(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$OneLevelWrapper2Props extends _$OneLevelWrapper2Props
+    with _$OneLevelWrapper2PropsAccessorsMixin
+    implements OneLevelWrapper2Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$OneLevelWrapper2Props(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $OneLevelWrapper2ComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'OneLevelWrapper2Props.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$OneLevelWrapper2Component extends OneLevelWrapper2Component {
+  @override
+  _$$OneLevelWrapper2Props typedPropsFactory(Map backingMap) =>
+      new _$$OneLevelWrapper2Props(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$OneLevelWrapper2Props.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForOneLevelWrapper2Props
+  ];
+}

--- a/test/test_util/component2/two_level_wrapper.dart
+++ b/test/test_util/component2/two_level_wrapper.dart
@@ -1,0 +1,30 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+part 'two_level_wrapper.over_react.g.dart';
+
+@Factory()
+UiFactory<TwoLevelWrapper2Props> TwoLevelWrapper2 = _$TwoLevelWrapper2;
+
+@Props()
+class _$TwoLevelWrapper2Props extends UiProps {}
+
+@Component(isWrapper: true)
+class TwoLevelWrapper2Component extends UiComponent<TwoLevelWrapper2Props> {
+  @override
+  render() => Dom.div()(props.children.single);
+}
+

--- a/test/test_util/component2/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/component2/two_level_wrapper.over_react.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'two_level_wrapper.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TwoLevelWrapper2ComponentFactory = registerComponent(
+    () => new _$TwoLevelWrapper2Component(),
+    builderFactory: TwoLevelWrapper2,
+    componentClass: TwoLevelWrapper2Component,
+    isWrapper: true,
+    parentType: null,
+    displayName: 'TwoLevelWrapper2');
+
+abstract class _$TwoLevelWrapper2PropsAccessorsMixin
+    implements _$TwoLevelWrapper2Props {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForTwoLevelWrapper2Props = const PropsMeta(
+  fields: _$TwoLevelWrapper2PropsAccessorsMixin.$props,
+  keys: _$TwoLevelWrapper2PropsAccessorsMixin.$propKeys,
+);
+
+class TwoLevelWrapper2Props extends _$TwoLevelWrapper2Props
+    with _$TwoLevelWrapper2PropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForTwoLevelWrapper2Props;
+}
+
+_$$TwoLevelWrapper2Props _$TwoLevelWrapper2([Map backingProps]) =>
+    new _$$TwoLevelWrapper2Props(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TwoLevelWrapper2Props extends _$TwoLevelWrapper2Props
+    with _$TwoLevelWrapper2PropsAccessorsMixin
+    implements TwoLevelWrapper2Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TwoLevelWrapper2Props(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $TwoLevelWrapper2ComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TwoLevelWrapper2Props.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TwoLevelWrapper2Component extends TwoLevelWrapper2Component {
+  @override
+  _$$TwoLevelWrapper2Props typedPropsFactory(Map backingMap) =>
+      new _$$TwoLevelWrapper2Props(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TwoLevelWrapper2Props.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTwoLevelWrapper2Props
+  ];
+}


### PR DESCRIPTION
**Dependent on https://github.com/cleandart/react-dart/pull/212**

---

## Motivation
There were some missing areas of test coverage for some of the new APIs added in 3.x, as well as some issues discovered while improving test coverage in the corresponding React 16 branches of react-dart.

## Changes
- React wrapper utilities
    - Fix `getProps` which did not work for `Component2`
    - Clean up `cloneElement` implementation
    - Add support for chaining refs on ReactElements with `createRef`-based refs
    - Add lots of tests using Component2 instances as input

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
