### PR TITLE
RM-58640 Release over_react 3.0.0-alpha.0+dart2 (Includes CPLAT-7545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 3.0.0
 
+__ReactJS 16.x Support__ _(and Dart 1 compatible)_
+
+* The underlying `react` dependency ([version 5.0.0](https://github.com/cleandart/react-dart/pull/214)) now provides ReactJS version 16 `.js` source files.
+* Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).
+
 __Breaking Changes__
 
 * [#314] The `.over_react.g.dart` part directive is required on Dart 2. The
@@ -9,6 +14,11 @@ __Breaking Changes__
   a missing part directive is detected. Previously, the builder only logged this
   as a warning. In other words, the issue has been promoted from a runtime
   exception to a build-time error.
+
+> Complete `3.0.0` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...3.0.0-alpha.0+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.0+dart1...3.0.0-alpha.0+dart1)
 
 ## 2.5.2
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -40,14 +40,13 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
       return js_util.getProperty(jsProps, 'children');
     }),
     'componentDidCatch': allowInteropCaptureThis((jsThis, error, info) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
       // Due to the error object being passed in from ReactJS it is a javascript object that does not get dartified.
       // To fix this we throw the error again from Dart to the JS side and catch it Dart side which re-dartifies it.
       try {
         throwErrorFromJS(error);
-      } catch (e, stack) {
-        // The Dart stack track gets lost so we manually add it to the info object for reference.
-        info['dartStackTrace'] = stack;
-        js_util.getProperty(js_util.getProperty(jsThis, 'props'), 'onComponentDidCatch')(error, info);
+      } catch (error, stack) {
+        js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
       }
     }),
   }));
@@ -67,11 +66,9 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
 })();
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
 typedef _ComponentDidCatchCallback(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
 typedef ReactElement _FallbackUiRenderer(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 /// A higher-order component that will catch ReactJS errors anywhere within the child component tree and

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -46,7 +46,11 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
       try {
         throwErrorFromJS(error);
       } catch (error, stack) {
-        js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
+        final callback = js_util.getProperty(jsProps, 'onComponentDidCatch');
+
+        if (callback != null) {
+          callback(error, info);
+        }
       }
     }),
   }));

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,13 +1,70 @@
+import 'dart:html';
+import 'dart:js_util' as js_util;
+
+import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
+import 'package:react/react_client.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/react_interop.dart' show React, ReactClassConfig;
 
 part 'error_boundary.over_react.g.dart';
 
-// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef _ComponentDidCatchCallback(Error error, /*ComponentStack*/dynamic componentStack);
+/// A __temporary, private JS component for use only by [ErrorBoundary]__ that utilizes its own lightweight
+/// JS interop to make use of the ReactJS 16 `componentDidCatch` lifecycle method to prevent consumer
+/// react component trees from unmounting as a result of child component errors being "uncaught".
+///
+/// > __Why this is here__
+/// >
+/// > In order to release react-dart 5.0.0 _(which upgrades to ReactJS 16)_
+///   without depending on Dart 2 / `Component2` (coming in react-dart 5.1.0) / `UiComponent2` (coming in over_react 3.1.0) -
+///   and all the new lifecycle methods that those expose, we need to ensure that - at a minimum - the `componentDidCatch`
+///   lifecycle method is handled by components wrapped in our [ErrorBoundary] component so that the behavior of
+///   an application when a component within a tree throws - is the same as it was when using ReactJS 15.
+/// >
+/// > Otherwise, the update to react-dart 5.0.0 / over_react 3.0.0 will result in consumer apps rendering completely
+///   "blank" screens when their trees unmount as a result of a child component throwing an error.
+///   This would be unexpected, unwanted - and since we will not add a Dart js-interop layer around `componentDidCatch`
+///   until react-dart 5.1.0 / over_react 3.1.0 - unmanageable for consumers.
+///
+/// __This will be removed in over_react 3.1.0__ once [ErrorBoundaryComponent] is extending from `UiStatefulComponent2`
+/// which will ensure that the [ErrorBoundaryComponent.componentDidCatch] lifecycle method has real js-interop bindings
+/// via react-dart 5.1.0's `Component2` base class.
+///
+/// TODO: Remove in 3.1.0
+final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponentFactory = (() {
+  var componentClass = React.createClass(jsifyAndAllowInterop({
+    'displayName': 'JsErrorBoundary',
+    'render': allowInteropCaptureThis((jsThis) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
+      return js_util.getProperty(jsProps, 'children');
+    }),
+    'componentDidCatch': allowInteropCaptureThis((jsThis, error, info) {
+      final jsProps = js_util.getProperty(jsThis, 'props');
+      js_util.getProperty(jsProps, 'onComponentDidCatch')(error, info);
+    }),
+  }));
+
+  // Despite what the ReactJS docs say about only needing _either_ componentDidCatch or getDerivedStateFromError
+  // in order to define an "error boundary" component, that is not actually the case.
+  //
+  // The tree will never get re-rendered after an error is caught unless both are defined.
+  js_util.setProperty(componentClass, 'getDerivedStateFromError', allowInterop((_) => js_util.newObject()));
+
+  var reactFactory = React.createFactory(componentClass);
+
+  return ([Map props = const {}, List children = const []]) {
+    return reactFactory(jsifyAndAllowInterop(props), listifyChildren(children));
+  };
+})();
 
 // TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef ReactElement _FallbackUiRenderer(Error error, /*ComponentStack*/dynamic componentStack);
+// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
+typedef _ComponentDidCatchCallback(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
+
+// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
+// TODO: Will it be possible to make the first argument typed as a real `Error` instance again in Dart 2?
+typedef ReactElement _FallbackUiRenderer(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
 
 /// A higher-order component that will catch ReactJS errors anywhere within the child component tree and
 /// display a fallback UI instead of the component tree that crashed.
@@ -91,12 +148,19 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   }
 
   @override
-  render() => state.hasError
-      ? props.fallbackUIRenderer(_error, _componentStack)
-      : props.children.single;
+  render() {
+    // TODO: 3.1.0 - Remove the `_jsErrorBoundaryComponentFactory`, and restore just the children of it once this component is extending from `UiStatefulComponent2`.
+    return _jsErrorBoundaryComponentFactory({
+      'onComponentDidCatch': props.onComponentDidCatch
+    },
+      state.hasError
+          ? [props.fallbackUIRenderer(_error, _componentStack)]
+          : props.children
+    );
+  }
 
   ReactElement _renderDefaultFallbackUI(_, __) =>
-      throw new UnimplementedError('Fallback UI will not be supported until support for ReactJS 16 is released in version 3.0.0');
+      throw new UnimplementedError('Fallback UI will not be supported until support for ReactJS 16 lifecycle methods is released in version 3.1.0');
 
   @mustCallSuper
   @override

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -49,6 +49,7 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
   // in order to define an "error boundary" component, that is not actually the case.
   //
   // The tree will never get re-rendered after an error is caught unless both are defined.
+  // ignore: argument_type_not_assignable
   js_util.setProperty(componentClass, 'getDerivedStateFromError', allowInterop((_) => js_util.newObject()));
 
   var reactFactory = React.createFactory(componentClass);

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -15,11 +15,12 @@
 /// Provides utilities around component type-checking.
 library over_react.component_declaration.component_type_checking;
 
+import 'dart:js_util';
+
 import 'package:over_react/src/component_declaration/component_base.dart' show UiFactory;
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations show Component;
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 
 // ----------------------------------------------------------------------

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -50,6 +50,7 @@ void setComponentTypeMeta(ReactDartComponentFactoryProxy factory, {
     bool isWrapper,
     ReactDartComponentFactoryProxy parentType
 }) {
+  // ignore: argument_type_not_assignable
   setProperty(factory.type, _componentTypeMetaKey, new ComponentTypeMeta(isWrapper, parentType));
 }
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,6 +24,7 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 
@@ -204,9 +205,9 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newC
         // are properly converted.
         Map convertedProps = new Map.from(newProps);
         ReactDomComponentFactoryProxy.convertProps(convertedProps);
-        propsChangeset = jsify(convertedProps);
+        propsChangeset = jsifyAndAllowInterop(convertedProps);
       } else {
-        propsChangeset = jsify(newProps);
+        propsChangeset = jsifyAndAllowInterop(newProps);
       }
     }
   } else {

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -17,13 +17,13 @@ library over_react.react_wrappers;
 
 import 'dart:collection';
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,7 +24,7 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
+import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
 import 'package:react/react_client/react_interop.dart';
 import 'package:react/react_dom.dart' as react_dom;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: over_react
-version: 3.0.0-dev.0
+version: 2.5.0+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
@@ -38,8 +38,9 @@ dev_dependencies:
   over_react_test: ^2.5.0
   test: ^1.0.0
 
+
 dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 5.1.0-wip
+      ref: 5.0.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^5.0.0-alpha.0
+  react: ^5.0.0-alpha
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,5 +35,5 @@ dev_dependencies:
   dart_dev: ^2.0.0
   dependency_validator: ^1.2.2
   mockito: ^4.0.0
-  over_react_test: ^2.5.0
+  over_react_test: ^2.5.2
   test: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^4.9.0
+  react: ^5.0.0-alpha.0
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,10 +37,3 @@ dev_dependencies:
   mockito: ^4.0.0
   over_react_test: ^2.5.0
   test: ^1.0.0
-
-
-dependency_overrides:
-  react:
-    git:
-      url: https://github.com/cleandart/react-dart.git
-      ref: 5.0.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,5 +45,5 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:cleandart/react-dart.git
+      url: https://github.com/cleandart/react-dart.git
       ref: 5.0.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.2+dart2
+version: 3.0.0-alpha.0+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0
-  w_flux: ^2.9.5
+  w_flux: ^2.10.4
   platform_detect: ^1.3.4
   quiver: ">=0.25.0 <3.0.0"
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: over_react
-version: 2.4.4+dart2
+version: 3.0.0-dev.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   analyzer: '>=0.35.0 <0.37.0'
@@ -38,9 +38,8 @@ dev_dependencies:
   over_react_test: ^2.5.0
   test: ^1.0.0
 
-
 dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 5.0.0-wip
+      ref: 5.1.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,3 +40,10 @@ dev_dependencies:
   mockito: ^4.0.0
   over_react_test: ^2.4.0
   test: ^1.0.0
+
+
+dependency_overrides:
+  react:
+    git:
+      url: git@github.com:cleandart/react-dart.git
+      ref: 5.0.0-wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   dart_dev: ^2.0.0
   dependency_validator: ^1.2.2
   mockito: ^4.0.0
-  over_react_test: ^2.4.0
+  over_react_test: ^2.5.0
   test: ^1.0.0
 
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -83,7 +83,7 @@ void main() {
       test('and calls `props.onComponentDidCatch`', () {
         expect(calls.single.keys, ['onComponentDidCatch']);
         final errArg = calls.single['onComponentDidCatch'][0];
-        expect(errArg, const isInstanceOf<Error>());
+        expect(errArg, isA<FlawedComponentException>());
 
         final infoArg = calls.single['onComponentDidCatch'][1];
         expect(infoArg, isNotNull);

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -65,7 +65,6 @@ void main() {
         jacket = mount(
           (ErrorBoundary()
             ..onComponentDidCatch = (err, info) {
-              print('onComponentDidCatch');
               calls.add({'onComponentDidCatch': [err, info]});
             }
           )(Flawed()()),
@@ -84,6 +83,8 @@ void main() {
       test('and calls `props.onComponentDidCatch`', () {
         expect(calls.single.keys, ['onComponentDidCatch']);
         final errArg = calls.single['onComponentDidCatch'][0];
+        // TODO: Figure out why a `const isInstanceOf<Error>()` doesn't work.
+        expect(errArg.toString(), contains('Instance of \'Error\''));
         expect(errArg.toString(), contains('FlawedComponent.componentWillUpdate'));
 
         final infoArg = calls.single['onComponentDidCatch'][1];
@@ -94,6 +95,13 @@ void main() {
         expect(mountNode.children, isNotEmpty,
             reason: 'rendered trees wrapped in an ErrorBoundary '
                     'should NOT get unmounted when an error is thrown within child component lifecycle methods');
+      });
+
+      test('does not throw a null exception when `props.onComponentDidCatch` is not set', () {
+        jacket = mount(ErrorBoundary()((Flawed()..addTestId('flawed'))()), mountNode: mountNode);
+        // The click causes the componentDidCatch lifecycle method to execute
+        // and we want to ensure that no Dart null error is thrown as a result of no consumer prop callback being set.
+        expect(() => jacket.getNode().click(), returnsNormally);
       });
     });
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -16,6 +16,7 @@
 library error_boundary_test;
 
 import 'dart:html';
+import 'dart:js';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
@@ -38,7 +39,7 @@ void main() {
 
     // TODO: Add tests that exercise the actual ReactJS 16 error lifecycle methods once implemented.
     group('catches component errors', () {
-      List<String> calls;
+      List<Map<String, List>> calls;
       DivElement mountNode;
 
       void verifyReact16ErrorHandlingWithoutErrorBoundary() {
@@ -63,7 +64,10 @@ void main() {
         calls = [];
         jacket = mount(
           (ErrorBoundary()
-            ..onComponentDidCatch = (_, __) { calls.add('onComponentDidCatch'); }
+            ..onComponentDidCatch = (err, info) {
+              print('onComponentDidCatch');
+              calls.add({'onComponentDidCatch': [err, info]});
+            }
           )(Flawed()()),
           mountNode: mountNode,
         );
@@ -78,7 +82,12 @@ void main() {
       });
 
       test('and calls `props.onComponentDidCatch`', () {
-        expect(calls, ['onComponentDidCatch']);
+        expect(calls.single.keys, ['onComponentDidCatch']);
+        final errArg = calls.single['onComponentDidCatch'][0];
+        expect(errArg.toString(), contains('FlawedComponent.componentWillUpdate'));
+
+        final infoArg = calls.single['onComponentDidCatch'][1];
+        expect(infoArg, isNotNull);
       });
 
       test('and re-renders the tree as a result', () {

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -83,9 +83,7 @@ void main() {
       test('and calls `props.onComponentDidCatch`', () {
         expect(calls.single.keys, ['onComponentDidCatch']);
         final errArg = calls.single['onComponentDidCatch'][0];
-        // TODO: Figure out why a `const isInstanceOf<Error>()` doesn't work.
-        expect(errArg.toString(), contains('Instance of \'Error\''));
-        expect(errArg.toString(), contains('FlawedComponent.componentWillUpdate'));
+        expect(errArg, const isInstanceOf<Error>());
 
         final infoArg = calls.single['onComponentDidCatch'][1];
         expect(infoArg, isNotNull);

--- a/test/over_react/component/fixtures/flawed_component.dart
+++ b/test/over_react/component/fixtures/flawed_component.dart
@@ -38,7 +38,7 @@ class FlawedComponent extends UiStatefulComponent<FlawedProps, FlawedState> {
   void componentWillUpdate(_, Map nextState) {
     final tNextState = typedStateFactory(nextState);
     if (tNextState.hasError && !state.hasError) {
-      throw new Error();
+      throw new FlawedComponentException();
     }
   }
 
@@ -51,4 +51,9 @@ class FlawedComponent extends UiStatefulComponent<FlawedProps, FlawedState> {
       }
     )('oh hai');
   }
+}
+
+class FlawedComponentException implements Exception {
+  @override
+  String toString() => 'FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!';
 }

--- a/test/over_react/component/fixtures/flawed_component.dart
+++ b/test/over_react/component/fixtures/flawed_component.dart
@@ -1,0 +1,54 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedProps> Flawed = _$Flawed;
+
+@Props()
+class _$FlawedProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedProps extends _$FlawedProps with _$FlawedPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedProps;
+}
+
+@State()
+class _$FlawedState extends UiState {
+  bool hasError;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedState extends _$FlawedState with _$FlawedStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = _$metaForFlawedState;
+}
+
+@Component()
+class FlawedComponent extends UiStatefulComponent<FlawedProps, FlawedState> {
+  @override
+  Map getInitialState() => (newState()..hasError = false);
+
+  @override
+  void componentWillUpdate(_, Map nextState) {
+    final tNextState = typedStateFactory(nextState);
+    if (tNextState.hasError && !state.hasError) {
+      throw new Error();
+    }
+  }
+
+  @override
+  render() {
+    return (Dom.button()
+      ..addTestId('flawedButton')
+      ..onClick = (_) {
+        setState(newState()..hasError = true);
+      }
+    )('oh hai');
+  }
+}

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -1,0 +1,141 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flawed_component.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FlawedComponentFactory = registerComponent(() => new _$FlawedComponent(),
+    builderFactory: Flawed,
+    componentClass: FlawedComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'Flawed');
+
+abstract class _$FlawedPropsAccessorsMixin implements _$FlawedProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForFlawedProps = const PropsMeta(
+  fields: _$FlawedPropsAccessorsMixin.$props,
+  keys: _$FlawedPropsAccessorsMixin.$propKeys,
+);
+
+_$$FlawedProps _$Flawed([Map backingProps]) => new _$$FlawedProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FlawedProps extends _$FlawedProps
+    with _$FlawedPropsAccessorsMixin
+    implements FlawedProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FlawedProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory => $FlawedComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FlawedProps.';
+}
+
+abstract class _$FlawedStateAccessorsMixin implements _$FlawedState {
+  @override
+  Map get state;
+
+  /// <!-- Generated from [_$FlawedState.hasError] -->
+  @override
+  bool get hasError =>
+      state[_$key__hasError___$FlawedState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$FlawedState.hasError] -->
+  @override
+  set hasError(bool value) => state[_$key__hasError___$FlawedState] = value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor _$prop__hasError___$FlawedState =
+      const StateDescriptor(_$key__hasError___$FlawedState);
+  static const String _$key__hasError___$FlawedState = 'FlawedState.hasError';
+
+  static const List<StateDescriptor> $state = const [
+    _$prop__hasError___$FlawedState
+  ];
+  static const List<String> $stateKeys = const [_$key__hasError___$FlawedState];
+}
+
+const StateMeta _$metaForFlawedState = const StateMeta(
+  fields: _$FlawedStateAccessorsMixin.$state,
+  keys: _$FlawedStateAccessorsMixin.$stateKeys,
+);
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$FlawedState extends _$FlawedState
+    with _$FlawedStateAccessorsMixin
+    implements FlawedState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FlawedState(Map backingMap) : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FlawedComponent extends FlawedComponent {
+  @override
+  _$$FlawedProps typedPropsFactory(Map backingMap) =>
+      new _$$FlawedProps(backingMap);
+
+  @override
+  _$$FlawedState typedStateFactory(Map backingMap) =>
+      new _$$FlawedState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FlawedProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFlawedProps
+  ];
+}

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -42,7 +42,7 @@ class _$BaseState extends BaseState {
   @override
   final int count2;
 
-  factory _$BaseState([void updates(BaseStateBuilder b)]) =>
+  factory _$BaseState([void Function(BaseStateBuilder) updates]) =>
       (new BaseStateBuilder()..update(updates)).build();
 
   _$BaseState._({this.count1, this.count2}) : super._() {
@@ -55,7 +55,7 @@ class _$BaseState extends BaseState {
   }
 
   @override
-  BaseState rebuild(void updates(BaseStateBuilder b)) =>
+  BaseState rebuild(void Function(BaseStateBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
@@ -114,7 +114,7 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
   }
 
   @override
-  void update(void updates(BaseStateBuilder b)) {
+  void update(void Function(BaseStateBuilder) updates) {
     if (updates != null) updates(this);
   }
 

--- a/test/over_react/dom/fixtures/dummy_composite_component.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.dart
@@ -53,6 +53,6 @@ class TestCompositeComponentComponent extends UiComponent<TestCompositeComponent
 
   @override
   render() {
-    return Dom.div()('oh hai');
+    return Dom.div()('oh hai', props.children);
   }
 }

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -16,12 +16,12 @@
 library react_wrappers_test;
 
 import 'dart:html';
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart';
 import 'package:react/react_client/react_interop.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:react/react_test_utils.dart' as react_test_utils;
@@ -350,7 +350,7 @@ main() {
         });
 
         test('a plain JS object', () {
-          expect(isValidElement(new EmptyObject()), isFalse);
+          expect(isValidElement(newObject()), isFalse);
         });
 
         test('a ReactElement', () {
@@ -987,7 +987,7 @@ main() {
         });
 
         test('an empty JS object', () {
-          expect(() => getProps(new EmptyObject()), throwsArgumentError);
+          expect(() => getProps(newObject()), throwsArgumentError);
         });
 
         test('a String', () {

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -991,7 +991,7 @@ main() {
         });
 
         test('a String', () {
-          expect(() => getProps('string'), throwsArgumentError);
+          expect(() => getProps('string'), throwsA(anything));
         });
 
         test('null', () {

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -1026,6 +1026,7 @@ main() {
             ]));
           });
 
+          // TODO: 3.0.0 this is failing on Dart 2 dart2js tests only.
           test('a JS composite component', () {
             var calls = [];
 
@@ -1047,6 +1048,7 @@ main() {
             ]));
           });
 
+          // TODO: 3.0.0 this is failing on Dart 2 dart2js tests only.
           test('a DOM component', () {
             var calls = [];
 

--- a/web/index.dart
+++ b/web/index.dart
@@ -9,20 +9,32 @@ void main() {
   setClientConfiguration();
 
   react_dom.render(
-    buttonExamplesDemo(), querySelector('$demoMountNodeSelectorPrefix--button'));
+    ErrorBoundary()(buttonExamplesDemo()), querySelector('$demoMountNodeSelectorPrefix--button'));
 
   react_dom.render(
-    listGroupBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--list-group'));
+    ErrorBoundary()(listGroupBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--list-group'));
 
   react_dom.render(
-    progressBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--progress'));
+    ErrorBoundary()(progressBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--progress'));
 
   react_dom.render(
-    tagBasicDemo(), querySelector('$demoMountNodeSelectorPrefix--tag'));
+    ErrorBoundary()(tagBasicDemo()), querySelector('$demoMountNodeSelectorPrefix--tag'));
 
   react_dom.render(
-    checkboxToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--checkbox-toggle'));
+    ErrorBoundary()(checkboxToggleButtonDemo()), querySelector('$demoMountNodeSelectorPrefix--checkbox-toggle'));
 
   react_dom.render(
-    radioToggleButtonDemo(), querySelector('$demoMountNodeSelectorPrefix--radio-toggle'));
+    ErrorBoundary()(radioToggleButtonDemo()), querySelector('$demoMountNodeSelectorPrefix--radio-toggle'));
+
+  react_dom.render(
+    (ErrorBoundary()
+      ..onComponentDidCatch = (error, info) {
+        print('Consumer props.onComponentDidCatch($error, $info)');
+      }
+    )(Faulty()()),
+    querySelector('$demoMountNodeSelectorPrefix--faulty-component'),
+  );
+
+  react_dom.render(
+    Faulty()(), querySelector('$demoMountNodeSelectorPrefix--faulty-component-without-error-boundary'));
 }

--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,18 @@
                     around with the component rendered below.</p>
                 <div class="component-demo__mount--radio-toggle"></div>
             </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws A Caught Error</h2>
+                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--faulty-component"></div>
+            </div>
+            <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws an Uncaught Error</h2>
+                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--faulty-component-without-error-boundary"></div>
+            </div>
         </div>
     </div>
 

--- a/web/src/demos.dart
+++ b/web/src/demos.dart
@@ -8,6 +8,8 @@ export 'demos/button/button-block.dart';
 export 'demos/button/button-active.dart';
 export 'demos/button/button-disabled.dart';
 
+export 'demos/faulty-component.dart';
+
 export 'demos/list-group/list-group-basic.dart';
 export 'demos/list-group/list-group-tags.dart';
 export 'demos/list-group/list-group-anchors-and-buttons.dart';

--- a/web/src/demos/faulty-component.dart
+++ b/web/src/demos/faulty-component.dart
@@ -1,0 +1,55 @@
+import 'package:over_react/over_react.dart';
+
+import '../demo_components.dart';
+
+part 'faulty-component.over_react.g.dart';
+
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FaultyProps> Faulty = _$Faulty;
+
+@Props()
+class _$FaultyProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FaultyProps extends _$FaultyProps with _$FaultyPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFaultyProps;
+}
+
+@State()
+class _$FaultyState extends UiState {
+  bool hasErrored;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FaultyState extends _$FaultyState with _$FaultyStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = _$metaForFaultyState;
+}
+
+@Component()
+class FaultyComponent extends UiStatefulComponent<FaultyProps, FaultyState> {
+  @override
+  Map getInitialState() => (newState()..hasErrored = false);
+
+  @override
+  void componentWillUpdate(_, Map nextState) {
+    final tNextState = typedStateFactory(nextState);
+    if (tNextState.hasErrored && !state.hasErrored) {
+      throw new Error();
+    }
+  }
+
+  @override
+  render() {
+    return (Dom.div()..className = 'btn-toolbar')(
+      (Button()..onClick = (_) {
+        setState(newState()..hasErrored = true);
+      })('Click me to throw an error'),
+    );
+  }
+}

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -1,0 +1,144 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'faulty-component.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FaultyComponentFactory = registerComponent(() => new _$FaultyComponent(),
+    builderFactory: Faulty,
+    componentClass: FaultyComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'Faulty');
+
+abstract class _$FaultyPropsAccessorsMixin implements _$FaultyProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForFaultyProps = const PropsMeta(
+  fields: _$FaultyPropsAccessorsMixin.$props,
+  keys: _$FaultyPropsAccessorsMixin.$propKeys,
+);
+
+_$$FaultyProps _$Faulty([Map backingProps]) => new _$$FaultyProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FaultyProps extends _$FaultyProps
+    with _$FaultyPropsAccessorsMixin
+    implements FaultyProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FaultyProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory => $FaultyComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FaultyProps.';
+}
+
+abstract class _$FaultyStateAccessorsMixin implements _$FaultyState {
+  @override
+  Map get state;
+
+  /// <!-- Generated from [_$FaultyState.hasErrored] -->
+  @override
+  bool get hasErrored =>
+      state[_$key__hasErrored___$FaultyState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$FaultyState.hasErrored] -->
+  @override
+  set hasErrored(bool value) => state[_$key__hasErrored___$FaultyState] = value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor _$prop__hasErrored___$FaultyState =
+      const StateDescriptor(_$key__hasErrored___$FaultyState);
+  static const String _$key__hasErrored___$FaultyState =
+      'FaultyState.hasErrored';
+
+  static const List<StateDescriptor> $state = const [
+    _$prop__hasErrored___$FaultyState
+  ];
+  static const List<String> $stateKeys = const [
+    _$key__hasErrored___$FaultyState
+  ];
+}
+
+const StateMeta _$metaForFaultyState = const StateMeta(
+  fields: _$FaultyStateAccessorsMixin.$state,
+  keys: _$FaultyStateAccessorsMixin.$stateKeys,
+);
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$FaultyState extends _$FaultyState
+    with _$FaultyStateAccessorsMixin
+    implements FaultyState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FaultyState(Map backingMap) : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FaultyComponent extends FaultyComponent {
+  @override
+  _$$FaultyProps typedPropsFactory(Map backingMap) =>
+      new _$$FaultyProps(backingMap);
+
+  @override
+  _$$FaultyState typedStateFactory(Map backingMap) =>
+      new _$$FaultyState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FaultyProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFaultyProps
+  ];
+}


### PR DESCRIPTION
__ReactJS 16.x Support__

- The underlying `react` dependency ([version 5.0.0-alpha](https://github.com/cleandart/react-dart/pull/214)) now provides ReactJS version 16 `.js` source files.
- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).

---

FYA @greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 