### PR TITLE
Make local builder private

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -8,7 +8,7 @@ builders:
 
   # Builder just for this package.
   _over_react_local_builder:
-    import: "package:over_react/builder.dart"
+    import: "lib/builder.dart"
     builder_factories: ["overReactBuilder"]
     build_extensions: {".dart" : [".over_react.g.dart"]}
     auto_apply: none

--- a/build.yaml
+++ b/build.yaml
@@ -7,7 +7,7 @@ builders:
     build_to: cache
 
   # Builder just for this package.
-  overReactLocalBuilder:
+  _over_react_local_builder:
     import: "package:over_react/builder.dart"
     builder_factories: ["overReactBuilder"]
     build_extensions: {".dart" : [".over_react.g.dart"]}
@@ -17,7 +17,7 @@ builders:
 targets:
   $default:
     builders:
-      over_react|overReactLocalBuilder:
+      over_react|_over_react_local_builder:
         enabled: true
         generate_for:
           exclude:


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Over_react specifies a builder which should only be applied to this package, since it generates to source, allowing this package to be published to the public pub repository. While this builder doesn't auto-apply to any dependents, it does still appear in the build script for these dependents. This comes with two negatives:
1) Consumers could inadvertently enable the source builder
2) It adds noise to the consumer's `build.dart` files

## Changes
  <!-- What this PR changes to fix the problem. -->
The build config actually supports private builder keys, so we should make this private. Nowhere within Workiva is using this builder (as expected).

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
