### PR TITLE
RM-59375 Release over_react 2.6.0+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # OverReact Changelog
 
+## 2.6.0
+
+> Complete `2.6.0` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.3+dart2...2.6.0+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.3+dart1...2.6.0+dart1)
+
+* Adds a placeholder prop API to mirror the 3.x ErrorBoundary APIs ([#370]) added to configure logging. 
+  The API is not wired up in 2.x, but will make the transition for consumers to 3.x smoother.
+
 ## 2.5.3
 
 > Complete `2.5.3` Changsets:

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 
@@ -47,6 +48,22 @@ class _$ErrorBoundaryProps extends UiProps {
   ///
   /// > Default: [ErrorBoundaryComponent._renderDefaultFallbackUI]
   _FallbackUiRenderer fallbackUIRenderer;
+
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// Not used if a custom [logger] is specified.
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  String loggerName;
+
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  bool shouldLogErrors;
+
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  Logger logger;
 }
 
 @State()

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -85,24 +85,98 @@ abstract class _$ErrorBoundaryPropsAccessorsMixin
   @override
   set fallbackUIRenderer(_FallbackUiRenderer value) =>
       props[_$key__fallbackUIRenderer___$ErrorBoundaryProps] = value;
+
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// Not used if a custom [logger] is specified.
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
+  @override
+  String get loggerName =>
+      props[_$key__loggerName___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// The name to use when the component's logger logs an error via [ErrorBoundaryComponent.componentDidCatch].
+  ///
+  /// Not used if a custom [logger] is specified.
+  ///
+  /// > Default: 'over_react.ErrorBoundary'
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.loggerName] -->
+  @override
+  set loggerName(String value) =>
+      props[_$key__loggerName___$ErrorBoundaryProps] = value;
+
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.shouldLogErrors] -->
+  @override
+  bool get shouldLogErrors =>
+      props[_$key__shouldLogErrors___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// Whether errors caught by this [ErrorBoundary] should be logged using a [Logger].
+  ///
+  /// > Default: `true`
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.shouldLogErrors] -->
+  @override
+  set shouldLogErrors(bool value) =>
+      props[_$key__shouldLogErrors___$ErrorBoundaryProps] = value;
+
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.logger] -->
+  @override
+  Logger get logger =>
+      props[_$key__logger___$ErrorBoundaryProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// An optional custom logger instance that will be used to log errors caught by
+  /// this [ErrorBoundary] when [shouldLogErrors] is true.
+  ///
+  /// <!-- Generated from [_$ErrorBoundaryProps.logger] -->
+  @override
+  set logger(Logger value) =>
+      props[_$key__logger___$ErrorBoundaryProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor
       _$prop__onComponentDidCatch___$ErrorBoundaryProps =
       const PropDescriptor(_$key__onComponentDidCatch___$ErrorBoundaryProps);
   static const PropDescriptor _$prop__fallbackUIRenderer___$ErrorBoundaryProps =
       const PropDescriptor(_$key__fallbackUIRenderer___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__loggerName___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__loggerName___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__shouldLogErrors___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__shouldLogErrors___$ErrorBoundaryProps);
+  static const PropDescriptor _$prop__logger___$ErrorBoundaryProps =
+      const PropDescriptor(_$key__logger___$ErrorBoundaryProps);
   static const String _$key__onComponentDidCatch___$ErrorBoundaryProps =
       'ErrorBoundaryProps.onComponentDidCatch';
   static const String _$key__fallbackUIRenderer___$ErrorBoundaryProps =
       'ErrorBoundaryProps.fallbackUIRenderer';
+  static const String _$key__loggerName___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.loggerName';
+  static const String _$key__shouldLogErrors___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.shouldLogErrors';
+  static const String _$key__logger___$ErrorBoundaryProps =
+      'ErrorBoundaryProps.logger';
 
   static const List<PropDescriptor> $props = const [
     _$prop__onComponentDidCatch___$ErrorBoundaryProps,
-    _$prop__fallbackUIRenderer___$ErrorBoundaryProps
+    _$prop__fallbackUIRenderer___$ErrorBoundaryProps,
+    _$prop__loggerName___$ErrorBoundaryProps,
+    _$prop__shouldLogErrors___$ErrorBoundaryProps,
+    _$prop__logger___$ErrorBoundaryProps
   ];
   static const List<String> $propKeys = const [
     _$key__onComponentDidCatch___$ErrorBoundaryProps,
-    _$key__fallbackUIRenderer___$ErrorBoundaryProps
+    _$key__fallbackUIRenderer___$ErrorBoundaryProps,
+    _$key__loggerName___$ErrorBoundaryProps,
+    _$key__shouldLogErrors___$ErrorBoundaryProps,
+    _$key__logger___$ErrorBoundaryProps
   ];
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.5.3+dart2
+version: 2.6.0+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This Dart 2 only stable release of over_react includes:

- [x] A placeholder prop API to mirror the 3.x `ErrorBoundary` APIs (#370) added to configure logging. The API is not wired up in 2.x, but will make the transition for consumers to 3.x smoother.

---

@greglittlefield-wf 