### PR TITLE
Remove unnecessary DDC workaround

### DIFF
--- a/example/builder/abstract_inheritance.over_react.g.dart
+++ b/example/builder/abstract_inheritance.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$SubPropsAccessorsMixin implements _$SubProps {
 
   /// <!-- Generated from [_$SubProps.subProp] -->
   @override
-  String get subProp =>
-      props[_$key__subProp___$SubProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subProp => props[_$key__subProp___$SubProps];
+
   /// <!-- Generated from [_$SubProps.subProp] -->
   @override
   set subProp(String value) => props[_$key__subProp___$SubProps] = value;
@@ -123,9 +122,8 @@ abstract class _$SubStateAccessorsMixin implements _$SubState {
 
   /// <!-- Generated from [_$SubState.subState] -->
   @override
-  String get subState =>
-      state[_$key__subState___$SubState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subState => state[_$key__subState___$SubState];
+
   /// <!-- Generated from [_$SubState.subState] -->
   @override
   set subState(String value) => state[_$key__subState___$SubState] = value;
@@ -270,9 +268,8 @@ abstract class _$SuperPropsAccessorsMixin implements _$SuperProps {
 
   /// <!-- Generated from [_$SuperProps.superProp] -->
   @override
-  String get superProp =>
-      props[_$key__superProp___$SuperProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp => props[_$key__superProp___$SuperProps];
+
   /// <!-- Generated from [_$SuperProps.superProp] -->
   @override
   set superProp(String value) => props[_$key__superProp___$SuperProps] = value;
@@ -302,9 +299,8 @@ abstract class _$SuperStateAccessorsMixin implements _$SuperState {
 
   /// <!-- Generated from [_$SuperState.superState] -->
   @override
-  String get superState =>
-      state[_$key__superState___$SuperState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superState => state[_$key__superState___$SuperState];
+
   /// <!-- Generated from [_$SuperState.superState] -->
   @override
   set superState(String value) =>

--- a/example/builder/basic.over_react.g.dart
+++ b/example/builder/basic.over_react.g.dart
@@ -26,9 +26,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp =>
-      props[_$key__basicProp___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   @deprecated
@@ -37,45 +36,40 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/example/builder/basic_library.over_react.g.dart
+++ b/example/builder/basic_library.over_react.g.dart
@@ -25,9 +25,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
-  String get basicProp =>
-      props[_$key__basicProp___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
   set basicProp(String value) =>
@@ -35,9 +34,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
@@ -45,9 +43,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
@@ -55,9 +52,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
@@ -65,9 +61,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
@@ -75,9 +70,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
@@ -211,9 +205,8 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
-  String get basicState =>
-      state[_$key__basicState___$BasicPartOfLibState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
+
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
@@ -379,9 +372,8 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
-  String get subProp =>
-      props[_$key__subProp___$SubPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
+
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
@@ -472,9 +464,8 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
-  String get superProp =>
-      props[_$key__superProp___$SuperPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
+
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>

--- a/example/builder/basic_with_state.over_react.g.dart
+++ b/example/builder/basic_with_state.over_react.g.dart
@@ -24,54 +24,48 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
-  String get basicProp =>
-      props[_$key__basicProp___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basicProp] -->
   @override
   set basicProp(String value) => props[_$key__basicProp___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;
@@ -195,9 +189,8 @@ abstract class _$BasicStateAccessorsMixin implements _$BasicState {
 
   /// <!-- Generated from [_$BasicState.basicState] -->
   @override
-  String get basicState =>
-      state[_$key__basicState___$BasicState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicState => state[_$key__basicState___$BasicState];
+
   /// <!-- Generated from [_$BasicState.basicState] -->
   @override
   set basicState(String value) =>

--- a/example/builder/basic_with_type_params.over_react.g.dart
+++ b/example/builder/basic_with_type_params.over_react.g.dart
@@ -26,8 +26,8 @@ abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
   /// <!-- Generated from [_$BasicProps.someGenericListProp] -->
   @override
   List<T> get someGenericListProp =>
-      props[_$key__someGenericListProp___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__someGenericListProp___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.someGenericListProp] -->
   @override
   set someGenericListProp(List<T> value) =>
@@ -35,9 +35,8 @@ abstract class _$BasicPropsAccessorsMixin<T, U extends UiProps>
 
   /// <!-- Generated from [_$BasicProps.somePropsClass] -->
   @override
-  U get somePropsClass =>
-      props[_$key__somePropsClass___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  U get somePropsClass => props[_$key__somePropsClass___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.somePropsClass] -->
   @override
   set somePropsClass(U value) =>

--- a/example/builder/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/generic_inheritance_sub.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$GenericSubPropsAccessorsMixin implements _$GenericSubProps {
 
   /// <!-- Generated from [_$GenericSubProps.subProp] -->
   @override
-  String get subProp =>
-      props[_$key__subProp___$GenericSubProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subProp => props[_$key__subProp___$GenericSubProps];
+
   /// <!-- Generated from [_$GenericSubProps.subProp] -->
   @override
   set subProp(String value) => props[_$key__subProp___$GenericSubProps] = value;
@@ -127,9 +126,8 @@ abstract class _$GenericSubStateAccessorsMixin implements _$GenericSubState {
 
   /// <!-- Generated from [_$GenericSubState.subState] -->
   @override
-  String get subState =>
-      state[_$key__subState___$GenericSubState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subState => state[_$key__subState___$GenericSubState];
+
   /// <!-- Generated from [_$GenericSubState.subState] -->
   @override
   set subState(String value) =>

--- a/example/builder/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/generic_inheritance_super.over_react.g.dart
@@ -26,8 +26,8 @@ abstract class _$GenericSuperPropsAccessorsMixin
   /// <!-- Generated from [_$GenericSuperProps.otherSuperProp] -->
   @override
   String get otherSuperProp =>
-      props[_$key__otherSuperProp___$GenericSuperProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__otherSuperProp___$GenericSuperProps];
+
   /// <!-- Generated from [_$GenericSuperProps.otherSuperProp] -->
   @override
   set otherSuperProp(String value) =>
@@ -35,9 +35,8 @@ abstract class _$GenericSuperPropsAccessorsMixin
 
   /// <!-- Generated from [_$GenericSuperProps.superProp] -->
   @override
-  String get superProp =>
-      props[_$key__superProp___$GenericSuperProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp => props[_$key__superProp___$GenericSuperProps];
+
   /// <!-- Generated from [_$GenericSuperProps.superProp] -->
   @override
   set superProp(String value) =>
@@ -45,9 +44,8 @@ abstract class _$GenericSuperPropsAccessorsMixin
 
   /// <!-- Generated from [_$GenericSuperProps.superProp1] -->
   @override
-  String get superProp1 =>
-      props[_$key__superProp1___$GenericSuperProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp1 => props[_$key__superProp1___$GenericSuperProps];
+
   /// <!-- Generated from [_$GenericSuperProps.superProp1] -->
   @override
   set superProp1(String value) =>
@@ -162,9 +160,8 @@ abstract class _$GenericSuperStateAccessorsMixin
 
   /// <!-- Generated from [_$GenericSuperState.superState] -->
   @override
-  String get superState =>
-      state[_$key__superState___$GenericSuperState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superState => state[_$key__superState___$GenericSuperState];
+
   /// <!-- Generated from [_$GenericSuperState.superState] -->
   @override
   set superState(String value) =>

--- a/example/builder/private_component.over_react.g.dart
+++ b/example/builder/private_component.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$_PrivatePropsAccessorsMixin implements _$_PrivateProps {
 
   /// <!-- Generated from [_$_PrivateProps.prop1] -->
   @override
-  bool get prop1 =>
-      props[_$key__prop1___$_PrivateProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get prop1 => props[_$key__prop1___$_PrivateProps];
+
   /// <!-- Generated from [_$_PrivateProps.prop1] -->
   @override
   set prop1(bool value) => props[_$key__prop1___$_PrivateProps] = value;
@@ -123,9 +122,8 @@ abstract class _$_PrivateStateAccessorsMixin implements _$_PrivateState {
 
   /// <!-- Generated from [_$_PrivateState.state1] -->
   @override
-  bool get state1 =>
-      state[_$key__state1___$_PrivateState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get state1 => state[_$key__state1___$_PrivateState];
+
   /// <!-- Generated from [_$_PrivateState.state1] -->
   @override
   set state1(bool value) => state[_$key__state1___$_PrivateState] = value;

--- a/example/builder/private_factory_public_component.over_react.g.dart
+++ b/example/builder/private_factory_public_component.over_react.g.dart
@@ -25,9 +25,8 @@ abstract class _$FormActionInputPropsAccessorsMixin
 
   /// <!-- Generated from [_$FormActionInputProps.prop1] -->
   @override
-  String get prop1 =>
-      props[_$key__prop1___$FormActionInputProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get prop1 => props[_$key__prop1___$FormActionInputProps];
+
   /// <!-- Generated from [_$FormActionInputProps.prop1] -->
   @override
   set prop1(String value) =>

--- a/example/builder/props_mixin.over_react.g.dart
+++ b/example/builder/props_mixin.over_react.g.dart
@@ -14,9 +14,8 @@ abstract class ExamplePropsMixinClass implements _$ExamplePropsMixinClass {
 
   /// <!-- Generated from [_$ExamplePropsMixinClass.propMixin1] -->
   @override
-  String get propMixin1 =>
-      props[_$key__propMixin1___$ExamplePropsMixinClass] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get propMixin1 => props[_$key__propMixin1___$ExamplePropsMixinClass];
+
   /// <!-- Generated from [_$ExamplePropsMixinClass.propMixin1] -->
   @override
   set propMixin1(String value) =>
@@ -50,8 +49,8 @@ abstract class MixesInOtherMixinMixin<T extends Iterable, U>
   /// <!-- Generated from [_$MixesInOtherMixinMixin.otherPropMixin] -->
   @override
   String get otherPropMixin =>
-      props[_$key__otherPropMixin___$MixesInOtherMixinMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__otherPropMixin___$MixesInOtherMixinMixin];
+
   /// <!-- Generated from [_$MixesInOtherMixinMixin.otherPropMixin] -->
   @override
   set otherPropMixin(String value) =>

--- a/example/builder/state_mixin.over_react.g.dart
+++ b/example/builder/state_mixin.over_react.g.dart
@@ -14,9 +14,8 @@ abstract class ExampleStateMixinClass implements _$ExampleStateMixinClass {
 
   /// <!-- Generated from [_$ExampleStateMixinClass.stateMixin1] -->
   @override
-  String get stateMixin1 =>
-      state[_$key__stateMixin1___$ExampleStateMixinClass] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stateMixin1 => state[_$key__stateMixin1___$ExampleStateMixinClass];
+
   /// <!-- Generated from [_$ExampleStateMixinClass.stateMixin1] -->
   @override
   set stateMixin1(String value) =>

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -115,8 +115,8 @@ abstract class _$MyProviderComponentStateAccessorsMixin
   /// <!-- Generated from [_$MyProviderComponentState.latestValue] -->
   @override
   String get latestValue =>
-      state[_$key__latestValue___$MyProviderComponentState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__latestValue___$MyProviderComponentState];
+
   /// <!-- Generated from [_$MyProviderComponentState.latestValue] -->
   @override
   set latestValue(String value) =>

--- a/example/over_react_redux/components/counter.over_react.g.dart
+++ b/example/over_react_redux/components/counter.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.currentCount] -->
   @override
-  int get currentCount =>
-      props[_$key__currentCount___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get currentCount => props[_$key__currentCount___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.currentCount] -->
   @override
   set currentCount(int value) =>
@@ -35,8 +34,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
   /// <!-- Generated from [_$CounterProps.wrapperStyles] -->
   @override
   Map<String, dynamic> get wrapperStyles =>
-      props[_$key__wrapperStyles___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__wrapperStyles___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.wrapperStyles] -->
   @override
   set wrapperStyles(Map<String, dynamic> value) =>
@@ -44,9 +43,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.increment] -->
   @override
-  void Function() get increment =>
-      props[_$key__increment___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  void Function() get increment => props[_$key__increment___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.increment] -->
   @override
   set increment(void Function() value) =>
@@ -54,9 +52,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.decrement] -->
   @override
-  void Function() get decrement =>
-      props[_$key__decrement___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  void Function() get decrement => props[_$key__decrement___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.decrement] -->
   @override
   set decrement(void Function() value) =>

--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -417,8 +417,8 @@ class ImplGenerator {
             if (variable.initializer != null) {
               logger.severe(messageWithSpan(
                   'Fields are stubs for generated setters/getters and should not have initializers.\n'
-                      'Instead, initialize ${type.isProps 
-                          ? 'prop values within getDefaultProps()' 
+                      'Instead, initialize ${type.isProps
+                          ? 'prop values within getDefaultProps()'
                           : 'state values within getInitialState()'}.',
                   span: getSpan(sourceFile, variable))
               );
@@ -518,7 +518,7 @@ class ImplGenerator {
                 // '  @tryInline\n'
                 '  @override\n'
                 '${metadataSrc.toString()}'
-                '  ${typeString}get $accessorName => $proxiedMapName[$keyConstantName] ?? null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;\n'
+                '  ${typeString}get $accessorName => $proxiedMapName[$keyConstantName];\n'
                 '  $docComment\n'
                 // '  @tryInline\n'
                 '  @override\n'

--- a/lib/src/component/abstract_transition.over_react.g.dart
+++ b/lib/src/component/abstract_transition.over_react.g.dart
@@ -39,8 +39,8 @@ abstract class _$AbstractTransitionStateAccessorsMixin
   /// <!-- Generated from [_$AbstractTransitionState.transitionPhase] -->
   @override
   TransitionPhase get transitionPhase =>
-      state[_$key__transitionPhase___$AbstractTransitionState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__transitionPhase___$AbstractTransitionState];
+
   /// The current phase of transition the [AbstractTransitionComponent] is in.
   ///
   /// Default:  [AbstractTransitionComponent.initiallyShown] ? [TransitionPhase.SHOWN] : [TransitionPhase.HIDDEN]

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -23,8 +23,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// <!-- Generated from [_$TransitionPropsMixin.transitionCount] -->
   @override
   int get transitionCount =>
-      props[_$key__transitionCount___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__transitionCount___$TransitionPropsMixin];
+
   /// The number of `transitionend` event that occur when the transition node is shown/hidden.
   ///
   /// Serves as the default for [transitionInCount]/[transitionOutCount] when they are not specified.
@@ -43,8 +43,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// <!-- Generated from [_$TransitionPropsMixin.transitionInCount] -->
   @override
   int get transitionInCount =>
-      props[_$key__transitionInCount___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__transitionInCount___$TransitionPropsMixin];
+
   /// The number of `transitionend` event that occur when the transition node is shown.
   ///
   /// Default: [transitionCount]
@@ -61,8 +61,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   /// <!-- Generated from [_$TransitionPropsMixin.transitionOutCount] -->
   @override
   int get transitionOutCount =>
-      props[_$key__transitionOutCount___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__transitionOutCount___$TransitionPropsMixin];
+
   /// The number of `transitionend` event that occur when the transition node is hidden.
   ///
   /// Default: [transitionCount]
@@ -78,9 +78,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onWillHide] -->
   @override
-  Callback get onWillHide =>
-      props[_$key__onWillHide___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Callback get onWillHide => props[_$key__onWillHide___$TransitionPropsMixin];
+
   /// Optional callback that fires before the [AbstractTransitionComponent] is hidden.
   ///
   /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will remain visible.
@@ -94,9 +93,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onDidHide] -->
   @override
-  Callback get onDidHide =>
-      props[_$key__onDidHide___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Callback get onDidHide => props[_$key__onDidHide___$TransitionPropsMixin];
+
   /// Optional callback that fires after the [AbstractTransitionComponent] is hidden.
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onDidHide] -->
@@ -110,9 +108,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onWillShow] -->
   @override
-  Callback get onWillShow =>
-      props[_$key__onWillShow___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Callback get onWillShow => props[_$key__onWillShow___$TransitionPropsMixin];
+
   /// Optional callback that fires before the [AbstractTransitionComponent] appears.
   ///
   /// Returning `false` will cancel default behavior, and the [AbstractTransitionComponent] will not appear.
@@ -126,9 +123,8 @@ abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onDidShow] -->
   @override
-  Callback get onDidShow =>
-      props[_$key__onDidShow___$TransitionPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Callback get onDidShow => props[_$key__onDidShow___$TransitionPropsMixin];
+
   /// Optional callback that fires after the [AbstractTransitionComponent] appears.
   ///
   /// <!-- Generated from [_$TransitionPropsMixin.onDidShow] -->

--- a/lib/src/component/aria_mixin.over_react.g.dart
+++ b/lib/src/component/aria_mixin.over_react.g.dart
@@ -33,8 +33,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   @override
   @Accessor(key: 'aria-activedescendant')
   String get activedescendant =>
-      props[_$key__activedescendant___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__activedescendant___$AriaPropsMixin];
+
   /// Identifies the currently active descendant of a compositewidget.
   ///
   /// This is used when a composite widget is responsible for managing its current active child
@@ -82,9 +82,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.atomic] -->
   @override
   @Accessor(key: 'aria-atomic')
-  bool get atomic =>
-      props[_$key__atomic___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get atomic => props[_$key__atomic___$AriaPropsMixin];
+
   /// Indicates whether assistive technologies will present all, or only parts of, the changed region
   /// based on the change notifications defined by the aria-relevant attribute. See related aria-relevant.
   ///
@@ -121,9 +120,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.autocomplete] -->
   @override
   @Accessor(key: 'aria-autocomplete')
-  dynamic get autocomplete =>
-      props[_$key__autocomplete___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get autocomplete => props[_$key__autocomplete___$AriaPropsMixin];
+
   /// Indicates whether user input completion suggestions are provided.
   ///
   /// For a textbox with the aria-autocomplete attribute set to either inline or both, authors SHOULD
@@ -152,9 +150,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.busy] -->
   @override
   @Accessor(key: 'aria-busy')
-  bool get busy =>
-      props[_$key__busy___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get busy => props[_$key__busy___$AriaPropsMixin];
+
   /// Indicates whether an element, and its subtree, are currently being updated.
   ///
   /// The default is that aria-busy is false. If authors know that multiple parts of the same element
@@ -192,9 +189,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.checked] -->
   @override
   @Accessor(key: 'aria-checked')
-  dynamic get checked =>
-      props[_$key__checked___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get checked => props[_$key__checked___$AriaPropsMixin];
+
   /// Indicates the current "checked" state of checkboxes, radio buttons, and other widgets. See
   /// related aria-pressed and aria-selected.
   ///
@@ -231,9 +227,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.controls] -->
   @override
   @Accessor(key: 'aria-controls')
-  dynamic get controls =>
-      props[_$key__controls___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get controls => props[_$key__controls___$AriaPropsMixin];
+
   /// Identifies the element (or elements) whose contents or presence are controlled by the current
   /// element. See related aria-owns.
   ///
@@ -266,9 +261,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.describedby] -->
   @override
   @Accessor(key: 'aria-describedby')
-  dynamic get describedby =>
-      props[_$key__describedby___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get describedby => props[_$key__describedby___$AriaPropsMixin];
+
   /// Identifies the element (or elements) that describes the object. See related aria-labelledby.
   ///
   /// The aria-labelledby attribute is similar to aria-describedby in that both reference other
@@ -304,9 +298,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.disabled] -->
   @override
   @Accessor(key: 'aria-disabled')
-  bool get disabled =>
-      props[_$key__disabled___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get disabled => props[_$key__disabled___$AriaPropsMixin];
+
   /// Indicates that the element is perceivable but disabled, so it is not editable or otherwise
   /// operable. See related aria-hidden and aria-readonly.
   ///
@@ -342,9 +335,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.dropeffect] -->
   @override
   @Accessor(key: 'aria-dropeffect')
-  dynamic get dropeffect =>
-      props[_$key__dropeffect___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dropeffect => props[_$key__dropeffect___$AriaPropsMixin];
+
   /// Indicates what functions can be performed when the dragged object is released on the drop
   /// target. This allows assistive technologies to convey the possible drag options available to
   /// users, including whether a pop-up menu of choices is provided by the application. Typically,
@@ -381,9 +373,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.expanded] -->
   @override
   @Accessor(key: 'aria-expanded')
-  dynamic get expanded =>
-      props[_$key__expanded___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get expanded => props[_$key__expanded___$AriaPropsMixin];
+
   /// Indicates whether the element, or another grouping element it controls, is currently expanded
   /// or collapsed.
   ///
@@ -423,9 +414,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.flowto] -->
   @override
   @Accessor(key: 'aria-flowto')
-  dynamic get flowto =>
-      props[_$key__flowto___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get flowto => props[_$key__flowto___$AriaPropsMixin];
+
   /// Identifies the next element (or elements) in an alternate reading order of content which,
   /// at the user's discretion, allows assistive technology to override the general default of reading
   /// in document source order.
@@ -463,9 +453,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.grabbed] -->
   @override
   @Accessor(key: 'aria-grabbed')
-  dynamic get grabbed =>
-      props[_$key__grabbed___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get grabbed => props[_$key__grabbed___$AriaPropsMixin];
+
   /// Indicates an element's "grabbed" state in a drag-and-drop operation.
   ///
   /// When it is set to true it has been selected for dragging, false indicates that the element
@@ -497,9 +486,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.haspopup] -->
   @override
   @Accessor(key: 'aria-haspopup')
-  bool get haspopup =>
-      props[_$key__haspopup___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get haspopup => props[_$key__haspopup___$AriaPropsMixin];
+
   /// Indicates that the element has a popup context menu or sub-level menu.
   ///
   /// This means that activation renders conditional content. Note that ordinary tooltips are not
@@ -563,9 +551,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.hidden] -->
   @override
   @Accessor(key: 'aria-hidden')
-  bool get hidden =>
-      props[_$key__hidden___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hidden => props[_$key__hidden___$AriaPropsMixin];
+
   /// Indicates that the element and all of its descendants are not visible or perceivable to any
   /// user as implemented by the author. See related aria-disabled.
   ///
@@ -638,9 +625,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.invalid] -->
   @override
   @Accessor(key: 'aria-invalid')
-  dynamic get invalid =>
-      props[_$key__invalid___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get invalid => props[_$key__invalid___$AriaPropsMixin];
+
   /// Indicates the entered value does not conform to the format expected by the application.
   ///
   /// If the value is computed to be invalid or out-of-range, the application author SHOULD set
@@ -686,9 +672,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.label] -->
   @override
   @Accessor(key: 'aria-label')
-  String get label =>
-      props[_$key__label___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get label => props[_$key__label___$AriaPropsMixin];
+
   /// Defines a string value that labels the current element. See related aria-labelledby.
   ///
   /// The purpose of aria-label is the same as that of aria-labelledby. It provides the user with
@@ -738,9 +723,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.labelledby] -->
   @override
   @Accessor(key: 'aria-labelledby')
-  dynamic get labelledby =>
-      props[_$key__labelledby___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get labelledby => props[_$key__labelledby___$AriaPropsMixin];
+
   /// Identifies the element (or elements) that labels the current element. See related aria-label
   /// and aria-describedby.
   ///
@@ -806,9 +790,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.level] -->
   @override
   @Accessor(key: 'aria-level')
-  int get level =>
-      props[_$key__level___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get level => props[_$key__level___$AriaPropsMixin];
+
   /// Defines the hierarchical level of an element within a structure.
   ///
   /// This can be applied inside trees to tree items, to headings inside a document, to nested grids,
@@ -883,9 +866,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.live] -->
   @override
   @Accessor(key: 'aria-live')
-  dynamic get live =>
-      props[_$key__live___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get live => props[_$key__live___$AriaPropsMixin];
+
   /// Indicates that an element will be updated, and describes the types of updates the user agents,
   /// assistive technologies, and user can expect from the live region.
   ///
@@ -938,9 +920,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.multiline] -->
   @override
   @Accessor(key: 'aria-multiline')
-  bool get multiline =>
-      props[_$key__multiline___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get multiline => props[_$key__multiline___$AriaPropsMixin];
+
   /// Indicates whether a text box accepts multiple lines of input or only a single line.
   ///
   /// Note: In most user agent implementations, the default behavior of the ENTER or RETURN key
@@ -972,9 +953,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.multiselectable] -->
   @override
   @Accessor(key: 'aria-multiselectable')
-  bool get multiselectable =>
-      props[_$key__multiselectable___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get multiselectable => props[_$key__multiselectable___$AriaPropsMixin];
+
   /// Indicates that the user may select more than one item from the current selectable descendants.
   ///
   /// Authors SHOULD ensure that selected descendants have the aria-selected attribute set to true,
@@ -999,9 +979,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.orientation] -->
   @override
   @Accessor(key: 'aria-orientation')
-  dynamic get orientation =>
-      props[_$key__orientation___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get orientation => props[_$key__orientation___$AriaPropsMixin];
+
   /// Indicates whether the element and orientation is horizontal or vertical.
   ///
   /// See: <http://www.w3.org/TR/wai-aria/states_and_properties#aria-orientation>
@@ -1031,9 +1010,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.owns] -->
   @override
   @Accessor(key: 'aria-owns')
-  dynamic get owns =>
-      props[_$key__owns___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get owns => props[_$key__owns___$AriaPropsMixin];
+
   /// Identifies an element (or elements) in order to define a visual, functional, or contextual
   /// parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent
   /// the relationship. See related aria-controls.
@@ -1072,9 +1050,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.posinset] -->
   @override
   @Accessor(key: 'aria-posinset')
-  int get posinset =>
-      props[_$key__posinset___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get posinset => props[_$key__posinset___$AriaPropsMixin];
+
   /// Defines an element's number or position in the current set of listitems or treeitems. Not
   /// required if all elements in the set are present in the DOM. See related aria-setsize.
   ///
@@ -1110,9 +1087,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.pressed] -->
   @override
   @Accessor(key: 'aria-pressed')
-  dynamic get pressed =>
-      props[_$key__pressed___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get pressed => props[_$key__pressed___$AriaPropsMixin];
+
   /// Indicates the current "pressed" state of toggle buttons. See related aria-checked and aria-selected.
   ///
   /// Toggle buttons require a full press-and-release cycle to change their value. Activating it
@@ -1149,9 +1125,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.readonly] -->
   @override
   @Accessor(key: 'aria-readonly')
-  bool get readonly =>
-      props[_$key__readonly___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get readonly => props[_$key__readonly___$AriaPropsMixin];
+
   ///  Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.
   ///
   /// This means the user can read but not set the value of the widget. Readonly elements are relevant
@@ -1219,9 +1194,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.relevant] -->
   @override
   @Accessor(key: 'aria-relevant')
-  dynamic get relevant =>
-      props[_$key__relevant___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get relevant => props[_$key__relevant___$AriaPropsMixin];
+
   /// Indicates what user agent change notifications (additions, removals, etc.) assistive technologies
   /// will receive within a live region. See related aria-atomic.
   ///
@@ -1290,9 +1264,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.required] -->
   @override
   @Accessor(key: 'aria-required')
-  bool get required =>
-      props[_$key__required___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get required => props[_$key__required___$AriaPropsMixin];
+
   /// Indicates that user input is required on the element before a form may be submitted.
   ///
   /// For example, if the user needs to fill in an address field, the author will need to set the
@@ -1320,9 +1293,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   ///
   /// <!-- Generated from [_$AriaPropsMixin.role] -->
   @override
-  String get role =>
-      props[_$key__role___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get role => props[_$key__role___$AriaPropsMixin];
+
   /// Specifies the the type defining a user interface element. Enriches the semantics of markup and
   /// gives assistive technologies information about how to handle each element.
   ///
@@ -1352,9 +1324,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.selected] -->
   @override
   @Accessor(key: 'aria-selected')
-  dynamic get selected =>
-      props[_$key__selected___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get selected => props[_$key__selected___$AriaPropsMixin];
+
   /// Indicates the current "selected" state of various widgets. See related aria-checked and aria-pressed.
   ///
   /// This attribute is used with single-selection and multiple-selection widgets:
@@ -1399,9 +1370,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.setsize] -->
   @override
   @Accessor(key: 'aria-setsize')
-  int get setsize =>
-      props[_$key__setsize___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get setsize => props[_$key__setsize___$AriaPropsMixin];
+
   /// Defines the number of items in the current set of listitems or treeitems. Not required if
   /// all elements in the set are present in the DOM. See related aria-posinset.
   ///
@@ -1436,9 +1406,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.sort] -->
   @override
   @Accessor(key: 'aria-sort')
-  dynamic get sort =>
-      props[_$key__sort___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get sort => props[_$key__sort___$AriaPropsMixin];
+
   /// Indicates if items in a table or grid are sorted in ascending or descending order.
   ///
   /// Authors SHOULD only apply this property to table headers or grid headers. If the property
@@ -1468,9 +1437,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.valuemax] -->
   @override
   @Accessor(key: 'aria-valuemax')
-  num get valuemax =>
-      props[_$key__valuemax___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  num get valuemax => props[_$key__valuemax___$AriaPropsMixin];
+
   /// Defines the maximum allowed value for a range widget.
   ///
   /// A range widget may start with a given value, which can be increased until a maximum value,
@@ -1506,9 +1474,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.valuemin] -->
   @override
   @Accessor(key: 'aria-valuemin')
-  num get valuemin =>
-      props[_$key__valuemin___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  num get valuemin => props[_$key__valuemin___$AriaPropsMixin];
+
   /// Defines the minimum allowed value for a range widget.
   ///
   /// A range widget may start with a given value, which can be decreased until a minimum value,
@@ -1562,9 +1529,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.valuenow] -->
   @override
   @Accessor(key: 'aria-valuenow')
-  num get valuenow =>
-      props[_$key__valuenow___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  num get valuenow => props[_$key__valuenow___$AriaPropsMixin];
+
   /// Defines the current value for a range widget. See related aria-valuetext.
   ///
   /// This property is used, for example, on a range widget such as a slider or progress bar.
@@ -1623,9 +1589,8 @@ abstract class AriaPropsMixin implements _$AriaPropsMixin {
   /// <!-- Generated from [_$AriaPropsMixin.valuetext] -->
   @override
   @Accessor(key: 'aria-valuetext')
-  String get valuetext =>
-      props[_$key__valuetext___$AriaPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get valuetext => props[_$key__valuetext___$AriaPropsMixin];
+
   /// Defines the human readable text alternative of aria-valuenow for a range widget.
   ///
   /// This property is used, for example, on a range widget such as a slider or progress bar.

--- a/lib/src/component/error_boundary_mixins.over_react.g.dart
+++ b/lib/src/component/error_boundary_mixins.over_react.g.dart
@@ -32,8 +32,8 @@ abstract class ErrorBoundaryPropsMixin implements _$ErrorBoundaryPropsMixin {
   /// <!-- Generated from [_$ErrorBoundaryPropsMixin.onComponentDidCatch] -->
   @override
   Function(dynamic error, ReactErrorInfo info) get onComponentDidCatch =>
-      props[_$key__onComponentDidCatch___$ErrorBoundaryPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onComponentDidCatch___$ErrorBoundaryPropsMixin];
+
   /// An optional callback that will be called with an [Error] and a [ReactErrorInfo]
   /// containing information about which component in the tree threw the error when
   /// the `componentDidCatch` lifecycle method is called.
@@ -62,8 +62,8 @@ abstract class ErrorBoundaryPropsMixin implements _$ErrorBoundaryPropsMixin {
   /// <!-- Generated from [_$ErrorBoundaryPropsMixin.fallbackUIRenderer] -->
   @override
   ReactElement Function() get fallbackUIRenderer =>
-      props[_$key__fallbackUIRenderer___$ErrorBoundaryPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__fallbackUIRenderer___$ErrorBoundaryPropsMixin];
+
   /// A renderer that will be used to render "fallback" UI instead of the child
   /// component tree that crashed.
   ///
@@ -112,9 +112,8 @@ abstract class ErrorBoundaryStateMixin implements _$ErrorBoundaryStateMixin {
   ///
   /// <!-- Generated from [_$ErrorBoundaryStateMixin.hasError] -->
   @override
-  bool get hasError =>
-      state[_$key__hasError___$ErrorBoundaryStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hasError => state[_$key__hasError___$ErrorBoundaryStateMixin];
+
   /// Whether the tree that the [ErrorBoundary] is wrapping around threw an error.
   ///
   /// When `true`, fallback UI will be rendered using [ErrorBoundaryProps.fallbackUIRenderer].

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -19,9 +19,8 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
   ///
   /// <!-- Generated from [_$ReactPropsMixin.children] -->
   @override
-  List get children =>
-      props[_$key__children___$ReactPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  List get children => props[_$key__children___$ReactPropsMixin];
+
   /// The children that were passed in to this component when it was built.
   ///
   /// <!-- Generated from [_$ReactPropsMixin.children] -->
@@ -35,9 +34,8 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
   ///
   /// <!-- Generated from [_$ReactPropsMixin.ref] -->
   @override
-  dynamic get ref =>
-      props[_$key__ref___$ReactPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get ref => props[_$key__ref___$ReactPropsMixin];
+
   /// Either a String used to retrieve the element at a later time via [react.Component.ref],
   /// or a Function that gets called with the element when it is mounted.
   ///
@@ -77,54 +75,48 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.cols] -->
   @override
-  int get cols =>
-      props[_$key__cols___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get cols => props[_$key__cols___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.cols] -->
   @override
   set cols(int value) => props[_$key__cols___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.rows] -->
   @override
-  int get rows =>
-      props[_$key__rows___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get rows => props[_$key__rows___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.rows] -->
   @override
   set rows(int value) => props[_$key__rows___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.size] -->
   @override
-  int get size =>
-      props[_$key__size___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get size => props[_$key__size___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.size] -->
   @override
   set size(int value) => props[_$key__size___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.span] -->
   @override
-  int get span =>
-      props[_$key__span___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get span => props[_$key__span___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.span] -->
   @override
   set span(int value) => props[_$key__span___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.start] -->
   @override
-  int get start =>
-      props[_$key__start___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get start => props[_$key__start___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.start] -->
   @override
   set start(int value) => props[_$key__start___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.allowFullScreen] -->
   @override
-  bool get allowFullScreen =>
-      props[_$key__allowFullScreen___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get allowFullScreen => props[_$key__allowFullScreen___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.allowFullScreen] -->
   @override
   set allowFullScreen(bool value) =>
@@ -132,63 +124,56 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.async] -->
   @override
-  bool get async =>
-      props[_$key__async___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get async => props[_$key__async___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.async] -->
   @override
   set async(bool value) => props[_$key__async___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.autoPlay] -->
   @override
-  bool get autoPlay =>
-      props[_$key__autoPlay___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get autoPlay => props[_$key__autoPlay___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.autoPlay] -->
   @override
   set autoPlay(bool value) => props[_$key__autoPlay___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.checked] -->
   @override
-  bool get checked =>
-      props[_$key__checked___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get checked => props[_$key__checked___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.checked] -->
   @override
   set checked(bool value) => props[_$key__checked___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.controls] -->
   @override
-  bool get controls =>
-      props[_$key__controls___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get controls => props[_$key__controls___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.controls] -->
   @override
   set controls(bool value) => props[_$key__controls___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.defer] -->
   @override
-  bool get defer =>
-      props[_$key__defer___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get defer => props[_$key__defer___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.defer] -->
   @override
   set defer(bool value) => props[_$key__defer___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.disabled] -->
   @override
-  bool get disabled =>
-      props[_$key__disabled___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get disabled => props[_$key__disabled___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.disabled] -->
   @override
   set disabled(bool value) => props[_$key__disabled___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.formNoValidate] -->
   @override
-  bool get formNoValidate =>
-      props[_$key__formNoValidate___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get formNoValidate => props[_$key__formNoValidate___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.formNoValidate] -->
   @override
   set formNoValidate(bool value) =>
@@ -196,45 +181,40 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.hidden] -->
   @override
-  bool get hidden =>
-      props[_$key__hidden___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hidden => props[_$key__hidden___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.hidden] -->
   @override
   set hidden(bool value) => props[_$key__hidden___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.loop] -->
   @override
-  bool get loop =>
-      props[_$key__loop___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get loop => props[_$key__loop___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.loop] -->
   @override
   set loop(bool value) => props[_$key__loop___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.multiple] -->
   @override
-  bool get multiple =>
-      props[_$key__multiple___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get multiple => props[_$key__multiple___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.multiple] -->
   @override
   set multiple(bool value) => props[_$key__multiple___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.muted] -->
   @override
-  bool get muted =>
-      props[_$key__muted___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get muted => props[_$key__muted___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.muted] -->
   @override
   set muted(bool value) => props[_$key__muted___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.noValidate] -->
   @override
-  bool get noValidate =>
-      props[_$key__noValidate___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get noValidate => props[_$key__noValidate___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.noValidate] -->
   @override
   set noValidate(bool value) =>
@@ -242,45 +222,40 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.readOnly] -->
   @override
-  bool get readOnly =>
-      props[_$key__readOnly___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get readOnly => props[_$key__readOnly___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.readOnly] -->
   @override
   set readOnly(bool value) => props[_$key__readOnly___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.required] -->
   @override
-  bool get required =>
-      props[_$key__required___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get required => props[_$key__required___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.required] -->
   @override
   set required(bool value) => props[_$key__required___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.seamless] -->
   @override
-  bool get seamless =>
-      props[_$key__seamless___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get seamless => props[_$key__seamless___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.seamless] -->
   @override
   set seamless(bool value) => props[_$key__seamless___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.selected] -->
   @override
-  bool get selected =>
-      props[_$key__selected___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get selected => props[_$key__selected___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.selected] -->
   @override
   set selected(bool value) => props[_$key__selected___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.style] -->
   @override
-  Map<String, dynamic> get style =>
-      props[_$key__style___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map<String, dynamic> get style => props[_$key__style___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.style] -->
   @override
   set style(Map<String, dynamic> value) =>
@@ -288,9 +263,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.className] -->
   @override
-  String get className =>
-      props[_$key__className___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get className => props[_$key__className___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.className] -->
   @override
   set className(String value) =>
@@ -298,36 +272,32 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
-  String get title =>
-      props[_$key__title___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get title => props[_$key__title___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
   set title(String value) => props[_$key__title___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.id] -->
   @override
-  String get id =>
-      props[_$key__id___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => props[_$key__id___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.id] -->
   @override
   set id(String value) => props[_$key__id___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
-  dynamic get accept =>
-      props[_$key__accept___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get accept => props[_$key__accept___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
   set accept(dynamic value) => props[_$key__accept___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
-  dynamic get acceptCharset =>
-      props[_$key__acceptCharset___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get acceptCharset => props[_$key__acceptCharset___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
   set acceptCharset(dynamic value) =>
@@ -335,9 +305,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
-  dynamic get accessKey =>
-      props[_$key__accessKey___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get accessKey => props[_$key__accessKey___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
   set accessKey(dynamic value) =>
@@ -345,9 +314,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
-  dynamic get action =>
-      props[_$key__action___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get action => props[_$key__action___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
   set action(dynamic value) => props[_$key__action___$DomPropsMixin] = value;
@@ -355,8 +323,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.allowTransparency] -->
   @override
   dynamic get allowTransparency =>
-      props[_$key__allowTransparency___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__allowTransparency___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.allowTransparency] -->
   @override
   set allowTransparency(dynamic value) =>
@@ -364,18 +332,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.alt] -->
   @override
-  dynamic get alt =>
-      props[_$key__alt___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get alt => props[_$key__alt___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.alt] -->
   @override
   set alt(dynamic value) => props[_$key__alt___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
   @override
-  dynamic get autoComplete =>
-      props[_$key__autoComplete___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get autoComplete => props[_$key__autoComplete___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
   @override
   set autoComplete(dynamic value) =>
@@ -383,9 +349,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.cellPadding] -->
   @override
-  dynamic get cellPadding =>
-      props[_$key__cellPadding___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get cellPadding => props[_$key__cellPadding___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.cellPadding] -->
   @override
   set cellPadding(dynamic value) =>
@@ -393,9 +358,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.cellSpacing] -->
   @override
-  dynamic get cellSpacing =>
-      props[_$key__cellSpacing___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get cellSpacing => props[_$key__cellSpacing___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.cellSpacing] -->
   @override
   set cellSpacing(dynamic value) =>
@@ -403,45 +367,40 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.charSet] -->
   @override
-  dynamic get charSet =>
-      props[_$key__charSet___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get charSet => props[_$key__charSet___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.charSet] -->
   @override
   set charSet(dynamic value) => props[_$key__charSet___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.classID] -->
   @override
-  dynamic get classID =>
-      props[_$key__classID___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get classID => props[_$key__classID___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.classID] -->
   @override
   set classID(dynamic value) => props[_$key__classID___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
-  dynamic get colSpan =>
-      props[_$key__colSpan___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get colSpan => props[_$key__colSpan___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
   set colSpan(dynamic value) => props[_$key__colSpan___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.content] -->
   @override
-  dynamic get content =>
-      props[_$key__content___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get content => props[_$key__content___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.content] -->
   @override
   set content(dynamic value) => props[_$key__content___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.contentEditable] -->
   @override
-  dynamic get contentEditable =>
-      props[_$key__contentEditable___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get contentEditable => props[_$key__contentEditable___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.contentEditable] -->
   @override
   set contentEditable(dynamic value) =>
@@ -449,9 +408,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
   @override
-  dynamic get contextMenu =>
-      props[_$key__contextMenu___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get contextMenu => props[_$key__contextMenu___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
   @override
   set contextMenu(dynamic value) =>
@@ -459,18 +417,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.coords] -->
   @override
-  dynamic get coords =>
-      props[_$key__coords___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get coords => props[_$key__coords___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.coords] -->
   @override
   set coords(dynamic value) => props[_$key__coords___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
   @override
-  dynamic get crossOrigin =>
-      props[_$key__crossOrigin___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get crossOrigin => props[_$key__crossOrigin___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
   @override
   set crossOrigin(dynamic value) =>
@@ -478,18 +434,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.data] -->
   @override
-  dynamic get data =>
-      props[_$key__data___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get data => props[_$key__data___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.data] -->
   @override
   set data(dynamic value) => props[_$key__data___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
   @override
-  dynamic get dateTime =>
-      props[_$key__dateTime___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dateTime => props[_$key__dateTime___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
   @override
   set dateTime(dynamic value) =>
@@ -497,18 +451,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.dir] -->
   @override
-  dynamic get dir =>
-      props[_$key__dir___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dir => props[_$key__dir___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.dir] -->
   @override
   set dir(dynamic value) => props[_$key__dir___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.download] -->
   @override
-  dynamic get download =>
-      props[_$key__download___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get download => props[_$key__download___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.download] -->
   @override
   set download(dynamic value) =>
@@ -516,9 +468,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.draggable] -->
   @override
-  dynamic get draggable =>
-      props[_$key__draggable___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get draggable => props[_$key__draggable___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.draggable] -->
   @override
   set draggable(dynamic value) =>
@@ -526,27 +477,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.encType] -->
   @override
-  dynamic get encType =>
-      props[_$key__encType___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get encType => props[_$key__encType___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.encType] -->
   @override
   set encType(dynamic value) => props[_$key__encType___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.form] -->
   @override
-  dynamic get form =>
-      props[_$key__form___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get form => props[_$key__form___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.form] -->
   @override
   set form(dynamic value) => props[_$key__form___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.frameBorder] -->
   @override
-  dynamic get frameBorder =>
-      props[_$key__frameBorder___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get frameBorder => props[_$key__frameBorder___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.frameBorder] -->
   @override
   set frameBorder(dynamic value) =>
@@ -554,27 +502,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.height] -->
   @override
-  dynamic get height =>
-      props[_$key__height___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get height => props[_$key__height___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.height] -->
   @override
   set height(dynamic value) => props[_$key__height___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.href] -->
   @override
-  dynamic get href =>
-      props[_$key__href___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get href => props[_$key__href___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.href] -->
   @override
   set href(dynamic value) => props[_$key__href___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
   @override
-  dynamic get hrefLang =>
-      props[_$key__hrefLang___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get hrefLang => props[_$key__hrefLang___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
   @override
   set hrefLang(dynamic value) =>
@@ -582,18 +527,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
   @override
-  dynamic get htmlFor =>
-      props[_$key__htmlFor___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get htmlFor => props[_$key__htmlFor___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
   @override
   set htmlFor(dynamic value) => props[_$key__htmlFor___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
   @override
-  dynamic get httpEquiv =>
-      props[_$key__httpEquiv___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get httpEquiv => props[_$key__httpEquiv___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
   @override
   set httpEquiv(dynamic value) =>
@@ -601,45 +544,40 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.icon] -->
   @override
-  dynamic get icon =>
-      props[_$key__icon___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get icon => props[_$key__icon___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.icon] -->
   @override
   set icon(dynamic value) => props[_$key__icon___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.label] -->
   @override
-  dynamic get label =>
-      props[_$key__label___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get label => props[_$key__label___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.label] -->
   @override
   set label(dynamic value) => props[_$key__label___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.lang] -->
   @override
-  dynamic get lang =>
-      props[_$key__lang___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get lang => props[_$key__lang___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.lang] -->
   @override
   set lang(dynamic value) => props[_$key__lang___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.list] -->
   @override
-  dynamic get list =>
-      props[_$key__list___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get list => props[_$key__list___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.list] -->
   @override
   set list(dynamic value) => props[_$key__list___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.manifest] -->
   @override
-  dynamic get manifest =>
-      props[_$key__manifest___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get manifest => props[_$key__manifest___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.manifest] -->
   @override
   set manifest(dynamic value) =>
@@ -647,18 +585,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
-  dynamic get max =>
-      props[_$key__max___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get max => props[_$key__max___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
   set max(dynamic value) => props[_$key__max___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.maxLength] -->
   @override
-  dynamic get maxLength =>
-      props[_$key__maxLength___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get maxLength => props[_$key__maxLength___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.maxLength] -->
   @override
   set maxLength(dynamic value) =>
@@ -666,18 +602,16 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.media] -->
   @override
-  dynamic get media =>
-      props[_$key__media___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get media => props[_$key__media___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.media] -->
   @override
   set media(dynamic value) => props[_$key__media___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
   @override
-  dynamic get mediaGroup =>
-      props[_$key__mediaGroup___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get mediaGroup => props[_$key__mediaGroup___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
   @override
   set mediaGroup(dynamic value) =>
@@ -685,54 +619,48 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.method] -->
   @override
-  dynamic get method =>
-      props[_$key__method___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get method => props[_$key__method___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.method] -->
   @override
   set method(dynamic value) => props[_$key__method___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
-  dynamic get min =>
-      props[_$key__min___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get min => props[_$key__min___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
   set min(dynamic value) => props[_$key__min___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.name] -->
   @override
-  dynamic get name =>
-      props[_$key__name___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get name => props[_$key__name___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.name] -->
   @override
   set name(dynamic value) => props[_$key__name___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.open] -->
   @override
-  dynamic get open =>
-      props[_$key__open___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get open => props[_$key__open___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.open] -->
   @override
   set open(dynamic value) => props[_$key__open___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.pattern] -->
   @override
-  dynamic get pattern =>
-      props[_$key__pattern___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get pattern => props[_$key__pattern___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.pattern] -->
   @override
   set pattern(dynamic value) => props[_$key__pattern___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
   @override
-  dynamic get placeholder =>
-      props[_$key__placeholder___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get placeholder => props[_$key__placeholder___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
   @override
   set placeholder(dynamic value) =>
@@ -740,27 +668,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.poster] -->
   @override
-  dynamic get poster =>
-      props[_$key__poster___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get poster => props[_$key__poster___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.poster] -->
   @override
   set poster(dynamic value) => props[_$key__poster___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.preload] -->
   @override
-  dynamic get preload =>
-      props[_$key__preload___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get preload => props[_$key__preload___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.preload] -->
   @override
   set preload(dynamic value) => props[_$key__preload___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
   @override
-  dynamic get radioGroup =>
-      props[_$key__radioGroup___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get radioGroup => props[_$key__radioGroup___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
   @override
   set radioGroup(dynamic value) =>
@@ -768,54 +693,48 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.rel] -->
   @override
-  dynamic get rel =>
-      props[_$key__rel___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get rel => props[_$key__rel___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.rel] -->
   @override
   set rel(dynamic value) => props[_$key__rel___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.role] -->
   @override
-  dynamic get role =>
-      props[_$key__role___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get role => props[_$key__role___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.role] -->
   @override
   set role(dynamic value) => props[_$key__role___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.rowSpan] -->
   @override
-  dynamic get rowSpan =>
-      props[_$key__rowSpan___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get rowSpan => props[_$key__rowSpan___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.rowSpan] -->
   @override
   set rowSpan(dynamic value) => props[_$key__rowSpan___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
   @override
-  dynamic get sandbox =>
-      props[_$key__sandbox___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get sandbox => props[_$key__sandbox___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
   @override
   set sandbox(dynamic value) => props[_$key__sandbox___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.scope] -->
   @override
-  dynamic get scope =>
-      props[_$key__scope___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get scope => props[_$key__scope___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.scope] -->
   @override
   set scope(dynamic value) => props[_$key__scope___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
   @override
-  dynamic get scrolling =>
-      props[_$key__scrolling___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get scrolling => props[_$key__scrolling___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
   @override
   set scrolling(dynamic value) =>
@@ -823,27 +742,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.shape] -->
   @override
-  dynamic get shape =>
-      props[_$key__shape___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get shape => props[_$key__shape___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.shape] -->
   @override
   set shape(dynamic value) => props[_$key__shape___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.sizes] -->
   @override
-  dynamic get sizes =>
-      props[_$key__sizes___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get sizes => props[_$key__sizes___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.sizes] -->
   @override
   set sizes(dynamic value) => props[_$key__sizes___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.spellCheck] -->
   @override
-  dynamic get spellCheck =>
-      props[_$key__spellCheck___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get spellCheck => props[_$key__spellCheck___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.spellCheck] -->
   @override
   set spellCheck(dynamic value) =>
@@ -851,45 +767,40 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.src] -->
   @override
-  dynamic get src =>
-      props[_$key__src___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get src => props[_$key__src___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.src] -->
   @override
   set src(dynamic value) => props[_$key__src___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
   @override
-  dynamic get srcDoc =>
-      props[_$key__srcDoc___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get srcDoc => props[_$key__srcDoc___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
   @override
   set srcDoc(dynamic value) => props[_$key__srcDoc___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
   @override
-  dynamic get srcSet =>
-      props[_$key__srcSet___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get srcSet => props[_$key__srcSet___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
   @override
   set srcSet(dynamic value) => props[_$key__srcSet___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.step] -->
   @override
-  dynamic get step =>
-      props[_$key__step___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get step => props[_$key__step___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.step] -->
   @override
   set step(dynamic value) => props[_$key__step___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.tabIndex] -->
   @override
-  dynamic get tabIndex =>
-      props[_$key__tabIndex___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get tabIndex => props[_$key__tabIndex___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.tabIndex] -->
   @override
   set tabIndex(dynamic value) =>
@@ -897,54 +808,48 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.target] -->
   @override
-  dynamic get target =>
-      props[_$key__target___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get target => props[_$key__target___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.target] -->
   @override
   set target(dynamic value) => props[_$key__target___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
-  dynamic get type =>
-      props[_$key__type___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get type => props[_$key__type___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
   set type(dynamic value) => props[_$key__type___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.useMap] -->
   @override
-  dynamic get useMap =>
-      props[_$key__useMap___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get useMap => props[_$key__useMap___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.useMap] -->
   @override
   set useMap(dynamic value) => props[_$key__useMap___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
-  dynamic get value =>
-      props[_$key__value___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get value => props[_$key__value___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
   set value(dynamic value) => props[_$key__value___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.width] -->
   @override
-  dynamic get width =>
-      props[_$key__width___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get width => props[_$key__width___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.width] -->
   @override
   set width(dynamic value) => props[_$key__width___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.wmode] -->
   @override
-  dynamic get wmode =>
-      props[_$key__wmode___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get wmode => props[_$key__wmode___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.wmode] -->
   @override
   set wmode(dynamic value) => props[_$key__wmode___$DomPropsMixin] = value;
@@ -952,8 +857,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onAnimationEnd] -->
   @override
   AnimationEventCallback get onAnimationEnd =>
-      props[_$key__onAnimationEnd___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationEnd___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onAnimationEnd] -->
   @override
   set onAnimationEnd(AnimationEventCallback value) =>
@@ -962,8 +867,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onAnimationIteration] -->
   @override
   AnimationEventCallback get onAnimationIteration =>
-      props[_$key__onAnimationIteration___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationIteration___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onAnimationIteration] -->
   @override
   set onAnimationIteration(AnimationEventCallback value) =>
@@ -972,8 +877,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onAnimationStart] -->
   @override
   AnimationEventCallback get onAnimationStart =>
-      props[_$key__onAnimationStart___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationStart___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onAnimationStart] -->
   @override
   set onAnimationStart(AnimationEventCallback value) =>
@@ -981,9 +886,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onCopy] -->
   @override
-  ClipboardEventCallback get onCopy =>
-      props[_$key__onCopy___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ClipboardEventCallback get onCopy => props[_$key__onCopy___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onCopy] -->
   @override
   set onCopy(ClipboardEventCallback value) =>
@@ -991,9 +895,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onCut] -->
   @override
-  ClipboardEventCallback get onCut =>
-      props[_$key__onCut___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ClipboardEventCallback get onCut => props[_$key__onCut___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onCut] -->
   @override
   set onCut(ClipboardEventCallback value) =>
@@ -1001,9 +904,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onPaste] -->
   @override
-  ClipboardEventCallback get onPaste =>
-      props[_$key__onPaste___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ClipboardEventCallback get onPaste => props[_$key__onPaste___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPaste] -->
   @override
   set onPaste(ClipboardEventCallback value) =>
@@ -1012,8 +914,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onKeyDown] -->
   @override
   KeyboardEventCallback get onKeyDown =>
-      props[_$key__onKeyDown___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyDown___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyDown] -->
   @override
   set onKeyDown(KeyboardEventCallback value) =>
@@ -1022,8 +924,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onKeyPress] -->
   @override
   KeyboardEventCallback get onKeyPress =>
-      props[_$key__onKeyPress___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyPress___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyPress] -->
   @override
   set onKeyPress(KeyboardEventCallback value) =>
@@ -1031,9 +933,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onKeyUp] -->
   @override
-  KeyboardEventCallback get onKeyUp =>
-      props[_$key__onKeyUp___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  KeyboardEventCallback get onKeyUp => props[_$key__onKeyUp___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyUp] -->
   @override
   set onKeyUp(KeyboardEventCallback value) =>
@@ -1041,9 +942,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onFocus] -->
   @override
-  FocusEventCallback get onFocus =>
-      props[_$key__onFocus___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FocusEventCallback get onFocus => props[_$key__onFocus___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onFocus] -->
   @override
   set onFocus(FocusEventCallback value) =>
@@ -1051,9 +951,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onBlur] -->
   @override
-  FocusEventCallback get onBlur =>
-      props[_$key__onBlur___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FocusEventCallback get onBlur => props[_$key__onBlur___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onBlur] -->
   @override
   set onBlur(FocusEventCallback value) =>
@@ -1061,9 +960,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onChange] -->
   @override
-  FormEventCallback get onChange =>
-      props[_$key__onChange___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FormEventCallback get onChange => props[_$key__onChange___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onChange] -->
   @override
   set onChange(FormEventCallback value) =>
@@ -1071,9 +969,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onInput] -->
   @override
-  FormEventCallback get onInput =>
-      props[_$key__onInput___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FormEventCallback get onInput => props[_$key__onInput___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onInput] -->
   @override
   set onInput(FormEventCallback value) =>
@@ -1081,9 +978,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onSubmit] -->
   @override
-  FormEventCallback get onSubmit =>
-      props[_$key__onSubmit___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FormEventCallback get onSubmit => props[_$key__onSubmit___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onSubmit] -->
   @override
   set onSubmit(FormEventCallback value) =>
@@ -1091,9 +987,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onReset] -->
   @override
-  FormEventCallback get onReset =>
-      props[_$key__onReset___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  FormEventCallback get onReset => props[_$key__onReset___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onReset] -->
   @override
   set onReset(FormEventCallback value) =>
@@ -1101,9 +996,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onClick] -->
   @override
-  MouseEventCallback get onClick =>
-      props[_$key__onClick___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  MouseEventCallback get onClick => props[_$key__onClick___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onClick] -->
   @override
   set onClick(MouseEventCallback value) =>
@@ -1112,8 +1006,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onContextMenu] -->
   @override
   MouseEventCallback get onContextMenu =>
-      props[_$key__onContextMenu___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onContextMenu___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onContextMenu] -->
   @override
   set onContextMenu(MouseEventCallback value) =>
@@ -1122,8 +1016,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDoubleClick] -->
   @override
   MouseEventCallback get onDoubleClick =>
-      props[_$key__onDoubleClick___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDoubleClick___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDoubleClick] -->
   @override
   set onDoubleClick(MouseEventCallback value) =>
@@ -1131,9 +1025,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onDrag] -->
   @override
-  MouseEventCallback get onDrag =>
-      props[_$key__onDrag___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  MouseEventCallback get onDrag => props[_$key__onDrag___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDrag] -->
   @override
   set onDrag(MouseEventCallback value) =>
@@ -1141,9 +1034,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onDragEnd] -->
   @override
-  MouseEventCallback get onDragEnd =>
-      props[_$key__onDragEnd___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  MouseEventCallback get onDragEnd => props[_$key__onDragEnd___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragEnd] -->
   @override
   set onDragEnd(MouseEventCallback value) =>
@@ -1152,8 +1044,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragEnter] -->
   @override
   MouseEventCallback get onDragEnter =>
-      props[_$key__onDragEnter___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragEnter___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragEnter] -->
   @override
   set onDragEnter(MouseEventCallback value) =>
@@ -1162,8 +1054,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragExit] -->
   @override
   MouseEventCallback get onDragExit =>
-      props[_$key__onDragExit___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragExit___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragExit] -->
   @override
   set onDragExit(MouseEventCallback value) =>
@@ -1172,8 +1064,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragLeave] -->
   @override
   MouseEventCallback get onDragLeave =>
-      props[_$key__onDragLeave___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragLeave___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragLeave] -->
   @override
   set onDragLeave(MouseEventCallback value) =>
@@ -1182,8 +1074,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragOver] -->
   @override
   MouseEventCallback get onDragOver =>
-      props[_$key__onDragOver___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragOver___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragOver] -->
   @override
   set onDragOver(MouseEventCallback value) =>
@@ -1192,8 +1084,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragStart] -->
   @override
   MouseEventCallback get onDragStart =>
-      props[_$key__onDragStart___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragStart___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragStart] -->
   @override
   set onDragStart(MouseEventCallback value) =>
@@ -1201,9 +1093,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onDrop] -->
   @override
-  MouseEventCallback get onDrop =>
-      props[_$key__onDrop___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  MouseEventCallback get onDrop => props[_$key__onDrop___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDrop] -->
   @override
   set onDrop(MouseEventCallback value) =>
@@ -1212,8 +1103,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseDown] -->
   @override
   MouseEventCallback get onMouseDown =>
-      props[_$key__onMouseDown___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseDown___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseDown] -->
   @override
   set onMouseDown(MouseEventCallback value) =>
@@ -1222,8 +1113,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseEnter] -->
   @override
   MouseEventCallback get onMouseEnter =>
-      props[_$key__onMouseEnter___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseEnter___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseEnter] -->
   @override
   set onMouseEnter(MouseEventCallback value) =>
@@ -1232,8 +1123,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseLeave] -->
   @override
   MouseEventCallback get onMouseLeave =>
-      props[_$key__onMouseLeave___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseLeave___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseLeave] -->
   @override
   set onMouseLeave(MouseEventCallback value) =>
@@ -1242,8 +1133,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseMove] -->
   @override
   MouseEventCallback get onMouseMove =>
-      props[_$key__onMouseMove___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseMove___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseMove] -->
   @override
   set onMouseMove(MouseEventCallback value) =>
@@ -1252,8 +1143,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseOut] -->
   @override
   MouseEventCallback get onMouseOut =>
-      props[_$key__onMouseOut___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOut___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseOut] -->
   @override
   set onMouseOut(MouseEventCallback value) =>
@@ -1262,8 +1153,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseOver] -->
   @override
   MouseEventCallback get onMouseOver =>
-      props[_$key__onMouseOver___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOver___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseOver] -->
   @override
   set onMouseOver(MouseEventCallback value) =>
@@ -1271,9 +1162,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onMouseUp] -->
   @override
-  MouseEventCallback get onMouseUp =>
-      props[_$key__onMouseUp___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  MouseEventCallback get onMouseUp => props[_$key__onMouseUp___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseUp] -->
   @override
   set onMouseUp(MouseEventCallback value) =>
@@ -1282,8 +1172,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerCancel] -->
   @override
   PointerEventCallback get onPointerCancel =>
-      props[_$key__onPointerCancel___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerCancel___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerCancel] -->
   @override
   set onPointerCancel(PointerEventCallback value) =>
@@ -1292,8 +1182,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerDown] -->
   @override
   PointerEventCallback get onPointerDown =>
-      props[_$key__onPointerDown___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerDown___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerDown] -->
   @override
   set onPointerDown(PointerEventCallback value) =>
@@ -1302,8 +1192,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerEnter] -->
   @override
   PointerEventCallback get onPointerEnter =>
-      props[_$key__onPointerEnter___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerEnter___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerEnter] -->
   @override
   set onPointerEnter(PointerEventCallback value) =>
@@ -1312,8 +1202,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerLeave] -->
   @override
   PointerEventCallback get onPointerLeave =>
-      props[_$key__onPointerLeave___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerLeave___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerLeave] -->
   @override
   set onPointerLeave(PointerEventCallback value) =>
@@ -1322,8 +1212,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerMove] -->
   @override
   PointerEventCallback get onPointerMove =>
-      props[_$key__onPointerMove___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerMove___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerMove] -->
   @override
   set onPointerMove(PointerEventCallback value) =>
@@ -1332,8 +1222,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerOver] -->
   @override
   PointerEventCallback get onPointerOver =>
-      props[_$key__onPointerOver___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerOver___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerOver] -->
   @override
   set onPointerOver(PointerEventCallback value) =>
@@ -1342,8 +1232,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerOut] -->
   @override
   PointerEventCallback get onPointerOut =>
-      props[_$key__onPointerOut___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerOut___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerOut] -->
   @override
   set onPointerOut(PointerEventCallback value) =>
@@ -1352,8 +1242,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPointerUp] -->
   @override
   PointerEventCallback get onPointerUp =>
-      props[_$key__onPointerUp___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerUp___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPointerUp] -->
   @override
   set onPointerUp(PointerEventCallback value) =>
@@ -1362,8 +1252,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancel] -->
   @override
   TouchEventCallback get onTouchCancel =>
-      props[_$key__onTouchCancel___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchCancel___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancel] -->
   @override
   set onTouchCancel(TouchEventCallback value) =>
@@ -1372,8 +1262,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchEnd] -->
   @override
   TouchEventCallback get onTouchEnd =>
-      props[_$key__onTouchEnd___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchEnd___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchEnd] -->
   @override
   set onTouchEnd(TouchEventCallback value) =>
@@ -1382,8 +1272,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchMove] -->
   @override
   TouchEventCallback get onTouchMove =>
-      props[_$key__onTouchMove___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchMove___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchMove] -->
   @override
   set onTouchMove(TouchEventCallback value) =>
@@ -1392,8 +1282,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchStart] -->
   @override
   TouchEventCallback get onTouchStart =>
-      props[_$key__onTouchStart___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchStart___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchStart] -->
   @override
   set onTouchStart(TouchEventCallback value) =>
@@ -1402,8 +1292,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTransitionEnd] -->
   @override
   TransitionEventCallback get onTransitionEnd =>
-      props[_$key__onTransitionEnd___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTransitionEnd___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTransitionEnd] -->
   @override
   set onTransitionEnd(TransitionEventCallback value) =>
@@ -1411,9 +1301,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onScroll] -->
   @override
-  UIEventCallback get onScroll =>
-      props[_$key__onScroll___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  UIEventCallback get onScroll => props[_$key__onScroll___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onScroll] -->
   @override
   set onScroll(UIEventCallback value) =>
@@ -1421,9 +1310,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.onWheel] -->
   @override
-  WheelEventCallback get onWheel =>
-      props[_$key__onWheel___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  WheelEventCallback get onWheel => props[_$key__onWheel___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onWheel] -->
   @override
   set onWheel(WheelEventCallback value) =>
@@ -1432,8 +1320,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onCopyCapture] -->
   @override
   ClipboardEventCallback get onCopyCapture =>
-      props[_$key__onCopyCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onCopyCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onCopyCapture] -->
   @override
   set onCopyCapture(ClipboardEventCallback value) =>
@@ -1442,8 +1330,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onCutCapture] -->
   @override
   ClipboardEventCallback get onCutCapture =>
-      props[_$key__onCutCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onCutCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onCutCapture] -->
   @override
   set onCutCapture(ClipboardEventCallback value) =>
@@ -1452,8 +1340,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onPasteCapture] -->
   @override
   ClipboardEventCallback get onPasteCapture =>
-      props[_$key__onPasteCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPasteCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onPasteCapture] -->
   @override
   set onPasteCapture(ClipboardEventCallback value) =>
@@ -1462,8 +1350,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onKeyDownCapture] -->
   @override
   KeyboardEventCallback get onKeyDownCapture =>
-      props[_$key__onKeyDownCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyDownCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyDownCapture] -->
   @override
   set onKeyDownCapture(KeyboardEventCallback value) =>
@@ -1472,8 +1360,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onKeyPressCapture] -->
   @override
   KeyboardEventCallback get onKeyPressCapture =>
-      props[_$key__onKeyPressCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyPressCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyPressCapture] -->
   @override
   set onKeyPressCapture(KeyboardEventCallback value) =>
@@ -1482,8 +1370,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onKeyUpCapture] -->
   @override
   KeyboardEventCallback get onKeyUpCapture =>
-      props[_$key__onKeyUpCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyUpCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onKeyUpCapture] -->
   @override
   set onKeyUpCapture(KeyboardEventCallback value) =>
@@ -1492,8 +1380,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onFocusCapture] -->
   @override
   FocusEventCallback get onFocusCapture =>
-      props[_$key__onFocusCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onFocusCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onFocusCapture] -->
   @override
   set onFocusCapture(FocusEventCallback value) =>
@@ -1502,8 +1390,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onBlurCapture] -->
   @override
   FocusEventCallback get onBlurCapture =>
-      props[_$key__onBlurCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onBlurCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onBlurCapture] -->
   @override
   set onBlurCapture(FocusEventCallback value) =>
@@ -1512,8 +1400,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onChangeCapture] -->
   @override
   FormEventCallback get onChangeCapture =>
-      props[_$key__onChangeCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onChangeCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onChangeCapture] -->
   @override
   set onChangeCapture(FormEventCallback value) =>
@@ -1522,8 +1410,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onInputCapture] -->
   @override
   FormEventCallback get onInputCapture =>
-      props[_$key__onInputCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onInputCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onInputCapture] -->
   @override
   set onInputCapture(FormEventCallback value) =>
@@ -1532,8 +1420,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onSubmitCapture] -->
   @override
   FormEventCallback get onSubmitCapture =>
-      props[_$key__onSubmitCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onSubmitCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onSubmitCapture] -->
   @override
   set onSubmitCapture(FormEventCallback value) =>
@@ -1542,8 +1430,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onResetCapture] -->
   @override
   FormEventCallback get onResetCapture =>
-      props[_$key__onResetCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onResetCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onResetCapture] -->
   @override
   set onResetCapture(FormEventCallback value) =>
@@ -1552,8 +1440,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onClickCapture] -->
   @override
   MouseEventCallback get onClickCapture =>
-      props[_$key__onClickCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onClickCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onClickCapture] -->
   @override
   set onClickCapture(MouseEventCallback value) =>
@@ -1562,8 +1450,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onContextMenuCapture] -->
   @override
   MouseEventCallback get onContextMenuCapture =>
-      props[_$key__onContextMenuCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onContextMenuCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onContextMenuCapture] -->
   @override
   set onContextMenuCapture(MouseEventCallback value) =>
@@ -1572,8 +1460,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDoubleClickCapture] -->
   @override
   MouseEventCallback get onDoubleClickCapture =>
-      props[_$key__onDoubleClickCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDoubleClickCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDoubleClickCapture] -->
   @override
   set onDoubleClickCapture(MouseEventCallback value) =>
@@ -1582,8 +1470,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragCapture] -->
   @override
   MouseEventCallback get onDragCapture =>
-      props[_$key__onDragCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragCapture] -->
   @override
   set onDragCapture(MouseEventCallback value) =>
@@ -1592,8 +1480,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragEndCapture] -->
   @override
   MouseEventCallback get onDragEndCapture =>
-      props[_$key__onDragEndCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragEndCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragEndCapture] -->
   @override
   set onDragEndCapture(MouseEventCallback value) =>
@@ -1602,8 +1490,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragEnterCapture] -->
   @override
   MouseEventCallback get onDragEnterCapture =>
-      props[_$key__onDragEnterCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragEnterCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragEnterCapture] -->
   @override
   set onDragEnterCapture(MouseEventCallback value) =>
@@ -1612,8 +1500,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragExitCapture] -->
   @override
   MouseEventCallback get onDragExitCapture =>
-      props[_$key__onDragExitCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragExitCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragExitCapture] -->
   @override
   set onDragExitCapture(MouseEventCallback value) =>
@@ -1622,8 +1510,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragLeaveCapture] -->
   @override
   MouseEventCallback get onDragLeaveCapture =>
-      props[_$key__onDragLeaveCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragLeaveCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragLeaveCapture] -->
   @override
   set onDragLeaveCapture(MouseEventCallback value) =>
@@ -1632,8 +1520,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragOverCapture] -->
   @override
   MouseEventCallback get onDragOverCapture =>
-      props[_$key__onDragOverCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragOverCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragOverCapture] -->
   @override
   set onDragOverCapture(MouseEventCallback value) =>
@@ -1642,8 +1530,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDragStartCapture] -->
   @override
   MouseEventCallback get onDragStartCapture =>
-      props[_$key__onDragStartCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragStartCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDragStartCapture] -->
   @override
   set onDragStartCapture(MouseEventCallback value) =>
@@ -1652,8 +1540,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onDropCapture] -->
   @override
   MouseEventCallback get onDropCapture =>
-      props[_$key__onDropCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDropCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onDropCapture] -->
   @override
   set onDropCapture(MouseEventCallback value) =>
@@ -1662,8 +1550,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseDownCapture] -->
   @override
   MouseEventCallback get onMouseDownCapture =>
-      props[_$key__onMouseDownCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseDownCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseDownCapture] -->
   @override
   set onMouseDownCapture(MouseEventCallback value) =>
@@ -1672,8 +1560,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseEnterCapture] -->
   @override
   MouseEventCallback get onMouseEnterCapture =>
-      props[_$key__onMouseEnterCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseEnterCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseEnterCapture] -->
   @override
   set onMouseEnterCapture(MouseEventCallback value) =>
@@ -1682,8 +1570,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseLeaveCapture] -->
   @override
   MouseEventCallback get onMouseLeaveCapture =>
-      props[_$key__onMouseLeaveCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseLeaveCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseLeaveCapture] -->
   @override
   set onMouseLeaveCapture(MouseEventCallback value) =>
@@ -1692,8 +1580,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseMoveCapture] -->
   @override
   MouseEventCallback get onMouseMoveCapture =>
-      props[_$key__onMouseMoveCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseMoveCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseMoveCapture] -->
   @override
   set onMouseMoveCapture(MouseEventCallback value) =>
@@ -1702,8 +1590,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseOutCapture] -->
   @override
   MouseEventCallback get onMouseOutCapture =>
-      props[_$key__onMouseOutCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOutCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseOutCapture] -->
   @override
   set onMouseOutCapture(MouseEventCallback value) =>
@@ -1712,8 +1600,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseOverCapture] -->
   @override
   MouseEventCallback get onMouseOverCapture =>
-      props[_$key__onMouseOverCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOverCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseOverCapture] -->
   @override
   set onMouseOverCapture(MouseEventCallback value) =>
@@ -1722,8 +1610,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onMouseUpCapture] -->
   @override
   MouseEventCallback get onMouseUpCapture =>
-      props[_$key__onMouseUpCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseUpCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onMouseUpCapture] -->
   @override
   set onMouseUpCapture(MouseEventCallback value) =>
@@ -1732,8 +1620,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onGotPointerCapture] -->
   @override
   PointerEventCallback get onGotPointerCapture =>
-      props[_$key__onGotPointerCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onGotPointerCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onGotPointerCapture] -->
   @override
   set onGotPointerCapture(PointerEventCallback value) =>
@@ -1742,8 +1630,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onLostPointerCapture] -->
   @override
   PointerEventCallback get onLostPointerCapture =>
-      props[_$key__onLostPointerCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onLostPointerCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onLostPointerCapture] -->
   @override
   set onLostPointerCapture(PointerEventCallback value) =>
@@ -1752,8 +1640,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancelCapture] -->
   @override
   TouchEventCallback get onTouchCancelCapture =>
-      props[_$key__onTouchCancelCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchCancelCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchCancelCapture] -->
   @override
   set onTouchCancelCapture(TouchEventCallback value) =>
@@ -1762,8 +1650,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchEndCapture] -->
   @override
   TouchEventCallback get onTouchEndCapture =>
-      props[_$key__onTouchEndCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchEndCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchEndCapture] -->
   @override
   set onTouchEndCapture(TouchEventCallback value) =>
@@ -1772,8 +1660,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchMoveCapture] -->
   @override
   TouchEventCallback get onTouchMoveCapture =>
-      props[_$key__onTouchMoveCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchMoveCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchMoveCapture] -->
   @override
   set onTouchMoveCapture(TouchEventCallback value) =>
@@ -1782,8 +1670,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onTouchStartCapture] -->
   @override
   TouchEventCallback get onTouchStartCapture =>
-      props[_$key__onTouchStartCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchStartCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onTouchStartCapture] -->
   @override
   set onTouchStartCapture(TouchEventCallback value) =>
@@ -1792,8 +1680,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onScrollCapture] -->
   @override
   UIEventCallback get onScrollCapture =>
-      props[_$key__onScrollCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onScrollCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onScrollCapture] -->
   @override
   set onScrollCapture(UIEventCallback value) =>
@@ -1802,8 +1690,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.onWheelCapture] -->
   @override
   WheelEventCallback get onWheelCapture =>
-      props[_$key__onWheelCapture___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onWheelCapture___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.onWheelCapture] -->
   @override
   set onWheelCapture(WheelEventCallback value) =>
@@ -1811,9 +1699,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.defaultChecked] -->
   @override
-  bool get defaultChecked =>
-      props[_$key__defaultChecked___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get defaultChecked => props[_$key__defaultChecked___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.defaultChecked] -->
   @override
   set defaultChecked(bool value) =>
@@ -1821,9 +1708,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
 
   /// <!-- Generated from [_$DomPropsMixin.defaultValue] -->
   @override
-  dynamic get defaultValue =>
-      props[_$key__defaultValue___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get defaultValue => props[_$key__defaultValue___$DomPropsMixin];
+
   /// <!-- Generated from [_$DomPropsMixin.defaultValue] -->
   @override
   set defaultValue(dynamic value) =>
@@ -1834,9 +1720,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   ///
   /// <!-- Generated from [_$DomPropsMixin.autoFocus] -->
   @override
-  bool get autoFocus =>
-      props[_$key__autoFocus___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get autoFocus => props[_$key__autoFocus___$DomPropsMixin];
+
   /// Polyfills/normalizes the `autofocus` attribute via AutoFocusMixin
   /// (mixed in by React DOM <input>, <textarea>, and <select>).
   ///
@@ -2812,9 +2697,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
-  dynamic get clipPath =>
-      props[_$key__clipPath___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get clipPath => props[_$key__clipPath___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
   set clipPath(dynamic value) =>
@@ -2822,63 +2706,56 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.cx] -->
   @override
-  dynamic get cx =>
-      props[_$key__cx___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get cx => props[_$key__cx___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.cx] -->
   @override
   set cx(dynamic value) => props[_$key__cx___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.cy] -->
   @override
-  dynamic get cy =>
-      props[_$key__cy___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get cy => props[_$key__cy___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.cy] -->
   @override
   set cy(dynamic value) => props[_$key__cy___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.d] -->
   @override
-  dynamic get d =>
-      props[_$key__d___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get d => props[_$key__d___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.d] -->
   @override
   set d(dynamic value) => props[_$key__d___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.dx] -->
   @override
-  dynamic get dx =>
-      props[_$key__dx___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dx => props[_$key__dx___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.dx] -->
   @override
   set dx(dynamic value) => props[_$key__dx___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.dy] -->
   @override
-  dynamic get dy =>
-      props[_$key__dy___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dy => props[_$key__dy___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.dy] -->
   @override
   set dy(dynamic value) => props[_$key__dy___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.fill] -->
   @override
-  dynamic get fill =>
-      props[_$key__fill___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fill => props[_$key__fill___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fill] -->
   @override
   set fill(dynamic value) => props[_$key__fill___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.fillOpacity] -->
   @override
-  dynamic get fillOpacity =>
-      props[_$key__fillOpacity___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fillOpacity => props[_$key__fillOpacity___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fillOpacity] -->
   @override
   set fillOpacity(dynamic value) =>
@@ -2886,9 +2763,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
   @override
-  dynamic get fontFamily =>
-      props[_$key__fontFamily___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fontFamily => props[_$key__fontFamily___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
   @override
   set fontFamily(dynamic value) =>
@@ -2896,9 +2772,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.fontSize] -->
   @override
-  dynamic get fontSize =>
-      props[_$key__fontSize___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fontSize => props[_$key__fontSize___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fontSize] -->
   @override
   set fontSize(dynamic value) =>
@@ -2906,18 +2781,16 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.fx] -->
   @override
-  dynamic get fx =>
-      props[_$key__fx___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fx => props[_$key__fx___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fx] -->
   @override
   set fx(dynamic value) => props[_$key__fx___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.fy] -->
   @override
-  dynamic get fy =>
-      props[_$key__fy___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get fy => props[_$key__fy___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.fy] -->
   @override
   set fy(dynamic value) => props[_$key__fy___$SvgPropsMixin] = value;
@@ -2925,8 +2798,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
   @override
   dynamic get gradientTransform =>
-      props[_$key__gradientTransform___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__gradientTransform___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
   @override
   set gradientTransform(dynamic value) =>
@@ -2934,9 +2807,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
   @override
-  dynamic get gradientUnits =>
-      props[_$key__gradientUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get gradientUnits => props[_$key__gradientUnits___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
   @override
   set gradientUnits(dynamic value) =>
@@ -2944,9 +2816,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
   @override
-  dynamic get markerEnd =>
-      props[_$key__markerEnd___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get markerEnd => props[_$key__markerEnd___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
   @override
   set markerEnd(dynamic value) =>
@@ -2954,9 +2825,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
   @override
-  dynamic get markerMid =>
-      props[_$key__markerMid___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get markerMid => props[_$key__markerMid___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
   @override
   set markerMid(dynamic value) =>
@@ -2964,9 +2834,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
   @override
-  dynamic get markerStart =>
-      props[_$key__markerStart___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get markerStart => props[_$key__markerStart___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
   @override
   set markerStart(dynamic value) =>
@@ -2974,18 +2843,16 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.offset] -->
   @override
-  dynamic get offset =>
-      props[_$key__offset___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get offset => props[_$key__offset___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.offset] -->
   @override
   set offset(dynamic value) => props[_$key__offset___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.opacity] -->
   @override
-  dynamic get opacity =>
-      props[_$key__opacity___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get opacity => props[_$key__opacity___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.opacity] -->
   @override
   set opacity(dynamic value) => props[_$key__opacity___$SvgPropsMixin] = value;
@@ -2993,8 +2860,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
   @override
   dynamic get patternContentUnits =>
-      props[_$key__patternContentUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__patternContentUnits___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
   @override
   set patternContentUnits(dynamic value) =>
@@ -3002,9 +2869,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
   @override
-  dynamic get patternUnits =>
-      props[_$key__patternUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get patternUnits => props[_$key__patternUnits___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
   @override
   set patternUnits(dynamic value) =>
@@ -3012,9 +2878,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.points] -->
   @override
-  dynamic get points =>
-      props[_$key__points___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get points => props[_$key__points___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.points] -->
   @override
   set points(dynamic value) => props[_$key__points___$SvgPropsMixin] = value;
@@ -3022,8 +2887,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
   @override
   dynamic get preserveAspectRatio =>
-      props[_$key__preserveAspectRatio___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__preserveAspectRatio___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
   @override
   set preserveAspectRatio(dynamic value) =>
@@ -3031,36 +2896,32 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.r] -->
   @override
-  dynamic get r =>
-      props[_$key__r___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get r => props[_$key__r___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.r] -->
   @override
   set r(dynamic value) => props[_$key__r___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.rx] -->
   @override
-  dynamic get rx =>
-      props[_$key__rx___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get rx => props[_$key__rx___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.rx] -->
   @override
   set rx(dynamic value) => props[_$key__rx___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.ry] -->
   @override
-  dynamic get ry =>
-      props[_$key__ry___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get ry => props[_$key__ry___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.ry] -->
   @override
   set ry(dynamic value) => props[_$key__ry___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
   @override
-  dynamic get spreadMethod =>
-      props[_$key__spreadMethod___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get spreadMethod => props[_$key__spreadMethod___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
   @override
   set spreadMethod(dynamic value) =>
@@ -3068,9 +2929,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
   @override
-  dynamic get stopColor =>
-      props[_$key__stopColor___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get stopColor => props[_$key__stopColor___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
   @override
   set stopColor(dynamic value) =>
@@ -3078,9 +2938,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.stopOpacity] -->
   @override
-  dynamic get stopOpacity =>
-      props[_$key__stopOpacity___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get stopOpacity => props[_$key__stopOpacity___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.stopOpacity] -->
   @override
   set stopOpacity(dynamic value) =>
@@ -3088,18 +2947,16 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
   @override
-  dynamic get stroke =>
-      props[_$key__stroke___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get stroke => props[_$key__stroke___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
   @override
   set stroke(dynamic value) => props[_$key__stroke___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.strokeDasharray] -->
   @override
-  dynamic get strokeDasharray =>
-      props[_$key__strokeDasharray___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get strokeDasharray => props[_$key__strokeDasharray___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.strokeDasharray] -->
   @override
   set strokeDasharray(dynamic value) =>
@@ -3107,9 +2964,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
   @override
-  dynamic get strokeLinecap =>
-      props[_$key__strokeLinecap___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get strokeLinecap => props[_$key__strokeLinecap___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
   @override
   set strokeLinecap(dynamic value) =>
@@ -3117,9 +2973,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.strokeOpacity] -->
   @override
-  dynamic get strokeOpacity =>
-      props[_$key__strokeOpacity___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get strokeOpacity => props[_$key__strokeOpacity___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.strokeOpacity] -->
   @override
   set strokeOpacity(dynamic value) =>
@@ -3127,9 +2982,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.strokeWidth] -->
   @override
-  dynamic get strokeWidth =>
-      props[_$key__strokeWidth___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get strokeWidth => props[_$key__strokeWidth___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.strokeWidth] -->
   @override
   set strokeWidth(dynamic value) =>
@@ -3137,9 +2991,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
   @override
-  dynamic get textAnchor =>
-      props[_$key__textAnchor___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get textAnchor => props[_$key__textAnchor___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
   @override
   set textAnchor(dynamic value) =>
@@ -3147,9 +3000,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.transform] -->
   @override
-  dynamic get transform =>
-      props[_$key__transform___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get transform => props[_$key__transform___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.transform] -->
   @override
   set transform(dynamic value) =>
@@ -3157,54 +3009,48 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.version] -->
   @override
-  dynamic get version =>
-      props[_$key__version___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get version => props[_$key__version___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.version] -->
   @override
   set version(dynamic value) => props[_$key__version___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
   @override
-  dynamic get viewBox =>
-      props[_$key__viewBox___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get viewBox => props[_$key__viewBox___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
   @override
   set viewBox(dynamic value) => props[_$key__viewBox___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.x1] -->
   @override
-  dynamic get x1 =>
-      props[_$key__x1___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get x1 => props[_$key__x1___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.x1] -->
   @override
   set x1(dynamic value) => props[_$key__x1___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.x2] -->
   @override
-  dynamic get x2 =>
-      props[_$key__x2___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get x2 => props[_$key__x2___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.x2] -->
   @override
   set x2(dynamic value) => props[_$key__x2___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.x] -->
   @override
-  dynamic get x =>
-      props[_$key__x___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get x => props[_$key__x___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.x] -->
   @override
   set x(dynamic value) => props[_$key__x___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
   @override
-  dynamic get xlinkActuate =>
-      props[_$key__xlinkActuate___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkActuate => props[_$key__xlinkActuate___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
   @override
   set xlinkActuate(dynamic value) =>
@@ -3212,9 +3058,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
   @override
-  dynamic get xlinkArcrole =>
-      props[_$key__xlinkArcrole___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkArcrole => props[_$key__xlinkArcrole___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
   @override
   set xlinkArcrole(dynamic value) =>
@@ -3222,9 +3067,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
   @override
-  dynamic get xlinkHref =>
-      props[_$key__xlinkHref___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkHref => props[_$key__xlinkHref___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
   @override
   set xlinkHref(dynamic value) =>
@@ -3232,9 +3076,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
   @override
-  dynamic get xlinkRole =>
-      props[_$key__xlinkRole___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkRole => props[_$key__xlinkRole___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
   @override
   set xlinkRole(dynamic value) =>
@@ -3242,9 +3085,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
   @override
-  dynamic get xlinkShow =>
-      props[_$key__xlinkShow___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkShow => props[_$key__xlinkShow___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
   @override
   set xlinkShow(dynamic value) =>
@@ -3252,9 +3094,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
   @override
-  dynamic get xlinkTitle =>
-      props[_$key__xlinkTitle___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkTitle => props[_$key__xlinkTitle___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
   @override
   set xlinkTitle(dynamic value) =>
@@ -3262,9 +3103,8 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
   @override
-  dynamic get xlinkType =>
-      props[_$key__xlinkType___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xlinkType => props[_$key__xlinkType___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
   @override
   set xlinkType(dynamic value) =>
@@ -3272,27 +3112,24 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
   @override
-  dynamic get xmlBase =>
-      props[_$key__xmlBase___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xmlBase => props[_$key__xmlBase___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
   @override
   set xmlBase(dynamic value) => props[_$key__xmlBase___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
   @override
-  dynamic get xmlLang =>
-      props[_$key__xmlLang___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xmlLang => props[_$key__xmlLang___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
   @override
   set xmlLang(dynamic value) => props[_$key__xmlLang___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
   @override
-  dynamic get xmlSpace =>
-      props[_$key__xmlSpace___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get xmlSpace => props[_$key__xmlSpace___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
   @override
   set xmlSpace(dynamic value) =>
@@ -3300,27 +3137,24 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.y1] -->
   @override
-  dynamic get y1 =>
-      props[_$key__y1___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get y1 => props[_$key__y1___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.y1] -->
   @override
   set y1(dynamic value) => props[_$key__y1___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.y2] -->
   @override
-  dynamic get y2 =>
-      props[_$key__y2___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get y2 => props[_$key__y2___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.y2] -->
   @override
   set y2(dynamic value) => props[_$key__y2___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.y] -->
   @override
-  dynamic get y =>
-      props[_$key__y___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get y => props[_$key__y___$SvgPropsMixin];
+
   /// <!-- Generated from [_$SvgPropsMixin.y] -->
   @override
   set y(dynamic value) => props[_$key__y___$SvgPropsMixin] = value;
@@ -3635,9 +3469,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.tabIndex] -->
   @override
-  dynamic get tabIndex =>
-      props[_$key__tabIndex___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get tabIndex => props[_$key__tabIndex___$UbiquitousDomPropsMixin];
+
   /// Whether the element if focusable.
   /// Must be a valid integer or String of valid integer.
   ///
@@ -3651,9 +3484,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.id] -->
   @override
-  String get id =>
-      props[_$key__id___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => props[_$key__id___$UbiquitousDomPropsMixin];
+
   /// Unique identifier.
   /// Must be unique amongst all the ids, and contain at least one character.
   ///
@@ -3665,9 +3497,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.title] -->
   @override
-  String get title =>
-      props[_$key__title___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get title => props[_$key__title___$UbiquitousDomPropsMixin];
+
   /// Represents advisory information about the element.
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.title] -->
@@ -3687,8 +3518,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.style] -->
   @override
   Map<String, dynamic> get style =>
-      props[_$key__style___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__style___$UbiquitousDomPropsMixin];
+
   /// An inline CSS style for the element.
   ///
   ///     ..style = {
@@ -3710,8 +3541,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onAnimationEnd] -->
   @override
   AnimationEventCallback get onAnimationEnd =>
-      props[_$key__onAnimationEnd___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationEnd___$UbiquitousDomPropsMixin];
+
   /// Callback for when a CSS Animation has completed.
   ///
   /// > Related: [onAnimationIteration], [onAnimationStart], [onTransitionEnd]
@@ -3728,8 +3559,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onAnimationIteration] -->
   @override
   AnimationEventCallback get onAnimationIteration =>
-      props[_$key__onAnimationIteration___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationIteration___$UbiquitousDomPropsMixin];
+
   /// Callback for when an iteration of a CSS Animation ends, and another one begins.
   ///
   /// > Related: [onAnimationEnd], [onAnimationStart]
@@ -3746,8 +3577,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onAnimationStart] -->
   @override
   AnimationEventCallback get onAnimationStart =>
-      props[_$key__onAnimationStart___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onAnimationStart___$UbiquitousDomPropsMixin];
+
   /// Callback for when a CSS animation has started.
   ///
   /// > Related: [onAnimationEnd], [onAnimationIteration]
@@ -3762,8 +3593,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCopy] -->
   @override
   ClipboardEventCallback get onCopy =>
-      props[_$key__onCopy___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onCopy___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user copies the content of an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCopy] -->
@@ -3776,8 +3607,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCut] -->
   @override
   ClipboardEventCallback get onCut =>
-      props[_$key__onCut___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onCut___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user cuts the content of an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onCut] -->
@@ -3790,8 +3621,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPaste] -->
   @override
   ClipboardEventCallback get onPaste =>
-      props[_$key__onPaste___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPaste___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user pastes some content in an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPaste] -->
@@ -3804,8 +3635,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyDown] -->
   @override
   KeyboardEventCallback get onKeyDown =>
-      props[_$key__onKeyDown___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyDown___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user is pressing a key
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyDown] -->
@@ -3818,8 +3649,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyPress] -->
   @override
   KeyboardEventCallback get onKeyPress =>
-      props[_$key__onKeyPress___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyPress___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user presses a key
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyPress] -->
@@ -3832,8 +3663,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyUp] -->
   @override
   KeyboardEventCallback get onKeyUp =>
-      props[_$key__onKeyUp___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onKeyUp___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user releases a key
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onKeyUp] -->
@@ -3846,8 +3677,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onFocus] -->
   @override
   FocusEventCallback get onFocus =>
-      props[_$key__onFocus___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onFocus___$UbiquitousDomPropsMixin];
+
   /// Callback for when an element gets focus
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onFocus] -->
@@ -3860,8 +3691,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onBlur] -->
   @override
   FocusEventCallback get onBlur =>
-      props[_$key__onBlur___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onBlur___$UbiquitousDomPropsMixin];
+
   /// Callback for when an element loses focus
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onBlur] -->
@@ -3875,8 +3706,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onChange] -->
   @override
   FormEventCallback get onChange =>
-      props[_$key__onChange___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onChange___$UbiquitousDomPropsMixin];
+
   /// Callback for  when the content of a form element, the selection, or the checked state have changed (for <input>,
   /// <keygen>, <select>, and <textarea>)
   ///
@@ -3890,8 +3721,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onInput] -->
   @override
   FormEventCallback get onInput =>
-      props[_$key__onInput___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onInput___$UbiquitousDomPropsMixin];
+
   /// Callback for when an element gets user input
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onInput] -->
@@ -3904,8 +3735,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onSubmit] -->
   @override
   FormEventCallback get onSubmit =>
-      props[_$key__onSubmit___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onSubmit___$UbiquitousDomPropsMixin];
+
   /// Callback for when a form is submitted
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onSubmit] -->
@@ -3918,8 +3749,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onReset] -->
   @override
   FormEventCallback get onReset =>
-      props[_$key__onReset___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onReset___$UbiquitousDomPropsMixin];
+
   /// Callback for when a form is reset
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onReset] -->
@@ -3932,8 +3763,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onClick] -->
   @override
   MouseEventCallback get onClick =>
-      props[_$key__onClick___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onClick___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user clicks on an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onClick] -->
@@ -3946,8 +3777,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onContextMenu] -->
   @override
   MouseEventCallback get onContextMenu =>
-      props[_$key__onContextMenu___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onContextMenu___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user right-clicks on an element to open a context menu
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onContextMenu] -->
@@ -3960,8 +3791,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDoubleClick] -->
   @override
   MouseEventCallback get onDoubleClick =>
-      props[_$key__onDoubleClick___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDoubleClick___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user double-clicks on an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDoubleClick] -->
@@ -3974,8 +3805,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrag] -->
   @override
   MouseEventCallback get onDrag =>
-      props[_$key__onDrag___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDrag___$UbiquitousDomPropsMixin];
+
   /// Callback for when an element is being dragged
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrag] -->
@@ -3988,8 +3819,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnd] -->
   @override
   MouseEventCallback get onDragEnd =>
-      props[_$key__onDragEnd___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragEnd___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user has finished dragging an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnd] -->
@@ -4002,8 +3833,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnter] -->
   @override
   MouseEventCallback get onDragEnter =>
-      props[_$key__onDragEnter___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragEnter___$UbiquitousDomPropsMixin];
+
   /// Callback for when the dragged element enters the drop target
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragEnter] -->
@@ -4016,8 +3847,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragExit] -->
   @override
   MouseEventCallback get onDragExit =>
-      props[_$key__onDragExit___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragExit___$UbiquitousDomPropsMixin];
+
   /// Callback for when the dragged element exits the drop target
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragExit] -->
@@ -4030,8 +3861,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragLeave] -->
   @override
   MouseEventCallback get onDragLeave =>
-      props[_$key__onDragLeave___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragLeave___$UbiquitousDomPropsMixin];
+
   /// Callback for when the dragged element leaves the drop target
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragLeave] -->
@@ -4044,8 +3875,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragOver] -->
   @override
   MouseEventCallback get onDragOver =>
-      props[_$key__onDragOver___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragOver___$UbiquitousDomPropsMixin];
+
   /// Callback for when the dragged element is over the drop target
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragOver] -->
@@ -4058,8 +3889,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragStart] -->
   @override
   MouseEventCallback get onDragStart =>
-      props[_$key__onDragStart___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDragStart___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user starts to drag an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDragStart] -->
@@ -4072,8 +3903,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrop] -->
   @override
   MouseEventCallback get onDrop =>
-      props[_$key__onDrop___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDrop___$UbiquitousDomPropsMixin];
+
   /// Callback for when the dragged element is dropped on the drop target
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onDrop] -->
@@ -4086,8 +3917,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseDown] -->
   @override
   MouseEventCallback get onMouseDown =>
-      props[_$key__onMouseDown___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseDown___$UbiquitousDomPropsMixin];
+
   /// Callback for when the user presses a mouse button over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseDown] -->
@@ -4100,8 +3931,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseEnter] -->
   @override
   MouseEventCallback get onMouseEnter =>
-      props[_$key__onMouseEnter___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseEnter___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved onto an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseEnter] -->
@@ -4114,8 +3945,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseLeave] -->
   @override
   MouseEventCallback get onMouseLeave =>
-      props[_$key__onMouseLeave___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseLeave___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved out of an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseLeave] -->
@@ -4128,8 +3959,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseMove] -->
   @override
   MouseEventCallback get onMouseMove =>
-      props[_$key__onMouseMove___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseMove___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moving while it is over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseMove] -->
@@ -4142,8 +3973,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOut] -->
   @override
   MouseEventCallback get onMouseOut =>
-      props[_$key__onMouseOut___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOut___$UbiquitousDomPropsMixin];
+
   /// Callback for when a user moves the mouse pointer out of an element, or out of one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOut] -->
@@ -4156,8 +3987,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOver] -->
   @override
   MouseEventCallback get onMouseOver =>
-      props[_$key__onMouseOver___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseOver___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved onto an element, or onto one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseOver] -->
@@ -4170,8 +4001,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseUp] -->
   @override
   MouseEventCallback get onMouseUp =>
-      props[_$key__onMouseUp___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onMouseUp___$UbiquitousDomPropsMixin];
+
   /// Callback for when a user releases a mouse button over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onMouseUp] -->
@@ -4184,8 +4015,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerCancel] -->
   @override
   PointerEventCallback get onPointerCancel =>
-      props[_$key__onPointerCancel___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerCancel___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointing device is interrupted
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerCancel] -->
@@ -4198,8 +4029,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerDown] -->
   @override
   PointerEventCallback get onPointerDown =>
-      props[_$key__onPointerDown___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerDown___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer becomes active over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerDown] -->
@@ -4212,8 +4043,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerEnter] -->
   @override
   PointerEventCallback get onPointerEnter =>
-      props[_$key__onPointerEnter___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerEnter___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved onto an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerEnter] -->
@@ -4226,8 +4057,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerLeave] -->
   @override
   PointerEventCallback get onPointerLeave =>
-      props[_$key__onPointerLeave___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerLeave___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved out of an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerLeave] -->
@@ -4240,8 +4071,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerMove] -->
   @override
   PointerEventCallback get onPointerMove =>
-      props[_$key__onPointerMove___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerMove___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moving while it is over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerMove] -->
@@ -4254,8 +4085,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
   @override
   PointerEventCallback get onPointerOver =>
-      props[_$key__onPointerOver___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerOver___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved onto an element, or onto one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOver] -->
@@ -4268,8 +4099,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOut] -->
   @override
   PointerEventCallback get onPointerOut =>
-      props[_$key__onPointerOut___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerOut___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer is moved out of an element, or out of one of its children
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerOut] -->
@@ -4282,8 +4113,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerUp] -->
   @override
   PointerEventCallback get onPointerUp =>
-      props[_$key__onPointerUp___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPointerUp___$UbiquitousDomPropsMixin];
+
   /// Callback for when the pointer becomes inactive over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onPointerUp] -->
@@ -4296,8 +4127,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchCancel] -->
   @override
   TouchEventCallback get onTouchCancel =>
-      props[_$key__onTouchCancel___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchCancel___$UbiquitousDomPropsMixin];
+
   /// Callback for when the touch is interrupted
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchCancel] -->
@@ -4310,8 +4141,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchEnd] -->
   @override
   TouchEventCallback get onTouchEnd =>
-      props[_$key__onTouchEnd___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchEnd___$UbiquitousDomPropsMixin];
+
   /// Callback for when a finger is removed from a touch screen
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchEnd] -->
@@ -4324,8 +4155,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchMove] -->
   @override
   TouchEventCallback get onTouchMove =>
-      props[_$key__onTouchMove___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchMove___$UbiquitousDomPropsMixin];
+
   /// Callback for when a finger is dragged across the screen
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchMove] -->
@@ -4338,8 +4169,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchStart] -->
   @override
   TouchEventCallback get onTouchStart =>
-      props[_$key__onTouchStart___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTouchStart___$UbiquitousDomPropsMixin];
+
   /// Callback for when a finger is placed on a touch screen
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTouchStart] -->
@@ -4354,8 +4185,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onTransitionEnd] -->
   @override
   TransitionEventCallback get onTransitionEnd =>
-      props[_$key__onTransitionEnd___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onTransitionEnd___$UbiquitousDomPropsMixin];
+
   /// Callback for when a CSS transition has completed.
   ///
   /// > Related: [onAnimationEnd]
@@ -4370,8 +4201,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onScroll] -->
   @override
   UIEventCallback get onScroll =>
-      props[_$key__onScroll___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onScroll___$UbiquitousDomPropsMixin];
+
   /// Callback for when an element's scrollbar is being scrolled
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onScroll] -->
@@ -4384,8 +4215,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onWheel] -->
   @override
   WheelEventCallback get onWheel =>
-      props[_$key__onWheel___$UbiquitousDomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onWheel___$UbiquitousDomPropsMixin];
+
   /// Callback for when the mouse wheel rolls up or down over an element
   ///
   /// <!-- Generated from [_$UbiquitousDomPropsMixin.onWheel] -->

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -114,8 +114,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// <!-- Generated from [_$ResizeSensorPropsMixin.onInitialize] -->
   @override
   ResizeSensorHandler get onInitialize =>
-      props[_$key__onInitialize___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onInitialize___$ResizeSensorPropsMixin];
+
   /// A function invoked with a `ResizeSensorEvent` argument when the resize sensor is initialized.
   ///
   /// > Will never be called if [quickMount] is `true`.
@@ -138,8 +138,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// <!-- Generated from [_$ResizeSensorPropsMixin.onResize] -->
   @override
   ResizeSensorHandler get onResize =>
-      props[_$key__onResize___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onResize___$ResizeSensorPropsMixin];
+
   /// A function invoked with a `ResizeSensorEvent` argument when the [ResizeSensor]
   /// resizes, either due to its parent or children resizing.
   ///
@@ -161,9 +161,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   ///
   /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexChild] -->
   @override
-  bool get isFlexChild =>
-      props[_$key__isFlexChild___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isFlexChild => props[_$key__isFlexChild___$ResizeSensorPropsMixin];
+
   /// Whether the [ResizeSensor] is a child of a flex item. Necessary to apply the correct styling.
   ///
   /// See this issue for details: <https://code.google.com/p/chromium/issues/detail?id=346275>
@@ -182,8 +181,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// <!-- Generated from [_$ResizeSensorPropsMixin.isFlexContainer] -->
   @override
   bool get isFlexContainer =>
-      props[_$key__isFlexContainer___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__isFlexContainer___$ResizeSensorPropsMixin];
+
   /// Whether the [ResizeSensor] is a flex container. Necessary to apply the correct styling.
   ///
   /// Default: false
@@ -202,9 +201,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   ///
   /// <!-- Generated from [_$ResizeSensorPropsMixin.shrink] -->
   @override
-  bool get shrink =>
-      props[_$key__shrink___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get shrink => props[_$key__shrink___$ResizeSensorPropsMixin];
+
   /// Whether the [ResizeSensor] should shrink to the size of its child.
   ///
   /// __WARNING:__ If set to true there is a possibility that the [ResizeSensor] will not work due to it being too
@@ -234,9 +232,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   ///
   /// <!-- Generated from [_$ResizeSensorPropsMixin.quickMount] -->
   @override
-  bool get quickMount =>
-      props[_$key__quickMount___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get quickMount => props[_$key__quickMount___$ResizeSensorPropsMixin];
+
   /// Whether quick-mount mode is enabled, which minimizes layouts caused by accessing element dimensions
   /// during initialization, allowing the component to mount faster.
   ///
@@ -285,8 +282,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// <!-- Generated from [_$ResizeSensorPropsMixin.onDetachedMountCheck] -->
   @override
   BoolCallback get onDetachedMountCheck =>
-      props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onDetachedMountCheck___$ResizeSensorPropsMixin];
+
   /// A callback that returns a `bool` that indicates whether the [ResizeSensor] was detached from the DOM
   /// when it first mounted.
   ///
@@ -323,9 +320,8 @@ abstract class ResizeSensorPropsMixin implements _$ResizeSensorPropsMixin {
   /// <!-- Generated from [_$ResizeSensorPropsMixin.onDidReset] -->
   @override
   @visibleForTesting
-  Callback get onDidReset =>
-      props[_$key__onDidReset___$ResizeSensorPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Callback get onDidReset => props[_$key__onDidReset___$ResizeSensorPropsMixin];
+
   /// A callback intended for use only within internal unit tests that is called when [ResizeSensorComponent._reset]
   /// is called.
   ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -807,4 +807,3 @@ class StateMeta implements AccessorMeta<StateDescriptor> {
 
   const StateMeta({this.fields, this.keys});
 }
-

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -15,8 +15,8 @@ abstract class ConnectPropsMixin implements _$ConnectPropsMixin {
   /// <!-- Generated from [_$ConnectPropsMixin.dispatch] -->
   @override
   dynamic Function(dynamic action) get dispatch =>
-      props[_$key__dispatch___$ConnectPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dispatch___$ConnectPropsMixin];
+
   /// <!-- Generated from [_$ConnectPropsMixin.dispatch] -->
   @override
   set dispatch(dynamic Function(dynamic action) value) =>

--- a/lib/src/util/class_names.over_react.g.dart
+++ b/lib/src/util/class_names.over_react.g.dart
@@ -19,9 +19,8 @@ abstract class CssClassPropsMixin implements _$CssClassPropsMixin {
   ///
   /// <!-- Generated from [_$CssClassPropsMixin.className] -->
   @override
-  String get className =>
-      props[_$key__className___$CssClassPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get className => props[_$key__className___$CssClassPropsMixin];
+
   /// String of space-delimited CSS classes to be added to the resultant DOM.
   ///
   /// All over_react components merge any added classes with this prop and the [classNameBlacklist] prop (see
@@ -40,8 +39,8 @@ abstract class CssClassPropsMixin implements _$CssClassPropsMixin {
   /// <!-- Generated from [_$CssClassPropsMixin.classNameBlacklist] -->
   @override
   String get classNameBlacklist =>
-      props[_$key__classNameBlacklist___$CssClassPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__classNameBlacklist___$CssClassPropsMixin];
+
   /// String of space-delimited CSS classes to be blacklisted from being added to the resultant DOM.
   ///
   /// All over_react components merge any added classes with this prop and the [className] prop (see

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onHandlePreShowing] -->
   @override
   Callback get onHandlePreShowing =>
-      props[_$key__onHandlePreShowing___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onHandlePreShowing___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onHandlePreShowing] -->
   @override
   set onHandlePreShowing(Callback value) =>
@@ -35,8 +35,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onHandleShowing] -->
   @override
   Callback get onHandleShowing =>
-      props[_$key__onHandleShowing___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onHandleShowing___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onHandleShowing] -->
   @override
   set onHandleShowing(Callback value) =>
@@ -45,8 +45,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onHandleShown] -->
   @override
   Callback get onHandleShown =>
-      props[_$key__onHandleShown___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onHandleShown___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onHandleShown] -->
   @override
   set onHandleShown(Callback value) =>
@@ -55,8 +55,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onHandleHiding] -->
   @override
   Callback get onHandleHiding =>
-      props[_$key__onHandleHiding___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onHandleHiding___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onHandleHiding] -->
   @override
   set onHandleHiding(Callback value) =>
@@ -65,8 +65,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onHandleHidden] -->
   @override
   Callback get onHandleHidden =>
-      props[_$key__onHandleHidden___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onHandleHidden___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onHandleHidden] -->
   @override
   set onHandleHidden(Callback value) =>
@@ -75,8 +75,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onPrepareShow] -->
   @override
   Callback get onPrepareShow =>
-      props[_$key__onPrepareShow___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPrepareShow___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onPrepareShow] -->
   @override
   set onPrepareShow(Callback value) =>
@@ -85,8 +85,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.onPrepareHide] -->
   @override
   Callback get onPrepareHide =>
-      props[_$key__onPrepareHide___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onPrepareHide___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.onPrepareHide] -->
   @override
   set onPrepareHide(Callback value) =>
@@ -94,9 +94,8 @@ abstract class _$TransitionerPropsAccessorsMixin
 
   /// <!-- Generated from [_$TransitionerProps.hasTransition] -->
   @override
-  bool get hasTransition =>
-      props[_$key__hasTransition___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hasTransition => props[_$key__hasTransition___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.hasTransition] -->
   @override
   set hasTransition(bool value) =>
@@ -104,9 +103,8 @@ abstract class _$TransitionerPropsAccessorsMixin
 
   /// <!-- Generated from [_$TransitionerProps.initiallyShown] -->
   @override
-  bool get initiallyShown =>
-      props[_$key__initiallyShown___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get initiallyShown => props[_$key__initiallyShown___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.initiallyShown] -->
   @override
   set initiallyShown(bool value) =>
@@ -115,8 +113,8 @@ abstract class _$TransitionerPropsAccessorsMixin
   /// <!-- Generated from [_$TransitionerProps.transitionTimeout] -->
   @override
   Duration get transitionTimeout =>
-      props[_$key__transitionTimeout___$TransitionerProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__transitionTimeout___$TransitionerProps];
+
   /// <!-- Generated from [_$TransitionerProps.transitionTimeout] -->
   @override
   set transitionTimeout(Duration value) =>

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -118,8 +118,8 @@ abstract class _$ContextProviderWrapperStateAccessorsMixin
   /// <!-- Generated from [_$ContextProviderWrapperState.latestValue] -->
   @override
   int get latestValue =>
-      state[_$key__latestValue___$ContextProviderWrapperState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__latestValue___$ContextProviderWrapperState];
+
   /// <!-- Generated from [_$ContextProviderWrapperState.latestValue] -->
   @override
   set latestValue(int value) =>

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$DummyPropsAccessorsMixin implements _$DummyProps {
   /// <!-- Generated from [_$DummyProps.onComponentDidMount] -->
   @override
   Function get onComponentDidMount =>
-      props[_$key__onComponentDidMount___$DummyProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onComponentDidMount___$DummyProps];
+
   /// <!-- Generated from [_$DummyProps.onComponentDidMount] -->
   @override
   set onComponentDidMount(Function value) =>

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -70,9 +70,8 @@ abstract class _$FlawedStateAccessorsMixin implements _$FlawedState {
 
   /// <!-- Generated from [_$FlawedState.hasError] -->
   @override
-  bool get hasError =>
-      state[_$key__hasError___$FlawedState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hasError => state[_$key__hasError___$FlawedState];
+
   /// <!-- Generated from [_$FlawedState.hasError] -->
   @override
   set hasError(bool value) => state[_$key__hasError___$FlawedState] = value;

--- a/test/over_react/component/forward_ref_test.over_react.g.dart
+++ b/test/over_react/component/forward_ref_test.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// <!-- Generated from [_$BasicProps.childId] -->
   @override
-  String get childId =>
-      props[_$key__childId___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get childId => props[_$key__childId___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.childId] -->
   @override
   set childId(String value) => props[_$key__childId___$BasicProps] = value;

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -13,9 +13,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -23,9 +22,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -33,9 +31,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -44,9 +41,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -57,8 +53,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +65,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -140,8 +136,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -150,8 +146,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -160,8 +156,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -171,8 +167,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -183,8 +179,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -195,10 +191,9 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp =>
-      props[
-          _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceProp => props[
+      _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -281,9 +276,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -291,9 +285,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -301,9 +294,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -312,9 +304,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -325,8 +316,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -337,8 +328,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -409,8 +400,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -419,8 +410,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -429,8 +420,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__untypedState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -440,8 +431,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -452,8 +443,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -464,10 +455,9 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceState =>
-      state[
-          _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceState => state[
+      _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -14,9 +14,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -24,9 +23,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -34,9 +32,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
   set untypedProp(value) => props[_$key__untypedProp___$TestPropsMixin] = value;
@@ -44,9 +41,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -57,8 +53,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +65,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -136,8 +132,8 @@ abstract class TestCustomNamespacePropsMixin
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -146,8 +142,8 @@ abstract class TestCustomNamespacePropsMixin
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -155,9 +151,8 @@ abstract class TestCustomNamespacePropsMixin
 
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -167,8 +162,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -179,8 +174,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -192,9 +187,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[
-          _$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -269,9 +263,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -279,9 +272,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -289,9 +281,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
@@ -300,9 +291,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -313,8 +303,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -325,8 +315,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -393,8 +383,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -403,8 +393,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -413,8 +403,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__untypedState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
@@ -424,8 +414,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -436,8 +426,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -449,9 +439,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[
-          _$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.over_react.g.dart
@@ -13,9 +13,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -23,9 +22,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -33,9 +31,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -44,9 +41,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -57,8 +53,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +65,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -135,8 +131,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -145,8 +141,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -155,8 +151,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -166,8 +162,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -178,8 +174,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -190,10 +186,9 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp =>
-      props[
-          _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceProp => props[
+      _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -270,9 +265,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -280,9 +274,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -290,9 +283,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -301,9 +293,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -314,8 +305,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -326,8 +317,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -393,8 +384,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -403,8 +394,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -413,8 +404,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__untypedState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -424,8 +415,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -436,8 +427,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -448,10 +439,9 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceState =>
-      state[
-          _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceState => state[
+      _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.over_react.g.dart
@@ -14,9 +14,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// <!-- Generated from [TestPropsMixin.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -24,9 +23,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// <!-- Generated from [TestPropsMixin.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -34,9 +32,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
 
   /// <!-- Generated from [TestPropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.untypedProp] -->
   @override
   set untypedProp(value) => props[_$key__untypedProp__TestPropsMixin] = value;
@@ -44,9 +41,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   /// <!-- Generated from [TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -56,9 +52,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   /// <!-- Generated from [TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
-  get customNamespaceProp =>
-      props[_$key__customNamespaceProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customNamespaceProp => props[_$key__customNamespaceProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +64,8 @@ abstract class $TestPropsMixin implements TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp__TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp__TestPropsMixin];
+
   /// <!-- Generated from [TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -136,8 +131,8 @@ abstract class $TestCustomNamespacePropsMixin
   /// <!-- Generated from [TestCustomNamespacePropsMixin.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -146,8 +141,8 @@ abstract class $TestCustomNamespacePropsMixin
   /// <!-- Generated from [TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -155,9 +150,8 @@ abstract class $TestCustomNamespacePropsMixin
 
   /// <!-- Generated from [TestCustomNamespacePropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -167,8 +161,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -179,8 +173,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -191,8 +185,8 @@ abstract class $TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp__TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp__TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -266,9 +260,8 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// <!-- Generated from [TestStateMixin.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -276,9 +269,8 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// <!-- Generated from [TestStateMixin.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -286,9 +278,8 @@ abstract class $TestStateMixin implements TestStateMixin {
 
   /// <!-- Generated from [TestStateMixin.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.untypedState] -->
   @override
   set untypedState(value) => state[_$key__untypedState__TestStateMixin] = value;
@@ -296,9 +287,8 @@ abstract class $TestStateMixin implements TestStateMixin {
   /// <!-- Generated from [TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -309,8 +299,8 @@ abstract class $TestStateMixin implements TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -321,8 +311,8 @@ abstract class $TestStateMixin implements TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState__TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState__TestStateMixin];
+
   /// <!-- Generated from [TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -388,8 +378,8 @@ abstract class $TestCustomNamespaceStateMixin
   /// <!-- Generated from [TestCustomNamespaceStateMixin.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -398,8 +388,8 @@ abstract class $TestCustomNamespaceStateMixin
   /// <!-- Generated from [TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -407,9 +397,8 @@ abstract class $TestCustomNamespaceStateMixin
 
   /// <!-- Generated from [TestCustomNamespaceStateMixin.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
@@ -419,8 +408,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -431,8 +420,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -443,8 +432,8 @@ abstract class $TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState__TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState__TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -34,9 +33,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -44,9 +42,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -55,9 +52,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -68,8 +64,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -80,8 +76,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -25,9 +25,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
@@ -36,9 +35,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   get generated1Prop =>
-      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   set generated1Prop(value) =>
@@ -35,8 +35,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   get generated2Prop =>
-      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   set generated2Prop(value) =>
@@ -46,8 +46,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
-      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
@@ -135,8 +135,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   get generated1State =>
-      state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated1State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   set generated1State(value) =>
@@ -145,8 +145,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   get generated2State =>
-      state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated2State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   set generated2State(value) =>
@@ -156,9 +156,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
-      state[
-          _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -35,8 +35,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -44,9 +44,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -56,8 +55,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -68,8 +67,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -80,8 +79,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -189,8 +188,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -199,8 +198,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -208,9 +207,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -220,8 +218,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -232,8 +230,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -244,8 +242,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -22,9 +22,8 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
-  String get _privateProp =>
-      props[_$key___privateProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get _privateProp => props[_$key___privateProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   set _privateProp(String value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -27,9 +27,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
@@ -43,9 +42,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isRequired: true,
       isNullable: true,
       requiredErrorMessage: 'This prop can be set to null!')
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -75,8 +75,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -85,8 +85,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -94,9 +94,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
 
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -106,8 +105,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -118,8 +117,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -130,8 +129,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -22,18 +22,16 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
 
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
-  String get unassignedProp =>
-      props[_$key__unassignedProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get unassignedProp => props[_$key__unassignedProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   set unassignedProp(String value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
@@ -13,9 +13,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -23,9 +22,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -33,9 +31,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -44,9 +41,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -57,8 +53,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +65,8 @@ abstract class _$TestAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestAbstractProps];
+
   /// <!-- Generated from [_$TestAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -140,8 +136,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -150,8 +146,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -160,8 +156,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__untypedProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -171,8 +167,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -183,8 +179,8 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -195,10 +191,9 @@ abstract class _$TestCustomNamespaceAbstractPropsAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceProp =>
-      props[
-          _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceProp => props[
+      _$key__customKeyAndNamespaceProp___$TestCustomNamespaceAbstractProps];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -281,9 +276,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -291,9 +285,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -301,9 +294,8 @@ abstract class _$TestAbstractStateAccessorsMixin
 
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -312,9 +304,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -325,8 +316,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -337,8 +328,8 @@ abstract class _$TestAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestAbstractState];
+
   /// <!-- Generated from [_$TestAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -409,8 +400,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.stringState] -->
   @override
   set stringState(String value) =>
@@ -419,8 +410,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -429,8 +420,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__untypedState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -440,8 +431,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -452,8 +443,8 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -464,10 +455,9 @@ abstract class _$TestCustomNamespaceAbstractStateAccessorsMixin
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
-  get customKeyAndNamespaceState =>
-      state[
-          _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyAndNamespaceState => state[
+      _$key__customKeyAndNamespaceState___$TestCustomNamespaceAbstractState];
+
   /// <!-- Generated from [_$TestCustomNamespaceAbstractState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
@@ -14,9 +14,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -24,9 +23,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -34,9 +32,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
 
   /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.untypedProp] -->
   @override
   set untypedProp(value) => props[_$key__untypedProp___$TestPropsMixin] = value;
@@ -44,9 +41,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -57,8 +53,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -69,8 +65,8 @@ abstract class TestPropsMixin implements _$TestPropsMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestPropsMixin];
+
   /// <!-- Generated from [_$TestPropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -136,8 +132,8 @@ abstract class TestCustomNamespacePropsMixin
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -146,8 +142,8 @@ abstract class TestCustomNamespacePropsMixin
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -155,9 +151,8 @@ abstract class TestCustomNamespacePropsMixin
 
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -167,8 +162,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -179,8 +174,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -192,9 +187,8 @@ abstract class TestCustomNamespacePropsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[
-          _$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$TestCustomNamespacePropsMixin];
+
   /// <!-- Generated from [_$TestCustomNamespacePropsMixin.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -269,9 +263,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
-  String get stringState =>
-      state[_$key__stringState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringState => state[_$key__stringState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -279,9 +272,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
-  dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicState => state[_$key__dynamicState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -289,9 +281,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
 
   /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
@@ -300,9 +291,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyState =>
-      state[_$key__customKeyState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyState => state[_$key__customKeyState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -313,8 +303,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -325,8 +315,8 @@ abstract class TestStateMixin implements _$TestStateMixin {
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$TestStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestStateMixin];
+
   /// <!-- Generated from [_$TestStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -393,8 +383,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.stringState] -->
   @override
   set stringState(String value) =>
@@ -403,8 +393,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -413,8 +403,8 @@ abstract class TestCustomNamespaceStateMixin
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   get untypedState =>
-      state[_$key__untypedState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__untypedState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.untypedState] -->
   @override
   set untypedState(value) =>
@@ -424,8 +414,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -436,8 +426,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -449,9 +439,8 @@ abstract class TestCustomNamespaceStateMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[
-          _$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$TestCustomNamespaceStateMixin];
+
   /// <!-- Generated from [_$TestCustomNamespaceStateMixin.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -25,9 +25,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -36,8 +35,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.shouldSetPropsDirectly] -->
   @override
   bool get shouldSetPropsDirectly =>
-      props[_$key__shouldSetPropsDirectly___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__shouldSetPropsDirectly___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.shouldSetPropsDirectly] -->
   @override
   set shouldSetPropsDirectly(bool value) =>
@@ -46,8 +45,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.shouldUseJsFactory] -->
   @override
   bool get shouldUseJsFactory =>
-      props[_$key__shouldUseJsFactory___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__shouldUseJsFactory___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.shouldUseJsFactory] -->
   @override
   set shouldUseJsFactory(bool value) =>
@@ -55,9 +54,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -65,9 +63,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -76,9 +73,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -89,8 +85,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -101,8 +97,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -26,9 +26,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
@@ -37,9 +36,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
@@ -49,8 +47,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @requiredProp
   List get requiredAndLengthLimited =>
-      props[_$key__requiredAndLengthLimited___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__requiredAndLengthLimited___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.requiredAndLengthLimited] -->
   @override
   @requiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -26,8 +26,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   get generated1Prop =>
-      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   set generated1Prop(value) =>
@@ -36,8 +36,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   get generated2Prop =>
-      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   set generated2Prop(value) =>
@@ -47,8 +47,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
-      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
@@ -178,8 +178,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   get generated1State =>
-      state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated1State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   set generated1State(value) =>
@@ -188,8 +188,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   get generated2State =>
-      state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated2State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   set generated2State(value) =>
@@ -199,9 +199,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
-      state[
-          _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -26,8 +26,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -36,8 +36,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -45,9 +45,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -57,8 +56,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -69,8 +68,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -81,8 +80,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -232,8 +231,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -242,8 +241,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -251,9 +250,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -263,8 +261,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -275,8 +273,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -287,8 +285,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
-  String get _privateProp =>
-      props[_$key___privateProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get _privateProp => props[_$key___privateProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   set _privateProp(String value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -28,9 +28,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
@@ -44,9 +43,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isRequired: true,
       isNullable: true,
       requiredErrorMessage: 'This prop can be set to null!')
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(
@@ -62,8 +60,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isNullable: false,
       requiredErrorMessage: 'This Prop Array is Required for testing purposes.')
   List get requiredAndLengthLimited =>
-      props[_$key__requiredAndLengthLimited___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__requiredAndLengthLimited___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.requiredAndLengthLimited] -->
   @override
   @Accessor(

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -28,8 +28,8 @@ abstract class _$StatefulComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestProps.setStateDirectly] -->
   @override
   bool get setStateDirectly =>
-      props[_$key__setStateDirectly___$StatefulComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__setStateDirectly___$StatefulComponentTestProps];
+
   /// Used to test if a component has the capability to set state via this.setState.
   ///
   /// <!-- Generated from [_$StatefulComponentTestProps.setStateDirectly] -->
@@ -141,8 +141,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -151,8 +151,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -160,9 +160,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
 
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -172,8 +171,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -184,8 +183,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -196,8 +195,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -24,18 +24,16 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
 
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
-  String get unassignedProp =>
-      props[_$key__unassignedProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get unassignedProp => props[_$key__unassignedProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   set unassignedProp(String value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -34,9 +33,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
-  dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get dynamicProp => props[_$key__dynamicProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -44,9 +42,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -55,9 +52,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
-  get customKeyProp =>
-      props[_$key__customKeyProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get customKeyProp => props[_$key__customKeyProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -68,8 +64,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -80,8 +76,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -25,9 +25,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @requiredProp
@@ -36,9 +35,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @nullableRequiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   get generated1Prop =>
-      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated1Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated1Prop] -->
   @override
   set generated1Prop(value) =>
@@ -35,8 +35,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   get generated2Prop =>
-      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__generated2Prop___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.generated2Prop] -->
   @override
   set generated2Prop(value) =>
@@ -46,8 +46,8 @@ abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedProp =>
-      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__explicitlyGeneratedProp___$DoNotGenerateAccessorTestProps];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestProps.explicitlyGeneratedProp] -->
   @override
   @Accessor(doNotGenerate: false)
@@ -140,8 +140,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   get generated1State =>
-      state[_$key__generated1State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated1State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated1State] -->
   @override
   set generated1State(value) =>
@@ -150,8 +150,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   get generated2State =>
-      state[_$key__generated2State___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__generated2State___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.generated2State] -->
   @override
   set generated2State(value) =>
@@ -161,9 +161,8 @@ abstract class _$DoNotGenerateAccessorTestStateAccessorsMixin
   @override
   @Accessor(doNotGenerate: false)
   get explicitlyGeneratedState =>
-      state[
-          _$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__explicitlyGeneratedState___$DoNotGenerateAccessorTestState];
+
   /// <!-- Generated from [_$DoNotGenerateAccessorTestState.explicitlyGeneratedState] -->
   @override
   @Accessor(doNotGenerate: false)

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   String get stringProp =>
-      props[_$key__stringProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__stringProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.stringProp] -->
   @override
   set stringProp(String value) =>
@@ -35,8 +35,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__dynamicProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.dynamicProp] -->
   @override
   set dynamicProp(dynamic value) =>
@@ -44,9 +44,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
-  get untypedProp =>
-      props[_$key__untypedProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedProp => props[_$key__untypedProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.untypedProp] -->
   @override
   set untypedProp(value) =>
@@ -56,8 +55,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyProp =>
-      props[_$key__customKeyProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyProp] -->
   @override
   @Accessor(key: 'custom key!')
@@ -68,8 +67,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceProp =>
-      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -80,8 +79,8 @@ abstract class _$NamespacedAccessorTestPropsAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__customKeyAndNamespaceProp___$NamespacedAccessorTestProps];
+
   /// <!-- Generated from [_$NamespacedAccessorTestProps.customKeyAndNamespaceProp] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
@@ -194,8 +193,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -204,8 +203,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -213,9 +212,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
 
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -225,8 +223,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -237,8 +235,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -249,8 +247,8 @@ abstract class _$NamespacedAccessorTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$NamespacedAccessorTestState];
+
   /// <!-- Generated from [_$NamespacedAccessorTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -22,9 +22,8 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
-  String get _privateProp =>
-      props[_$key___privateProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get _privateProp => props[_$key___privateProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps._privateProp] -->
   @override
   set _privateProp(String value) =>

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -27,9 +27,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
   @Accessor(
       isRequired: true,
       requiredErrorMessage: 'This Prop is Required for testing purposes.')
-  get required =>
-      props[_$key__required___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get required => props[_$key__required___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.required] -->
   @override
   @Accessor(
@@ -43,9 +42,8 @@ abstract class _$ComponentTestPropsAccessorsMixin
       isRequired: true,
       isNullable: true,
       requiredErrorMessage: 'This prop can be set to null!')
-  get nullable =>
-      props[_$key__nullable___$ComponentTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get nullable => props[_$key__nullable___$ComponentTestProps];
+
   /// <!-- Generated from [_$ComponentTestProps.nullable] -->
   @override
   @Accessor(

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -80,8 +80,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   String get stringState =>
-      state[_$key__stringState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__stringState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.stringState] -->
   @override
   set stringState(String value) =>
@@ -90,8 +90,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   dynamic get dynamicState =>
-      state[_$key__dynamicState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__dynamicState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.dynamicState] -->
   @override
   set dynamicState(dynamic value) =>
@@ -99,9 +99,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
 
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
-  get untypedState =>
-      state[_$key__untypedState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get untypedState => state[_$key__untypedState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.untypedState] -->
   @override
   set untypedState(value) =>
@@ -111,8 +110,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(key: 'custom key!')
   get customKeyState =>
-      state[_$key__customKeyState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyState] -->
   @override
   @Accessor(key: 'custom key!')
@@ -123,8 +122,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   get customNamespaceState =>
-      state[_$key__customNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
@@ -135,8 +134,8 @@ abstract class _$StatefulComponentTestStateAccessorsMixin
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   get customKeyAndNamespaceState =>
-      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      state[_$key__customKeyAndNamespaceState___$StatefulComponentTestState];
+
   /// <!-- Generated from [_$StatefulComponentTestState.customKeyAndNamespaceState] -->
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -22,18 +22,16 @@ abstract class _$FooPropsAccessorsMixin implements _$FooProps {
 
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
-  String get stringProp =>
-      props[_$key__stringProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get stringProp => props[_$key__stringProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.stringProp] -->
   @override
   set stringProp(String value) => props[_$key__stringProp___$FooProps] = value;
 
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
-  String get unassignedProp =>
-      props[_$key__unassignedProp___$FooProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get unassignedProp => props[_$key__unassignedProp___$FooProps];
+
   /// <!-- Generated from [_$FooProps.unassignedProp] -->
   @override
   set unassignedProp(String value) =>

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -462,9 +462,8 @@ abstract class _$TestPropValidationPropsAccessorsMixin
   /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
-  String get required =>
-      props[_$key__required___$TestPropValidationProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get required => props[_$key__required___$TestPropValidationProps];
+
   /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
@@ -1663,8 +1662,8 @@ abstract class _$TestStatefulPropValidationPropsAccessorsMixin
   @override
   @requiredProp
   String get required =>
-      props[_$key__required___$TestStatefulPropValidationProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__required___$TestStatefulPropValidationProps];
+
   /// <!-- Generated from [_$TestStatefulPropValidationProps.required] -->
   @override
   @override

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -285,9 +285,8 @@ abstract class _$TestPropValidationPropsAccessorsMixin
   /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
-  String get required =>
-      props[_$key__required___$TestPropValidationProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get required => props[_$key__required___$TestPropValidationProps];
+
   /// <!-- Generated from [_$TestPropValidationProps.required] -->
   @override
   @requiredProp
@@ -982,8 +981,8 @@ abstract class _$TestStatefulPropValidationPropsAccessorsMixin
   @override
   @requiredProp
   String get required =>
-      props[_$key__required___$TestStatefulPropValidationProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__required___$TestStatefulPropValidationProps];
+
   /// <!-- Generated from [_$TestStatefulPropValidationProps.required] -->
   @override
   @override

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -25,8 +25,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidMount] -->
   @override
   Function get onComponentDidMount =>
-      props[_$key__onComponentDidMount___$TestCompositeComponentProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onComponentDidMount___$TestCompositeComponentProps];
+
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidMount] -->
   @override
   set onComponentDidMount(Function value) =>
@@ -35,8 +35,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentWillUnmount] -->
   @override
   Function get onComponentWillUnmount =>
-      props[_$key__onComponentWillUnmount___$TestCompositeComponentProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onComponentWillUnmount___$TestCompositeComponentProps];
+
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentWillUnmount] -->
   @override
   set onComponentWillUnmount(Function value) =>
@@ -46,8 +46,8 @@ abstract class _$TestCompositeComponentPropsAccessorsMixin
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidUpdate] -->
   @override
   Function get onComponentDidUpdate =>
-      props[_$key__onComponentDidUpdate___$TestCompositeComponentProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__onComponentDidUpdate___$TestCompositeComponentProps];
+
   /// <!-- Generated from [_$TestCompositeComponentProps.onComponentDidUpdate] -->
   @override
   set onComponentDidUpdate(Function value) =>

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -22,18 +22,16 @@ abstract class _$TestPropsAccessorsMixin implements _$TestProps {
 
   /// <!-- Generated from [_$TestProps.foo] -->
   @override
-  String get foo =>
-      props[_$key__foo___$TestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get foo => props[_$key__foo___$TestProps];
+
   /// <!-- Generated from [_$TestProps.foo] -->
   @override
   set foo(String value) => props[_$key__foo___$TestProps] = value;
 
   /// <!-- Generated from [_$TestProps.bar] -->
   @override
-  String get bar =>
-      props[_$key__bar___$TestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get bar => props[_$key__bar___$TestProps];
+
   /// <!-- Generated from [_$TestProps.bar] -->
   @override
   set bar(String value) => props[_$key__bar___$TestProps] = value;

--- a/test/over_react_redux/fixtures/counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter.over_react.g.dart
@@ -24,9 +24,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.currentCount] -->
   @override
-  int get currentCount =>
-      props[_$key__currentCount___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get currentCount => props[_$key__currentCount___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.currentCount] -->
   @override
   set currentCount(int value) =>
@@ -35,8 +34,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
   /// <!-- Generated from [_$CounterProps.wrapperStyles] -->
   @override
   Map<String, dynamic> get wrapperStyles =>
-      props[_$key__wrapperStyles___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__wrapperStyles___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.wrapperStyles] -->
   @override
   set wrapperStyles(Map<String, dynamic> value) =>
@@ -44,9 +43,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.increment] -->
   @override
-  void Function() get increment =>
-      props[_$key__increment___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  void Function() get increment => props[_$key__increment___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.increment] -->
   @override
   set increment(void Function() value) =>
@@ -54,9 +52,8 @@ abstract class _$CounterPropsAccessorsMixin implements _$CounterProps {
 
   /// <!-- Generated from [_$CounterProps.decrement] -->
   @override
-  void Function() get decrement =>
-      props[_$key__decrement___$CounterProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  void Function() get decrement => props[_$key__decrement___$CounterProps];
+
   /// <!-- Generated from [_$CounterProps.decrement] -->
   @override
   set decrement(void Function() value) =>

--- a/test/vm_tests/builder/impl_generation_test.dart
+++ b/test/vm_tests/builder/impl_generation_test.dart
@@ -162,16 +162,16 @@ main() {
 
                 group('with concrete implementations', () {
                   test('', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set someField(String value) => ${isProps ? 'props' : 'state'}[_\$key__someField___\$$className] = value'));
                   });
 
                   test('for multiple fields declared on same line', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set foo(bool value) => ${isProps ? 'props' : 'state'}[_\$key__foo___\$$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set bar(bool value) => ${isProps ? 'props' : 'state'}[_\$key__bar___\$$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set baz(bool value) => ${isProps ? 'props' : 'state'}[_\$key__baz___\$$className] = value'));
                   });
 
@@ -220,16 +220,16 @@ main() {
 
                 group('with concrete implementations', () {
                   test('', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField__$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  String get someField => ${isProps ? 'props' : 'state'}[_\$key__someField__$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set someField(String value) => ${isProps ? 'props' : 'state'}[_\$key__someField__$className] = value'));
                   });
 
                   test('for multiple fields declared on same line', () {
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo__$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get foo => ${isProps ? 'props' : 'state'}[_\$key__foo__$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set foo(bool value) => ${isProps ? 'props' : 'state'}[_\$key__foo__$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar__$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get bar => ${isProps ? 'props' : 'state'}[_\$key__bar__$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set bar(bool value) => ${isProps ? 'props' : 'state'}[_\$key__bar__$className] = value'));
-                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz__$className] ?? null;'));
+                    expect(implGenerator.outputContentsBuffer.toString(), contains('  bool get baz => ${isProps ? 'props' : 'state'}[_\$key__baz__$className];'));
                     expect(implGenerator.outputContentsBuffer.toString(), contains('  set baz(bool value) => ${isProps ? 'props' : 'state'}[_\$key__baz__$className] = value'));
                   });
 
@@ -406,7 +406,7 @@ main() {
           test('for covariant keywords', () {
             final ors = OverReactSrc.abstractProps(backwardsCompatible: backwardsCompatible, body: 'covariant String foo;');
             generateFromSource(ors.source);
-            expect(implGenerator.outputContentsBuffer.toString(), contains('String get foo => props[_\$key__foo___\$${ors.propsClassName}] ?? null;'));
+            expect(implGenerator.outputContentsBuffer.toString(), contains('String get foo => props[_\$key__foo___\$${ors.propsClassName}];'));
             expect(implGenerator.outputContentsBuffer.toString(), contains('set foo(covariant String value) => props[_\$key__foo___\$${ors.propsClassName}] = value;'));
           });
 

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -26,9 +26,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp =>
-      props[_$key__basicProp___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicProps];
+
   /// Test that doc comment is copied over.
   ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
@@ -39,45 +38,40 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -26,9 +26,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
-  String get basicProp =>
-      props[_$key__basicProp___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
+
   /// Test that doc comment is copied over.
   ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
@@ -38,9 +37,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
@@ -48,9 +46,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
@@ -58,9 +55,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
@@ -68,9 +64,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
@@ -78,9 +73,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
@@ -175,9 +169,8 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
-  String get basicState =>
-      state[_$key__basicState___$BasicPartOfLibState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
+
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
@@ -266,9 +259,8 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
-  String get subProp =>
-      props[_$key__subProp___$SubPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
+
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
@@ -354,9 +346,8 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
-  String get superProp =>
-      props[_$key__superProp___$SuperPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
+
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -26,9 +26,8 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override
   @deprecated
   @requiredProp
-  String get basicProp =>
-      props[_$key__basicProp___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicProps];
+
   /// Test that doc comment is copied over.
   ///
   /// <!-- Generated from [_$BasicProps.basicProp] -->
@@ -39,45 +38,40 @@ abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
 
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic1] -->
   @override
   set basic1(String value) => props[_$key__basic1___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic2] -->
   @override
   set basic2(String value) => props[_$key__basic2___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic3] -->
   @override
   set basic3(String value) => props[_$key__basic3___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic4] -->
   @override
   set basic4(String value) => props[_$key__basic4___$BasicProps] = value;
 
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicProps];
+
   /// <!-- Generated from [_$BasicProps.basic5] -->
   @override
   set basic5(String value) => props[_$key__basic5___$BasicProps] = value;

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -26,9 +26,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
   @override
-  String get basicProp =>
-      props[_$key__basicProp___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicProp => props[_$key__basicProp___$BasicPartOfLibProps];
+
   /// Test that doc comment is copied over.
   ///
   /// <!-- Generated from [_$BasicPartOfLibProps.basicProp] -->
@@ -38,9 +37,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
-  String get basic1 =>
-      props[_$key__basic1___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic1 => props[_$key__basic1___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic1] -->
   @override
   set basic1(String value) =>
@@ -48,9 +46,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
-  String get basic2 =>
-      props[_$key__basic2___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic2 => props[_$key__basic2___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic2] -->
   @override
   set basic2(String value) =>
@@ -58,9 +55,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
-  String get basic3 =>
-      props[_$key__basic3___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic3 => props[_$key__basic3___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic3] -->
   @override
   set basic3(String value) =>
@@ -68,9 +64,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
-  String get basic4 =>
-      props[_$key__basic4___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic4 => props[_$key__basic4___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic4] -->
   @override
   set basic4(String value) =>
@@ -78,9 +73,8 @@ abstract class _$BasicPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
-  String get basic5 =>
-      props[_$key__basic5___$BasicPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basic5 => props[_$key__basic5___$BasicPartOfLibProps];
+
   /// <!-- Generated from [_$BasicPartOfLibProps.basic5] -->
   @override
   set basic5(String value) =>
@@ -180,9 +174,8 @@ abstract class _$BasicPartOfLibStateAccessorsMixin
 
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
-  String get basicState =>
-      state[_$key__basicState___$BasicPartOfLibState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get basicState => state[_$key__basicState___$BasicPartOfLibState];
+
   /// <!-- Generated from [_$BasicPartOfLibState.basicState] -->
   @override
   set basicState(String value) =>
@@ -276,9 +269,8 @@ abstract class _$SubPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
-  String get subProp =>
-      props[_$key__subProp___$SubPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get subProp => props[_$key__subProp___$SubPartOfLibProps];
+
   /// <!-- Generated from [_$SubPartOfLibProps.subProp] -->
   @override
   set subProp(String value) =>
@@ -369,9 +361,8 @@ abstract class _$SuperPartOfLibPropsAccessorsMixin
 
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
-  String get superProp =>
-      props[_$key__superProp___$SuperPartOfLibProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get superProp => props[_$key__superProp___$SuperPartOfLibProps];
+
   /// <!-- Generated from [_$SuperPartOfLibProps.superProp] -->
   @override
   set superProp(String value) =>

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -28,9 +28,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.skin] -->
   @override
-  ButtonSkin get skin =>
-      props[_$key__skin___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSkin get skin => props[_$key__skin___$ButtonProps];
+
   /// The skin / "context" for the [Button].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#examples>.
@@ -49,9 +48,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.size] -->
   @override
-  ButtonSize get size =>
-      props[_$key__size___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSize get size => props[_$key__size___$ButtonProps];
+
   /// The size of the [Button].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#sizes>.
@@ -70,9 +68,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.isActive] -->
   @override
-  bool get isActive =>
-      props[_$key__isActive___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isActive => props[_$key__isActive___$ButtonProps];
+
   /// Whether the [Button] should appear "active".
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#active-state>
@@ -92,9 +89,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled =>
-      props[_$key__isDisabled___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isDisabled => props[_$key__isDisabled___$ButtonProps];
+
   /// Whether the [Button] is disabled.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#disabled-state>
@@ -113,9 +109,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.isBlock] -->
   @override
-  bool get isBlock =>
-      props[_$key__isBlock___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isBlock => props[_$key__isBlock___$ButtonProps];
+
   /// Whether the [Button] is a block level button -- that which spans the full
   /// width of its parent.
   ///
@@ -134,9 +129,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.href] -->
   @override
   @Accessor(keyNamespace: '')
-  String get href =>
-      props[_$key__href___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get href => props[_$key__href___$ButtonProps];
+
   /// The HTML `href` attribute value for the [Button].
   ///
   /// If set, the item will render via [Dom.a].
@@ -157,9 +151,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.target] -->
   @override
   @Accessor(keyNamespace: '')
-  String get target =>
-      props[_$key__target___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get target => props[_$key__target___$ButtonProps];
+
   /// The HTML `target` attribute value for the [Button].
   ///
   /// If set, the item will render via [Dom.a].
@@ -182,9 +175,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.type] -->
   @override
-  ButtonType get type =>
-      props[_$key__type___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonType get type => props[_$key__type___$ButtonProps];
+
   /// The HTML `type` attribute value for the [Button] when
   /// rendered via [Dom.button].
   ///

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -29,9 +29,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.size] -->
   @override
-  ButtonGroupSize get size =>
-      props[_$key__size___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonGroupSize get size => props[_$key__size___$ButtonGroupProps];
+
   /// Apply a button size variation universally to every [Button] within the [ButtonGroup].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#sizing>.
@@ -47,9 +46,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.skin] -->
   @override
-  ButtonSkin get skin =>
-      props[_$key__skin___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSkin get skin => props[_$key__skin___$ButtonGroupProps];
+
   /// The [ButtonSkin] variation applied to every [Button] within the [ButtonGroup].
   ///
   /// <!-- Generated from [_$ButtonGroupProps.skin] -->
@@ -64,9 +62,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.isVertical] -->
   @override
-  bool get isVertical =>
-      props[_$key__isVertical___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isVertical => props[_$key__isVertical___$ButtonGroupProps];
+
   /// Make the [Button]s within a [ButtonGroup] stack vertically.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -29,8 +29,8 @@ abstract class _$ListGroupPropsAccessorsMixin implements _$ListGroupProps {
   /// <!-- Generated from [_$ListGroupProps.elementType] -->
   @override
   ListGroupElementType get elementType =>
-      props[_$key__elementType___$ListGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__elementType___$ListGroupProps];
+
   /// The HTML element type for the [ListGroup], specifying its
   /// DOM representation when rendered.
   ///

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -32,8 +32,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.elementType] -->
   @override
   ListGroupItemElementType get elementType =>
-      props[_$key__elementType___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__elementType___$ListGroupItemProps];
+
   /// The HTML element type for the [ListGroupItem], specifying its DOM
   /// representation when rendered.
   ///
@@ -53,9 +53,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.header] -->
   @override
-  dynamic get header =>
-      props[_$key__header___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get header => props[_$key__header___$ListGroupItemProps];
+
   /// Optional header text to display within the [ListGroupItem] above
   /// the value of [children].
   ///
@@ -73,8 +72,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.headerSize] -->
   @override
   ListGroupItemHeaderElementSize get headerSize =>
-      props[_$key__headerSize___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__headerSize___$ListGroupItemProps];
+
   /// The size of the [header] text you desire.
   ///
   /// Default: [ListGroupItemHeaderElementSize.H5]
@@ -88,9 +87,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
   @override
-  Map get headerProps =>
-      props[_$key__headerProps___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get headerProps => props[_$key__headerProps___$ListGroupItemProps];
+
   /// Additional props to be added to the [header] element _(if specified)_.
   ///
   /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
@@ -106,9 +104,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.skin] -->
   @override
-  ListGroupItemSkin get skin =>
-      props[_$key__skin___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ListGroupItemSkin get skin => props[_$key__skin___$ListGroupItemProps];
+
   /// The skin / "context" for the [ListGroupItem].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#contextual-classes>.
@@ -128,9 +125,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.isActive] -->
   @override
-  bool get isActive =>
-      props[_$key__isActive___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isActive => props[_$key__isActive___$ListGroupItemProps];
+
   /// Whether the [ListGroupItem] should appear "active".
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#anchors-and-buttons>
@@ -151,9 +147,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled =>
-      props[_$key__isDisabled___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isDisabled => props[_$key__isDisabled___$ListGroupItemProps];
+
   /// Whether the [ListGroupItem] is disabled.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#disabled-items>
@@ -175,9 +170,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.href] -->
   @override
   @Accessor(keyNamespace: '')
-  String get href =>
-      props[_$key__href___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get href => props[_$key__href___$ListGroupItemProps];
+
   /// The HTML `href` attribute value for the [ListGroupItem].
   ///
   /// If set, the item will render via [Dom.a].
@@ -198,9 +192,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.target] -->
   @override
   @Accessor(keyNamespace: '')
-  String get target =>
-      props[_$key__target___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get target => props[_$key__target___$ListGroupItemProps];
+
   /// The HTML `target` attribute value for the [ListGroupItem].
   ///
   /// If set, the item will render via [Dom.a].
@@ -224,9 +217,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.type] -->
   @override
-  ButtonType get type =>
-      props[_$key__type___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonType get type => props[_$key__type___$ListGroupItemProps];
+
   /// The HTML `type` attribute value for the [ListGroupItem] when
   /// rendered via [Dom.button].
   ///

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -29,9 +29,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.value] -->
   @override
-  double get value =>
-      props[_$key__value___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get value => props[_$key__value___$ProgressProps];
+
   /// The current value of the [Progress] component.
   ///
   /// This value should be between the [min] and [max] values.
@@ -48,9 +47,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.min] -->
   @override
-  double get min =>
-      props[_$key__min___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get min => props[_$key__min___$ProgressProps];
+
   /// The min value of the [Progress] component.
   ///
   /// Default: `0.0`
@@ -65,9 +63,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.max] -->
   @override
-  double get max =>
-      props[_$key__max___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get max => props[_$key__max___$ProgressProps];
+
   /// The max value of the [Progress] component.
   ///
   /// Default: `100.0`
@@ -84,9 +81,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.skin] -->
   @override
-  ProgressSkin get skin =>
-      props[_$key__skin___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ProgressSkin get skin => props[_$key__skin___$ProgressProps];
+
   /// The skin / "context" for the [Progress] component.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/progress/#contextual-alternatives>.
@@ -103,9 +99,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.isStriped] -->
   @override
-  bool get isStriped =>
-      props[_$key__isStriped___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isStriped => props[_$key__isStriped___$ProgressProps];
+
   /// Whether to render a "Barber Pole" gradient stripe effect in the [Progress] component.
   ///
   /// Default: false
@@ -122,9 +117,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.isAnimated] -->
   @override
-  bool get isAnimated =>
-      props[_$key__isAnimated___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isAnimated => props[_$key__isAnimated___$ProgressProps];
+
   /// Whether to animate the "Barber Pole" gradient stripe effect in the [Progress] component.
   ///
   /// __Note:__ Has no effect if [isStriped] is `false`.
@@ -144,9 +138,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.caption] -->
   @override
-  String get caption =>
-      props[_$key__caption___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get caption => props[_$key__caption___$ProgressProps];
+
   /// Optionally add a caption that describes the context of the [Progress] component.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/progress/#example>.
@@ -161,9 +154,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.captionProps] -->
   @override
-  Map get captionProps =>
-      props[_$key__captionProps___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get captionProps => props[_$key__captionProps___$ProgressProps];
+
   /// Additional props to be added to the [caption] element _(if specified)_.
   ///
   /// <!-- Generated from [_$ProgressProps.captionProps] -->
@@ -177,9 +169,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.showCaption] -->
   @override
-  bool get showCaption =>
-      props[_$key__showCaption___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get showCaption => props[_$key__showCaption___$ProgressProps];
+
   /// Whether the [caption] should be visible.
   ///
   /// Default: false
@@ -196,8 +187,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   /// <!-- Generated from [_$ProgressProps.showPercentComplete] -->
   @override
   bool get showPercentComplete =>
-      props[_$key__showPercentComplete___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__showPercentComplete___$ProgressProps];
+
   /// Whether the [caption] should be appended with the value of [value].
   ///
   /// Default: true
@@ -211,9 +202,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
   @override
-  Map get rootNodeProps =>
-      props[_$key__rootNodeProps___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get rootNodeProps => props[_$key__rootNodeProps___$ProgressProps];
+
   /// Additional props to be added to the [Dom.div] that wraps around the [caption] element and `<progress>` element.
   ///
   /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
@@ -344,9 +334,8 @@ abstract class _$ProgressStateAccessorsMixin implements _$ProgressState {
   ///
   /// <!-- Generated from [_$ProgressState.id] -->
   @override
-  String get id =>
-      state[_$key__id___$ProgressState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => state[_$key__id___$ProgressState];
+
   /// An autogenerated GUID, used as a fallback when [ProgressProps.id] is unspecified, and
   /// saved on the state so it will persist across remounts.
   ///

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -28,9 +28,8 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   ///
   /// <!-- Generated from [_$TagProps.skin] -->
   @override
-  TagSkin get skin =>
-      props[_$key__skin___$TagProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  TagSkin get skin => props[_$key__skin___$TagProps];
+
   /// The skin / "context" for the [Tag].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/tag/#contextual-variations>.
@@ -50,9 +49,8 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   ///
   /// <!-- Generated from [_$TagProps.isPill] -->
   @override
-  bool get isPill =>
-      props[_$key__isPill___$TagProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isPill => props[_$key__isPill___$TagProps];
+
   /// Whether to render the [Tag] with rounded corners that make it look
   /// more like a "pill" (a.k.a Bootstrap v3 "badge")
   ///

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -32,9 +32,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.autoFocus] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get autoFocus =>
-      props[_$key__autoFocus___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get autoFocus => props[_$key__autoFocus___$ToggleButtonProps];
+
   /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
   ///
   /// _Proxies [DomProps.autoFocus]._
@@ -63,9 +62,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.defaultChecked] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get defaultChecked =>
-      props[_$key__defaultChecked___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get defaultChecked => props[_$key__defaultChecked___$ToggleButtonProps];
+
   /// Whether the [ToggleButton] is checked by default.
   ///
   /// Setting this without the setting the [checked] prop to will make the
@@ -100,9 +98,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.checked] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get checked =>
-      props[_$key__checked___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get checked => props[_$key__checked___$ToggleButtonProps];
+
   /// Whether the [ToggleButton] is checked.
   ///
   /// Setting this will make the [ToggleButton] _controlled_; it will not update
@@ -199,9 +196,8 @@ abstract class _$ToggleButtonStateAccessorsMixin
   ///
   /// <!-- Generated from [_$ToggleButtonState.isFocused] -->
   @override
-  bool get isFocused =>
-      state[_$key__isFocused___$ToggleButtonState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isFocused => state[_$key__isFocused___$ToggleButtonState];
+
   /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
   /// class.
   ///
@@ -218,9 +214,8 @@ abstract class _$ToggleButtonStateAccessorsMixin
   ///
   /// <!-- Generated from [_$ToggleButtonState.isChecked] -->
   @override
-  bool get isChecked =>
-      state[_$key__isChecked___$ToggleButtonState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isChecked => state[_$key__isChecked___$ToggleButtonState];
+
   /// Tracks if the [ToggleButton] input is `checked`. Determines whether to render with the `active` CSS class.
   ///
   /// Initial: [ToggleButtonProps.checked] `??` [ToggleButtonProps.defaultChecked] `?? false`

--- a/web/component1/src/shared/constants.over_react.g.dart
+++ b/web/component1/src/shared/constants.over_react.g.dart
@@ -22,9 +22,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.name] -->
   @override
   @Accessor(keyNamespace: '')
-  String get name =>
-      props[_$key__name___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get name => props[_$key__name___$AbstractInputPropsMixin];
+
   /// The HTML `name` attribute to be applied to `<input>`.
   ///
   /// If unspecified, [AbstractInputStateMixin.name] will be generated.
@@ -47,9 +46,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.value] -->
   @override
   @Accessor(keyNamespace: '')
-  dynamic get value =>
-      props[_$key__value___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get value => props[_$key__value___$AbstractInputPropsMixin];
+
   /// The value of the input. Setting this will make the input's value _controlled_; it will not update automatically in
   /// response to user input, but instead will always render the value of this prop.
   ///
@@ -73,8 +71,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.toggleType] -->
   @override
   ToggleBehaviorType get toggleType =>
-      props[_$key__toggleType___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__toggleType___$AbstractInputPropsMixin];
+
   /// The type of "toggle" behavior an HTML `<input>` should exhibit:
   ///
   /// * [ToggleBehaviorType.CHECKBOX] - More than one can be active at once.
@@ -129,9 +127,8 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
   ///
   /// <!-- Generated from [_$AbstractInputStateMixin.id] -->
   @override
-  String get id =>
-      state[_$key__id___$AbstractInputStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => state[_$key__id___$AbstractInputStateMixin];
+
   /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,
   /// and saved on the state so it will persist across remounts.
   ///
@@ -150,9 +147,8 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
   ///
   /// <!-- Generated from [_$AbstractInputStateMixin.name] -->
   @override
-  String get name =>
-      state[_$key__name___$AbstractInputStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get name => state[_$key__name___$AbstractInputStateMixin];
+
   /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.name] is unspecified,
   /// and saved on the state so it will persist across remounts.
   ///

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -30,9 +30,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.skin] -->
   @override
-  ButtonSkin get skin =>
-      props[_$key__skin___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSkin get skin => props[_$key__skin___$ButtonProps];
+
   /// The skin / "context" for the [Button].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#examples>.
@@ -51,9 +50,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.size] -->
   @override
-  ButtonSize get size =>
-      props[_$key__size___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSize get size => props[_$key__size___$ButtonProps];
+
   /// The size of the [Button].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#sizes>.
@@ -72,9 +70,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.isActive] -->
   @override
-  bool get isActive =>
-      props[_$key__isActive___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isActive => props[_$key__isActive___$ButtonProps];
+
   /// Whether the [Button] should appear "active".
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#active-state>
@@ -94,9 +91,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled =>
-      props[_$key__isDisabled___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isDisabled => props[_$key__isDisabled___$ButtonProps];
+
   /// Whether the [Button] is disabled.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#disabled-state>
@@ -115,9 +111,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.isBlock] -->
   @override
-  bool get isBlock =>
-      props[_$key__isBlock___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isBlock => props[_$key__isBlock___$ButtonProps];
+
   /// Whether the [Button] is a block level button -- that which spans the full
   /// width of its parent.
   ///
@@ -136,9 +131,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.href] -->
   @override
   @Accessor(keyNamespace: '')
-  String get href =>
-      props[_$key__href___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get href => props[_$key__href___$ButtonProps];
+
   /// The HTML `href` attribute value for the [Button].
   ///
   /// If set, the item will render via [Dom.a].
@@ -159,9 +153,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   /// <!-- Generated from [_$ButtonProps.target] -->
   @override
   @Accessor(keyNamespace: '')
-  String get target =>
-      props[_$key__target___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get target => props[_$key__target___$ButtonProps];
+
   /// The HTML `target` attribute value for the [Button].
   ///
   /// If set, the item will render via [Dom.a].
@@ -184,9 +177,8 @@ abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   ///
   /// <!-- Generated from [_$ButtonProps.type] -->
   @override
-  ButtonType get type =>
-      props[_$key__type___$ButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonType get type => props[_$key__type___$ButtonProps];
+
   /// The HTML `type` attribute value for the [Button] when
   /// rendered via [Dom.button].
   ///

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -30,9 +30,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.size] -->
   @override
-  ButtonGroupSize get size =>
-      props[_$key__size___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonGroupSize get size => props[_$key__size___$ButtonGroupProps];
+
   /// Apply a button size variation universally to every [Button] within the [ButtonGroup].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#sizing>.
@@ -48,9 +47,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.skin] -->
   @override
-  ButtonSkin get skin =>
-      props[_$key__skin___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonSkin get skin => props[_$key__skin___$ButtonGroupProps];
+
   /// The [ButtonSkin] variation applied to every [Button] within the [ButtonGroup].
   ///
   /// <!-- Generated from [_$ButtonGroupProps.skin] -->
@@ -65,9 +63,8 @@ abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   ///
   /// <!-- Generated from [_$ButtonGroupProps.isVertical] -->
   @override
-  bool get isVertical =>
-      props[_$key__isVertical___$ButtonGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isVertical => props[_$key__isVertical___$ButtonGroupProps];
+
   /// Make the [Button]s within a [ButtonGroup] stack vertically.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/button-group/#vertical-variation>.

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -30,8 +30,8 @@ abstract class _$ListGroupPropsAccessorsMixin implements _$ListGroupProps {
   /// <!-- Generated from [_$ListGroupProps.elementType] -->
   @override
   ListGroupElementType get elementType =>
-      props[_$key__elementType___$ListGroupProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__elementType___$ListGroupProps];
+
   /// The HTML element type for the [ListGroup], specifying its
   /// DOM representation when rendered.
   ///

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -33,8 +33,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.elementType] -->
   @override
   ListGroupItemElementType get elementType =>
-      props[_$key__elementType___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__elementType___$ListGroupItemProps];
+
   /// The HTML element type for the [ListGroupItem], specifying its DOM
   /// representation when rendered.
   ///
@@ -54,9 +54,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.header] -->
   @override
-  dynamic get header =>
-      props[_$key__header___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get header => props[_$key__header___$ListGroupItemProps];
+
   /// Optional header text to display within the [ListGroupItem] above
   /// the value of [children].
   ///
@@ -74,8 +73,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.headerSize] -->
   @override
   ListGroupItemHeaderElementSize get headerSize =>
-      props[_$key__headerSize___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__headerSize___$ListGroupItemProps];
+
   /// The size of the [header] text you desire.
   ///
   /// Default: [ListGroupItemHeaderElementSize.H5]
@@ -89,9 +88,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
   @override
-  Map get headerProps =>
-      props[_$key__headerProps___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get headerProps => props[_$key__headerProps___$ListGroupItemProps];
+
   /// Additional props to be added to the [header] element _(if specified)_.
   ///
   /// <!-- Generated from [_$ListGroupItemProps.headerProps] -->
@@ -107,9 +105,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.skin] -->
   @override
-  ListGroupItemSkin get skin =>
-      props[_$key__skin___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ListGroupItemSkin get skin => props[_$key__skin___$ListGroupItemProps];
+
   /// The skin / "context" for the [ListGroupItem].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#contextual-classes>.
@@ -129,9 +126,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.isActive] -->
   @override
-  bool get isActive =>
-      props[_$key__isActive___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isActive => props[_$key__isActive___$ListGroupItemProps];
+
   /// Whether the [ListGroupItem] should appear "active".
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#anchors-and-buttons>
@@ -152,9 +148,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.isDisabled] -->
   @override
   @Accessor(key: 'disabled', keyNamespace: '')
-  bool get isDisabled =>
-      props[_$key__isDisabled___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isDisabled => props[_$key__isDisabled___$ListGroupItemProps];
+
   /// Whether the [ListGroupItem] is disabled.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/list-group/#disabled-items>
@@ -176,9 +171,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.href] -->
   @override
   @Accessor(keyNamespace: '')
-  String get href =>
-      props[_$key__href___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get href => props[_$key__href___$ListGroupItemProps];
+
   /// The HTML `href` attribute value for the [ListGroupItem].
   ///
   /// If set, the item will render via [Dom.a].
@@ -199,9 +193,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   /// <!-- Generated from [_$ListGroupItemProps.target] -->
   @override
   @Accessor(keyNamespace: '')
-  String get target =>
-      props[_$key__target___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get target => props[_$key__target___$ListGroupItemProps];
+
   /// The HTML `target` attribute value for the [ListGroupItem].
   ///
   /// If set, the item will render via [Dom.a].
@@ -225,9 +218,8 @@ abstract class _$ListGroupItemPropsAccessorsMixin
   ///
   /// <!-- Generated from [_$ListGroupItemProps.type] -->
   @override
-  ButtonType get type =>
-      props[_$key__type___$ListGroupItemProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ButtonType get type => props[_$key__type___$ListGroupItemProps];
+
   /// The HTML `type` attribute value for the [ListGroupItem] when
   /// rendered via [Dom.button].
   ///

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -30,9 +30,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.value] -->
   @override
-  double get value =>
-      props[_$key__value___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get value => props[_$key__value___$ProgressProps];
+
   /// The current value of the [Progress] component.
   ///
   /// This value should be between the [min] and [max] values.
@@ -49,9 +48,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.min] -->
   @override
-  double get min =>
-      props[_$key__min___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get min => props[_$key__min___$ProgressProps];
+
   /// The min value of the [Progress] component.
   ///
   /// Default: `0.0`
@@ -66,9 +64,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.max] -->
   @override
-  double get max =>
-      props[_$key__max___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  double get max => props[_$key__max___$ProgressProps];
+
   /// The max value of the [Progress] component.
   ///
   /// Default: `100.0`
@@ -85,9 +82,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.skin] -->
   @override
-  ProgressSkin get skin =>
-      props[_$key__skin___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  ProgressSkin get skin => props[_$key__skin___$ProgressProps];
+
   /// The skin / "context" for the [Progress] component.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/progress/#contextual-alternatives>.
@@ -104,9 +100,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.isStriped] -->
   @override
-  bool get isStriped =>
-      props[_$key__isStriped___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isStriped => props[_$key__isStriped___$ProgressProps];
+
   /// Whether to render a "Barber Pole" gradient stripe effect in the [Progress] component.
   ///
   /// Default: false
@@ -123,9 +118,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.isAnimated] -->
   @override
-  bool get isAnimated =>
-      props[_$key__isAnimated___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isAnimated => props[_$key__isAnimated___$ProgressProps];
+
   /// Whether to animate the "Barber Pole" gradient stripe effect in the [Progress] component.
   ///
   /// __Note:__ Has no effect if [isStriped] is `false`.
@@ -145,9 +139,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.caption] -->
   @override
-  String get caption =>
-      props[_$key__caption___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get caption => props[_$key__caption___$ProgressProps];
+
   /// Optionally add a caption that describes the context of the [Progress] component.
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/progress/#example>.
@@ -162,9 +155,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.captionProps] -->
   @override
-  Map get captionProps =>
-      props[_$key__captionProps___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get captionProps => props[_$key__captionProps___$ProgressProps];
+
   /// Additional props to be added to the [caption] element _(if specified)_.
   ///
   /// <!-- Generated from [_$ProgressProps.captionProps] -->
@@ -178,9 +170,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.showCaption] -->
   @override
-  bool get showCaption =>
-      props[_$key__showCaption___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get showCaption => props[_$key__showCaption___$ProgressProps];
+
   /// Whether the [caption] should be visible.
   ///
   /// Default: false
@@ -197,8 +188,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   /// <!-- Generated from [_$ProgressProps.showPercentComplete] -->
   @override
   bool get showPercentComplete =>
-      props[_$key__showPercentComplete___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__showPercentComplete___$ProgressProps];
+
   /// Whether the [caption] should be appended with the value of [value].
   ///
   /// Default: true
@@ -212,9 +203,8 @@ abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   ///
   /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
   @override
-  Map get rootNodeProps =>
-      props[_$key__rootNodeProps___$ProgressProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  Map get rootNodeProps => props[_$key__rootNodeProps___$ProgressProps];
+
   /// Additional props to be added to the [Dom.div] that wraps around the [caption] element and `<progress>` element.
   ///
   /// <!-- Generated from [_$ProgressProps.rootNodeProps] -->
@@ -378,9 +368,8 @@ abstract class _$ProgressStateAccessorsMixin implements _$ProgressState {
   ///
   /// <!-- Generated from [_$ProgressState.id] -->
   @override
-  String get id =>
-      state[_$key__id___$ProgressState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => state[_$key__id___$ProgressState];
+
   /// An autogenerated GUID, used as a fallback when [ProgressProps.id] is unspecified, and
   /// saved on the state so it will persist across remounts.
   ///

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -25,18 +25,16 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.count] -->
   @override
-  int get count =>
-      props[_$key__count___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get count => props[_$key__count___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.count] -->
   @override
   set count(int value) => props[_$key__count___$PropTypesTestProps] = value;
 
   /// <!-- Generated from [_$PropTypesTestProps.twoObjects] -->
   @override
-  List get twoObjects =>
-      props[_$key__twoObjects___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  List get twoObjects => props[_$key__twoObjects___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.twoObjects] -->
   @override
   set twoObjects(List value) =>
@@ -44,9 +42,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.defaultCount] -->
   @override
-  int get defaultCount =>
-      props[_$key__defaultCount___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  int get defaultCount => props[_$key__defaultCount___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.defaultCount] -->
   @override
   set defaultCount(int value) =>
@@ -54,9 +51,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.content] -->
   @override
-  bool get content =>
-      props[_$key__content___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get content => props[_$key__content___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.content] -->
   @override
   set content(bool value) =>
@@ -64,9 +60,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.hideHeader] -->
   @override
-  bool get hideHeader =>
-      props[_$key__hideHeader___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hideHeader => props[_$key__hideHeader___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.hideHeader] -->
   @override
   set hideHeader(bool value) =>
@@ -74,9 +69,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.header] -->
   @override
-  dynamic get header =>
-      props[_$key__header___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get header => props[_$key__header___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.header] -->
   @override
   set header(dynamic value) =>
@@ -85,8 +79,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
   /// <!-- Generated from [_$PropTypesTestProps.initiallyExpandedKeys] -->
   @override
   List get initiallyExpandedKeys =>
-      props[_$key__initiallyExpandedKeys___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__initiallyExpandedKeys___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.initiallyExpandedKeys] -->
   @override
   set initiallyExpandedKeys(List value) =>
@@ -94,18 +88,16 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.targetKey] -->
   @override
-  get targetKey =>
-      props[_$key__targetKey___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  get targetKey => props[_$key__targetKey___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.targetKey] -->
   @override
   set targetKey(value) => props[_$key__targetKey___$PropTypesTestProps] = value;
 
   /// <!-- Generated from [_$PropTypesTestProps.hideLabel] -->
   @override
-  bool get hideLabel =>
-      props[_$key__hideLabel___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hideLabel => props[_$key__hideLabel___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.hideLabel] -->
   @override
   set hideLabel(bool value) =>
@@ -113,9 +105,8 @@ abstract class _$PropTypesTestPropsAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesTestProps.label] -->
   @override
-  String get label =>
-      props[_$key__label___$PropTypesTestProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get label => props[_$key__label___$PropTypesTestProps];
+
   /// <!-- Generated from [_$PropTypesTestProps.label] -->
   @override
   set label(String value) => props[_$key__label___$PropTypesTestProps] = value;

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -114,9 +114,8 @@ abstract class _$PropTypesWrapStateAccessorsMixin
 
   /// <!-- Generated from [_$PropTypesWrapState.twoObjects] -->
   @override
-  List get twoObjects =>
-      state[_$key__twoObjects___$PropTypesWrapState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  List get twoObjects => state[_$key__twoObjects___$PropTypesWrapState];
+
   /// <!-- Generated from [_$PropTypesWrapState.twoObjects] -->
   @override
   set twoObjects(List value) =>

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -30,9 +30,8 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   ///
   /// <!-- Generated from [_$TagProps.skin] -->
   @override
-  TagSkin get skin =>
-      props[_$key__skin___$TagProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  TagSkin get skin => props[_$key__skin___$TagProps];
+
   /// The skin / "context" for the [Tag].
   ///
   /// See: <http://v4-alpha.getbootstrap.com/components/tag/#contextual-variations>.
@@ -52,9 +51,8 @@ abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   ///
   /// <!-- Generated from [_$TagProps.isPill] -->
   @override
-  bool get isPill =>
-      props[_$key__isPill___$TagProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isPill => props[_$key__isPill___$TagProps];
+
   /// Whether to render the [Tag] with rounded corners that make it look
   /// more like a "pill" (a.k.a Bootstrap v3 "badge")
   ///

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -33,9 +33,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.autoFocus] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get autoFocus =>
-      props[_$key__autoFocus___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get autoFocus => props[_$key__autoFocus___$ToggleButtonProps];
+
   /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
   ///
   /// _Proxies [DomProps.autoFocus]._
@@ -64,9 +63,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.defaultChecked] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get defaultChecked =>
-      props[_$key__defaultChecked___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get defaultChecked => props[_$key__defaultChecked___$ToggleButtonProps];
+
   /// Whether the [ToggleButton] is checked by default.
   ///
   /// Setting this without the setting the [checked] prop to will make the
@@ -101,9 +99,8 @@ abstract class _$ToggleButtonPropsAccessorsMixin
   /// <!-- Generated from [_$ToggleButtonProps.checked] -->
   @override
   @Accessor(keyNamespace: '')
-  bool get checked =>
-      props[_$key__checked___$ToggleButtonProps] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get checked => props[_$key__checked___$ToggleButtonProps];
+
   /// Whether the [ToggleButton] is checked.
   ///
   /// Setting this will make the [ToggleButton] _controlled_; it will not update
@@ -233,9 +230,8 @@ abstract class _$ToggleButtonStateAccessorsMixin
   ///
   /// <!-- Generated from [_$ToggleButtonState.isFocused] -->
   @override
-  bool get isFocused =>
-      state[_$key__isFocused___$ToggleButtonState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isFocused => state[_$key__isFocused___$ToggleButtonState];
+
   /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
   /// class.
   ///
@@ -252,9 +248,8 @@ abstract class _$ToggleButtonStateAccessorsMixin
   ///
   /// <!-- Generated from [_$ToggleButtonState.isChecked] -->
   @override
-  bool get isChecked =>
-      state[_$key__isChecked___$ToggleButtonState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get isChecked => state[_$key__isChecked___$ToggleButtonState];
+
   /// Tracks if the [ToggleButton] input is `checked`. Determines whether to render with the `active` CSS class.
   ///
   /// Initial: [ToggleButtonProps.checked] `??` [ToggleButtonProps.defaultChecked] `?? false`

--- a/web/component2/src/shared/constants.over_react.g.dart
+++ b/web/component2/src/shared/constants.over_react.g.dart
@@ -22,9 +22,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.name] -->
   @override
   @Accessor(keyNamespace: '')
-  String get name =>
-      props[_$key__name___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get name => props[_$key__name___$AbstractInputPropsMixin];
+
   /// The HTML `name` attribute to be applied to `<input>`.
   ///
   /// If unspecified, [AbstractInputStateMixin.name] will be generated.
@@ -47,9 +46,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.value] -->
   @override
   @Accessor(keyNamespace: '')
-  dynamic get value =>
-      props[_$key__value___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  dynamic get value => props[_$key__value___$AbstractInputPropsMixin];
+
   /// The value of the input. Setting this will make the input's value _controlled_; it will not update automatically in
   /// response to user input, but instead will always render the value of this prop.
   ///
@@ -73,8 +71,8 @@ abstract class AbstractInputPropsMixin implements _$AbstractInputPropsMixin {
   /// <!-- Generated from [_$AbstractInputPropsMixin.toggleType] -->
   @override
   ToggleBehaviorType get toggleType =>
-      props[_$key__toggleType___$AbstractInputPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+      props[_$key__toggleType___$AbstractInputPropsMixin];
+
   /// The type of "toggle" behavior an HTML `<input>` should exhibit:
   ///
   /// * [ToggleBehaviorType.CHECKBOX] - More than one can be active at once.
@@ -129,9 +127,8 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
   ///
   /// <!-- Generated from [_$AbstractInputStateMixin.id] -->
   @override
-  String get id =>
-      state[_$key__id___$AbstractInputStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get id => state[_$key__id___$AbstractInputStateMixin];
+
   /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,
   /// and saved on the state so it will persist across remounts.
   ///
@@ -150,9 +147,8 @@ abstract class AbstractInputStateMixin implements _$AbstractInputStateMixin {
   ///
   /// <!-- Generated from [_$AbstractInputStateMixin.name] -->
   @override
-  String get name =>
-      state[_$key__name___$AbstractInputStateMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  String get name => state[_$key__name___$AbstractInputStateMixin];
+
   /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.name] is unspecified,
   /// and saved on the state so it will persist across remounts.
   ///

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -70,9 +70,8 @@ abstract class _$FaultyStateAccessorsMixin implements _$FaultyState {
 
   /// <!-- Generated from [_$FaultyState.hasErrored] -->
   @override
-  bool get hasErrored =>
-      state[_$key__hasErrored___$FaultyState] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  bool get hasErrored => state[_$key__hasErrored___$FaultyState];
+
   /// <!-- Generated from [_$FaultyState.hasErrored] -->
   @override
   set hasErrored(bool value) => state[_$key__hasErrored___$FaultyState] = value;


### PR DESCRIPTION
## Motivation
#252 added a workaround for https://github.com/dart-lang/sdk/issues/36052 - which was fixed in Dart 2.2.1. 

> Because the 3.1.0 release will require at least Dart 2.4.0 for consumers, it is safe to remove the workaround.

## Changes
* Revert the builder changes that add the workaround
* Leave the regression tests intact to guard against further regressions in the Dart SDK

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @corwinsheahan-wf @evanweible-wf @kealjones-wk @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Passing CI
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
