### PR TITLE
CPLAT-7557 Update Component References to Component2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@
 
 ---
 
-> **Dart 2 Migration Guide**
->
-> If you have existing over_react code written on Dart 1 and want to upgrade to
-> Dart 2, please read the [**Dart 2 Migration Guide**](https://github.com/Workiva/over_react/blob/master/doc/dart2_migration.md)
-
----
-
-
 * __[Using it in your project](#using-it-in-your-project)__
     * [Running tests in your project](#running-tests-in-your-project)
 * __[Anatomy of an OverReact component](#anatomy-of-an-overreact-component)__
@@ -110,7 +102,7 @@ properly. Unfortunately, this is a known limitation in the analysis server at th
 When running tests on code that uses our [builder] _(or any code that imports `over_react`)_,
 __you must run your tests using build_runner__.
 >**Warning:** Do **_not_** run tests via `pub run build_runner test` in a package while another instance of `build_runner`
-(e.g. `pub run build_runner serve`)is running in that same package. [This workflow is unsupported by build_runner](https://github.com/dart-lang/build/issues/352#issuecomment-461554316)
+(e.g. `pub run build_runner serve`) is running in that same package. [This workflow is unsupported by build_runner](https://github.com/dart-lang/build/issues/352#issuecomment-461554316)
 
 1. Run tests through build_runner, and specify the platform to be a browser platform. Example:
 
@@ -200,8 +192,8 @@ class _$FooProps extends UiProps {
   String color;
 }
 
-@Component()
-class FooComponent extends UiComponent<FooProps> {
+@Component2()
+class FooComponent extends UiComponent2<FooProps> {
   // ...
 }
 
@@ -238,8 +230,8 @@ class _$FooProps extends UiProps {
   String color;
 }
 
-@Component()
-class FooComponent extends UiComponent<FooProps> {
+@Component2()
+class FooComponent extends UiComponent2<FooProps> {
   ReactElement bar() {
     // Create a UiProps instance to serve as a builder
     FooProps builder = Foo();
@@ -292,12 +284,12 @@ use the generated version, `FooState`.
 
 ### UiComponent
 
-__`UiComponent` is a subclass of [`react.Component`][react.component]__, containing lifecycle methods
+__`UiComponent2` is a subclass of [`react.Component2`][react.component2]__, containing lifecycle methods
 and rendering logic for components.
 
 ```dart
-@Component()
-class FooComponent extends UiComponent<FooProps> {
+@Component2()
+class FooComponent extends UiComponent2<FooProps> {
   // ...
 }
 ```
@@ -311,27 +303,27 @@ prop forwarding and CSS class merging.
 
 #### Accessing and manipulating props / state within UiComponent
 
-* Within the `UiComponent` class, `props` and `state` are not just `Map`s.
+* Within the `UiComponent2` class, `props` and `state` are not just `Map`s.
 They are instances of `UiProps` and `UiState`, __which means you don’t need String keys to access them!__
 * `newProps()` and `newState()` are also exposed to conveniently create empty instances of `UiProps` and
 `UiState` as needed.
 * `typedPropsFactory()` and `typedStateFactory()` are also exposed to conveniently create typed `props` / `state` objects out of any provided backing map.
 
 ```dart
-@Component()
-class FooComponent extends UiStatefulComponent<FooProps, FooState> {
+@Component2()
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
   @override
-  getDefaultProps() => (newProps()
+  get defaultProps => (newProps()
     ..color = '#66cc00'
   );
 
   @override
-  getInitialState() => (newState()
+  get initialState => (newState()
     ..isActive = false
   );
 
   @override
-  componentWillUpdate(Map newProps, Map newState) {
+  componentWillUpdate(Map newProps, Map newState, [dynamic snapshot]) {
     var tNewState = typedStateFactory(newState);
     var tNewProps = typedPropsFactory(newProps);
 
@@ -685,7 +677,7 @@ that you get for free from OverReact, you're ready to start building your own cu
 
 ### Component Boilerplate Templates
 
-* #### [Dart 1 and Dart 2 Backwards Compatible VS Code and WebStorm/IntelliJ Snippets](https://github.com/Workiva/over_react/blob/master/snippets/README.md)
+* #### [VS Code and WebStorm/IntelliJ Snippets](https://github.com/Workiva/over_react/blob/master/snippets/README.md)
 
 * #### Component Boilerplate
 
@@ -702,10 +694,10 @@ that you get for free from OverReact, you're ready to start building your own cu
       Iterable<String> items;
     }
 
-    @Component()
-    class FooComponent extends UiComponent<FooProps> {
+    @Component2()
+    class FooComponent extends UiComponent2<FooProps> {
       @override
-      Map getDefaultProps() => (newProps()
+      get defaultProps => (newProps()
         // Cascade default props here
         ..isDisabled = false
         ..items = []
@@ -741,17 +733,17 @@ that you get for free from OverReact, you're ready to start building your own cu
       bool isShown;
     }
 
-    @Component()
-    class BarComponent extends UiStatefulComponent<BarProps, BarState> {
+    @Component2()
+    class BarComponent extends UiStatefulComponent2<BarProps, BarState> {
       @override
-      Map getDefaultProps() => (newProps()
+      get defaultProps => (newProps()
         // Cascade default props here
         ..isDisabled = false
         ..items = []
       );
 
       @override
-      Map getInitialState() => (newState()
+      get initialState => (newState()
         // Cascade initial state here
         ..isShown = true
       );
@@ -779,9 +771,10 @@ that you get for free from OverReact, you're ready to start building your own cu
       // `actions` and `store` are already defined for you!
     }
 
-    @Component()
-    class BazComponent extends FluxUiComponent<BazProps> {
-      getDefaultProps() => (newProps()
+    @Component2()
+    class BazComponent extends FluxUiComponent2<BazProps> {
+      @override
+      get defaultProps => (newProps()
         // Cascade default props here
       );
 
@@ -814,14 +807,15 @@ that you get for free from OverReact, you're ready to start building your own cu
       // State goes here, declared as fields.
     }
 
-    @Component()
-    class BazComponent extends FluxUiStatefulComponent<BazProps, BazState> {
-      getDefaultProps() => (newProps()
+    @Component2()
+    class BazComponent extends FluxUiStatefulComponent2<BazProps, BazState> {
+      @override
+      get defaultProps => (newProps()
         // Cascade default props here
       );
 
       @override
-      Map getInitialState() => (newState()
+      get initialState => (newState()
         // Cascade initial state here
       );
 
@@ -899,17 +893,17 @@ and document that value in a comment.
       bool isOpen;
     }
 
-    @Component()
+    @Component2()
     DropdownButtonComponent
-        extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
+        extends UiStatefulComponent2<DropdownButtonProps, DropdownButtonState> {
       @override
-      Map getDefaultProps() => (newProps()
+      get defaultProps => (newProps()
         ..isDisabled = false
         ..initiallyOpen = false
       );
 
       @override
-      Map getInitialState() => (newState()
+      get initialState => (newState()
         ..isOpen = props.initiallyOpen
       );
     }
@@ -928,9 +922,9 @@ and document that value in a comment.
       bool isOpen;
     }
 
-    @Component()
+    @Component2()
     DropdownButtonComponent
-        extends UiStatefulComponent<DropdownButtonProps, DropdownButtonState> {
+        extends UiStatefulComponent2<DropdownButtonProps, DropdownButtonState> {
       // Confusing stuff is gonna happen in here with
       // bool props that could be null.
     }

--- a/example/builder/abstract_inheritance.dart
+++ b/example/builder/abstract_inheritance.dart
@@ -12,10 +12,10 @@ abstract class _$SuperState extends UiState {
   String superState;
 }
 
-@AbstractComponent()
-abstract class SuperComponent<T extends SuperProps, V extends SuperState> extends UiStatefulComponent<T, V> {
+@AbstractComponent2()
+abstract class SuperComponent<T extends SuperProps, V extends SuperState> extends UiStatefulComponent2<T, V> {
   @override
-  Map getDefaultProps() => newProps()..id = 'super';
+  get defaultProps => newProps()..id = 'super';
 
   @override
   render() {
@@ -39,13 +39,13 @@ class _$SubState extends SuperState {
   String subState;
 }
 
-@Component()
+@Component2()
 class SubComponent extends SuperComponent<SubProps, SubState> {
   @override
-  Map getDefaultProps() => newProps()..id = 'sub';
+  get defaultProps => newProps()..id = 'sub';
 
   @override
-  Map getInitialState() {
+  get initialState {
     return newState()
       ..superState = '<the super state value>'
       ..subState = '<the sub state value>';

--- a/example/builder/abstract_inheritance.over_react.g.dart
+++ b/example/builder/abstract_inheritance.over_react.g.dart
@@ -9,12 +9,14 @@ part of 'abstract_inheritance.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $SubComponentFactory = registerComponent(() => new _$SubComponent(),
-    builderFactory: Sub,
-    componentClass: SubComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Sub');
+final $SubComponentFactory = registerComponent2(
+  () => new _$SubComponent(),
+  builderFactory: Sub,
+  componentClass: SubComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Sub',
+);
 
 abstract class _$SubPropsAccessorsMixin implements _$SubProps {
   @override
@@ -48,24 +50,25 @@ class SubProps extends _$SubProps with _$SubPropsAccessorsMixin {
   static const PropsMeta meta = _$metaForSubProps;
 }
 
-_$$SubProps _$Sub([Map backingProps]) => new _$$SubProps(backingProps);
+_$$SubProps _$Sub([Map backingProps]) => backingProps == null
+    ? new _$$SubProps$JsMap(new JsBackedMap())
+    : new _$$SubProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$SubProps extends _$SubProps
+abstract class _$$SubProps extends _$SubProps
     with _$SubPropsAccessorsMixin
     implements SubProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$SubProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$SubProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$SubProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$SubProps$JsMap(backingMap);
+    } else {
+      return new _$$SubProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -79,6 +82,39 @@ class _$$SubProps extends _$SubProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => 'SubProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$SubProps$PlainMap extends _$$SubProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SubProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$SubProps$JsMap extends _$$SubProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SubProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$SubStateAccessorsMixin implements _$SubState {
@@ -116,12 +152,31 @@ class SubState extends _$SubState with _$SubStateAccessorsMixin {
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$SubState extends _$SubState
+abstract class _$$SubState extends _$SubState
     with _$SubStateAccessorsMixin
     implements SubState {
+  _$$SubState._();
+
+  factory _$$SubState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$SubState$JsMap(backingMap);
+    } else {
+      return new _$$SubState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$SubState$PlainMap extends _$$SubState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$SubState(Map backingMap) : this._state = {} {
+  _$$SubState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -129,10 +184,23 @@ class _$$SubState extends _$SubState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$SubState$JsMap extends _$$SubState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SubState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -140,8 +208,48 @@ class _$$SubState extends _$SubState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$SubComponent extends SubComponent {
+  _$$SubProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$SubProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$SubProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$SubProps$JsMap(backingMap);
+
   @override
   _$$SubProps typedPropsFactory(Map backingMap) => new _$$SubProps(backingMap);
+
+  _$$SubState$JsMap _cachedTypedState;
+  @override
+  _$$SubState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$SubState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$SubState$JsMap(backingMap);
 
   @override
   _$$SubState typedStateFactory(Map backingMap) => new _$$SubState(backingMap);

--- a/example/builder/basic.dart
+++ b/example/builder/basic.dart
@@ -18,10 +18,10 @@ class _$BasicProps extends UiProps {
   String basic5;
 }
 
-@Component()
-class BasicComponent extends UiComponent<BasicProps> {
+@Component2()
+class BasicComponent extends UiComponent2<BasicProps> {
   @override
-  Map getDefaultProps() => newProps()..id = 'basic component'
+  get defaultProps => newProps()..id = 'basic component'
       ..basicProp = 'defaultBasicProps'; // ignore: deprecated_member_use
 
 

--- a/example/builder/basic.over_react.g.dart
+++ b/example/builder/basic.over_react.g.dart
@@ -9,12 +9,14 @@ part of 'basic.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent(() => new _$BasicComponent(),
-    builderFactory: Basic,
-    componentClass: BasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Basic');
+final $BasicComponentFactory = registerComponent2(
+  () => new _$BasicComponent(),
+  builderFactory: Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
 
 abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
@@ -124,24 +126,25 @@ class BasicProps extends _$BasicProps with _$BasicPropsAccessorsMixin {
   static const PropsMeta meta = _$metaForBasicProps;
 }
 
-_$$BasicProps _$Basic([Map backingProps]) => new _$$BasicProps(backingProps);
+_$$BasicProps _$Basic([Map backingProps]) => backingProps == null
+    ? new _$$BasicProps$JsMap(new JsBackedMap())
+    : new _$$BasicProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$BasicProps extends _$BasicProps
+abstract class _$$BasicProps extends _$BasicProps
     with _$BasicPropsAccessorsMixin
     implements BasicProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$BasicProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$BasicProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicProps$JsMap(backingMap);
+    } else {
+      return new _$$BasicProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -157,11 +160,66 @@ class _$$BasicProps extends _$BasicProps
   String get propKeyNamespace => 'BasicProps.';
 }
 
+// Concrete props implementation that can be backed by any [Map].
+class _$$BasicProps$PlainMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicProps$JsMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
 // Concrete component implementation mixin.
 //
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$BasicComponent extends BasicComponent {
+  _$$BasicProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$BasicProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$BasicProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicProps$JsMap(backingMap);
+
   @override
   _$$BasicProps typedPropsFactory(Map backingMap) =>
       new _$$BasicProps(backingMap);

--- a/example/builder/basic_library.over_react.g.dart
+++ b/example/builder/basic_library.over_react.g.dart
@@ -9,13 +9,14 @@ part of 'basic_library.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicPartOfLibComponentFactory = registerComponent(
-    () => new _$BasicPartOfLibComponent(),
-    builderFactory: BasicPartOfLib,
-    componentClass: BasicPartOfLibComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'BasicPartOfLib');
+final $BasicPartOfLibComponentFactory = registerComponent2(
+  () => new _$BasicPartOfLibComponent(),
+  builderFactory: BasicPartOfLib,
+  componentClass: BasicPartOfLibComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'BasicPartOfLib',
+);
 
 abstract class _$BasicPartOfLibPropsAccessorsMixin
     implements _$BasicPartOfLibProps {
@@ -136,24 +137,25 @@ class BasicPartOfLibProps extends _$BasicPartOfLibProps
 }
 
 _$$BasicPartOfLibProps _$BasicPartOfLib([Map backingProps]) =>
-    new _$$BasicPartOfLibProps(backingProps);
+    backingProps == null
+        ? new _$$BasicPartOfLibProps$JsMap(new JsBackedMap())
+        : new _$$BasicPartOfLibProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
+abstract class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
     with _$BasicPartOfLibPropsAccessorsMixin
     implements BasicPartOfLibProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicPartOfLibProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$BasicPartOfLibProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$BasicPartOfLibProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicPartOfLibProps$JsMap(backingMap);
+    } else {
+      return new _$$BasicPartOfLibProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -167,6 +169,39 @@ class _$$BasicPartOfLibProps extends _$BasicPartOfLibProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => 'BasicPartOfLibProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$BasicPartOfLibProps$PlainMap extends _$$BasicPartOfLibProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicPartOfLibProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicPartOfLibProps$JsMap extends _$$BasicPartOfLibProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicPartOfLibProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$BasicPartOfLibStateAccessorsMixin
@@ -210,12 +245,31 @@ class BasicPartOfLibState extends _$BasicPartOfLibState
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$BasicPartOfLibState extends _$BasicPartOfLibState
+abstract class _$$BasicPartOfLibState extends _$BasicPartOfLibState
     with _$BasicPartOfLibStateAccessorsMixin
     implements BasicPartOfLibState {
+  _$$BasicPartOfLibState._();
+
+  factory _$$BasicPartOfLibState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicPartOfLibState$JsMap(backingMap);
+    } else {
+      return new _$$BasicPartOfLibState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$BasicPartOfLibState$PlainMap extends _$$BasicPartOfLibState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicPartOfLibState(Map backingMap) : this._state = {} {
+  _$$BasicPartOfLibState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -223,10 +277,23 @@ class _$$BasicPartOfLibState extends _$BasicPartOfLibState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicPartOfLibState$JsMap extends _$$BasicPartOfLibState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicPartOfLibState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -234,9 +301,49 @@ class _$$BasicPartOfLibState extends _$BasicPartOfLibState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
+  _$$BasicPartOfLibProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$BasicPartOfLibProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$BasicPartOfLibProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicPartOfLibProps$JsMap(backingMap);
+
   @override
   _$$BasicPartOfLibProps typedPropsFactory(Map backingMap) =>
       new _$$BasicPartOfLibProps(backingMap);
+
+  _$$BasicPartOfLibState$JsMap _cachedTypedState;
+  @override
+  _$$BasicPartOfLibState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$BasicPartOfLibState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicPartOfLibState$JsMap(backingMap);
 
   @override
   _$$BasicPartOfLibState typedStateFactory(Map backingMap) =>

--- a/example/builder/basic_with_state.dart
+++ b/example/builder/basic_with_state.dart
@@ -22,14 +22,14 @@ class _$BasicState extends UiState with ExampleStateMixinClass {
   String basicState;
 }
 
-@Component()
-class BasicComponent extends UiStatefulComponent<BasicProps, BasicState> {
+@Component2()
+class BasicComponent extends UiStatefulComponent2<BasicProps, BasicState> {
   @override
-  Map getDefaultProps() => newProps()..id = 'basic component'
+  get defaultProps => newProps()..id = 'basic component'
       ..basicProp = 'defaultBasicProps';
 
   @override
-  Map getInitialState() => newState()..basicState = '<basic state>'
+  get initialState => newState()..basicState = '<basic state>'
       ..stateMixin1 = '<state mixin>';
 
   @override

--- a/example/builder/basic_with_state.over_react.g.dart
+++ b/example/builder/basic_with_state.over_react.g.dart
@@ -9,12 +9,14 @@ part of 'basic_with_state.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent(() => new _$BasicComponent(),
-    builderFactory: Basic,
-    componentClass: BasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Basic');
+final $BasicComponentFactory = registerComponent2(
+  () => new _$BasicComponent(),
+  builderFactory: Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
 
 abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
@@ -120,24 +122,25 @@ class BasicProps extends _$BasicProps with _$BasicPropsAccessorsMixin {
   static const PropsMeta meta = _$metaForBasicProps;
 }
 
-_$$BasicProps _$Basic([Map backingProps]) => new _$$BasicProps(backingProps);
+_$$BasicProps _$Basic([Map backingProps]) => backingProps == null
+    ? new _$$BasicProps$JsMap(new JsBackedMap())
+    : new _$$BasicProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$BasicProps extends _$BasicProps
+abstract class _$$BasicProps extends _$BasicProps
     with _$BasicPropsAccessorsMixin
     implements BasicProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$BasicProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$BasicProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicProps$JsMap(backingMap);
+    } else {
+      return new _$$BasicProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -151,6 +154,39 @@ class _$$BasicProps extends _$BasicProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => 'BasicProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$BasicProps$PlainMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicProps$JsMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$BasicStateAccessorsMixin implements _$BasicState {
@@ -191,12 +227,31 @@ class BasicState extends _$BasicState with _$BasicStateAccessorsMixin {
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$BasicState extends _$BasicState
+abstract class _$$BasicState extends _$BasicState
     with _$BasicStateAccessorsMixin
     implements BasicState {
+  _$$BasicState._();
+
+  factory _$$BasicState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicState$JsMap(backingMap);
+    } else {
+      return new _$$BasicState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$BasicState$PlainMap extends _$$BasicState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicState(Map backingMap) : this._state = {} {
+  _$$BasicState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -204,10 +259,23 @@ class _$$BasicState extends _$BasicState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicState$JsMap extends _$$BasicState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -215,9 +283,49 @@ class _$$BasicState extends _$BasicState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$BasicComponent extends BasicComponent {
+  _$$BasicProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$BasicProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$BasicProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicProps$JsMap(backingMap);
+
   @override
   _$$BasicProps typedPropsFactory(Map backingMap) =>
       new _$$BasicProps(backingMap);
+
+  _$$BasicState$JsMap _cachedTypedState;
+  @override
+  _$$BasicState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$BasicState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicState$JsMap(backingMap);
 
   @override
   _$$BasicState typedStateFactory(Map backingMap) =>

--- a/example/builder/basic_with_type_params.dart
+++ b/example/builder/basic_with_type_params.dart
@@ -11,10 +11,10 @@ class _$BasicProps<T, U extends UiProps> extends UiProps {
   U somePropsClass;
 }
 
-@Component()
-class BasicComponent extends UiComponent<BasicProps> {
+@Component2()
+class BasicComponent extends UiComponent2<BasicProps> {
   @override
-  Map getDefaultProps() => newProps()..id = 'basic component';
+  get defaultProps => newProps()..id = 'basic component';
 
   @override
   render() {

--- a/example/builder/basic_with_type_params.over_react.g.dart
+++ b/example/builder/basic_with_type_params.over_react.g.dart
@@ -9,12 +9,14 @@ part of 'basic_with_type_params.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent(() => new _$BasicComponent(),
-    builderFactory: Basic,
-    componentClass: BasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Basic');
+final $BasicComponentFactory = registerComponent2(
+  () => new _$BasicComponent(),
+  builderFactory: Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
 
 abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
     implements _$BasicProps<T, U> {
@@ -70,24 +72,25 @@ class BasicProps<T, U extends UiProps> extends _$BasicProps<T, U>
   static const PropsMeta meta = _$metaForBasicProps;
 }
 
-_$$BasicProps _$Basic([Map backingProps]) => new _$$BasicProps(backingProps);
+_$$BasicProps _$Basic([Map backingProps]) => backingProps == null
+    ? new _$$BasicProps$JsMap(new JsBackedMap())
+    : new _$$BasicProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$BasicProps<T, U extends UiProps> extends _$BasicProps<T, U>
+abstract class _$$BasicProps<T, U extends UiProps> extends _$BasicProps<T, U>
     with _$BasicPropsAccessorsMixin<T, U>
     implements BasicProps<T, U> {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$BasicProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$BasicProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$BasicProps$JsMap(backingMap);
+    } else {
+      return new _$$BasicProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -103,11 +106,66 @@ class _$$BasicProps<T, U extends UiProps> extends _$BasicProps<T, U>
   String get propKeyNamespace => 'BasicProps.';
 }
 
+// Concrete props implementation that can be backed by any [Map].
+class _$$BasicProps$PlainMap<T, U extends UiProps> extends _$$BasicProps<T, U> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicProps$JsMap<T, U extends UiProps> extends _$$BasicProps<T, U> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
 // Concrete component implementation mixin.
 //
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$BasicComponent extends BasicComponent {
+  _$$BasicProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$BasicProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$BasicProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$BasicProps$JsMap(backingMap);
+
   @override
   _$$BasicProps typedPropsFactory(Map backingMap) =>
       new _$$BasicProps(backingMap);

--- a/example/builder/generic_inheritance_sub.dart
+++ b/example/builder/generic_inheritance_sub.dart
@@ -16,13 +16,13 @@ class _$GenericSubState extends GenericSuperState {
   String subState;
 }
 
-@Component()
+@Component2()
 class GenericSubComponent extends GenericSuperComponent<GenericSubProps, GenericSubState> {
   @override
-  Map getDefaultProps() => newProps()..id = 'generic_sub';
+  get defaultProps => newProps()..id = 'generic_sub';
 
   @override
-  Map getInitialState() => newState()
+  get initialState => newState()
     ..subState = '<generic sub state>'
     ..superState = '<generic super state>';
 

--- a/example/builder/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/generic_inheritance_sub.over_react.g.dart
@@ -9,13 +9,14 @@ part of 'generic_inheritance_sub.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $GenericSubComponentFactory = registerComponent(
-    () => new _$GenericSubComponent(),
-    builderFactory: GenericSub,
-    componentClass: GenericSubComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'GenericSub');
+final $GenericSubComponentFactory = registerComponent2(
+  () => new _$GenericSubComponent(),
+  builderFactory: GenericSub,
+  componentClass: GenericSubComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'GenericSub',
+);
 
 abstract class _$GenericSubPropsAccessorsMixin implements _$GenericSubProps {
   @override
@@ -53,25 +54,25 @@ class GenericSubProps extends _$GenericSubProps
   static const PropsMeta meta = _$metaForGenericSubProps;
 }
 
-_$$GenericSubProps _$GenericSub([Map backingProps]) =>
-    new _$$GenericSubProps(backingProps);
+_$$GenericSubProps _$GenericSub([Map backingProps]) => backingProps == null
+    ? new _$$GenericSubProps$JsMap(new JsBackedMap())
+    : new _$$GenericSubProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$GenericSubProps extends _$GenericSubProps
+abstract class _$$GenericSubProps extends _$GenericSubProps
     with _$GenericSubPropsAccessorsMixin
     implements GenericSubProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$GenericSubProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$GenericSubProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$GenericSubProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$GenericSubProps$JsMap(backingMap);
+    } else {
+      return new _$$GenericSubProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -85,6 +86,39 @@ class _$$GenericSubProps extends _$GenericSubProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => 'GenericSubProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$GenericSubProps$PlainMap extends _$$GenericSubProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSubProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$GenericSubProps$JsMap extends _$$GenericSubProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSubProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$GenericSubStateAccessorsMixin implements _$GenericSubState {
@@ -127,12 +161,31 @@ class GenericSubState extends _$GenericSubState
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$GenericSubState extends _$GenericSubState
+abstract class _$$GenericSubState extends _$GenericSubState
     with _$GenericSubStateAccessorsMixin
     implements GenericSubState {
+  _$$GenericSubState._();
+
+  factory _$$GenericSubState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$GenericSubState$JsMap(backingMap);
+    } else {
+      return new _$$GenericSubState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$GenericSubState$PlainMap extends _$$GenericSubState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$GenericSubState(Map backingMap) : this._state = {} {
+  _$$GenericSubState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -140,10 +193,23 @@ class _$$GenericSubState extends _$GenericSubState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$GenericSubState$JsMap extends _$$GenericSubState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSubState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -151,9 +217,49 @@ class _$$GenericSubState extends _$GenericSubState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$GenericSubComponent extends GenericSubComponent {
+  _$$GenericSubProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$GenericSubProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$GenericSubProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$GenericSubProps$JsMap(backingMap);
+
   @override
   _$$GenericSubProps typedPropsFactory(Map backingMap) =>
       new _$$GenericSubProps(backingMap);
+
+  _$$GenericSubState$JsMap _cachedTypedState;
+  @override
+  _$$GenericSubState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$GenericSubState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$GenericSubState$JsMap(backingMap);
 
   @override
   _$$GenericSubState typedStateFactory(Map backingMap) =>

--- a/example/builder/generic_inheritance_super.dart
+++ b/example/builder/generic_inheritance_super.dart
@@ -19,13 +19,13 @@ class _$GenericSuperState extends UiState {
 }
 
 
-@Component()
-class GenericSuperComponent<T extends GenericSuperProps, V extends GenericSuperState> extends UiStatefulComponent<T, V> {
+@Component2()
+class GenericSuperComponent<T extends GenericSuperProps, V extends GenericSuperState> extends UiStatefulComponent2<T, V> {
   @override
-  Map getDefaultProps() => newProps()..id = 'generic_super';
+  get defaultProps => newProps()..id = 'generic_super';
 
   @override
-  Map getInitialState() => newState()..superState = '<generic super state>';
+  get initialState => newState()..superState = '<generic super state>';
 
   @override
   render() {

--- a/example/builder/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/generic_inheritance_super.over_react.g.dart
@@ -9,13 +9,14 @@ part of 'generic_inheritance_super.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $GenericSuperComponentFactory = registerComponent(
-    () => new _$GenericSuperComponent(),
-    builderFactory: GenericSuper,
-    componentClass: GenericSuperComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'GenericSuper');
+final $GenericSuperComponentFactory = registerComponent2(
+  () => new _$GenericSuperComponent(),
+  builderFactory: GenericSuper,
+  componentClass: GenericSuperComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'GenericSuper',
+);
 
 abstract class _$GenericSuperPropsAccessorsMixin
     implements _$GenericSuperProps {
@@ -87,25 +88,25 @@ class GenericSuperProps extends _$GenericSuperProps
   static const PropsMeta meta = _$metaForGenericSuperProps;
 }
 
-_$$GenericSuperProps _$GenericSuper([Map backingProps]) =>
-    new _$$GenericSuperProps(backingProps);
+_$$GenericSuperProps _$GenericSuper([Map backingProps]) => backingProps == null
+    ? new _$$GenericSuperProps$JsMap(new JsBackedMap())
+    : new _$$GenericSuperProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$GenericSuperProps extends _$GenericSuperProps
+abstract class _$$GenericSuperProps extends _$GenericSuperProps
     with _$GenericSuperPropsAccessorsMixin
     implements GenericSuperProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$GenericSuperProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$GenericSuperProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$GenericSuperProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$GenericSuperProps$JsMap(backingMap);
+    } else {
+      return new _$$GenericSuperProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -119,6 +120,39 @@ class _$$GenericSuperProps extends _$GenericSuperProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => 'GenericSuperProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$GenericSuperProps$PlainMap extends _$$GenericSuperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSuperProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$GenericSuperProps$JsMap extends _$$GenericSuperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSuperProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$GenericSuperStateAccessorsMixin
@@ -162,12 +196,31 @@ class GenericSuperState extends _$GenericSuperState
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$GenericSuperState extends _$GenericSuperState
+abstract class _$$GenericSuperState extends _$GenericSuperState
     with _$GenericSuperStateAccessorsMixin
     implements GenericSuperState {
+  _$$GenericSuperState._();
+
+  factory _$$GenericSuperState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$GenericSuperState$JsMap(backingMap);
+    } else {
+      return new _$$GenericSuperState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$GenericSuperState$PlainMap extends _$$GenericSuperState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$GenericSuperState(Map backingMap) : this._state = {} {
+  _$$GenericSuperState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -175,10 +228,23 @@ class _$$GenericSuperState extends _$GenericSuperState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$GenericSuperState$JsMap extends _$$GenericSuperState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$GenericSuperState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -186,9 +252,49 @@ class _$$GenericSuperState extends _$GenericSuperState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$GenericSuperComponent extends GenericSuperComponent {
+  _$$GenericSuperProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$GenericSuperProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$GenericSuperProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$GenericSuperProps$JsMap(backingMap);
+
   @override
   _$$GenericSuperProps typedPropsFactory(Map backingMap) =>
       new _$$GenericSuperProps(backingMap);
+
+  _$$GenericSuperState$JsMap _cachedTypedState;
+  @override
+  _$$GenericSuperState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$GenericSuperState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$GenericSuperState$JsMap(backingMap);
 
   @override
   _$$GenericSuperState typedStateFactory(Map backingMap) =>

--- a/example/builder/part_of_basic_library.dart
+++ b/example/builder/part_of_basic_library.dart
@@ -20,13 +20,13 @@ class _$BasicPartOfLibState extends UiState
   String basicState;
 }
 
-@Component()
-class BasicPartOfLibComponent extends UiStatefulComponent<BasicPartOfLibProps, BasicPartOfLibState> {
+@Component2()
+class BasicPartOfLibComponent extends UiStatefulComponent2<BasicPartOfLibProps, BasicPartOfLibState> {
   @override
-  Map getDefaultProps() => newProps()..id = 'BasicPartOfLib';
+  get defaultProps => newProps()..id = 'BasicPartOfLib';
 
   @override
-  Map getInitialState() => newState()..basicState = '<Basic state>'
+  get initialState => newState()..basicState = '<Basic state>'
       ..stateMixin1 = '<state mixin>';
 
   @override

--- a/example/builder/private_component.dart
+++ b/example/builder/private_component.dart
@@ -15,13 +15,13 @@ class _$_PrivateState extends UiState {
   bool state1;
 }
 
-@Component()
-class PrivateComponent extends UiStatefulComponent<_PrivateProps, _PrivateState> {
+@Component2()
+class PrivateComponent extends UiStatefulComponent2<_PrivateProps, _PrivateState> {
   @override
-  Map getDefaultProps() => newProps()..prop1 = true;
+  get defaultProps => newProps()..prop1 = true;
 
   @override
-  Map getInitialState() => newState()..state1 = true;
+  get initialState => newState()..state1 = true;
 
   @override
   render() {

--- a/example/builder/private_component.over_react.g.dart
+++ b/example/builder/private_component.over_react.g.dart
@@ -9,13 +9,14 @@ part of 'private_component.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $PrivateComponentFactory = registerComponent(
-    () => new _$PrivateComponent(),
-    builderFactory: _Private,
-    componentClass: PrivateComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: '_Private');
+final $PrivateComponentFactory = registerComponent2(
+  () => new _$PrivateComponent(),
+  builderFactory: _Private,
+  componentClass: PrivateComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: '_Private',
+);
 
 abstract class _$_PrivatePropsAccessorsMixin implements _$_PrivateProps {
   @override
@@ -49,25 +50,25 @@ class _PrivateProps extends _$_PrivateProps with _$_PrivatePropsAccessorsMixin {
   static const PropsMeta meta = _$metaFor_PrivateProps;
 }
 
-_$$_PrivateProps _$_Private([Map backingProps]) =>
-    new _$$_PrivateProps(backingProps);
+_$$_PrivateProps _$_Private([Map backingProps]) => backingProps == null
+    ? new _$$_PrivateProps$JsMap(new JsBackedMap())
+    : new _$$_PrivateProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$_PrivateProps extends _$_PrivateProps
+abstract class _$$_PrivateProps extends _$_PrivateProps
     with _$_PrivatePropsAccessorsMixin
     implements _PrivateProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$_PrivateProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$_PrivateProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$_PrivateProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$_PrivateProps$JsMap(backingMap);
+    } else {
+      return new _$$_PrivateProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -81,6 +82,39 @@ class _$$_PrivateProps extends _$_PrivateProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '_PrivateProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$_PrivateProps$PlainMap extends _$$_PrivateProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$_PrivateProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$_PrivateProps$JsMap extends _$$_PrivateProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$_PrivateProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }
 
 abstract class _$_PrivateStateAccessorsMixin implements _$_PrivateState {
@@ -118,12 +152,31 @@ class _PrivateState extends _$_PrivateState with _$_PrivateStateAccessorsMixin {
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-class _$$_PrivateState extends _$_PrivateState
+abstract class _$$_PrivateState extends _$_PrivateState
     with _$_PrivateStateAccessorsMixin
     implements _PrivateState {
+  _$$_PrivateState._();
+
+  factory _$$_PrivateState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$_PrivateState$JsMap(backingMap);
+    } else {
+      return new _$$_PrivateState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$_PrivateState$PlainMap extends _$$_PrivateState {
   // This initializer of `_state` to an empty map, as well as the reassignment
   // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$_PrivateState(Map backingMap) : this._state = {} {
+  _$$_PrivateState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
     this._state = backingMap ?? {};
   }
 
@@ -131,10 +184,23 @@ class _$$_PrivateState extends _$_PrivateState
   @override
   Map get state => _state;
   Map _state;
+}
 
-  /// Let [UiState] internals know that this class has been generated.
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$_PrivateState$JsMap extends _$$_PrivateState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$_PrivateState$JsMap(JsBackedMap backingMap)
+      : this._state = new JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
   @override
-  bool get $isClassGenerated => true;
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
 }
 
 // Concrete component implementation mixin.
@@ -142,9 +208,49 @@ class _$$_PrivateState extends _$_PrivateState
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$PrivateComponent extends PrivateComponent {
+  _$$_PrivateProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$_PrivateProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$_PrivateProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$_PrivateProps$JsMap(backingMap);
+
   @override
   _$$_PrivateProps typedPropsFactory(Map backingMap) =>
       new _$$_PrivateProps(backingMap);
+
+  _$$_PrivateState$JsMap _cachedTypedState;
+  @override
+  _$$_PrivateState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initializeState (within the init lifecycle method) or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$_PrivateState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      new _$$_PrivateState$JsMap(backingMap);
 
   @override
   _$$_PrivateState typedStateFactory(Map backingMap) =>

--- a/example/builder/private_factory_public_component.dart
+++ b/example/builder/private_factory_public_component.dart
@@ -17,8 +17,8 @@ class _$FormActionInputProps extends UiProps {
   String prop1;
 }
 
-@Component()
-class FormActionInputComponent extends UiComponent<FormActionInputProps> {
+@Component2()
+class FormActionInputComponent extends UiComponent2<FormActionInputProps> {
   @override
   render() {
     return Dom.div()(props.children);

--- a/example/builder/private_factory_public_component.over_react.g.dart
+++ b/example/builder/private_factory_public_component.over_react.g.dart
@@ -9,13 +9,14 @@ part of 'private_factory_public_component.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $FormActionInputComponentFactory = registerComponent(
-    () => new _$FormActionInputComponent(),
-    builderFactory: _FormActionInput,
-    componentClass: FormActionInputComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: '_FormActionInput');
+final $FormActionInputComponentFactory = registerComponent2(
+  () => new _$FormActionInputComponent(),
+  builderFactory: _FormActionInput,
+  componentClass: FormActionInputComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: '_FormActionInput',
+);
 
 abstract class _$FormActionInputPropsAccessorsMixin
     implements _$FormActionInputProps {
@@ -56,24 +57,25 @@ class FormActionInputProps extends _$FormActionInputProps
 }
 
 _$$FormActionInputProps _$_FormActionInput([Map backingProps]) =>
-    new _$$FormActionInputProps(backingProps);
+    backingProps == null
+        ? new _$$FormActionInputProps$JsMap(new JsBackedMap())
+        : new _$$FormActionInputProps(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-class _$$FormActionInputProps extends _$FormActionInputProps
+abstract class _$$FormActionInputProps extends _$FormActionInputProps
     with _$FormActionInputPropsAccessorsMixin
     implements FormActionInputProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$FormActionInputProps(Map backingMap) : this._props = {} {
-    this._props = backingMap ?? {};
-  }
+  _$$FormActionInputProps._();
 
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
+  factory _$$FormActionInputProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return new _$$FormActionInputProps$JsMap(backingMap);
+    } else {
+      return new _$$FormActionInputProps$PlainMap(backingMap);
+    }
+  }
 
   /// Let [UiProps] internals know that this class has been generated.
   @override
@@ -89,11 +91,66 @@ class _$$FormActionInputProps extends _$FormActionInputProps
   String get propKeyNamespace => 'FormActionInputProps.';
 }
 
+// Concrete props implementation that can be backed by any [Map].
+class _$$FormActionInputProps$PlainMap extends _$$FormActionInputProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FormActionInputProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$FormActionInputProps$JsMap extends _$$FormActionInputProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FormActionInputProps$JsMap(JsBackedMap backingMap)
+      : this._props = new JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? new JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
 // Concrete component implementation mixin.
 //
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
 class _$FormActionInputComponent extends FormActionInputComponent {
+  _$$FormActionInputProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$FormActionInputProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$FormActionInputProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      new _$$FormActionInputProps$JsMap(backingMap);
+
   @override
   _$$FormActionInputProps typedPropsFactory(Map backingMap) =>
       new _$$FormActionInputProps(backingMap);

--- a/example/context/components/my_context_component.dart
+++ b/example/context/components/my_context_component.dart
@@ -15,7 +15,7 @@ class MyContextComponentComponent extends UiComponent2<MyContextComponentProps> 
   get contextType => someContext.reactDartContext;
 
   @override
-  Map getDefaultProps() => (newProps());
+  get defaultProps => (newProps());
 
   @override
   render() {

--- a/lib/src/builder/README.md
+++ b/lib/src/builder/README.md
@@ -39,8 +39,8 @@ own components by viewing the generated .over_react.g.dart file.
       // ...
     }
     
-    @Component()
-    class FooComponent extends UiComponent<FooProps> {
+    @Component2()
+    class FooComponent extends UiComponent2<FooProps> {
       @override
       render() { 
         // ...
@@ -48,7 +48,7 @@ own components by viewing the generated .over_react.g.dart file.
     }
     ```
 
-    Note that we've annotated our component pieces with `@Factory()`, `@Props()`, and `@Component()`. 
+    Note that we've annotated our component pieces with `@Factory()`, `@Props()`, and `@Component2()`. 
     These are what the builder uses as "hooks" to find your component.
 
     Okay, so we've defined our component. Let's look at what the builder does.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We updated over_react's web example and snippets to use `UiComponent2`, but not the README and other markdown files or the `example` dir.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Update the README to only have references to `UiComponent2` / `Component2`.
- Update the builder REDME to reference `UiComponent2`.
- Update all components in `example` to use `UiComponent2` (or it's equivalent, e.g. `UiStatefulComponent2`).
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @kealjones-wk @sydneyjodon-wk @greglittlefield-wf 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
