### PR TITLE
RM-59372 Release over_react 2.6.0+dart1

### DIFF
--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 
@@ -49,6 +50,22 @@ class _$ErrorBoundaryProps extends UiProps {
   ///
   /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
   _FallbackUiRenderer fallbackUIRenderer;
+
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// Not used if a custom [logger] is specified.
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  String loggerName;
+
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  bool shouldLogErrors;
+
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  Logger logger;
 }
 
 @State()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.3+dart1
+version: 2.6.0+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This Dart 1 only stable release of over_react includes:

- [x] A placeholder prop API to mirror the 3.x `ErrorBoundary` APIs (#373) added to configure logging. The API is not wired up in 2.x, but will make the transition for consumers to 3.x smoother.

---

@greglittlefield-wf 