### PR TITLE
CPLAT-7721 Add error logging to ErrorBoundary

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -35,7 +35,7 @@ export 'src/component/abstract_transition.dart';
 export 'src/component/abstract_transition_props.dart';
 export 'src/component/aria_mixin.dart';
 export 'src/component/callback_typedefs.dart';
-export 'src/component/error_boundary.dart';
+export 'src/component/error_boundary.dart' hide defaultErrorBoundaryLoggerName;
 export 'src/component/dom_components.dart';
 export 'src/component/dummy_component.dart';
 export 'src/component/prop_mixins.dart';

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -208,33 +208,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   );
 
   @mustCallSuper
-  @override
-  void componentWillMount() {
-    super.componentWillMount();
-
-    _logger = Logger(_getLoggerName());
-  }
-
-  @mustCallSuper
-  @override
-  void componentWillUnmount() {
-    super.componentWillUnmount();
-
-    _logger.clearListeners();
-  }
-
-  @mustCallSuper
-  @override
-  void componentWillReceiveProps(Map nextProps) {
-    super.componentWillReceiveProps(nextProps);
-
-    final tNextProps = typedPropsFactory(nextProps);
-    if (tNextProps.loggerName != props.loggerName) {
-      _logger = Logger(_getLoggerName(tNextProps));
-    }
-  }
-
-  @mustCallSuper
   /*@override*/
   S getDerivedStateFromError(_) {
     return newState()..hasError = true;
@@ -428,17 +401,8 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   String _getReadableErrorInfo(/*NativeJavascriptObject*/dynamic jsErrorInfo) =>
       getProperty(jsErrorInfo, 'componentStack');
 
-  /// The logger that logs errors when a component somewhere within the React tree wrapped by
-  /// this [ErrorBoundary] instance throws within the React lifecycle.
-  Logger get logger => _logger;
-  Logger _logger;
-
-  String _getLoggerName([T propsMap]) {
-    propsMap ??= props;
-    if (propsMap.loggerName != null && propsMap.loggerName.isNotEmpty) return propsMap.loggerName;
-
-    return defaultErrorBoundaryLoggerName;
-  }
+  /// The value that will be used when creating a [Logger] to log errors from this component.
+  String get loggerName => props.loggerName ?? defaultErrorBoundaryLoggerName;
 
   // ----- [3] ----- //
   void _logErrorCaughtByErrorBoundary(
@@ -457,6 +421,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
       // The error / exception doesn't extend from Error or Exception
     }
 
-    _logger.severe(message, error, stackTrace);
+    Logger(loggerName).severe(message, error, stackTrace);
   }
 }

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -443,12 +443,12 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   // ----- [3] ----- //
   void _logErrorCaughtByErrorBoundary(
     /*Error|Exception*/ dynamic error,
-    /*ReactErrorInfo*/ dynamic info, {
+    /*ReactErrorInfo*/ String info, {
     bool isRecoverable = true,
   }) {
     String message = isRecoverable
-        ? 'An error was caught by an ErrorBoundary'
-        : 'An unrecoverable error was caught by an ErrorBoundary (the entire react tree had to be unmounted)';
+        ? 'An error was caught by an ErrorBoundary: \nInfo: $info'
+        : 'An unrecoverable error was caught by an ErrorBoundary (attempting to remount it was unsuccessful): \nInfo: $info';
 
     dynamic stackTrace;
     try {

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -413,8 +413,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   String _getReadableErrorInfo(/*NativeJavascriptObject*/dynamic jsErrorInfo) =>
       getProperty(jsErrorInfo, 'componentStack');
 
-  /// The value that will be used when creating a [Logger] to log errors from this component.
-  String get loggerName {
+  String get _loggerName {
     if (props.logger != null) return props.logger.name;
 
     return props.loggerName ?? defaultErrorBoundaryLoggerName;
@@ -439,6 +438,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
       // The error / exception doesn't extend from Error or Exception
     }
 
-    (props.logger ?? Logger(loggerName)).severe(message, error, stackTrace);
+    (props.logger ?? Logger(_loggerName)).severe(message, error, stackTrace);
   }
 }

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -197,6 +197,8 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
 
   /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
   ///
+  /// Not used if a custom [logger] is specified.
+  ///
   /// > Default: 'over_react.ErrorBoundary'
   ///
   /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
@@ -206,12 +208,48 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
   ///
+  /// Not used if a custom [logger] is specified.
+  ///
   /// > Default: 'over_react.ErrorBoundary'
   ///
   /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
   @override
   set loggerName(String value) =>
       props[_$key__loggerName___$ErrorBoundaryProps] = value;
+
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.shouldLogErrors] -->
+  @override
+  bool get shouldLogErrors =>
+      props[_$key__shouldLogErrors___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.shouldLogErrors] -->
+  @override
+  set shouldLogErrors(bool value) =>
+      props[_$key__shouldLogErrors___$ErrorBoundaryProps] = value;
+
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.logger] -->
+  @override
+  Logger get logger =>
+      props[_$key__logger___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.logger] -->
+  @override
+  set logger(Logger value) =>
+      props[_$key__logger___$ErrorBoundaryProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor
       _$prop__onComponentDidCatch___$ErrorBoundaryProps =
@@ -228,6 +266,10 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
           _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps);
   static const PropDescriptor _$prop__loggerName___$ErrorBoundaryProps =
       const PropDescriptor(_$key__loggerName___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__shouldLogErrors___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__shouldLogErrors___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__logger___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__logger___$ErrorBoundaryProps);
   static const String _$key__onComponentDidCatch___$ErrorBoundaryProps =
       'ErrorBoundaryProps.onComponentDidCatch';
   static const String _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps =
