### PR TITLE
CPLAT-7606 Improve handling of “repeat” errors thrown from components wrapped by an ErrorBoundary

### DIFF
--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -111,27 +111,27 @@ class _$ErrorBoundaryProps extends UiProps {
   /// > Related: [onComponentIsUnrecoverable]
   _ComponentDidCatchCallback onComponentDidCatch;
 
-  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// An optional callback that will be called _(when [fallbackUIRenderer] is not set)_
   /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
   /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
   /// to lock the main thread.
   ///
-  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// The locking of the main thread is possible in this scenario because when [fallbackUIRenderer]
   /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
   /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
   /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
   ///
   /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
   /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
-  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  /// static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
   ///
   /// 1. Passing in a new child
   ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
-  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  /// 2. Calling [ErrorBoundaryComponent.reset].
   ///
-  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  /// > Will never be called when [fallbackUIRenderer] is set.
   ///
   /// > Related: [identicalErrorFrequencyTolerance]
   _ComponentDidCatchCallback onComponentIsUnrecoverable;
@@ -146,12 +146,12 @@ class _$ErrorBoundaryProps extends UiProps {
   /// within the tree wrapped by this [ErrorBoundary].
   ///
   /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
-  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
-  /// the specified duration, the [ErrorBoundary] will:
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] -- more often than
+  /// the specified duration -- the [ErrorBoundary] will:
   ///
   ///   1. Call [onComponentIsUnrecoverable].
   ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
-  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///   3. Render a static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// When this happens, recovery can only occur by passing in a new child to
   /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
@@ -172,8 +172,8 @@ class _$ErrorBoundaryState extends UiState {
   ///   the tree to attempt to automatically recover from the error.
   ///
   ///   If an identical error is thrown from an identical component within the tree consecutively
-  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
-  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a static copy of
+  ///   the render tree's HTML that was captured at the time of the error will be rendered.
   ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   bool hasError;
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,5 +1,6 @@
-import 'dart:html';
+import 'dart:async';
 import 'dart:js_util' as js_util;
+import 'dart:js_util';
 
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
@@ -69,11 +70,11 @@ final ReactElement Function([Map props, List children]) _jsErrorBoundaryComponen
   };
 })();
 
-// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef _ComponentDidCatchCallback(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
+// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "errorInfo".
+typedef _ComponentDidCatchCallback(/*Error||Exception*/dynamic error, /*ComponentStack*/dynamic errorInfo);
 
-// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "componentStack".
-typedef ReactElement _FallbackUiRenderer(/*Error*/dynamic error, /*ComponentStack*/dynamic componentStack);
+// TODO: Need to type the second argument once react-dart implements bindings for the ReactJS "errorInfo".
+typedef ReactElement _FallbackUiRenderer(/*Error||Exception*/dynamic error, /*ComponentStack*/dynamic errorInfo);
 
 /// A higher-order component that will catch ReactJS errors anywhere within the child component tree and
 /// display a fallback UI instead of the component tree that crashed.
@@ -90,53 +91,110 @@ UiFactory<ErrorBoundaryProps> ErrorBoundary = _$ErrorBoundary;
 
 @Props()
 class _$ErrorBoundaryProps extends UiProps {
-  /// An optional callback that will be called with an [Error] and a `ComponentStack`
-  /// containing information about which component in the tree threw the error when
-  /// the `componentDidCatch` lifecycle method is called.
+  /// An optional callback that will be called with an [Error] _(or [Exception])_
+  /// and `errorInfo` containing information about which component in the tree
+  /// threw when the `componentDidCatch` lifecycle method is called.
   ///
   /// This callback can be used to log component errors like so:
   ///
   ///     (ErrorBoundary()
-  ///       ..onComponentDidCatch = (error, componentStack) {
+  ///       ..onComponentDidCatch = (error, errorInfo) {
   ///         // It is up to you to implement the service / thing that calls the service.
-  ///         logComponentStackToAService(error, componentStack);
+  ///         logComponentStackToAService(error, errorInfo);
   ///       }
   ///     )(
   ///       // The rest of your component tree
   ///     )
   ///
   /// > See: <https://reactjs.org/docs/react-component.html#componentdidcatch>
+  ///
+  /// > Related: [onComponentIsUnrecoverable]
   _ComponentDidCatchCallback onComponentDidCatch;
+
+  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
+  /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
+  /// to lock the main thread.
+  ///
+  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
+  /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
+  /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
+  ///
+  /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
+  /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
+  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  ///
+  /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
+  ///
+  /// 1. Passing in a new child
+  ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
+  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  ///
+  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  ///
+  /// > Related: [identicalErrorFrequencyTolerance]
+  _ComponentDidCatchCallback onComponentIsUnrecoverable;
 
   /// A renderer that will be used to render "fallback" UI instead of the child
   /// component tree that crashed.
   ///
-  /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
+  /// > Related: [onComponentIsUnrecoverable], [onComponentDidCatch]
   _FallbackUiRenderer fallbackUIRenderer;
+
+  /// The amount of time that is "acceptable" between consecutive identical errors thrown from a component
+  /// within the tree wrapped by this [ErrorBoundary].
+  ///
+  /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
+  /// the specified duration, the [ErrorBoundary] will:
+  ///
+  ///   1. Call [onComponentIsUnrecoverable].
+  ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
+  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///
+  /// When this happens, recovery can only occur by passing in a new child to
+  /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
+  ///
+  /// __DO NOT MODIFY THIS VALUE UNLESS YOU KNOW WHAT YOU ARE DOING.__
+  ///
+  /// > Default: `const Duration(seconds: 5)`
+  Duration identicalErrorFrequencyTolerance;
 }
 
 @State()
 class _$ErrorBoundaryState extends UiState {
-  /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
+  /// Whether a component within the tree that the [ErrorBoundary] is wrapping around threw an error.
   ///
-  /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is set, the return value of that callback
+  ///   will be rendered instead.
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is not set, the [ErrorBoundary] will re-mount
+  ///   the tree to attempt to automatically recover from the error.
+  ///
+  ///   If an identical error is thrown from an identical component within the tree consecutively
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
+  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   bool hasError;
+
+  /// Whether to show "fallback" UI when [hasError] is true.
+  ///
+  /// This value will always be true if [ErrorBoundaryProps.fallbackUIRenderer] is non-null.
+  bool showFallbackUIOnError;
 }
 
 @Component(isWrapper: true)
 class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBoundaryState>
     extends UiStatefulComponent<T, S> {
-  Error _error;
-  /*ComponentStack*/dynamic _componentStack;
-
   @override
   Map getDefaultProps() => (newProps()
-    ..fallbackUIRenderer = _renderDefaultFallbackUI
+    ..identicalErrorFrequencyTolerance = Duration(seconds: 5)
   );
 
   @override
   Map getInitialState() => (newState()
     ..hasError = false
+    ..showFallbackUIOnError = props.fallbackUIRenderer != null
   );
 
   @mustCallSuper
@@ -147,12 +205,24 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
 
   @mustCallSuper
   /*@override*/
-  void componentDidCatch(Error error, /*ComponentStack*/dynamic componentStack) {
-    _error = error;
-    _componentStack = componentStack;
-
+  void componentDidCatch(/*Error||Exception*/dynamic error, /*NativeJavascriptObject*/dynamic jsErrorInfo) {
     if (props.onComponentDidCatch != null) {
-      props.onComponentDidCatch(error, componentStack);
+      props.onComponentDidCatch(error, _getReadableErrorInfo(jsErrorInfo));
+    }
+
+    _handleErrorInComponentTree(error, jsErrorInfo);
+  }
+
+  @mustCallSuper
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState) {
+    // If the child is different, and the error boundary is currently in an error state,
+    // give the child a chance to remount itself and "recover" from the previous error.
+    if (state.hasError) {
+      final childThatCausedError = typedPropsFactory(prevProps).children.single;
+      if (childThatCausedError != props.children.single) {
+        reset();
+      }
     }
   }
 
@@ -160,16 +230,13 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   render() {
     // TODO: 3.1.0 - Remove the `_jsErrorBoundaryComponentFactory`, and restore just the children of it once this component is extending from `UiStatefulComponent2`.
     return _jsErrorBoundaryComponentFactory({
-      'onComponentDidCatch': props.onComponentDidCatch
+      'onComponentDidCatch': componentDidCatch,
     },
-      state.hasError
-          ? [props.fallbackUIRenderer(_error, _componentStack)]
+      state.hasError && state.showFallbackUIOnError
+          ? [(props.fallbackUIRenderer ?? _renderStringDomAfterUnrecoverableErrors)(_lastError, _lastErrorInfo)]
           : props.children
     );
   }
-
-  ReactElement _renderDefaultFallbackUI(_, __) =>
-      throw new UnimplementedError('Fallback UI will not be supported until support for ReactJS 16 lifecycle methods is released in version 3.1.0');
 
   @mustCallSuper
   @override
@@ -183,4 +250,136 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
       throw new PropError.value(children, 'children', 'ErrorBoundary accepts only a single ReactComponent child.');
     }
   }
