### PR TITLE
RM-58745 Release over_react 3.0.0-alpha.1+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,39 @@
 # OverReact Changelog
 
-## 3.0.0
+## 3.0.0 (alpha)
 
-__ReactJS 16.x Support__ _(and Dart 1 compatible)_
+- __3.0.0-alpha.1__
 
-* The underlying `react` dependency ([version 5.0.0](https://github.com/cleandart/react-dart/pull/214)) now provides ReactJS version 16 `.js` source files.
-* Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).
+  * [#350] Improve handling of “repeat” errors thrown from components wrapped by an `ErrorBoundary`.
 
-__Breaking Changes__
+  > Complete `3.0.0-alpha.1` Changesets:
+  >
+  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.0+dart2...3.0.0-alpha.1+dart2)
+  > - [Dart 1](https://github.com/Workiva/over_react/compare/3.0.0-alpha.0+dart1...3.0.0-alpha.1+dart1)
 
-* [#314] The `.over_react.g.dart` part directive is required on Dart 2. The
-  builder now logs at the `SEVERE` level (which causes the build to fail) when
-  a missing part directive is detected. Previously, the builder only logged this
-  as a warning. In other words, the issue has been promoted from a runtime
-  exception to a build-time error.
+- __3.0.0-alpha.0__
 
-> Complete `3.0.0` Changsets:
->
-> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...3.0.0-alpha.0+dart2)
-> - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.0+dart1...3.0.0-alpha.0+dart1)
+  __ReactJS 16.x Support__ _(and Dart 1 compatible)_
+
+  * The underlying `react` dependency ([version 5.0.0](https://github.com/cleandart/react-dart/pull/214)) now provides ReactJS version 16 `.js` source files.
+  * Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).
+
+  __Breaking Changes__
+
+  * [#314] The `.over_react.g.dart` part directive is required on Dart 2. The
+    builder now logs at the `SEVERE` level (which causes the build to fail) when
+    a missing part directive is detected. Previously, the builder only logged this
+    as a warning. In other words, the issue has been promoted from a runtime
+    exception to a build-time error.
+
+  > Complete `3.0.0-alpha.0` Changesets:
+  >
+  > - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...3.0.0-alpha.0+dart2)
+  > - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.0+dart1...3.0.0-alpha.0+dart1)
 
 ## 2.5.2
 
-> Complete `2.5.2` Changsets:
+> Complete `2.5.2` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.1+dart2...2.5.2+dart2)
 > - Dart 1 (no changes)
@@ -31,7 +42,7 @@ __Breaking Changes__
 
 ## 2.5.1
 
-> Complete `2.5.1` Changsets:
+> Complete `2.5.1` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.0+dart2...2.5.1+dart2)
 > - Dart 1 (no changes)
@@ -40,7 +51,7 @@ __Breaking Changes__
 
 ## 2.5.0
 
-> Complete `2.5.0` Changsets:
+> Complete `2.5.0` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.4+dart2...2.5.0+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.4.2+dart1...2.5.0+dart1)
@@ -49,7 +60,7 @@ __Breaking Changes__
 
 ## 2.4.4
 
-> Complete `2.4.4` Changsets:
+> Complete `2.4.4` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.3+dart2...2.4.4+dart2)
 > - Dart 1 (no changes)
@@ -58,7 +69,7 @@ __Breaking Changes__
 
 ## 2.4.3
 
-> Complete `2.4.3` Changsets:
+> Complete `2.4.3` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.2+dart2...2.4.3+dart2)
 > - Dart 1 (no changes)
@@ -71,7 +82,7 @@ __Breaking Changes__
 
 ## 2.4.2
 
-> Complete `2.4.2` Changsets:
+> Complete `2.4.2` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.1+dart2...2.4.2+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.4.1+dart1...2.4.2+dart1)
@@ -82,7 +93,7 @@ __Breaking Changes__
 
 ## 2.4.1
 
-> Complete `2.4.1` Changsets:
+> Complete `2.4.1` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.4.0+dart2...2.4.1+dart2)
 > - Dart 1 (no changes)
@@ -91,7 +102,7 @@ __Breaking Changes__
 
 ## 2.4.0
 
-> Complete `2.4.0` Changsets:
+> Complete `2.4.0` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.3.1+dart2...2.4.0+dart2)
 > - Dart 1 (no changes)
@@ -103,7 +114,7 @@ __Breaking Changes__
 
 ## 2.3.1
 
-> Complete `2.3.1` Changsets:
+> Complete `2.3.1` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.3.0+dart2...2.3.1+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.3.0+dart1...2.3.1+dart1)
@@ -112,7 +123,7 @@ __Breaking Changes__
 
 ## 2.3.0
 
-> Complete `2.3.0` Changsets:
+> Complete `2.3.0` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.2.0+dart2...2.3.0+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.2.0+dart1...2.3.0+dart1)
@@ -122,7 +133,7 @@ __Breaking Changes__
 
 ## 2.2.0
 
-> Complete `2.2.0` Changsets:
+> Complete `2.2.0` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.1.0+dart2...2.2.0+dart2)
 > - [Dart 1](https://github.com/Workiva/over_react/compare/2.1.0+dart1...2.2.0+dart1)
@@ -135,7 +146,7 @@ __Breaking Changes__
 
 ## 2.1.0
 
-> Complete `2.1.0` Changsets:
+> Complete `2.1.0` Changesets:
 >
 > - [Dart 2](https://github.com/Workiva/over_react/compare/2.0.0+dart2...2.1.0+dart2)
 > - Dart 1 (no changes)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.0+dart2
+version: 3.0.0-alpha.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Pulls included in this __Dart 2 only (alpha)__ release:

- [x] #350 Improve handling of “repeat” errors thrown from components wrapped by an ErrorBoundary

---

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 