### PR TITLE
`manageAndReturnTypedDisposable` null exception

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -368,7 +368,7 @@ abstract class UiComponent<TProps extends UiProps> extends react.Component imple
   /// The parameter may not be `null`.
   @override
   T manageAndReturnTypedDisposable<T extends Disposable>(T disposable) =>
-      _disposableProxy.manageAndReturnTypedDisposable(disposable);
+      _getDisposableProxy().manageAndReturnTypedDisposable(disposable);
 
   //
   //   END DisposableManagerV7 interface implementation

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -750,6 +750,14 @@ main() {
           expect(disposable.isDisposed, isTrue);
         });
 
+        test('should dispose managed Disposable returned by manageAndReturnTypedDisposable', () async {
+          var disposable = new Disposable();
+          expect(component.manageAndReturnTypedDisposable(disposable), same(disposable));
+          expect(disposable.isDisposed, isFalse);
+          await unmountAndDisposal();
+          expect(disposable.isDisposed, isTrue);
+        });
+
         test('should complete uncompleted managed Completer with ObjectDisposedException', () async {
           var completer = new Completer<Null>();
           component.manageCompleter(completer);


### PR DESCRIPTION
## Motivation

I've hit the following exception a few times in tests/app when trying to use `manageAndReturnTypedDisposable`.

```
NoSuchMethodError: invalid member on null: 'manageAndReturnTypedDisposable' at package:over_react/src/component_declaration/component_base.dart 371:24
```

This seems to only happen if you don't call another `manage*Disposable` (`manageDisposable`, `manageAndReturnDisposable`) method before `manageAndReturnTypedDisposable`, where `_disposableProxy` hasn't been initialized and is still `null`.

## Changes

call `_getDisposableProxy()` like all the other `manage*Disposable` methods do to initialize `_disposableProxy` if it hasn't been initialized.

#### Release Notes

Fix an issue where calling `manageAndReturnTypedDisposable` throws a null exception unless another `manage` method is called first.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

### QA Checklist
- [X] Tests were updated and provide good coverage of the changeset and other affected code
  - [X] Unit test added to call `manageAndReturnTypedDisposable`, which results in an exception on master and passes on this branch
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Try and call `manageAndReturnTypedDisposable` on master inside a component, this should result in an exception
        - [ ] Try and call `manageAndReturnTypedDisposable` on this branch, which should not throw

To test this myself, I just temporarily hijacked `button-examples.dart` to render a component with `manageAndReturnTypedDisposable`

```Dart
import 'package:over_react/over_react.dart';
import 'package:w_common/disposable.dart';

import '../../demo_components.dart';

import 'package:over_react/over_react.dart';

// ignore: uri_has_not_been_generated
part 'button-examples.over_react.g.dart';

ReactElement buttonExamplesDemo() => ButtonExamples()();

@Factory()
// ignore: undefined_identifier
UiFactory<ButtonExamplesProps> ButtonExamples = _$ButtonExamples;

@Props()
class _$ButtonExamplesProps extends UiProps {}

// AF-3369 This will be removed once the transition to Dart 2 is complete.
// ignore: mixin_of_non_class, undefined_class
class ButtonExamplesProps extends _$ButtonExamplesProps with _$ButtonExamplesPropsAccessorsMixin {
  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
  static const PropsMeta meta = _$metaForButtonExamplesProps;
}

class ExampleDisposable extends Disposable {}

@Component()
class ButtonExamplesComponent extends UiComponent<ButtonExamplesProps> {
  @override
  Map getDefaultProps() => (newProps());

  @override
  void componentDidMount() {
    manageAndReturnTypedDisposable(new ExampleDisposable());
  }

  @override
  render() => null;
}

```

When on master:
![Screen Shot 2019-10-15 at 5 31 06 PM](https://user-images.githubusercontent.com/28708633/66877139-9d3eeb00-ef71-11e9-9eb8-317b787515cd.png)
When on this branch:
![Screen Shot 2019-10-15 at 5 30 33 PM](https://user-images.githubusercontent.com/28708633/66877131-97e1a080-ef71-11e9-9719-e0954c9eacbe.png)

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