@@ -239,20 +281,28 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
       'ErrorBoundaryProps.identicalErrorFrequencyTolerance';
   static const String _$key__loggerName___$ErrorBoundaryProps =
       'ErrorBoundaryProps.loggerName';
+  static const String _$key__shouldLogErrors___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.shouldLogErrors';
+  static const String _$key__logger___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.logger';
 
   static const List<PropDescriptor> $props = const [
     _$prop__onComponentDidCatch___$ErrorBoundaryProps,
     _$prop__onComponentIsUnrecoverable___$ErrorBoundaryProps,
     _$prop__fallbackUIRenderer___$ErrorBoundaryProps,
     _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps,
-    _$prop__loggerName___$ErrorBoundaryProps
+    _$prop__loggerName___$ErrorBoundaryProps,
+    _$prop__shouldLogErrors___$ErrorBoundaryProps,
+    _$prop__logger___$ErrorBoundaryProps
   ];
   static const List<String> $propKeys = const [
     _$key__onComponentDidCatch___$ErrorBoundaryProps,
     _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps,
     _$key__fallbackUIRenderer___$ErrorBoundaryProps,
     _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps,
-    _$key__loggerName___$ErrorBoundaryProps
+    _$key__loggerName___$ErrorBoundaryProps,
+    _$key__shouldLogErrors___$ErrorBoundaryProps,
+    _$key__logger___$ErrorBoundaryProps
   ];
 }
 

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -194,6 +194,24 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   set identicalErrorFrequencyTolerance(Duration value) =>
       props[_$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps] =
           value;
+
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
+  @override
+  String get loggerName =>
+      props[_$key__loggerName___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
+  @override
+  set loggerName(String value) =>
+      props[_$key__loggerName___$ErrorBoundaryProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor
       _$prop__onComponentDidCatch___$ErrorBoundaryProps =
@@ -208,6 +226,8 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
       _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps =
       const PropDescriptor(
           _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__loggerName___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__loggerName___$ErrorBoundaryProps);
   static const String _$key__onComponentDidCatch___$ErrorBoundaryProps =
       'ErrorBoundaryProps.onComponentDidCatch';
   static const String _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps =
@@ -217,18 +237,22 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   static const String
       _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps =
       'ErrorBoundaryProps.identicalErrorFrequencyTolerance';
+  static const String _$key__loggerName___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.loggerName';
 
   static const List<PropDescriptor> $props = const [
     _$prop__onComponentDidCatch___$ErrorBoundaryProps,
     _$prop__onComponentIsUnrecoverable___$ErrorBoundaryProps,
     _$prop__fallbackUIRenderer___$ErrorBoundaryProps,
-    _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps
+    _$prop__identicalErrorFrequencyTolerance___$ErrorBoundaryProps,
+    _$prop__loggerName___$ErrorBoundaryProps
   ];
   static const List<String> $propKeys = const [
     _$key__onComponentDidCatch___$ErrorBoundaryProps,
     _$key__onComponentIsUnrecoverable___$ErrorBoundaryProps,
     _$key__fallbackUIRenderer___$ErrorBoundaryProps,
-    _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps
+    _$key__identicalErrorFrequencyTolerance___$ErrorBoundaryProps,
+    _$key__loggerName___$ErrorBoundaryProps
   ];
 }
 

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -768,7 +768,8 @@ void main() {
           expect(logRecords.single.level, Level.SEVERE);
           expect(logRecords.single.loggerName, defaultErrorBoundaryLoggerName);
           expect(logRecords.single.error, calls.single['onComponentDidCatch'][0]);
-          expect(logRecords.single.message, 'An error was caught by an ErrorBoundary');
+          expect(logRecords.single.message, 'An error was caught by an ErrorBoundary:'
+              ' \nInfo: ${calls.single['onComponentDidCatch'][1]}');
         });
 
         test('and an unrecoverable component error is caught', () async {
@@ -781,7 +782,8 @@ void main() {
           expect(logRecords[1].loggerName, defaultErrorBoundaryLoggerName);
           expect(logRecords[1].error, calls[2]['onComponentIsUnrecoverable'][0]);
           expect(logRecords[1].message,
-              'An unrecoverable error was caught by an ErrorBoundary (the entire react tree had to be unmounted)');
+              'An unrecoverable error was caught by an ErrorBoundary (attempting to remount it was unsuccessful):'
+              ' \nInfo: ${calls[2]['onComponentIsUnrecoverable'][1]}');
         });
 
         group('but then `props.loggerName` is set', () {


### PR DESCRIPTION
## Motivation
Consumers currently have to set their own `onComponentDidCatch` prop callback, and then manually pass the errors passed to that callback into their own instance of `Logger`.

## Changes
* Add logging functionality to `ErrorBoundary` so that consumers get it for free, and they can simply set `props.loggerName` to customize the logger name if they choose.
* Consumers can then simply listen to the `ErrorBoundaryComponent.logger` if they want to log it to the service of their choice.

#### Release Notes
Add logging functionality to the ErrorBoundary

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk @maxwellpeterson-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Passing CI
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
