### PR TITLE
CPLAT-7550 Change open attribute typing to bool

### DIFF
--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -73,7 +73,7 @@ abstract class _$DomPropsMixin {
   int cols, rows, size, span, start;
 
   bool allowFullScreen, async, autoPlay, checked, controls, defer, disabled, formNoValidate, hidden, loop, multiple,
-    muted, noValidate, readOnly, required, seamless, selected;
+    muted, noValidate, open, readOnly, required, seamless, selected;
 
   Map<String, dynamic> style;
 
@@ -82,7 +82,7 @@ abstract class _$DomPropsMixin {
   dynamic accept, acceptCharset, accessKey, action, allowTransparency, alt, autoComplete, cellPadding, cellSpacing,
     charSet, classID, colSpan, content, contentEditable, contextMenu, coords, crossOrigin, data, dateTime,
     dir, download, draggable, encType, form, frameBorder, height, href, hrefLang, htmlFor, httpEquiv, icon, label,
-    lang, list, manifest, max, maxLength, media, mediaGroup, method, min, name, open, pattern, placeholder,
+    lang, list, manifest, max, maxLength, media, mediaGroup, method, min, name, pattern, placeholder,
     poster, preload, radioGroup, rel, role, rowSpan, sandbox, scope, scrolling, shape, sizes, spellCheck, src, srcDoc,
     srcSet, step, tabIndex, target, type, useMap, value, width, wmode;
 

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -240,6 +240,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set noValidate(bool value) =>
       props[_$key__noValidate___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.open] -->
+  @override
+  bool get open =>
+      props[_$key__open___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.open] -->
+  @override
+  set open(bool value) => props[_$key__open___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.readOnly] -->
   @override
   bool get readOnly =>
@@ -709,15 +718,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.name] -->
   @override
   set name(dynamic value) => props[_$key__name___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.open] -->
-  @override
-  dynamic get open =>
-      props[_$key__open___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.open] -->
-  @override
-  set open(dynamic value) => props[_$key__open___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.pattern] -->
   @override
@@ -1780,6 +1780,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__muted___$DomPropsMixin);
   static const PropDescriptor _$prop__noValidate___$DomPropsMixin =
       const PropDescriptor(_$key__noValidate___$DomPropsMixin);
+  static const PropDescriptor _$prop__open___$DomPropsMixin =
+      const PropDescriptor(_$key__open___$DomPropsMixin);
   static const PropDescriptor _$prop__readOnly___$DomPropsMixin =
       const PropDescriptor(_$key__readOnly___$DomPropsMixin);
   static const PropDescriptor _$prop__required___$DomPropsMixin =
@@ -1880,8 +1882,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__min___$DomPropsMixin);
   static const PropDescriptor _$prop__name___$DomPropsMixin =
       const PropDescriptor(_$key__name___$DomPropsMixin);
-  static const PropDescriptor _$prop__open___$DomPropsMixin =
-      const PropDescriptor(_$key__open___$DomPropsMixin);
   static const PropDescriptor _$prop__pattern___$DomPropsMixin =
       const PropDescriptor(_$key__pattern___$DomPropsMixin);
   static const PropDescriptor _$prop__placeholder___$DomPropsMixin =
@@ -2109,6 +2109,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__multiple___$DomPropsMixin = 'multiple';
   static const String _$key__muted___$DomPropsMixin = 'muted';
   static const String _$key__noValidate___$DomPropsMixin = 'noValidate';
+  static const String _$key__open___$DomPropsMixin = 'open';
   static const String _$key__readOnly___$DomPropsMixin = 'readOnly';
   static const String _$key__required___$DomPropsMixin = 'required';
   static const String _$key__seamless___$DomPropsMixin = 'seamless';
@@ -2161,7 +2162,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__method___$DomPropsMixin = 'method';
   static const String _$key__min___$DomPropsMixin = 'min';
   static const String _$key__name___$DomPropsMixin = 'name';
-  static const String _$key__open___$DomPropsMixin = 'open';
   static const String _$key__pattern___$DomPropsMixin = 'pattern';
   static const String _$key__placeholder___$DomPropsMixin = 'placeholder';
   static const String _$key__poster___$DomPropsMixin = 'poster';
@@ -2313,6 +2313,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__multiple___$DomPropsMixin,
     _$prop__muted___$DomPropsMixin,
     _$prop__noValidate___$DomPropsMixin,
+    _$prop__open___$DomPropsMixin,
     _$prop__readOnly___$DomPropsMixin,
     _$prop__required___$DomPropsMixin,
     _$prop__seamless___$DomPropsMixin,
@@ -2363,7 +2364,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__method___$DomPropsMixin,
     _$prop__min___$DomPropsMixin,
     _$prop__name___$DomPropsMixin,
-    _$prop__open___$DomPropsMixin,
     _$prop__pattern___$DomPropsMixin,
     _$prop__placeholder___$DomPropsMixin,
     _$prop__poster___$DomPropsMixin,
@@ -2488,6 +2488,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__multiple___$DomPropsMixin,
     _$key__muted___$DomPropsMixin,
     _$key__noValidate___$DomPropsMixin,
+    _$key__open___$DomPropsMixin,
     _$key__readOnly___$DomPropsMixin,
     _$key__required___$DomPropsMixin,
     _$key__seamless___$DomPropsMixin,
@@ -2538,7 +2539,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__method___$DomPropsMixin,
     _$key__min___$DomPropsMixin,
     _$key__name___$DomPropsMixin,
-    _$key__open___$DomPropsMixin,
     _$key__pattern___$DomPropsMixin,
     _$key__placeholder___$DomPropsMixin,
     _$key__poster___$DomPropsMixin,


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
To ensure that over_react's DOM elements have the same attributes, and attribute behavior, as React, we should update the `open` attribute to be a bool.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Change `open` from `dynamic` to `bool`.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Update the `open` HTML attribute typing to match that of the JavaScript community (and React specifically). 
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @kealjones-wk @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
