### PR TITLE
RM-56701 Release over_react 2.5.3+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.5.3
+
+> Complete `2.5.3` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...2.5.3+dart2)
+> - Dart 1 (no changes)
+
+* [#363] Dart 2 Widen `analyzer` dependency range
+
 ## 2.5.2
 
 > Complete `2.5.2` Changsets:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.2+dart2
+version: 2.5.3+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Pulls included in this Dart 2 only stable release:

 #363 Widen `analyzer` dependency range

---

@corwinsheahan-wf @joebingham-wk @greglittlefield-wf @kealjones-wk 