### PR TITLE
Fix uncovertJsProps calls

### DIFF
--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -1132,7 +1132,7 @@ main() {
   });
 }
 
-dynamic getJsChildren(instance) => unconvertJsProps(instance)['children'];
+dynamic getJsChildren(instance) => JsBackedMap.backedBy(instance.props)['children'];
 
 dynamic getDartChildren(var renderedInstance) {
   assert(isDartComponent(renderedInstance));

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -17,6 +17,7 @@ library over_react.component_declaration.component_base_test;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:over_react/over_react.dart' show Dom, DummyComponent, JsBackedMap, UiComponent2, ValidationUtil;
 import 'package:over_react/over_react.dart' as over_react;
@@ -1132,7 +1133,7 @@ main() {
   });
 }
 
-dynamic getJsChildren(instance) => JsBackedMap.backedBy(instance.props)['children'];
+dynamic getJsChildren(instance) => getProperty(instance.props, 'children');
 
 dynamic getDartChildren(var renderedInstance) {
   assert(isDartComponent(renderedInstance));

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -27,6 +27,7 @@ import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
 import 'package:test/test.dart';
 
+import '../component_declaration/component_base_test.dart';
 import '../../test_util/one_level_wrapper.dart';
 import '../../test_util/test_util.dart';
 import '../../test_util/two_level_wrapper.dart';
@@ -64,8 +65,8 @@ main() {
           // If these objects are equal, then they proxy the same JS props object.
           expect(clone.props, isNot(original.props));
 
-          Map originalProps = unconvertJsProps(original);
-          Map cloneProps = unconvertJsProps(clone);
+          Map originalProps = JsBackedMap.backedBy(original.props);
+          Map cloneProps = JsBackedMap.backedBy(clone.props);
 
           // Verify all props (including children, excluding react-dart internals) are equal.
           Map originalShallowProps = new Map.from(originalProps);
@@ -382,8 +383,8 @@ main() {
           var renderedClone = render(clone);
 
           // Verify that children are overridden according to React
-          Map cloneProps = unconvertJsProps(renderedClone);
-          expect(cloneProps['children'], testOverrideChildren);
+          var clonePropsChildren = getJsChildren(renderedClone);
+          expect(clonePropsChildren, testOverrideChildren);
 
           // Verify that children are overridden according to the Dart component.
           Map cloneDartProps = getDartComponent(renderedClone).props;


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
[react-dart #209](https://github.com/cleandart/react-dart/pull/209) added a new assertment that changed broke tests in `3.1.0`. This PR fixes those broken test.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Change `getJsChildren` to access props via `getProperty` instead of `unconvertJsProps`.
- Update a test case to use `JsBackedMap` to access props rather than `unconvertJsProps`.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @kealjones-wk @greglittlefield-wf @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