+
+  /// Resets the [ErrorBoundary] to a non-error state.
+  ///
+  /// This can be called manually on the component instance using a `ref` -
+  /// or by passing in a new child instance after a child has thrown an error.
+  void reset() {
+    setState((newState()
+      ..hasError = false
+      ..showFallbackUIOnError = props.fallbackUIRenderer != null
+    ), _resetInternalErrorTracking);
+  }
+
+  // ---------------------------------------------- \/ ----------------------------------------------
+  // Wrapped Component Error Handling
+  //
+  // [1] If the consumer has defined a fallback UI, put the boundary into an error state and move on
+  //     since their fallbackUI renderer will take care of the visuals.
+  //
+  //     [1.1] Store the error on some instance fields so it can be
+  //           passed to the consumer's `fallbackUIRenderer` callback within `render`.
+  //
+  // [2] Otherwise, we can't currently make any assumptions about what the consumer would like to have
+  //     rendered as a fallback when a component throws - so we just remount the children
+  //     as a result of keeping `state.showFallbackUIOnError` set to false.
+  //
+  //     [2.1] However, as a way to handle the edge case where the exact same component wrapped by an
+  //           `ErrorBoundary` throws the exact same error more than once before the `_identicalErrorTimer`
+  //           "times out", we should not just keep remounting since the component
+  //           should - at that point - be considered "unrecoverable",
+  //           and the repeated errors will most likely lock up the main thread.
+  //
+  //     [2.2] So we'll set `state.showFallbackUIOnError` to true, which will cause our default fallback UI
+  //           to be rendered - which is simply a String snapshot of the DOM (`_domAtTimeOfError`).
+  //
+  //           [2.2.1] We will also fire `props.onComponentIsUnrecoverable` if set - to give the
+  //                   consumer the ability to have knowledge of the unrecoverable error state - and
+  //                   to optionally manually recover from the error by:
+  //
+  //                   1. Passing in a new child (see: componentDidUpdate)
+  //                   2. Calling the `reset()` instance method
+  //
+  //           [2.2.2] Since we should __never__ throw an error from our... uh... error boundary,
+  //                   wrap in a try catch just in case `findDomNode` throws as a result of the
+  //                   wrapped react tree rendering a string instead of a composite or dom component.
+  // ---------------------------------------------- /\ ----------------------------------------------
+
+  String _domAtTimeOfError;
+  /*Error||Exception*/dynamic _lastError;
+  String _lastErrorInfo;
+  Timer _identicalErrorTimer;
+
+  /// Called by [componentDidCatch].
+  void _handleErrorInComponentTree(/*Error||Exception*/dynamic error, /*NativeJavascriptObject*/dynamic jsErrorInfo) {
+    bool sameErrorWasThrownTwiceConsecutively =
+        error.toString() == _lastError?.toString() && _getReadableErrorInfo(jsErrorInfo) == _lastErrorInfo;
+
+    // ----- [1] ----- //
+    if (props.fallbackUIRenderer != null) {
+      _lastError = error; // [1.1]
+      _lastErrorInfo = _getReadableErrorInfo(jsErrorInfo); // [1.1]
+
+      setState(newState()..hasError = true); // [1]
+      return;
+    }
+    // ----- [2] ----- //
+    else {
+      if (sameErrorWasThrownTwiceConsecutively) { // [2.1]
+        try { // [2.2.2]
+          _domAtTimeOfError = findDomNode(this)?.innerHtml; // [2.2]
+        } catch (_) {}
+
+        if (props.onComponentIsUnrecoverable != null) { // [2.2.1]
+          props.onComponentIsUnrecoverable(error, _getReadableErrorInfo(jsErrorInfo));
+        }
+      } else {
+        _lastError = error;
+        _lastErrorInfo = _getReadableErrorInfo(jsErrorInfo);
+      }
+
+      setState(newState()
+        ..hasError = true
+        ..showFallbackUIOnError = sameErrorWasThrownTwiceConsecutively // [2.2]
+      );
+
+      _startIdenticalErrorTimer();
+    }
+  }
+
+  // [2.2]
+  ReactElement _renderStringDomAfterUnrecoverableErrors(_, __) {
+    return (Dom.div()
+      ..key = 'ohnoes'
+      ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
+      ..['dangerouslySetInnerHTML'] = {'__html': _domAtTimeOfError} ?? ''
+    )();
+  }
+
+  /// Called via [componentDidCatch] to start a `Timer` that will nullify the [_lastError] and [_lastErrorInfo]
+  /// internal fields that keep track of the last error thrown.
+  ///
+  /// If an identical error is thrown by an identical child component twice in a row:
+  ///
+  /// * __Before the timer's callback fires__ - internal component logic will treat the second error
+  ///   as an unrecoverable one that has the potential to lock the main thread.
+  /// * __After the timer's callback fires__ - internal component logic will NOT treat the second error
+  ///   as an unrecoverable one.
+  ///
+  /// > Not used when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  void _startIdenticalErrorTimer() {
+    if (_identicalErrorTimer != null) return;
+
+    _identicalErrorTimer = Timer(props.identicalErrorFrequencyTolerance, _resetInternalErrorTracking);
+  }
+
+  /// Resets all the internal fields used by [_handleErrorInComponentTree], and cancels
+  /// any pending [_identicalErrorTimer] callbacks that would put the component
+  /// into an "unrecoverable" error state.
+  void _resetInternalErrorTracking() {
+    _domAtTimeOfError = null;
+    _lastError = null;
+    _lastErrorInfo = null;
+    _identicalErrorTimer?.cancel();
+    _identicalErrorTimer = null;
+  }
+
+  /// Returns the single `componentStack` key value within the `errorInfo` passed from ReactJS
+  /// so that its readable for Dart consumers instead of being `[Object object]`.
+  ///
+  /// Also used to determine if multiple consecutive identical errors
+  /// were thrown by the exact same component within the tree.
+  String _getReadableErrorInfo(/*NativeJavascriptObject*/dynamic jsErrorInfo) =>
+      getProperty(jsErrorInfo, 'componentStack');
 }

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -256,10 +256,12 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   /// This can be called manually on the component instance using a `ref` -
   /// or by passing in a new child instance after a child has thrown an error.
   void reset() {
-    setState((newState()
+    _resetInternalErrorTracking();
+
+    setState(newState()
       ..hasError = false
       ..showFallbackUIOnError = props.fallbackUIRenderer != null
-    ), _resetInternalErrorTracking);
+    );
   }
 
   // ---------------------------------------------- \/ ----------------------------------------------

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -345,7 +345,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     return (Dom.div()
       ..key = 'ohnoes'
       ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
-      ..['dangerouslySetInnerHTML'] = {'__html': _domAtTimeOfError} ?? ''
+      ..['dangerouslySetInnerHTML'] = {'__html': _domAtTimeOfError ?? ''}
     )();
   }
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -305,9 +305,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
 
   /// Called by [componentDidCatch].
   void _handleErrorInComponentTree(/*Error||Exception*/dynamic error, /*NativeJavascriptObject*/dynamic jsErrorInfo) {
-    bool sameErrorWasThrownTwiceConsecutively =
-        error.toString() == _lastError?.toString() && _getReadableErrorInfo(jsErrorInfo) == _lastErrorInfo;
-
     // ----- [1] ----- //
     if (props.fallbackUIRenderer != null) {
       _lastError = error; // [1.1]
@@ -318,6 +315,9 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     }
     // ----- [2] ----- //
     else {
+      bool sameErrorWasThrownTwiceConsecutively =
+          error.toString() == _lastError?.toString() && _getReadableErrorInfo(jsErrorInfo) == _lastErrorInfo;
+
       if (sameErrorWasThrownTwiceConsecutively) { // [2.1]
         try { // [2.2.2]
           _domAtTimeOfError = findDomNode(this)?.innerHtml; // [2.2]

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -361,7 +361,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   void _startIdenticalErrorTimer() {
     if (_identicalErrorTimer != null) return;
 
-    _identicalErrorTimer = Timer(props.identicalErrorFrequencyTolerance, _resetInternalErrorTracking);
+    _identicalErrorTimer = getManagedTimer(props.identicalErrorFrequencyTolerance, _resetInternalErrorTracking);
   }
 
   /// Resets all the internal fields used by [_handleErrorInComponentTree], and cancels

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -22,38 +22,40 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   @override
   Map get props;
 
-  /// An optional callback that will be called with an [Error] and a `ComponentStack`
-  /// containing information about which component in the tree threw the error when
-  /// the `componentDidCatch` lifecycle method is called.
+  /// An optional callback that will be called with an [Error] _(or [Exception])_
+  /// and `errorInfo` containing information about which component in the tree
+  /// threw when the `componentDidCatch` lifecycle method is called.
   ///
   /// This callback can be used to log component errors like so:
   ///
   ///     (ErrorBoundary()
-  ///       ..onComponentDidCatch = (error, componentStack) {
+  ///       ..onComponentDidCatch = (error, errorInfo) {
   ///         // It is up to you to implement the service / thing that calls the service.
-  ///         logComponentStackToAService(error, componentStack);
+  ///         logComponentStackToAService(error, errorInfo);
   ///       }
   ///     )(
   ///       // The rest of your component tree
   ///     )
   ///
   /// > See: <https://reactjs.org/docs/react-component.html#componentdidcatch>
+  ///
+  /// > Related: [onComponentIsUnrecoverable]
   ///
   /// <!-- Generated from [_$ErrorBoundaryProps.onComponentDidCatch] -->
   @override
   _ComponentDidCatchCallback get onComponentDidCatch =>
       props[_$key__onComponentDidCatch___$ErrorBoundaryProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// An optional callback that will be called with an [Error] and a `ComponentStack`
-  /// containing information about which component in the tree threw the error when
-  /// the `componentDidCatch` lifecycle method is called.
+  /// An optional callback that will be called with an [Error] _(or [Exception])_
+  /// and `errorInfo` containing information about which component in the tree
+  /// threw when the `componentDidCatch` lifecycle method is called.
   ///
   /// This callback can be used to log component errors like so:
   ///
   ///     (ErrorBoundary()
-  ///       ..onComponentDidCatch = (error, componentStack) {
+  ///       ..onComponentDidCatch = (error, errorInfo) {
   ///         // It is up to you to implement the service / thing that calls the service.
-  ///         logComponentStackToAService(error, componentStack);
+  ///         logComponentStackToAService(error, errorInfo);
   ///       }
   ///     )(
   ///       // The rest of your component tree
@@ -61,15 +63,75 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   ///
   /// > See: <https://reactjs.org/docs/react-component.html#componentdidcatch>
   ///
+  /// > Related: [onComponentIsUnrecoverable]
+  ///
   /// <!-- Generated from [_$ErrorBoundaryProps.onComponentDidCatch] -->
   @override
   set onComponentDidCatch(_ComponentDidCatchCallback value) =>
       props[_$key__onComponentDidCatch___$ErrorBoundaryProps] = value;
 
+  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
+  /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
+  /// to lock the main thread.
+  ///
+  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
+  /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
+  /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
+  ///
+  /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
+  /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
+  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  ///
+  /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
+  ///
+  /// 1. Passing in a new child
+  ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
+  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  ///
+  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  ///
+  /// > Related: [identicalErrorFrequencyTolerance]
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.onComponentIsUnrecoverable] -->
+  @override
+  _ComponentDidCatchCallback get onComponentIsUnrecoverable =>
+      props[_$key__onComponentIsUnrecoverable___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
+  /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
+  /// to lock the main thread.
+  ///
+  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
+  /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
+  /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
+  ///
+  /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
+  /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
+  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  ///
+  /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
+  ///
+  /// 1. Passing in a new child
+  ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
+  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  ///
+  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  ///
+  /// > Related: [identicalErrorFrequencyTolerance]
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.onComponentIsUnrecoverable] -->
+  @override
+  set onComponentIsUnrecoverable(_ComponentDidCatchCallback value) =>
+      props[_$key__onComponentIsUnrecoverable___$ErrorBoundaryProps] = value;
+
   /// A renderer that will be used to render "fallback" UI instead of the child
   /// component tree that crashed.
   ///
-  /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
+  /// > Related: [onComponentIsUnrecoverable], [onComponentDidCatch]
   ///
   /// <!-- Generated from [_$ErrorBoundaryProps.fallbackUIRenderer] -->
   @override
@@ -79,30 +141,94 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   /// A renderer that will be used to render "fallback" UI instead of the child
   /// component tree that crashed.
   ///
-  /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
+  /// > Related: [onComponentIsUnrecoverable], [onComponentDidCatch]
   ///
   /// <!-- Generated from [_$ErrorBoundaryProps.fallbackUIRenderer] -->
   @override
   set fallbackUIRenderer(_FallbackUiRenderer value) =>
       props[_$key__fallbackUIRenderer___$ErrorBoundaryProps] = value;
+
+  /// The amount of time that is "acceptable" between consecutive identical errors thrown from a component
+  /// within the tree wrapped by this [ErrorBoundary].
+  ///
+  /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
+  /// the specified duration, the [ErrorBoundary] will:
+  ///
+  ///   1. Call [onComponentIsUnrecoverable].
+  ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
+  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///
+  /// When this happens, recovery can only occur by passing in a new child to
+  /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
+  ///
+  /// __DO NOT MODIFY THIS VALUE UNLESS YOU KNOW WHAT YOU ARE DOING.__
+  ///
+  /// > Default: `const Duration(seconds: 5)`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.identicalErrorFrequencyTolerance] -->
+  @override
+  Duration get identicalErrorFrequencyTolerance =>
+      props[_$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// The amount of time that is "acceptable" between consecutive identical errors thrown from a component
+  /// within the tree wrapped by this [ErrorBoundary].
+  ///
+  /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
+  /// the specified duration, the [ErrorBoundary] will:
+  ///
+  ///   1. Call [onComponentIsUnrecoverable].
+  ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
+  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///
+  /// When this happens, recovery can only occur by passing in a new child to
+  /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
+  ///
+  /// __DO NOT MODIFY THIS VALUE UNLESS YOU KNOW WHAT YOU ARE DOING.__
+  ///
+  /// > Default: `const Duration(seconds: 5)`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.identicalErrorFrequencyTolerance] -->
+  @override
+  set identicalErrorFrequencyTolerance(Duration value) =>
+      props[_$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps] =
+          value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor
       _$prop__onComponentDidCatch___$ErrorBoundaryProps =
       const PropDescriptor(_$key__onComponentDidCatch___$ErrorBoundaryProps);
+  static const PropDescriptor
+      _$prop__onComponentIsUnrecoverable___$ErrorBoundaryProps =
+      const PropDescriptor(
+          _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps);
   static const PropDescriptor _$prop__fallbackUIRenderer___$ErrorBoundaryProps =
       const PropDescriptor(_$key__fallbackUIRenderer___$ErrorBoundaryProps);
+  static const PropDescriptor
+      _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps =
+      const PropDescriptor(
+          _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps);
   static const String _$key__onComponentDidCatch___$ErrorBoundaryProps =
       'ErrorBoundaryProps.onComponentDidCatch';
+  static const String _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.onComponentIsUnrecoverable';
   static const String _$key__fallbackUIRenderer___$ErrorBoundaryProps =
       'ErrorBoundaryProps.fallbackUIRenderer';
+  static const String
+      _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.identicalErrorFrequencyTolerance';
 
   static const List<PropDescriptor> $props = const [
     _$prop__onComponentDidCatch___$ErrorBoundaryProps,
-    _$prop__fallbackUIRenderer___$ErrorBoundaryProps
+    _$prop__onComponentIsUnrecoverable___$ErrorBoundaryProps,
+    _$prop__fallbackUIRenderer___$ErrorBoundaryProps,
+    _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps
   ];
   static const List<String> $propKeys = const [
     _$key__onComponentDidCatch___$ErrorBoundaryProps,
-    _$key__fallbackUIRenderer___$ErrorBoundaryProps
+    _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps,
+    _$key__fallbackUIRenderer___$ErrorBoundaryProps,
+    _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps
   ];
 }
 
@@ -156,34 +282,75 @@ abstract class _$ErrorBoundaryStateAccessorsMixin
   @override
   Map get state;
 
-  /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
+  /// Whether a component within the tree that the [ErrorBoundary] is wrapping around threw an error.
   ///
-  /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is set, the return value of that callback
+  ///   will be rendered instead.
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is not set, the [ErrorBoundary] will re-mount
+  ///   the tree to attempt to automatically recover from the error.
+  ///
+  ///   If an identical error is thrown from an identical component within the tree consecutively
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
+  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   ///
   /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->
   @override
   bool get hasError =>
       state[_$key__hasError___$ErrorBoundaryState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
+  /// Whether a component within the tree that the [ErrorBoundary] is wrapping around threw an error.
   ///
-  /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is set, the return value of that callback
+  ///   will be rendered instead.
+  /// * When `true`, and [ErrorBoundaryProps.fallbackUIRenderer] is not set, the [ErrorBoundary] will re-mount
+  ///   the tree to attempt to automatically recover from the error.
+  ///
+  ///   If an identical error is thrown from an identical component within the tree consecutively
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
+  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   ///
   /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->
   @override
   set hasError(bool value) =>
       state[_$key__hasError___$ErrorBoundaryState] = value;
+
+  /// Whether to show "fallback" UI when [hasError] is true.
+  ///
+  /// This value will always be true if [ErrorBoundaryProps.fallbackUIRenderer] is non-null.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryState.showFallbackUIOnError] -->
+  @override
+  bool get showFallbackUIOnError =>
+      state[_$key__showFallbackUIOnError___$ErrorBoundaryState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Whether to show "fallback" UI when [hasError] is true.
+  ///
+  /// This value will always be true if [ErrorBoundaryProps.fallbackUIRenderer] is non-null.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryState.showFallbackUIOnError] -->
+  @override
+  set showFallbackUIOnError(bool value) =>
+      state[_$key__showFallbackUIOnError___$ErrorBoundaryState] = value;
   /* GENERATED CONSTANTS */
   static const StateDescriptor _$prop__hasError___$ErrorBoundaryState =
       const StateDescriptor(_$key__hasError___$ErrorBoundaryState);
+  static const StateDescriptor
+      _$prop__showFallbackUIOnError___$ErrorBoundaryState =
+      const StateDescriptor(_$key__showFallbackUIOnError___$ErrorBoundaryState);
   static const String _$key__hasError___$ErrorBoundaryState =
       'ErrorBoundaryState.hasError';
+  static const String _$key__showFallbackUIOnError___$ErrorBoundaryState =
+      'ErrorBoundaryState.showFallbackUIOnError';
 
   static const List<StateDescriptor> $state = const [
-    _$prop__hasError___$ErrorBoundaryState
+    _$prop__hasError___$ErrorBoundaryState,
+    _$prop__showFallbackUIOnError___$ErrorBoundaryState
   ];
   static const List<String> $stateKeys = const [
-    _$key__hasError___$ErrorBoundaryState
+    _$key__hasError___$ErrorBoundaryState,
+    _$key__showFallbackUIOnError___$ErrorBoundaryState
   ];
 }
 

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -70,27 +70,27 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   set onComponentDidCatch(_ComponentDidCatchCallback value) =>
       props[_$key__onComponentDidCatch___$ErrorBoundaryProps] = value;
 
-  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// An optional callback that will be called _(when [fallbackUIRenderer] is not set)_
   /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
   /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
   /// to lock the main thread.
   ///
-  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// The locking of the main thread is possible in this scenario because when [fallbackUIRenderer]
   /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
   /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
   /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
   ///
   /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
   /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
-  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  /// static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
   ///
   /// 1. Passing in a new child
   ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
-  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  /// 2. Calling [ErrorBoundaryComponent.reset].
   ///
-  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  /// > Will never be called when [fallbackUIRenderer] is set.
   ///
   /// > Related: [identicalErrorFrequencyTolerance]
   ///
@@ -99,27 +99,27 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   _ComponentDidCatchCallback get onComponentIsUnrecoverable =>
       props[_$key__onComponentIsUnrecoverable___$ErrorBoundaryProps] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// An optional callback that will be called _(when [fallbackUIRenderer] is not set)_
   /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
   /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
   /// to lock the main thread.
   ///
-  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// The locking of the main thread is possible in this scenario because when [fallbackUIRenderer]
   /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
   /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
   /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
   ///
   /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
   /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
-  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  /// static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
   ///
   /// 1. Passing in a new child
   ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
-  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  /// 2. Calling [ErrorBoundaryComponent.reset].
   ///
-  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  /// > Will never be called when [fallbackUIRenderer] is set.
   ///
   /// > Related: [identicalErrorFrequencyTolerance]
   ///
@@ -152,12 +152,12 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   /// within the tree wrapped by this [ErrorBoundary].
   ///
   /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
-  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
-  /// the specified duration, the [ErrorBoundary] will:
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] -- more often than
+  /// the specified duration -- the [ErrorBoundary] will:
   ///
   ///   1. Call [onComponentIsUnrecoverable].
   ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
-  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///   3. Render a static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// When this happens, recovery can only occur by passing in a new child to
   /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
@@ -175,12 +175,12 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   /// within the tree wrapped by this [ErrorBoundary].
   ///
   /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
-  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
-  /// the specified duration, the [ErrorBoundary] will:
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] -- more often than
+  /// the specified duration -- the [ErrorBoundary] will:
   ///
   ///   1. Call [onComponentIsUnrecoverable].
   ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
-  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///   3. Render a static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// When this happens, recovery can only occur by passing in a new child to
   /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
@@ -290,8 +290,8 @@ abstract class _$ErrorBoundaryStateAccessorsMixin
   ///   the tree to attempt to automatically recover from the error.
   ///
   ///   If an identical error is thrown from an identical component within the tree consecutively
-  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
-  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a static copy of
+  ///   the render tree's HTML that was captured at the time of the error will be rendered.
   ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   ///
   /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->
@@ -307,8 +307,8 @@ abstract class _$ErrorBoundaryStateAccessorsMixin
   ///   the tree to attempt to automatically recover from the error.
   ///
   ///   If an identical error is thrown from an identical component within the tree consecutively
-  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
-  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a static copy of
+  ///   the render tree's HTML that was captured at the time of the error will be rendered.
   ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   ///
   /// <!-- Generated from [_$ErrorBoundaryState.hasError] -->

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -49,8 +49,10 @@ void main() {
         document.body.append(mountNode);
         var jacketOfFlawedComponentWithNoErrorBoundary = mount(Flawed()(), mountNode: mountNode);
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
+
         final buttonThatShouldThrowAnErrorWhenClicked = queryByTestId(jacketOfFlawedComponentWithNoErrorBoundary.getInstance(), 'flawedComponent_flawedButton');
         expect(buttonThatShouldThrowAnErrorWhenClicked, isNotNull, reason: 'test setup sanity check');
+
         buttonThatShouldThrowAnErrorWhenClicked.click();
         expect(mountNode.children, isEmpty,
             reason: 'rendered trees not wrapped in an ErrorBoundary '

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -16,7 +16,6 @@
 library error_boundary_test;
 
 import 'dart:html';
-import 'dart:js';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
@@ -29,7 +28,7 @@ void main() {
     ReactElement dummyChild;
 
     setUp(() {
-      dummyChild = Dom.div()('hi there');
+      dummyChild = (Dom.div()..addTestId('dummyChild'))('hi there');
     });
 
     tearDown(() {
@@ -47,7 +46,9 @@ void main() {
         document.body.append(mountNode);
         var jacketOfFlawedComponentWithNoErrorBoundary = mount(Flawed()(), mountNode: mountNode);
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
-        jacketOfFlawedComponentWithNoErrorBoundary.getNode().click();
+        final buttonThatShouldThrowAnErrorWhenClicked = queryByTestId(jacketOfFlawedComponentWithNoErrorBoundary.getInstance(), 'flawedComponent_flawedButton');
+        expect(buttonThatShouldThrowAnErrorWhenClicked, isNotNull, reason: 'test setup sanity check');
+        buttonThatShouldThrowAnErrorWhenClicked.click();
         expect(mountNode.children, isEmpty,
             reason: 'rendered trees not wrapped in an ErrorBoundary '
                     'should get unmounted when an error is thrown within child component lifecycle methods');
@@ -72,7 +73,7 @@ void main() {
         );
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
         // Cause an error to be thrown within a ReactJS lifecycle method
-        jacket.getNode().click();
+        queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton').click();
       });
 
       tearDown(() {
@@ -86,7 +87,11 @@ void main() {
         expect(errArg, isA<FlawedComponentException>());
 
         final infoArg = calls.single['onComponentDidCatch'][1];
-        expect(infoArg, isNotNull);
+        expect(infoArg, isA<String>());
+      });
+
+      test('and sets `state.hasError` to true', () {
+        expect(jacket.getDartInstance().state.hasError, isTrue);
       });
 
       test('and re-renders the tree as a result', () {
@@ -99,14 +104,14 @@ void main() {
         jacket = mount(ErrorBoundary()((Flawed()..addTestId('flawed'))()), mountNode: mountNode);
         // The click causes the componentDidCatch lifecycle method to execute
         // and we want to ensure that no Dart null error is thrown as a result of no consumer prop callback being set.
-        expect(() => jacket.getNode().click(), returnsNormally);
+        expect(() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton').click(), returnsNormally);
       });
     });
 
     test('initializes with the expected default prop values', () {
       jacket = mount(ErrorBoundary()(dummyChild));
 
-      expect(() => ErrorBoundary(jacket.getProps()).fallbackUIRenderer(null, null), throwsUnimplementedError);
+      expect(ErrorBoundary(jacket.getProps()).identicalErrorFrequencyTolerance.inSeconds, 5);
     });
 
     test('initializes with the expected initial state values', () {
@@ -123,13 +128,30 @@ void main() {
         expect(jacket.getNode().text, 'hi there');
       });
 
-      group('fallback UI when `state.error` is true', () {
-        test('', () {
-          jacket = mount(ErrorBoundary()(dummyChild));
-          final component = jacket.getDartInstance();
+      test('its child when `state.error` is true and `state.showFallbackUIOnError` is false', () {
+        jacket = mount(ErrorBoundary()(dummyChild));
+        final component = jacket.getDartInstance();
+        component.setState(component.newState()
+          ..hasError = true
+          ..showFallbackUIOnError = false
+        );
 
-          // Using throws for now since this is temporary, and the throwsUnimplementedError doesn't work here for some reason
-          expect(() => component.setState(component.newState()..hasError = true), throws);
+        expect(jacket.getNode().text, 'hi there');
+      });
+
+      group('fallback UI when `state.error` is true', () {
+        test('and `state.showFallbackUIOnError` is true ("unrecoverable" error state)', () {
+          jacket = mount(ErrorBoundary()(dummyChild));
+          expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNotNull);
+          final component = jacket.getDartInstance();
+          component.setState(component.newState()
+            ..hasError = true
+            ..showFallbackUIOnError = true
+          );
+
+          expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNull,
+              reason: 'The child component tree should have been removed from the dom');
+          expect(jacket.getNode(), hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
         });
 
         // TODO: Update this test to assert the error / component stack values passed to the callback once the actual ReactJS 16 error lifecycle methods are implemented.
@@ -144,6 +166,446 @@ void main() {
 
           expect(jacket.getNode(), hasNodeName('H4'));
           expect(jacket.getNode().text, 'Something super not awesome just happened.');
+        });
+
+        group('and then switches back to rendering the child', () {
+          setUp(() {
+            jacket = mount((ErrorBoundary()
+              ..fallbackUIRenderer = (_, __) => (Dom.div()..addTestId('fallbackNode'))('Something went wrong')
+            )(dummyChild));
+            final component = jacket.getDartInstance();
+            component.setState(component.newState()
+              ..hasError = true
+              ..showFallbackUIOnError = true
+            );
+            expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNotNull);
+          });
+
+          test('when reset() is called', () {
+            jacket.getDartInstance().reset();
+            expect(jacket.getDartInstance().state.hasError, isFalse);
+            expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue);
+            expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNotNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNull);
+          });
+
+          test('when a new child is passed in', () {
+            final newDummyChild = (Dom.div()..addTestId('newDummyChild'))('hi there');
+            jacket.rerender((ErrorBoundary()
+              ..fallbackUIRenderer = (_, __) => (Dom.div()..addTestId('fallbackNode'))('Something went wrong')
+            )(newDummyChild));
+            expect(jacket.getDartInstance().state.hasError, isFalse);
+            expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue);
+            expect(getByTestId(jacket.getInstance(), 'newDummyChild'), isNotNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNull);
+          });
+        });
+      });
+    });
+
+    group('gracefully handles errors in its tree when `props.fallbackUIRenderer` is not set', () {
+      List<Map<String, List>> calls;
+      DivElement mountNode;
+      var flawedRenderedInstance;
+      var nestedFlawedRenderedInstance;
+      const identicalErrorFrequencyToleranceInMs = 100;
+      dynamic errorSentToComponentDidCatchCallback;
+      dynamic errorInfoSentToComponentDidCatchCallback;
+      dynamic errorSentToComponentIsUnrecoverableCallback;
+      dynamic errorInfoSentToComponentIsUnrecoverableCallback;
+
+      Element getFlawedButtonNode() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton');
+      Element getFlawedButtonThatThrowsADifferentErrorNode() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButtonThatThrowsADifferentError');
+      Element getNestedFlawedButtonNode() => queryByTestId(jacket.getInstance(), 'nestedFlawedComponent_flawedButton');
+      Element getNestedFlawedButtonThatThrowsADifferentErrorNode() => queryByTestId(jacket.getInstance(), 'nestedFlawedComponent_flawedButtonThatThrowsADifferentError');
+
+      void _setCallbackVarValues() {
+        expect(calls, isNotNull, reason: 'test setup sanity check');
+        expect(calls, isNotEmpty, reason: 'test setup sanity check');
+        expect(calls[0].keys.single, 'onComponentDidCatch', reason: 'test setup sanity check');
+        expect(jacket.getDartInstance().state.hasError, isTrue, reason: 'test setup sanity check');
+
+        final componentDidCatchCallbackArguments = calls[0]['onComponentDidCatch'];
+        if (componentDidCatchCallbackArguments != null) {
+          errorSentToComponentDidCatchCallback = componentDidCatchCallbackArguments[0];
+          errorInfoSentToComponentDidCatchCallback = componentDidCatchCallbackArguments[1];
+        }
+
+        if (calls.length > 1) {
+          expect(calls[1].keys.single, 'onComponentIsUnrecoverable', reason: 'test setup sanity check');
+          final componentIsUnrecoverableCallbackArguments = calls[1]['onComponentIsUnrecoverable'];
+          if (componentIsUnrecoverableCallbackArguments != null) {
+            errorSentToComponentIsUnrecoverableCallback = componentIsUnrecoverableCallbackArguments[0];
+            errorInfoSentToComponentIsUnrecoverableCallback = componentIsUnrecoverableCallbackArguments[1];
+          }
+        }
+      }
+
+      setUp(() {
+        mountNode = new DivElement();
+        document.body.append(mountNode);
+
+        calls = [];
+
+        jacket = mount(
+          (ErrorBoundary()
+            ..identicalErrorFrequencyTolerance = const Duration(
+                milliseconds: identicalErrorFrequencyToleranceInMs)
+            ..onComponentDidCatch = (err, info) {
+              calls.add({'onComponentDidCatch': [err, info]});
+            }
+            ..onComponentIsUnrecoverable = (err, info) {
+              calls.add({'onComponentIsUnrecoverable': [err, info]});
+            }
+          )(
+            (Flawed()..addTestId('flawedComponent'))(
+              (Flawed()
+                ..buttonTestIdPrefix = 'nestedFlawedComponent_'
+                ..addTestId('nestedFlawedComponent')
+              )(),
+            ),
+          ),
+          mountNode: mountNode,
+        );
+
+        flawedRenderedInstance = getByTestId(jacket.getInstance(), 'flawedComponent');
+        expect(flawedRenderedInstance, isNotNull, reason: 'test setup sanity check');
+
+        nestedFlawedRenderedInstance = getByTestId(jacket.getInstance(), 'nestedFlawedComponent');
+        expect(nestedFlawedRenderedInstance, isNotNull, reason: 'test setup sanity check');
+      });
+
+      tearDown(() {
+        calls = null;
+        flawedRenderedInstance = null;
+        nestedFlawedRenderedInstance = null;
+        errorSentToComponentDidCatchCallback = null;
+        errorInfoSentToComponentDidCatchCallback = null;
+        errorSentToComponentIsUnrecoverableCallback = null;
+        errorInfoSentToComponentIsUnrecoverableCallback = null;
+        mountNode.remove();
+        mountNode = null;
+      });
+
+      group('and consecutive errors are thrown from the same component', () {
+        Future<Null> triggerErrorsThatSignifyAnUnrecoverableComponent() async {
+          getFlawedButtonNode().click();
+          expect(calls.length, 1, reason: 'test setup sanity check');
+          expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+          calls.clear();
+          await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+          getFlawedButtonNode().click();
+          _setCallbackVarValues();
+        }
+
+        group('and the errors are exactly the same', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            String errorBoundaryInnerHtmlBeforeUnrecoverableError;
+
+            setUp(() async {
+              expect(jacket.getNode(),
+                  isNot(hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')),
+                  reason: 'test setup sanity check');
+              errorBoundaryInnerHtmlBeforeUnrecoverableError = jacket.getNode().innerHtml;
+              await triggerErrorsThatSignifyAnUnrecoverableComponent();
+            });
+
+            tearDown(() {
+              errorBoundaryInnerHtmlBeforeUnrecoverableError = null;
+            });
+
+            test('the components wrapped by the ErrorBoundary get unmounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
+                  reason: 'The flawed component should have been unmounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
+                  reason: 'Fallback UI should be rendered instead of the flawed component tree');
+              expect(jacket.getNode(),
+                  hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
+              expect(jacket.getNode().innerHtml, errorBoundaryInnerHtmlBeforeUnrecoverableError);
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
+                  reason: 'onComponentIsUnrecoverable should have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+              expect(errorSentToComponentIsUnrecoverableCallback, isA<FlawedComponentException>());
+              expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
+
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+              expect(errorInfoSentToComponentIsUnrecoverableCallback, isA<String>());
+              expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getFlawedButtonNode().click();
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+
+            // Test that unrecoverable errors that come after recoverable ones produce the same behavior
+            // as unrecoverable errors that are the first caught by the ErrorBoundary after being mounted.
+            group('but are then followed by two more errors that are exactly the same, '
+                'more frequent than the value of props.identicalErrorFrequencyTolerance', () {
+              setUp(() async {
+                await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+                calls.clear();
+                await triggerErrorsThatSignifyAnUnrecoverableComponent();
+              });
+
+              test('the components wrapped by the ErrorBoundary get unmounted', () {
+                expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
+                    reason: 'The flawed component should have been unmounted');
+                expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
+                    reason: 'Fallback UI should be rendered instead of the flawed component tree');
+              });
+
+              test('the correct callbacks are called with the correct arguments', () {
+                expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
+                    reason: 'onComponentIsUnrecoverable should have been called');
+
+                expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+                expect(errorSentToComponentIsUnrecoverableCallback, isA<FlawedComponentException>());
+                expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
+
+                expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+                expect(errorInfoSentToComponentIsUnrecoverableCallback, isA<String>());
+                expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
+              });
+            });
+          });
+        });
+
+        group('and the errors are different', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getFlawedButtonThatThrowsADifferentErrorNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', isNot('$secondError'), reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException2>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getFlawedButtonThatThrowsADifferentErrorNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', isNot('$secondError'), reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException2>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
+        });
+      });
+
+      group('and consecutive errors are thrown from different components in the same tree', () {
+        group('and the errors are exactly the same', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getNestedFlawedButtonNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', '$secondError', reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getNestedFlawedButtonNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', '$secondError', reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
+        });
+
+        group('and the errors are different', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getNestedFlawedButtonThatThrowsADifferentErrorNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', isNot('$secondError'), reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException2>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getNestedFlawedButtonThatThrowsADifferentErrorNode().click();
+              final secondError = calls[0]['onComponentDidCatch'][0];
+
+              expect('$firstError', isNot('$secondError'), reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException2>());
+              expect(errorInfoSentToComponentDidCatchCallback, isA<String>());
+            });
+          });
         });
       });
     });

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -20,10 +20,27 @@ abstract class _$FlawedPropsAccessorsMixin implements _$FlawedProps {
   @override
   Map get props;
 
+  /// <!-- Generated from [_$FlawedProps.buttonTestIdPrefix] -->
+  @override
+  String get buttonTestIdPrefix =>
+      props[_$key__buttonTestIdPrefix___$FlawedProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$FlawedProps.buttonTestIdPrefix] -->
+  @override
+  set buttonTestIdPrefix(String value) =>
+      props[_$key__buttonTestIdPrefix___$FlawedProps] = value;
   /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__buttonTestIdPrefix___$FlawedProps =
+      const PropDescriptor(_$key__buttonTestIdPrefix___$FlawedProps);
+  static const String _$key__buttonTestIdPrefix___$FlawedProps =
+      'FlawedProps.buttonTestIdPrefix';
 
-  static const List<PropDescriptor> $props = const [];
-  static const List<String> $propKeys = const [];
+  static const List<PropDescriptor> $props = const [
+    _$prop__buttonTestIdPrefix___$FlawedProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__buttonTestIdPrefix___$FlawedProps
+  ];
 }
 
 const PropsMeta _$metaForFlawedProps = const PropsMeta(
@@ -68,23 +85,43 @@ abstract class _$FlawedStateAccessorsMixin implements _$FlawedState {
   @override
   Map get state;
 
-  /// <!-- Generated from [_$FlawedState.hasError] -->
+  /// <!-- Generated from [_$FlawedState.errorCount] -->
   @override
-  bool get hasError =>
-      state[_$key__hasError___$FlawedState] ??
+  int get errorCount =>
+      state[_$key__errorCount___$FlawedState] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$FlawedState.hasError] -->
+  /// <!-- Generated from [_$FlawedState.errorCount] -->
   @override
-  set hasError(bool value) => state[_$key__hasError___$FlawedState] = value;
+  set errorCount(int value) => state[_$key__errorCount___$FlawedState] = value;
+
+  /// <!-- Generated from [_$FlawedState.differentTypeOfErrorCount] -->
+  @override
+  int get differentTypeOfErrorCount =>
+      state[_$key__differentTypeOfErrorCount___$FlawedState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$FlawedState.differentTypeOfErrorCount] -->
+  @override
+  set differentTypeOfErrorCount(int value) =>
+      state[_$key__differentTypeOfErrorCount___$FlawedState] = value;
   /* GENERATED CONSTANTS */
-  static const StateDescriptor _$prop__hasError___$FlawedState =
-      const StateDescriptor(_$key__hasError___$FlawedState);
-  static const String _$key__hasError___$FlawedState = 'FlawedState.hasError';
+  static const StateDescriptor _$prop__errorCount___$FlawedState =
+      const StateDescriptor(_$key__errorCount___$FlawedState);
+  static const StateDescriptor
+      _$prop__differentTypeOfErrorCount___$FlawedState =
+      const StateDescriptor(_$key__differentTypeOfErrorCount___$FlawedState);
+  static const String _$key__errorCount___$FlawedState =
+      'FlawedState.errorCount';
+  static const String _$key__differentTypeOfErrorCount___$FlawedState =
+      'FlawedState.differentTypeOfErrorCount';
 
   static const List<StateDescriptor> $state = const [
-    _$prop__hasError___$FlawedState
+    _$prop__errorCount___$FlawedState,
+    _$prop__differentTypeOfErrorCount___$FlawedState
   ];
-  static const List<String> $stateKeys = const [_$key__hasError___$FlawedState];
+  static const List<String> $stateKeys = const [
+    _$key__errorCount___$FlawedState,
+    _$key__differentTypeOfErrorCount___$FlawedState
+  ];
 }
 
 const StateMeta _$metaForFlawedState = const StateMeta(

--- a/test/over_react/component/fixtures/flawed_component_on_mount.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_on_mount.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedOnMountProps> FlawedOnMount = _$FlawedOnMount;
+
+@Props()
+class _$FlawedOnMountProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedOnMountProps extends _$FlawedOnMountProps with _$FlawedOnMountPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedOnMountProps;
+}
+
+@Component()
+class FlawedOnMountComponent extends UiComponent<FlawedOnMountProps> {
+  @override
+  void componentDidMount() {
+    throw FlawedOnMountComponentException();
+  }
+
+  @override
+  render() {
+    return (Dom.div()..addProps(copyUnconsumedDomProps()))(props.children);
+  }
+}
+
+class FlawedOnMountComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedOnMountComponentException: I was thrown from inside FlawedOnMountComponent.componentDidMount!';
+}

