### PR TITLE
RM-59378 Release over_react 3.0.0-alpha.3+dart1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.2+dart1
+version: 3.0.0-alpha.3+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This Dart 1 only __alpha__ release of over_react includes:

- [x] #373 Add error logging to ErrorBoundary

---

@greglittlefield-wf 