### PR TITLE
RM-59138 Release over_react 3.0.0-alpha.2+dart1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.1+dart1
+version: 3.0.0-alpha.2+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
There are no functional changes  in this Dart 1 only __alpha__ release. It is merely a version bump to match the [analogous `+dart2` patch release](https://github.com/Workiva/over_react/pull/369).

---

@corwinsheahan-wf @joebingham-wk @greglittlefield-wf @kealjones-wk