### PR TITLE
RM-55765 Release over_react 2.5.3+dart1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.0+dart1
+version: 2.5.3+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
There are no functional changes  in this Dart 1 only stable release. It is merely a version bump to match the [analogous `+dart2` patch release](https://github.com/Workiva/over_react/pull/367).

@corwinsheahan-wf