--- a/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
@@ -1,0 +1,90 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flawed_component_on_mount.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FlawedOnMountComponentFactory = registerComponent(
+    () => new _$FlawedOnMountComponent(),
+    builderFactory: FlawedOnMount,
+    componentClass: FlawedOnMountComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'FlawedOnMount');
+
+abstract class _$FlawedOnMountPropsAccessorsMixin
+    implements _$FlawedOnMountProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForFlawedOnMountProps = const PropsMeta(
+  fields: _$FlawedOnMountPropsAccessorsMixin.$props,
+  keys: _$FlawedOnMountPropsAccessorsMixin.$propKeys,
+);
+
+_$$FlawedOnMountProps _$FlawedOnMount([Map backingProps]) =>
+    new _$$FlawedOnMountProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FlawedOnMountProps extends _$FlawedOnMountProps
+    with _$FlawedOnMountPropsAccessorsMixin
+    implements FlawedOnMountProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FlawedOnMountProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $FlawedOnMountComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FlawedOnMountProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FlawedOnMountComponent extends FlawedOnMountComponent {
+  @override
+  _$$FlawedOnMountProps typedPropsFactory(Map backingMap) =>
+      new _$$FlawedOnMountProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FlawedOnMountProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFlawedOnMountProps
+  ];
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_that_renders_a_string.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedWithStringChildProps> FlawedWithStringChild = _$FlawedWithStringChild;
+
+@Props()
+class _$FlawedWithStringChildProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedWithStringChildProps extends _$FlawedWithStringChildProps with _$FlawedWithStringChildPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedWithStringChildProps;
+}
+
+@Component()
+class FlawedWithStringChildComponent extends UiComponent<FlawedWithStringChildProps> {
+  @override
+  void componentDidMount() {
+    throw FlawedWithStringChildComponentException();
+  }
+
+  @override
+  render() {
+    return 'just a string, yo';
+  }
+}
+
+class FlawedWithStringChildComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedWithStringChildComponentException: I was thrown from inside FlawedWithStringChildComponent.componentDidMount!';
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
@@ -1,0 +1,90 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flawed_component_that_renders_a_string.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FlawedWithStringChildComponentFactory = registerComponent(
+    () => new _$FlawedWithStringChildComponent(),
+    builderFactory: FlawedWithStringChild,
+    componentClass: FlawedWithStringChildComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'FlawedWithStringChild');
+
+abstract class _$FlawedWithStringChildPropsAccessorsMixin
+    implements _$FlawedWithStringChildProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForFlawedWithStringChildProps = const PropsMeta(
+  fields: _$FlawedWithStringChildPropsAccessorsMixin.$props,
+  keys: _$FlawedWithStringChildPropsAccessorsMixin.$propKeys,
+);
+
+_$$FlawedWithStringChildProps _$FlawedWithStringChild([Map backingProps]) =>
+    new _$$FlawedWithStringChildProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FlawedWithStringChildProps extends _$FlawedWithStringChildProps
+    with _$FlawedWithStringChildPropsAccessorsMixin
+    implements FlawedWithStringChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FlawedWithStringChildProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $FlawedWithStringChildComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FlawedWithStringChildProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FlawedWithStringChildComponent extends FlawedWithStringChildComponent {
+  @override
+  _$$FlawedWithStringChildProps typedPropsFactory(Map backingMap) =>
+      new _$$FlawedWithStringChildProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FlawedWithStringChildProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFlawedWithStringChildProps
+  ];
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_that_renders_nothing.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedWithNoChildProps> FlawedWithNoChild = _$FlawedWithNoChild;
+
+@Props()
+class _$FlawedWithNoChildProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedWithNoChildProps extends _$FlawedWithNoChildProps with _$FlawedWithNoChildPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedWithNoChildProps;
+}
+
+@Component()
+class FlawedWithNoChildComponent extends UiComponent<FlawedWithNoChildProps> {
+  @override
+  void componentDidMount() {
+    throw FlawedWithNoChildComponentException();
+  }
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+class FlawedWithNoChildComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedWithNoChildComponentException: I was thrown from inside FlawedWithNoChildComponent.componentDidMount!';
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
@@ -1,0 +1,90 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flawed_component_that_renders_nothing.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FlawedWithNoChildComponentFactory = registerComponent(
+    () => new _$FlawedWithNoChildComponent(),
+    builderFactory: FlawedWithNoChild,
+    componentClass: FlawedWithNoChildComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'FlawedWithNoChild');
+
+abstract class _$FlawedWithNoChildPropsAccessorsMixin
+    implements _$FlawedWithNoChildProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = const [];
+  static const List<String> $propKeys = const [];
+}
+
+const PropsMeta _$metaForFlawedWithNoChildProps = const PropsMeta(
+  fields: _$FlawedWithNoChildPropsAccessorsMixin.$props,
+  keys: _$FlawedWithNoChildPropsAccessorsMixin.$propKeys,
+);
+
+_$$FlawedWithNoChildProps _$FlawedWithNoChild([Map backingProps]) =>
+    new _$$FlawedWithNoChildProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$FlawedWithNoChildProps extends _$FlawedWithNoChildProps
+    with _$FlawedWithNoChildPropsAccessorsMixin
+    implements FlawedWithNoChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$FlawedWithNoChildProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $FlawedWithNoChildComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FlawedWithNoChildProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FlawedWithNoChildComponent extends FlawedWithNoChildComponent {
+  @override
+  _$$FlawedWithNoChildProps typedPropsFactory(Map backingMap) =>
+      new _$$FlawedWithNoChildProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FlawedWithNoChildProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFlawedWithNoChildProps
+  ];
+}


