### PR TITLE
Fix link to contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,7 @@ The `over_react` library adheres to [Semantic Versioning](http://semver.org/):
 
 [component demos]: https://workiva.github.io/over_react/demos
 
-[contributing-docs]: https://github.com/Workiva/over_react/blob/master/.github/CONTRIBUTING.md
+[contributing-docs]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md
 [builder]: https://github.com/Workiva/over_react/blob/master/lib/src/builder/README.md
 [annotations]: https://github.com/Workiva/over_react/blob/master/lib/src/component_declaration/annotations.dart
 [annotation]: https://github.com/Workiva/over_react/blob/master/lib/src/component_declaration/annotations.dart


### PR DESCRIPTION
## Motivation
The link at https://github.com/Workiva/over_react#contributing 404s

## Changes
Update the link from https://github.com/Workiva/over_react/blob/master/.github/CONTRIBUTING.md to https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md

#### Release Notes
N/A?

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

### QA Checklist
- [X] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Verify the link is now correct

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
