### PR TITLE
RM-59140 Release over_react 3.0.0-alpha.2+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 3.0.0 (alpha)
 
+- __3.0.0-alpha.2__
+
+  * [#363] Dart 2 Widen `analyzer` dependency range
+
+  > Complete `3.0.0-alpha.2` Changesets:
+  >
+  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.1+dart2...3.0.0-alpha.2+dart2)
+  > - Dart 1 (no changes)
+
 - __3.0.0-alpha.1__
 
   * [#350] Improve handling of “repeat” errors thrown from components wrapped by an `ErrorBoundary`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.1+dart2
+version: 3.0.0-alpha.2+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Pulls included in this Dart 2 only __alpha__ release:

 #363 Widen `analyzer` dependency range

---

@corwinsheahan-wf @joebingham-wk @greglittlefield-wf @kealjones-wk 