### PR DESCRIPTION
## Motivation
While testing the recent `3.0.0-alpha.0` release in a consumer library, a problem was discovered.

Currently, our `ErrorBoundary` component - when `props.fallbackUIRenderer` is not specified - will attempt to remount its child component tree when an error is caught.  In most cases, this is a sane default - however - if a component in that tree throws __every time it mounts__ - this causes a huge problem, since it creates a sort of "infinite loop" of `component throws in componentDidMount -> ErrorBoundary remounts the componnet -> component throws in componentDidMount -> ...`.  This infinite loop has the potential to completely lock up the main CPU thread.

## Changes
> See code comments for much more in-depth information about what happens when / why

1. Add some internal component fields to `ErrorBoundaryComponent` that keep track of the error that was thrown, and the "component stack" from the `info` object made available from ReactJS when a component wrapped in an error boundary throws.
2. Use these new fields when a second error is thrown to evaluate whether the second error is identical to the first - and whether it was thrown from the exact same place in the tree.
3. If it is identical - and the errors happen within 5 seconds of each other, render a non-interactive String representation of the DOM that existed before the error was thrown.
4. Allow consumers to get ErrorBoundary out of error states by either passing in a new child, or by calling the new `reset` instance method.
5. Add lots of tests and docs.

#### Release Notes
Improve handling of “repeat” errors thrown from components wrapped by an ErrorBoundary component.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
