### PR TITLE
CPLAT-7607 [Dart 1] Improve handling of “repeat” errors thrown from components wrapped by an ErrorBoundary

### DIFF
--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -113,27 +113,27 @@ class _$ErrorBoundaryProps extends UiProps {
   /// > Related: [onComponentIsUnrecoverable]
   _ComponentDidCatchCallback onComponentDidCatch;
 
-  /// An optional callback that will be called _(when [ErrorBoundaryProps.fallbackUIRenderer] is not set)_
+  /// An optional callback that will be called _(when [fallbackUIRenderer] is not set)_
   /// with an [Error] _(or [Exception])_ and `errorInfo` containing information about which component in
   /// the tree threw multiple consecutive errors/exceptions frequently enough that it has the potential
   /// to lock the main thread.
   ///
-  /// The locking of the main thread is possible in this scenario because when [ErrorBoundaryProps.fallbackUIRenderer]
+  /// The locking of the main thread is possible in this scenario because when [fallbackUIRenderer]
   /// is not set, the [ErrorBoundary] simply re-mounts the child when an error occurs to try to "recover" automatically.
   /// However, if multiple identical errors are thrown from the exact same component in the tree - every time
   /// the [ErrorBoundary] re-mounts the tree, a sort of "infinite loop" will occur.
   ///
   /// When this callback is called, the tree wrapped by this [ErrorBoundary] has "crashed" - and is completely
   /// non-functional. Instead of re-mounting the component tree, the [ErrorBoundary] will simply render a
-  /// non-interactive `String` representation of the DOM that was captured at the time of the error.
+  /// static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// Once this happens, regaining interactivity within the tree wrapped by this [ErrorBoundary] is possible by:
   ///
   /// 1. Passing in a new child
   ///   _(preferably one that will not repeatedly throw errors when the [ErrorBoundary] mounts it)_.
-  /// 2. Calling the [ErrorBoundaryComponent.reset] instance method using a `ref`.
+  /// 2. Calling [ErrorBoundaryComponent.reset].
   ///
-  /// > Will never be called when [ErrorBoundaryProps.fallbackUIRenderer] is set.
+  /// > Will never be called when [fallbackUIRenderer] is set.
   ///
   /// > Related: [identicalErrorFrequencyTolerance]
   _ComponentDidCatchCallback onComponentIsUnrecoverable;
@@ -148,12 +148,12 @@ class _$ErrorBoundaryProps extends UiProps {
   /// within the tree wrapped by this [ErrorBoundary].
   ///
   /// If [fallbackUIRenderer] is not set, and more than one identical error is thrown consecutively by
-  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] - more often than
-  /// the specified duration, the [ErrorBoundary] will:
+  /// the exact same component anywhere within the tree wrapped by this [ErrorBoundary] -- more often than
+  /// the specified duration -- the [ErrorBoundary] will:
   ///
   ///   1. Call [onComponentIsUnrecoverable].
   ///   2. Stop attempting to re-mount the tree (to protect the main thread from being locked up).
-  ///   3. Render a non-interactive `String` representation of the DOM at the time of the error.
+  ///   3. Render a static copy of the render tree's HTML that was captured at the time of the error.
   ///
   /// When this happens, recovery can only occur by passing in a new child to
   /// the [ErrorBoundary], or by calling [ErrorBoundaryComponent.reset].
@@ -174,8 +174,8 @@ class _$ErrorBoundaryState extends UiState {
   ///   the tree to attempt to automatically recover from the error.
   ///
   ///   If an identical error is thrown from an identical component within the tree consecutively
-  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a non-interactive
-  ///   `String` representation of the DOM that was captured at the time of the error will be rendered.
+  ///   more frequently than [ErrorBoundaryProps.identicalErrorFrequencyTolerance], a static copy of
+  ///   the render tree's HTML that was captured at the time of the error will be rendered.
   ///   See: [ErrorBoundaryProps.onComponentIsUnrecoverable] for more information about this scenario.
   bool hasError;
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -307,14 +307,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
 
   /// Called by [componentDidCatch].
   void _handleErrorInComponentTree(/*Error||Exception*/dynamic error, /*NativeJavascriptObject*/dynamic jsErrorInfo) {
-    if (_lastError != null) {
-      print('\n\nerror: $error');
-      print('\n\n_lastError: $_lastError');
-    }
-
-    bool sameErrorWasThrownTwiceConsecutively =
-        error.toString() == _lastError?.toString() && _getReadableErrorInfo(jsErrorInfo) == _lastErrorInfo;
-
     // ----- [1] ----- //
     if (props.fallbackUIRenderer != null) {
       _lastError = error; // [1.1]
@@ -325,6 +317,9 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     }
     // ----- [2] ----- //
     else {
+      bool sameErrorWasThrownTwiceConsecutively =
+          error.toString() == _lastError?.toString() && _getReadableErrorInfo(jsErrorInfo) == _lastErrorInfo;
+
       if (sameErrorWasThrownTwiceConsecutively) { // [2.1]
         try { // [2.2.2]
           _domAtTimeOfError = findDomNode(this)?.innerHtml; // [2.2]

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -258,10 +258,12 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   /// This can be called manually on the component instance using a `ref` -
   /// or by passing in a new child instance after a child has thrown an error.
   void reset() {
-    setState((newState()
+    _resetInternalErrorTracking();
+
+    setState(newState()
       ..hasError = false
       ..showFallbackUIOnError = props.fallbackUIRenderer != null
-    ), _resetInternalErrorTracking);
+    );
   }
 
   // ---------------------------------------------- \/ ----------------------------------------------

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -368,7 +368,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   void _startIdenticalErrorTimer() {
     if (_identicalErrorTimer != null) return;
 
-    _identicalErrorTimer = new Timer(props.identicalErrorFrequencyTolerance, _resetInternalErrorTracking);
+    _identicalErrorTimer = getManagedTimer(props.identicalErrorFrequencyTolerance, _resetInternalErrorTracking);
   }
 
   /// Resets all the internal fields used by [_handleErrorInComponentTree], and cancels

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -347,7 +347,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     return (Dom.div()
       ..key = 'ohnoes'
       ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
-      ..['dangerouslySetInnerHTML'] = {'__html': _domAtTimeOfError} ?? ''
+      ..['dangerouslySetInnerHTML'] = {'__html': _domAtTimeOfError ?? ''}
     )();
   }
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -15,8 +15,8 @@
 @Timeout(const Duration(seconds: 2))
 library error_boundary_test;
 
+import 'dart:async';
 import 'dart:html';
-import 'dart:js';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
@@ -29,7 +29,7 @@ void main() {
     ReactElement dummyChild;
 
     setUp(() {
-      dummyChild = Dom.div()('hi there');
+      dummyChild = (Dom.div()..addTestId('dummyChild'))('hi there');
     });
 
     tearDown(() {
@@ -47,7 +47,9 @@ void main() {
         document.body.append(mountNode);
         var jacketOfFlawedComponentWithNoErrorBoundary = mount(Flawed()(), mountNode: mountNode);
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
-        jacketOfFlawedComponentWithNoErrorBoundary.getNode().click();
+        final buttonThatShouldThrowAnErrorWhenClicked = queryByTestId(jacketOfFlawedComponentWithNoErrorBoundary.getInstance(), 'flawedComponent_flawedButton');
+        expect(buttonThatShouldThrowAnErrorWhenClicked, isNotNull, reason: 'test setup sanity check');
+        buttonThatShouldThrowAnErrorWhenClicked.click();
         expect(mountNode.children, isEmpty,
             reason: 'rendered trees not wrapped in an ErrorBoundary '
                     'should get unmounted when an error is thrown within child component lifecycle methods');
@@ -72,7 +74,7 @@ void main() {
         );
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
         // Cause an error to be thrown within a ReactJS lifecycle method
-        jacket.getNode().click();
+        queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton').click();
       });
 
       tearDown(() {
@@ -86,7 +88,11 @@ void main() {
         expect(errArg.toString(), contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
 
         final infoArg = calls.single['onComponentDidCatch'][1];
-        expect(infoArg, isNotNull);
+        expect(infoArg, const isInstanceOf<String>());
+      });
+
+      test('and sets `state.hasError` to true', () {
+        expect(jacket.getDartInstance().state.hasError, isTrue);
       });
 
       test('and re-renders the tree as a result', () {
@@ -99,14 +105,14 @@ void main() {
         jacket = mount(ErrorBoundary()((Flawed()..addTestId('flawed'))()), mountNode: mountNode);
         // The click causes the componentDidCatch lifecycle method to execute
         // and we want to ensure that no Dart null error is thrown as a result of no consumer prop callback being set.
-        expect(() => jacket.getNode().click(), returnsNormally);
+        expect(() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton').click(), returnsNormally);
       });
     });
 
     test('initializes with the expected default prop values', () {
       jacket = mount(ErrorBoundary()(dummyChild));
 
-      expect(() => ErrorBoundary(jacket.getProps()).fallbackUIRenderer(null, null), throwsUnimplementedError);
+      expect(ErrorBoundary(jacket.getProps()).identicalErrorFrequencyTolerance.inSeconds, 5);
     });
 
     test('initializes with the expected initial state values', () {
@@ -123,13 +129,30 @@ void main() {
         expect(jacket.getNode().text, 'hi there');
       });
 
-      group('fallback UI when `state.error` is true', () {
-        test('', () {
-          jacket = mount(ErrorBoundary()(dummyChild));
-          final component = jacket.getDartInstance();
+      test('its child when `state.error` is true and `state.showFallbackUIOnError` is false', () {
+        jacket = mount(ErrorBoundary()(dummyChild));
+        final component = jacket.getDartInstance();
+        component.setState(component.newState()
+          ..hasError = true
+          ..showFallbackUIOnError = false
+        );
 
-          // Using throws for now since this is temporary, and the throwsUnimplementedError doesn't work here for some reason
-          expect(() => component.setState(component.newState()..hasError = true), throws);
+        expect(jacket.getNode().text, 'hi there');
+      });
+
+      group('fallback UI when `state.error` is true', () {
+        test('and `state.showFallbackUIOnError` is true ("unrecoverable" error state)', () {
+          jacket = mount(ErrorBoundary()(dummyChild));
+          expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNotNull);
+          final component = jacket.getDartInstance();
+          component.setState(component.newState()
+            ..hasError = true
+            ..showFallbackUIOnError = true
+          );
+
+          expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNull,
+              reason: 'The child component tree should have been removed from the dom');
+          expect(jacket.getNode(), hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
         });
 
         // TODO: Update this test to assert the error / component stack values passed to the callback once the actual ReactJS 16 error lifecycle methods are implemented.
@@ -145,8 +168,452 @@ void main() {
           expect(jacket.getNode(), hasNodeName('H4'));
           expect(jacket.getNode().text, 'Something super not awesome just happened.');
         });
+
+        group('and then switches back to rendering the child', () {
+          setUp(() {
+            jacket = mount((ErrorBoundary()
+              ..fallbackUIRenderer = (_, __) => (Dom.div()..addTestId('fallbackNode'))('Something went wrong')
+            )(dummyChild));
+            final component = jacket.getDartInstance();
+            component.setState(component.newState()
+              ..hasError = true
+              ..showFallbackUIOnError = true
+            );
+            expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNotNull);
+          });
+
+          test('when reset() is called', () {
+            jacket.getDartInstance().reset();
+            expect(jacket.getDartInstance().state.hasError, isFalse);
+            expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue);
+            expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNotNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNull);
+          });
+
+          test('when a new child is passed in', () {
+            final newDummyChild = (Dom.div()..addTestId('newDummyChild'))('hi there');
+            jacket.rerender((ErrorBoundary()
+              ..fallbackUIRenderer = (_, __) => (Dom.div()..addTestId('fallbackNode'))('Something went wrong')
+            )(newDummyChild));
+            expect(jacket.getDartInstance().state.hasError, isFalse);
+            expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue);
+            expect(getByTestId(jacket.getInstance(), 'newDummyChild'), isNotNull);
+            expect(getByTestId(jacket.getInstance(), 'fallbackNode'), isNull);
+          });
+        });
       });
     });
+
+    group('gracefully handles errors in its tree when `props.fallbackUIRenderer` is not set', () {
+      List<Map<String, List>> calls;
+      DivElement mountNode;
+      var flawedRenderedInstance;
+      var nestedFlawedRenderedInstance;
+      const identicalErrorFrequencyToleranceInMs = 100;
+      dynamic errorSentToComponentDidCatchCallback;
+      dynamic errorInfoSentToComponentDidCatchCallback;
+      dynamic errorSentToComponentIsUnrecoverableCallback;
+      dynamic errorInfoSentToComponentIsUnrecoverableCallback;
+
+      Element getFlawedButtonNode() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButton');
+      Element getFlawedButtonThatThrowsADifferentErrorNode() => queryByTestId(jacket.getInstance(), 'flawedComponent_flawedButtonThatThrowsADifferentError');
+      Element getNestedFlawedButtonNode() => queryByTestId(jacket.getInstance(), 'nestedFlawedComponent_flawedButton');
+      Element getNestedFlawedButtonThatThrowsADifferentErrorNode() => queryByTestId(jacket.getInstance(), 'nestedFlawedComponent_flawedButtonThatThrowsADifferentError');
+
+      void _setCallbackVarValues() {
+        expect(calls, isNotNull, reason: 'test setup sanity check');
+        expect(calls, isNotEmpty, reason: 'test setup sanity check');
+        expect(calls[0].keys.single, 'onComponentDidCatch', reason: 'test setup sanity check');
+        expect(jacket.getDartInstance().state.hasError, isTrue, reason: 'test setup sanity check');
+
+        final componentDidCatchCallbackArguments = calls[0]['onComponentDidCatch'];
+        if (componentDidCatchCallbackArguments != null) {
+          errorSentToComponentDidCatchCallback = componentDidCatchCallbackArguments[0];
+          errorInfoSentToComponentDidCatchCallback = componentDidCatchCallbackArguments[1];
+        }
+
+        if (calls.length > 1) {
+          expect(calls[1].keys.single, 'onComponentIsUnrecoverable', reason: 'test setup sanity check');
+          final componentIsUnrecoverableCallbackArguments = calls[1]['onComponentIsUnrecoverable'];
+          if (componentIsUnrecoverableCallbackArguments != null) {
+            errorSentToComponentIsUnrecoverableCallback = componentIsUnrecoverableCallbackArguments[0];
+            errorInfoSentToComponentIsUnrecoverableCallback = componentIsUnrecoverableCallbackArguments[1];
+          }
+        }
+      }
+
+      setUp(() {
+        mountNode = new DivElement();
+        document.body.append(mountNode);
+
+        calls = [];
+
+        jacket = mount(
+          (ErrorBoundary()
+            ..identicalErrorFrequencyTolerance = const Duration(
+                milliseconds: identicalErrorFrequencyToleranceInMs)
+            ..onComponentDidCatch = (err, info) {
+              calls.add({'onComponentDidCatch': [err, info]});
+            }
+            ..onComponentIsUnrecoverable = (err, info) {
+              calls.add({'onComponentIsUnrecoverable': [err, info]});
+            }
+          )(
+            (Flawed()..addTestId('flawedComponent'))(
+              (Flawed()
+                ..buttonTestIdPrefix = 'nestedFlawedComponent_'
+                ..addTestId('nestedFlawedComponent')
+              )(),
+            ),
+          ),
+          mountNode: mountNode,
+        );
+
+        flawedRenderedInstance = getByTestId(jacket.getInstance(), 'flawedComponent');
+        expect(flawedRenderedInstance, isNotNull, reason: 'test setup sanity check');
+
+        nestedFlawedRenderedInstance = getByTestId(jacket.getInstance(), 'nestedFlawedComponent');
+        expect(nestedFlawedRenderedInstance, isNotNull, reason: 'test setup sanity check');
+      });
+
+      tearDown(() {
+        calls = null;
+        flawedRenderedInstance = null;
+        nestedFlawedRenderedInstance = null;
+        errorSentToComponentDidCatchCallback = null;
+        errorInfoSentToComponentDidCatchCallback = null;
+        errorSentToComponentIsUnrecoverableCallback = null;
+        errorInfoSentToComponentIsUnrecoverableCallback = null;
+        mountNode.remove();
+        mountNode = null;
+      });
+
+      group('and consecutive errors are thrown from the same component', () {
+        Future<Null> triggerErrorsThatSignifyAnUnrecoverableComponent() async {
+          getFlawedButtonNode().click();
+          expect(calls.length, 1, reason: 'test setup sanity check');
+          expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+          calls.clear();
+          await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+          getFlawedButtonNode().click();
+          _setCallbackVarValues();
+        }
+
+        group('and the errors are exactly the same', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            String errorBoundaryInnerHtmlBeforeUnrecoverableError;
+
+            setUp(() async {
+              expect(jacket.getNode(),
+                  isNot(hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')),
+                  reason: 'test setup sanity check');
+              errorBoundaryInnerHtmlBeforeUnrecoverableError = jacket.getNode().innerHtml;
+              await triggerErrorsThatSignifyAnUnrecoverableComponent();
+            });
+
+            tearDown(() {
+              errorBoundaryInnerHtmlBeforeUnrecoverableError = null;
+            });
+
+            test('the components wrapped by the ErrorBoundary get unmounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
+                  reason: 'The flawed component should have been unmounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
+                  reason: 'Fallback UI should be rendered instead of the flawed component tree');
+              expect(jacket.getNode(),
+                  hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
+              expect(jacket.getNode().innerHtml, errorBoundaryInnerHtmlBeforeUnrecoverableError);
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
+                  reason: 'onComponentIsUnrecoverable should have been called');
+
+              expect(errorSentToComponentDidCatchCallback, const isInstanceOf<FlawedComponentException>());
+              expect(errorSentToComponentIsUnrecoverableCallback, const isInstanceOf<FlawedComponentException>());
+              expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
+
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+              expect(errorInfoSentToComponentIsUnrecoverableCallback, const isInstanceOf<String>());
+              expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getFlawedButtonNode().click();
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+
+            // Test that unrecoverable errors that come after recoverable ones produce the same behavior
+            // as unrecoverable errors that are the first caught by the ErrorBoundary after being mounted.
+            group('but are then followed by two more errors that are exactly the same, '
+                'more frequent than the value of props.identicalErrorFrequencyTolerance', () {
+              setUp(() async {
+                await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+                calls.clear();
+                await triggerErrorsThatSignifyAnUnrecoverableComponent();
+              });
+
+              test('the components wrapped by the ErrorBoundary get unmounted', () {
+                expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
+                    reason: 'The flawed component should have been unmounted');
+                expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
+                    reason: 'Fallback UI should be rendered instead of the flawed component tree');
+              });
+
+              test('the correct callbacks are called with the correct arguments', () {
+                expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
+                    reason: 'onComponentIsUnrecoverable should have been called');
+
+                expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+                expect(errorSentToComponentIsUnrecoverableCallback.toString(),
+                  contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+                expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
+
+                expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+                expect(errorInfoSentToComponentIsUnrecoverableCallback, const isInstanceOf<String>());
+                expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
+              });
+            });
+          });
+        });
+
+        group('and the errors are different', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getFlawedButtonThatThrowsADifferentErrorNode().click();
+
+              expect('$firstError'.contains('FlawedComponentException2'), isFalse, reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException2: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getFlawedButtonThatThrowsADifferentErrorNode().click();
+
+              expect('$firstError'.contains('FlawedComponentException2'), isFalse, reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException2: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+        });
+      });
+
+      group('and consecutive errors are thrown from different components in the same tree', () {
+        group('and the errors are exactly the same', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getNestedFlawedButtonNode().click();
+
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getNestedFlawedButtonNode().click();
+
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+        });
+
+        group('and the errors are different', () {
+          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs - 50));
+
+              getNestedFlawedButtonThatThrowsADifferentErrorNode().click();
+
+              expect('$firstError'.contains('FlawedComponentException2'), isFalse, reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException2: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+
+          group('and they occurred less frequently than the value of props.identicalErrorFrequencyTolerance:', () {
+            setUp(() async {
+              getFlawedButtonNode().click();
+              expect(calls.length, 1, reason: 'test setup sanity check');
+              expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
+              final firstError = calls[0]['onComponentDidCatch'][0];
+
+              calls.clear();
+              await new Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs + 50));
+
+              getNestedFlawedButtonThatThrowsADifferentErrorNode().click();
+
+              expect('$firstError'.contains('FlawedComponentException2'), isFalse, reason: 'test setup sanity check');
+              _setCallbackVarValues();
+            });
+
+            test('the components wrapped by the ErrorBoundary get remounted', () {
+              expect(getByTestId(jacket.getInstance(), 'nestedFlawedComponent'), isNotNull,
+                  reason: 'The flawed component should have been remounted');
+              expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
+                  reason: 'Fallback UI should be not be rendered');
+            });
+
+            test('the correct callbacks are called with the correct arguments', () {
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
+
+              expect(errorSentToComponentDidCatchCallback.toString(),
+                  contains('FlawedComponentException2: I was thrown from inside FlawedComponent.componentWillUpdate!'));
+              expect(errorInfoSentToComponentDidCatchCallback, const isInstanceOf<String>());
+            });
+          });
+        });
+      });
+    // Doesn't work great in Dartium since the `toString` of the errors includes the entire call stack,
+    // causing the error boundary to not think the same error was thrown, so it will keep re-mounting.
+    //
+    // The fix works as expected in dart2js though - which - for our last remnants of Dart 1 support -
+    // seems good enough to me.
+    }, testOn: 'js');
 
     group('throws a PropError when', () {
       test('more than one child is provided', () {

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -50,8 +50,10 @@ void main() {
         document.body.append(mountNode);
         var jacketOfFlawedComponentWithNoErrorBoundary = mount(Flawed()(), mountNode: mountNode);
         expect(mountNode.children, isNotEmpty, reason: 'test setup sanity check');
+
         final buttonThatShouldThrowAnErrorWhenClicked = queryByTestId(jacketOfFlawedComponentWithNoErrorBoundary.getInstance(), 'flawedComponent_flawedButton');
         expect(buttonThatShouldThrowAnErrorWhenClicked, isNotNull, reason: 'test setup sanity check');
+
         buttonThatShouldThrowAnErrorWhenClicked.click();
         expect(mountNode.children, isEmpty,
             reason: 'rendered trees not wrapped in an ErrorBoundary '

--- a/test/over_react/component/fixtures/flawed_component.dart
+++ b/test/over_react/component/fixtures/flawed_component.dart
@@ -8,7 +8,9 @@ part 'flawed_component.over_react.g.dart';
 UiFactory<FlawedProps> Flawed = _$Flawed;
 
 @Props()
-class _$FlawedProps extends UiProps {}
+class _$FlawedProps extends UiProps {
+  String buttonTestIdPrefix;
+}
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
 // ignore: mixin_of_non_class, undefined_class
@@ -19,7 +21,8 @@ class FlawedProps extends _$FlawedProps with _$FlawedPropsAccessorsMixin {
 
 @State()
 class _$FlawedState extends UiState {
-  bool hasError;
+  int errorCount;
+  int differentTypeOfErrorCount;
 }
 
 // AF-3369 This will be removed once the transition to Dart 2 is complete.
@@ -32,28 +35,56 @@ class FlawedState extends _$FlawedState with _$FlawedStateAccessorsMixin {
 @Component()
 class FlawedComponent extends UiStatefulComponent<FlawedProps, FlawedState> {
   @override
-  Map getInitialState() => (newState()..hasError = false);
+  Map getDefaultProps() => (newProps()..buttonTestIdPrefix = 'flawedComponent_');
+
+  @override
+  Map getInitialState() => (newState()
+    ..errorCount = 0
+    ..differentTypeOfErrorCount = 0
+  );
 
   @override
   void componentWillUpdate(_, Map nextState) {
     final tNextState = typedStateFactory(nextState);
-    if (tNextState.hasError && !state.hasError) {
+    if (tNextState.errorCount > state.errorCount) {
       throw new FlawedComponentException();
+    }
+
+    if (tNextState.differentTypeOfErrorCount > state.differentTypeOfErrorCount) {
+      throw new FlawedComponentException2();
     }
   }
 
   @override
   render() {
-    return (Dom.button()
-      ..addTestId('flawedButton')
-      ..onClick = (_) {
-        setState(newState()..hasError = true);
-      }
-    )('oh hai');
+    return Dom.div()(
+      (Dom.button()
+        ..addTestId('${props.buttonTestIdPrefix}flawedButton')
+        ..onClick = (_) {
+          setState(newState()..errorCount = state.errorCount + 1);
+        }
+      )(
+        'oh hai',
+      ),
+      (Dom.button()
+        ..addTestId('${props.buttonTestIdPrefix}flawedButtonThatThrowsADifferentError')
+        ..onClick = (_) {
+          setState(newState()..differentTypeOfErrorCount = state.differentTypeOfErrorCount + 1);
+        }
+      )(
+        'oh hai',
+      ),
+      props.children,
+    );
   }
 }
 
 class FlawedComponentException implements Exception {
   @override
   String toString() => 'FlawedComponentException: I was thrown from inside FlawedComponent.componentWillUpdate!';
+}
+
+class FlawedComponentException2 implements Exception {
+  @override
+  String toString() => 'FlawedComponentException2: I was thrown from inside FlawedComponent.componentWillUpdate!';
 }

--- a/test/over_react/component/fixtures/flawed_component_on_mount.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_on_mount.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedOnMountProps> FlawedOnMount = _$FlawedOnMount;
+
+@Props()
+class _$FlawedOnMountProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedOnMountProps extends _$FlawedOnMountProps with _$FlawedOnMountPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedOnMountProps;
+}
+
+@Component()
+class FlawedOnMountComponent extends UiComponent<FlawedOnMountProps> {
+  @override
+  void componentDidMount() {
+    throw new FlawedOnMountComponentException();
+  }
+
+  @override
+  render() {
+    return (Dom.div()..addProps(copyUnconsumedDomProps()))(props.children);
+  }
+}
+
+class FlawedOnMountComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedOnMountComponentException: I was thrown from inside FlawedOnMountComponent.componentDidMount!';
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_that_renders_a_string.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedWithStringChildProps> FlawedWithStringChild = _$FlawedWithStringChild;
+
+@Props()
+class _$FlawedWithStringChildProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedWithStringChildProps extends _$FlawedWithStringChildProps with _$FlawedWithStringChildPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedWithStringChildProps;
+}
+
+@Component()
+class FlawedWithStringChildComponent extends UiComponent<FlawedWithStringChildProps> {
+  @override
+  void componentDidMount() {
+    throw new FlawedWithStringChildComponentException();
+  }
+
+  @override
+  render() {
+    return 'just a string, yo';
+  }
+}
+
+class FlawedWithStringChildComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedWithStringChildComponentException: I was thrown from inside FlawedWithStringChildComponent.componentDidMount!';
+}

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.dart
@@ -1,0 +1,37 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'flawed_component_that_renders_nothing.over_react.g.dart';
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FlawedWithNoChildProps> FlawedWithNoChild = _$FlawedWithNoChild;
+
+@Props()
+class _$FlawedWithNoChildProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FlawedWithNoChildProps extends _$FlawedWithNoChildProps with _$FlawedWithNoChildPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFlawedWithNoChildProps;
+}
+
+@Component()
+class FlawedWithNoChildComponent extends UiComponent<FlawedWithNoChildProps> {
+  @override
+  void componentDidMount() {
+    throw new FlawedWithNoChildComponentException();
+  }
+
+  @override
+  render() {
+    return null;
+  }
+}
+
+class FlawedWithNoChildComponentException implements Exception {
+  @override
+  String toString() =>
+      'FlawedWithNoChildComponentException: I was thrown from inside FlawedWithNoChildComponent.componentDidMount!';
+}


### PR DESCRIPTION
+ Dart 1 port of #350

> See #350 for full description

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 