### PR TITLE
RM-59694 Release over_react 2.6.1+dart2 (Hotfix to update prop typedef to work around Dart 2.6 compiler regression (CPLAT-7898))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 2.6.1
+
+> Complete `2.6.1` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.6.0+dart2...2.6.1+dart2)
+> - Dart 1 (No Changes)
+
+* [#382] Update prop typedef to work around [Dart 2.6 compiler regression](https://github.com/dart-lang/sdk/issues/38880)
+
 ## 2.6.0
 
 > Complete `2.6.0` Changsets:

--- a/lib/src/component/prop_typedefs.dart
+++ b/lib/src/component/prop_typedefs.dart
@@ -18,5 +18,8 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:react/react_client.dart';
 
-/// A typedef for props that allow a custom rendering function to be provided to render some part of a component.
-typedef ReactElement CustomRenderFunction<TProps extends UiProps, TState extends UiState, TComponent extends component_base.UiComponent<TProps>> (TProps props, TState state, TComponent component);
+/// A custom rendering prop typedef that allows a custom rendering function to be provided
+/// with the current [props] and [state] of the [component].
+typedef ReactElement CustomRenderFunction<T extends UiProps,
+                                          S extends UiState,
+                                          C extends component_base.UiComponent> (T props, S state, C component);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.6.0+dart2
+version: 2.6.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.dart
@@ -1,0 +1,11 @@
+library prop_tyepdef_test_fixtures;
+
+import 'package:over_react/over_react.dart';
+
+part 'prop_typedef_fixtures/abstract_component_with_custom_render_prop.dart';
+part 'prop_typedef_fixtures/component_consuming_abstract_custom_render_prop.dart';
+part 'prop_typedef_fixtures/component_consuming_custom_render_prop.dart';
+part 'prop_typedef_fixtures/component_extending_from_abstract_component_with_custom_render_prop.dart';
+part 'prop_typedef_fixtures/component_with_custom_render_prop.dart';
+
+part 'prop_typedef_fixtures.over_react.g.dart';

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
@@ -1,0 +1,854 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'prop_typedef_fixtures.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+abstract class _$TestAbstractCustomRendererComponentPropsAccessorsMixin
+    implements _$TestAbstractCustomRendererComponentProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.customRenderer] -->
+  @override
+  CustomRenderFunction get customRenderer =>
+      props[
+          _$key__customRenderer___$TestAbstractCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.customRenderer] -->
+  @override
+  set customRenderer(CustomRenderFunction value) =>
+      props[_$key__customRenderer___$TestAbstractCustomRendererComponentProps] =
+          value;
+
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.parameterizedCustomRenderer] -->
+  @override
+  CustomRenderFunction<
+          TestAbstractCustomRendererComponentProps,
+          TestAbstractCustomRendererComponentState,
+          TestAbstractCustomRendererComponentComponent>
+      get parameterizedCustomRenderer =>
+          props[
+              _$key__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps] ??
+          null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.parameterizedCustomRenderer] -->
+  @override
+  set parameterizedCustomRenderer(
+          CustomRenderFunction<
+                  TestAbstractCustomRendererComponentProps,
+                  TestAbstractCustomRendererComponentState,
+                  TestAbstractCustomRendererComponentComponent>
+              value) =>
+      props[_$key__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps] =
+          value;
+
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.somePropKey] -->
+  @override
+  String get somePropKey =>
+      props[_$key__somePropKey___$TestAbstractCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentProps.somePropKey] -->
+  @override
+  set somePropKey(String value) =>
+      props[_$key__somePropKey___$TestAbstractCustomRendererComponentProps] =
+          value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__customRenderer___$TestAbstractCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__customRenderer___$TestAbstractCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__somePropKey___$TestAbstractCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__somePropKey___$TestAbstractCustomRendererComponentProps);
+  static const String
+      _$key__customRenderer___$TestAbstractCustomRendererComponentProps =
+      'TestAbstractCustomRendererComponentProps.customRenderer';
+  static const String
+      _$key__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps =
+      'TestAbstractCustomRendererComponentProps.parameterizedCustomRenderer';
+  static const String
+      _$key__somePropKey___$TestAbstractCustomRendererComponentProps =
+      'TestAbstractCustomRendererComponentProps.somePropKey';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__customRenderer___$TestAbstractCustomRendererComponentProps,
+    _$prop__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps,
+    _$prop__somePropKey___$TestAbstractCustomRendererComponentProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__customRenderer___$TestAbstractCustomRendererComponentProps,
+    _$key__parameterizedCustomRenderer___$TestAbstractCustomRendererComponentProps,
+    _$key__somePropKey___$TestAbstractCustomRendererComponentProps
+  ];
+}
+
+const PropsMeta _$metaForTestAbstractCustomRendererComponentProps =
+    const PropsMeta(
+  fields: _$TestAbstractCustomRendererComponentPropsAccessorsMixin.$props,
+  keys: _$TestAbstractCustomRendererComponentPropsAccessorsMixin.$propKeys,
+);
+
+abstract class TestAbstractCustomRendererComponentProps
+    extends _$TestAbstractCustomRendererComponentProps
+    with _$TestAbstractCustomRendererComponentPropsAccessorsMixin {
+  static const PropsMeta meta =
+      _$metaForTestAbstractCustomRendererComponentProps;
+}
+
+abstract class _$TestAbstractCustomRendererComponentStateAccessorsMixin
+    implements _$TestAbstractCustomRendererComponentState {
+  @override
+  Map get state;
+
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentState.someStateKey] -->
+  @override
+  String get someStateKey =>
+      state[_$key__someStateKey___$TestAbstractCustomRendererComponentState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestAbstractCustomRendererComponentState.someStateKey] -->
+  @override
+  set someStateKey(String value) =>
+      state[_$key__someStateKey___$TestAbstractCustomRendererComponentState] =
+          value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor
+      _$prop__someStateKey___$TestAbstractCustomRendererComponentState =
+      const StateDescriptor(
+          _$key__someStateKey___$TestAbstractCustomRendererComponentState);
+  static const String
+      _$key__someStateKey___$TestAbstractCustomRendererComponentState =
+      'TestAbstractCustomRendererComponentState.someStateKey';
+
+  static const List<StateDescriptor> $state = const [
+    _$prop__someStateKey___$TestAbstractCustomRendererComponentState
+  ];
+  static const List<String> $stateKeys = const [
+    _$key__someStateKey___$TestAbstractCustomRendererComponentState
+  ];
+}
+
+const StateMeta _$metaForTestAbstractCustomRendererComponentState =
+    const StateMeta(
+  fields: _$TestAbstractCustomRendererComponentStateAccessorsMixin.$state,
+  keys: _$TestAbstractCustomRendererComponentStateAccessorsMixin.$stateKeys,
+);
+
+abstract class TestAbstractCustomRendererComponentState
+    extends _$TestAbstractCustomRendererComponentState
+    with _$TestAbstractCustomRendererComponentStateAccessorsMixin {
+  static const StateMeta meta =
+      _$metaForTestAbstractCustomRendererComponentState;
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestConsumingAbstractCustomRendererComponentComponentFactory =
+    registerComponent(
+        () => new _$TestConsumingAbstractCustomRendererComponentComponent(),
+        builderFactory: TestConsumingAbstractCustomRendererComponent,
+        componentClass: TestConsumingAbstractCustomRendererComponentComponent,
+        isWrapper: false,
+        parentType: null,
+        displayName: 'TestConsumingAbstractCustomRendererComponent');
+
+abstract class _$TestConsumingAbstractCustomRendererComponentPropsAccessorsMixin
+    implements _$TestConsumingAbstractCustomRendererComponentProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$TestConsumingAbstractCustomRendererComponentProps.propKeyValueToTest] -->
+  @override
+  String get propKeyValueToTest =>
+      props[
+          _$key__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestConsumingAbstractCustomRendererComponentProps.propKeyValueToTest] -->
+  @override
+  set propKeyValueToTest(String value) => props[
+          _$key__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps] =
+      value;
+
+  /// <!-- Generated from [_$TestConsumingAbstractCustomRendererComponentProps.stateKeyValueToTest] -->
+  @override
+  String get stateKeyValueToTest =>
+      props[
+          _$key__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestConsumingAbstractCustomRendererComponentProps.stateKeyValueToTest] -->
+  @override
+  set stateKeyValueToTest(String value) => props[
+          _$key__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps] =
+      value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps);
+  static const String
+      _$key__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps =
+      'TestConsumingAbstractCustomRendererComponentProps.propKeyValueToTest';
+  static const String
+      _$key__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps =
+      'TestConsumingAbstractCustomRendererComponentProps.stateKeyValueToTest';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps,
+    _$prop__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__propKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps,
+    _$key__stateKeyValueToTest___$TestConsumingAbstractCustomRendererComponentProps
+  ];
+}
+
+const PropsMeta _$metaForTestConsumingAbstractCustomRendererComponentProps =
+    const PropsMeta(
+  fields:
+      _$TestConsumingAbstractCustomRendererComponentPropsAccessorsMixin.$props,
+  keys: _$TestConsumingAbstractCustomRendererComponentPropsAccessorsMixin
+      .$propKeys,
+);
+
+class TestConsumingAbstractCustomRendererComponentProps
+    extends _$TestConsumingAbstractCustomRendererComponentProps
+    with _$TestConsumingAbstractCustomRendererComponentPropsAccessorsMixin {
+  static const PropsMeta meta =
+      _$metaForTestConsumingAbstractCustomRendererComponentProps;
+}
+
+_$$TestConsumingAbstractCustomRendererComponentProps
+    _$TestConsumingAbstractCustomRendererComponent([Map backingProps]) =>
+        new _$$TestConsumingAbstractCustomRendererComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TestConsumingAbstractCustomRendererComponentProps
+    extends _$TestConsumingAbstractCustomRendererComponentProps
+    with _$TestConsumingAbstractCustomRendererComponentPropsAccessorsMixin
+    implements TestConsumingAbstractCustomRendererComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestConsumingAbstractCustomRendererComponentProps(Map backingMap)
+      : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $TestConsumingAbstractCustomRendererComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace =>
+      'TestConsumingAbstractCustomRendererComponentProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestConsumingAbstractCustomRendererComponentComponent
+    extends TestConsumingAbstractCustomRendererComponentComponent {
+  @override
+  _$$TestConsumingAbstractCustomRendererComponentProps typedPropsFactory(
+          Map backingMap) =>
+      new _$$TestConsumingAbstractCustomRendererComponentProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestConsumingAbstractCustomRendererComponentProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestConsumingAbstractCustomRendererComponentProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestConsumingCustomRendererComponentComponentFactory = registerComponent(
+    () => new _$TestConsumingCustomRendererComponentComponent(),
+    builderFactory: TestConsumingCustomRendererComponent,
+    componentClass: TestConsumingCustomRendererComponentComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'TestConsumingCustomRendererComponent');
+
+abstract class _$TestConsumingCustomRendererComponentPropsAccessorsMixin
+    implements _$TestConsumingCustomRendererComponentProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$TestConsumingCustomRendererComponentProps.propKeyValueToTest] -->
+  @override
+  String get propKeyValueToTest =>
+      props[
+          _$key__propKeyValueToTest___$TestConsumingCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestConsumingCustomRendererComponentProps.propKeyValueToTest] -->
+  @override
+  set propKeyValueToTest(String value) => props[
+          _$key__propKeyValueToTest___$TestConsumingCustomRendererComponentProps] =
+      value;
+
+  /// <!-- Generated from [_$TestConsumingCustomRendererComponentProps.stateKeyValueToTest] -->
+  @override
+  String get stateKeyValueToTest =>
+      props[
+          _$key__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestConsumingCustomRendererComponentProps.stateKeyValueToTest] -->
+  @override
+  set stateKeyValueToTest(String value) => props[
+          _$key__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps] =
+      value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__propKeyValueToTest___$TestConsumingCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__propKeyValueToTest___$TestConsumingCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps);
+  static const String
+      _$key__propKeyValueToTest___$TestConsumingCustomRendererComponentProps =
+      'TestConsumingCustomRendererComponentProps.propKeyValueToTest';
+  static const String
+      _$key__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps =
+      'TestConsumingCustomRendererComponentProps.stateKeyValueToTest';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__propKeyValueToTest___$TestConsumingCustomRendererComponentProps,
+    _$prop__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__propKeyValueToTest___$TestConsumingCustomRendererComponentProps,
+    _$key__stateKeyValueToTest___$TestConsumingCustomRendererComponentProps
+  ];
+}
+
+const PropsMeta _$metaForTestConsumingCustomRendererComponentProps =
+    const PropsMeta(
+  fields: _$TestConsumingCustomRendererComponentPropsAccessorsMixin.$props,
+  keys: _$TestConsumingCustomRendererComponentPropsAccessorsMixin.$propKeys,
+);
+
+class TestConsumingCustomRendererComponentProps
+    extends _$TestConsumingCustomRendererComponentProps
+    with _$TestConsumingCustomRendererComponentPropsAccessorsMixin {
+  static const PropsMeta meta =
+      _$metaForTestConsumingCustomRendererComponentProps;
+}
+
+_$$TestConsumingCustomRendererComponentProps
+    _$TestConsumingCustomRendererComponent([Map backingProps]) =>
+        new _$$TestConsumingCustomRendererComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TestConsumingCustomRendererComponentProps
+    extends _$TestConsumingCustomRendererComponentProps
+    with _$TestConsumingCustomRendererComponentPropsAccessorsMixin
+    implements TestConsumingCustomRendererComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestConsumingCustomRendererComponentProps(Map backingMap)
+      : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $TestConsumingCustomRendererComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TestConsumingCustomRendererComponentProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestConsumingCustomRendererComponentComponent
+    extends TestConsumingCustomRendererComponentComponent {
+  @override
+  _$$TestConsumingCustomRendererComponentProps typedPropsFactory(
+          Map backingMap) =>
+      new _$$TestConsumingCustomRendererComponentProps(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestConsumingCustomRendererComponentProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestConsumingCustomRendererComponentProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestCustomRendererFromAbstractComponentComponentFactory =
+    registerComponent(
+        () => new _$TestCustomRendererFromAbstractComponentComponent(),
+        builderFactory: TestCustomRendererFromAbstractComponent,
+        componentClass: TestCustomRendererFromAbstractComponentComponent,
+        isWrapper: false,
+        parentType: null,
+        displayName: 'TestCustomRendererFromAbstractComponent');
+
+abstract class _$TestCustomRendererFromAbstractComponentPropsAccessorsMixin
+    implements _$TestCustomRendererFromAbstractComponentProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$TestCustomRendererFromAbstractComponentProps.someInitialStateKeyValue] -->
+  @override
+  String get someInitialStateKeyValue =>
+      props[
+          _$key__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererFromAbstractComponentProps.someInitialStateKeyValue] -->
+  @override
+  set someInitialStateKeyValue(String value) => props[
+          _$key__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps] =
+      value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps =
+      const PropDescriptor(
+          _$key__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps);
+  static const String
+      _$key__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps =
+      'TestCustomRendererFromAbstractComponentProps.someInitialStateKeyValue';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__someInitialStateKeyValue___$TestCustomRendererFromAbstractComponentProps
+  ];
+}
+
+const PropsMeta _$metaForTestCustomRendererFromAbstractComponentProps =
+    const PropsMeta(
+  fields: _$TestCustomRendererFromAbstractComponentPropsAccessorsMixin.$props,
+  keys: _$TestCustomRendererFromAbstractComponentPropsAccessorsMixin.$propKeys,
+);
+
+class TestCustomRendererFromAbstractComponentProps
+    extends _$TestCustomRendererFromAbstractComponentProps
+    with _$TestCustomRendererFromAbstractComponentPropsAccessorsMixin {
+  static const PropsMeta meta =
+      _$metaForTestCustomRendererFromAbstractComponentProps;
+}
+
+_$$TestCustomRendererFromAbstractComponentProps
+    _$TestCustomRendererFromAbstractComponent([Map backingProps]) =>
+        new _$$TestCustomRendererFromAbstractComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TestCustomRendererFromAbstractComponentProps
+    extends _$TestCustomRendererFromAbstractComponentProps
+    with _$TestCustomRendererFromAbstractComponentPropsAccessorsMixin
+    implements TestCustomRendererFromAbstractComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestCustomRendererFromAbstractComponentProps(Map backingMap)
+      : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $TestCustomRendererFromAbstractComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace =>
+      'TestCustomRendererFromAbstractComponentProps.';
+}
+
+abstract class _$TestCustomRendererFromAbstractComponentStateAccessorsMixin
+    implements _$TestCustomRendererFromAbstractComponentState {
+  @override
+  Map get state;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<StateDescriptor> $state = const [];
+  static const List<String> $stateKeys = const [];
+}
+
+const StateMeta _$metaForTestCustomRendererFromAbstractComponentState =
+    const StateMeta(
+  fields: _$TestCustomRendererFromAbstractComponentStateAccessorsMixin.$state,
+  keys: _$TestCustomRendererFromAbstractComponentStateAccessorsMixin.$stateKeys,
+);
+
+class TestCustomRendererFromAbstractComponentState
+    extends _$TestCustomRendererFromAbstractComponentState
+    with _$TestCustomRendererFromAbstractComponentStateAccessorsMixin {
+  static const StateMeta meta =
+      _$metaForTestCustomRendererFromAbstractComponentState;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$TestCustomRendererFromAbstractComponentState
+    extends _$TestCustomRendererFromAbstractComponentState
+    with _$TestCustomRendererFromAbstractComponentStateAccessorsMixin
+    implements TestCustomRendererFromAbstractComponentState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestCustomRendererFromAbstractComponentState(Map backingMap)
+      : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestCustomRendererFromAbstractComponentComponent
+    extends TestCustomRendererFromAbstractComponentComponent {
+  @override
+  _$$TestCustomRendererFromAbstractComponentProps typedPropsFactory(
+          Map backingMap) =>
+      new _$$TestCustomRendererFromAbstractComponentProps(backingMap);
+
+  @override
+  _$$TestCustomRendererFromAbstractComponentState typedStateFactory(
+          Map backingMap) =>
+      new _$$TestCustomRendererFromAbstractComponentState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestCustomRendererFromAbstractComponentProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestCustomRendererFromAbstractComponentProps
+  ];
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestCustomRendererComponentComponentFactory = registerComponent(
+    () => new _$TestCustomRendererComponentComponent(),
+    builderFactory: TestCustomRendererComponent,
+    componentClass: TestCustomRendererComponentComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'TestCustomRendererComponent');
+
+abstract class _$TestCustomRendererComponentPropsAccessorsMixin
+    implements _$TestCustomRendererComponentProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.customRenderer] -->
+  @override
+  CustomRenderFunction get customRenderer =>
+      props[_$key__customRenderer___$TestCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.customRenderer] -->
+  @override
+  set customRenderer(CustomRenderFunction value) =>
+      props[_$key__customRenderer___$TestCustomRendererComponentProps] = value;
+
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.parameterizedCustomRenderer] -->
+  @override
+  CustomRenderFunction<
+          TestCustomRendererComponentProps,
+          TestCustomRendererComponentState,
+          TestCustomRendererComponentComponent>
+      get parameterizedCustomRenderer =>
+          props[
+              _$key__parameterizedCustomRenderer___$TestCustomRendererComponentProps] ??
+          null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.parameterizedCustomRenderer] -->
+  @override
+  set parameterizedCustomRenderer(
+          CustomRenderFunction<
+                  TestCustomRendererComponentProps,
+                  TestCustomRendererComponentState,
+                  TestCustomRendererComponentComponent>
+              value) =>
+      props[_$key__parameterizedCustomRenderer___$TestCustomRendererComponentProps] =
+          value;
+
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.somePropKey] -->
+  @override
+  String get somePropKey =>
+      props[_$key__somePropKey___$TestCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.somePropKey] -->
+  @override
+  set somePropKey(String value) =>
+      props[_$key__somePropKey___$TestCustomRendererComponentProps] = value;
+
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.someInitialStateKeyValue] -->
+  @override
+  String get someInitialStateKeyValue =>
+      props[
+          _$key__someInitialStateKeyValue___$TestCustomRendererComponentProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererComponentProps.someInitialStateKeyValue] -->
+  @override
+  set someInitialStateKeyValue(String value) => props[
+          _$key__someInitialStateKeyValue___$TestCustomRendererComponentProps] =
+      value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__customRenderer___$TestCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__customRenderer___$TestCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__parameterizedCustomRenderer___$TestCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__parameterizedCustomRenderer___$TestCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__somePropKey___$TestCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__somePropKey___$TestCustomRendererComponentProps);
+  static const PropDescriptor
+      _$prop__someInitialStateKeyValue___$TestCustomRendererComponentProps =
+      const PropDescriptor(
+          _$key__someInitialStateKeyValue___$TestCustomRendererComponentProps);
+  static const String
+      _$key__customRenderer___$TestCustomRendererComponentProps =
+      'TestCustomRendererComponentProps.customRenderer';
+  static const String
+      _$key__parameterizedCustomRenderer___$TestCustomRendererComponentProps =
+      'TestCustomRendererComponentProps.parameterizedCustomRenderer';
+  static const String _$key__somePropKey___$TestCustomRendererComponentProps =
+      'TestCustomRendererComponentProps.somePropKey';
+  static const String
+      _$key__someInitialStateKeyValue___$TestCustomRendererComponentProps =
+      'TestCustomRendererComponentProps.someInitialStateKeyValue';
+
+  static const List<PropDescriptor> $props = const [
+    _$prop__customRenderer___$TestCustomRendererComponentProps,
+    _$prop__parameterizedCustomRenderer___$TestCustomRendererComponentProps,
+    _$prop__somePropKey___$TestCustomRendererComponentProps,
+    _$prop__someInitialStateKeyValue___$TestCustomRendererComponentProps
+  ];
+  static const List<String> $propKeys = const [
+    _$key__customRenderer___$TestCustomRendererComponentProps,
+    _$key__parameterizedCustomRenderer___$TestCustomRendererComponentProps,
+    _$key__somePropKey___$TestCustomRendererComponentProps,
+    _$key__someInitialStateKeyValue___$TestCustomRendererComponentProps
+  ];
+}
+
+const PropsMeta _$metaForTestCustomRendererComponentProps = const PropsMeta(
+  fields: _$TestCustomRendererComponentPropsAccessorsMixin.$props,
+  keys: _$TestCustomRendererComponentPropsAccessorsMixin.$propKeys,
+);
+
+class TestCustomRendererComponentProps
+    extends _$TestCustomRendererComponentProps
+    with _$TestCustomRendererComponentPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForTestCustomRendererComponentProps;
+}
+
+_$$TestCustomRendererComponentProps _$TestCustomRendererComponent(
+        [Map backingProps]) =>
+    new _$$TestCustomRendererComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TestCustomRendererComponentProps
+    extends _$TestCustomRendererComponentProps
+    with _$TestCustomRendererComponentPropsAccessorsMixin
+    implements TestCustomRendererComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestCustomRendererComponentProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let [UiProps] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The [ReactComponentFactory] associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      $TestCustomRendererComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TestCustomRendererComponentProps.';
+}
+
+abstract class _$TestCustomRendererComponentStateAccessorsMixin
+    implements _$TestCustomRendererComponentState {
+  @override
+  Map get state;
+
+  /// <!-- Generated from [_$TestCustomRendererComponentState.someStateKey] -->
+  @override
+  String get someStateKey =>
+      state[_$key__someStateKey___$TestCustomRendererComponentState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$TestCustomRendererComponentState.someStateKey] -->
+  @override
+  set someStateKey(String value) =>
+      state[_$key__someStateKey___$TestCustomRendererComponentState] = value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor
+      _$prop__someStateKey___$TestCustomRendererComponentState =
+      const StateDescriptor(
+          _$key__someStateKey___$TestCustomRendererComponentState);
+  static const String _$key__someStateKey___$TestCustomRendererComponentState =
+      'TestCustomRendererComponentState.someStateKey';
+
+  static const List<StateDescriptor> $state = const [
+    _$prop__someStateKey___$TestCustomRendererComponentState
+  ];
+  static const List<String> $stateKeys = const [
+    _$key__someStateKey___$TestCustomRendererComponentState
+  ];
+}
+
+const StateMeta _$metaForTestCustomRendererComponentState = const StateMeta(
+  fields: _$TestCustomRendererComponentStateAccessorsMixin.$state,
+  keys: _$TestCustomRendererComponentStateAccessorsMixin.$stateKeys,
+);
+
+class TestCustomRendererComponentState
+    extends _$TestCustomRendererComponentState
+    with _$TestCustomRendererComponentStateAccessorsMixin {
+  static const StateMeta meta = _$metaForTestCustomRendererComponentState;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+class _$$TestCustomRendererComponentState
+    extends _$TestCustomRendererComponentState
+    with _$TestCustomRendererComponentStateAccessorsMixin
+    implements TestCustomRendererComponentState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around an unknown ddc issue.
+  // See <https://jira.atl.workiva.net/browse/CPLAT-4673> for more details
+  _$$TestCustomRendererComponentState(Map backingMap) : this._state = {} {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+
+  /// Let [UiState] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestCustomRendererComponentComponent
+    extends TestCustomRendererComponentComponent {
+  @override
+  _$$TestCustomRendererComponentProps typedPropsFactory(Map backingMap) =>
+      new _$$TestCustomRendererComponentProps(backingMap);
+
+  @override
+  _$$TestCustomRendererComponentState typedStateFactory(Map backingMap) =>
+      new _$$TestCustomRendererComponentState(backingMap);
+
+  /// Let [UiComponent] internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestCustomRendererComponentProps.
+  /// Used in [UiProps.consumedProps] if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestCustomRendererComponentProps
+  ];
+}

--- a/test/over_react/component/fixtures/prop_typedef_fixtures/abstract_component_with_custom_render_prop.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures/abstract_component_with_custom_render_prop.dart
@@ -1,0 +1,35 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of prop_tyepdef_test_fixtures;
+
+@AbstractProps()
+abstract class _$TestAbstractCustomRendererComponentProps extends UiProps {
+  CustomRenderFunction customRenderer;
+  CustomRenderFunction<TestAbstractCustomRendererComponentProps,
+                       TestAbstractCustomRendererComponentState,
+                       TestAbstractCustomRendererComponentComponent> parameterizedCustomRenderer;
+
+  String somePropKey;
+}
+
+@AbstractState()
+abstract class _$TestAbstractCustomRendererComponentState extends UiState {
+  String someStateKey;
+}
+
+@AbstractComponent()
+abstract class TestAbstractCustomRendererComponentComponent<T extends TestAbstractCustomRendererComponentProps,
+                                                            S extends TestAbstractCustomRendererComponentState>
+    extends UiStatefulComponent<T, S> {}

--- a/test/over_react/component/fixtures/prop_typedef_fixtures/component_consuming_abstract_custom_render_prop.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures/component_consuming_abstract_custom_render_prop.dart
@@ -1,0 +1,55 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: avoid_as
+
+part of prop_tyepdef_test_fixtures;
+
+@Factory()
+UiFactory<TestConsumingAbstractCustomRendererComponentProps> TestConsumingAbstractCustomRendererComponent =
+    _$TestConsumingAbstractCustomRendererComponent;
+
+@Props()
+class _$TestConsumingAbstractCustomRendererComponentProps extends UiProps {
+  String propKeyValueToTest;
+  String stateKeyValueToTest;
+}
+
+@Component()
+class TestConsumingAbstractCustomRendererComponentComponent
+    extends UiComponent<TestConsumingAbstractCustomRendererComponentProps> {
+  @override
+  render() {
+    return (TestCustomRendererFromAbstractComponent()
+      ..somePropKey = props.propKeyValueToTest
+      ..someInitialStateKeyValue = props.stateKeyValueToTest
+      ..customRenderer = (props, state, component) {
+        return (Dom.div()
+          ..addTestId('customRendererContainer')
+        )(
+          'props.somePropKey: ${(props as TestCustomRendererFromAbstractComponentProps).somePropKey} \n'
+          'props.someStateKey: ${(state as TestCustomRendererFromAbstractComponentState).someStateKey}'
+        );
+      }
+      ..parameterizedCustomRenderer = (props, state, component) {
+        return (Dom.div()
+          ..addTestId('parameterizedCustomRendererContainer')
+        )(
+          'props.somePropKey: ${props.somePropKey} \n'
+          'props.someStateKey: ${state.someStateKey}'
+        );
+      }
+    )();
+  }
+}

--- a/test/over_react/component/fixtures/prop_typedef_fixtures/component_consuming_custom_render_prop.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures/component_consuming_custom_render_prop.dart
@@ -1,0 +1,54 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ignore_for_file: avoid_as
+
+part of prop_tyepdef_test_fixtures;
+
+@Factory()
+UiFactory<TestConsumingCustomRendererComponentProps> TestConsumingCustomRendererComponent =
+    _$TestConsumingCustomRendererComponent;
+
+@Props()
+class _$TestConsumingCustomRendererComponentProps extends UiProps {
+  String propKeyValueToTest;
+  String stateKeyValueToTest;
+}
+
+@Component()
+class TestConsumingCustomRendererComponentComponent extends UiComponent<TestConsumingCustomRendererComponentProps> {
+  @override
+  render() {
+    return (TestCustomRendererComponent()
+      ..somePropKey = props.propKeyValueToTest
+      ..someInitialStateKeyValue = props.stateKeyValueToTest
+      ..customRenderer = (props, state, component) {
+        return (Dom.div()
+          ..addTestId('customRendererContainer')
+        )(
+          'props.somePropKey: ${(props as TestCustomRendererComponentProps).somePropKey} \n'
+          'props.someStateKey: ${(state as TestCustomRendererComponentState).someStateKey}'
+        );
+      }
+      ..parameterizedCustomRenderer = (props, state, component) {
+        return (Dom.div()
+          ..addTestId('parameterizedCustomRendererContainer')
+        )(
+          'props.somePropKey: ${props.somePropKey} \n'
+          'props.someStateKey: ${state.someStateKey}'
+        );
+      }
+    )();
+  }
+}

--- a/test/over_react/component/fixtures/prop_typedef_fixtures/component_extending_from_abstract_component_with_custom_render_prop.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures/component_extending_from_abstract_component_with_custom_render_prop.dart
@@ -1,0 +1,43 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of prop_tyepdef_test_fixtures;
+
+@Factory()
+UiFactory<TestCustomRendererFromAbstractComponentProps> TestCustomRendererFromAbstractComponent =
+    _$TestCustomRendererFromAbstractComponent;
+
+@Props()
+class _$TestCustomRendererFromAbstractComponentProps extends TestAbstractCustomRendererComponentProps {
+  String someInitialStateKeyValue;
+}
+
+@State()
+class _$TestCustomRendererFromAbstractComponentState extends TestAbstractCustomRendererComponentState {}
+
+@Component()
+class TestCustomRendererFromAbstractComponentComponent
+    extends TestAbstractCustomRendererComponentComponent<TestCustomRendererFromAbstractComponentProps,
+                                                         TestCustomRendererFromAbstractComponentState> {
+  @override
+  Map getInitialState() => (newState()..someStateKey = props.someInitialStateKeyValue);
+
+  @override
+  render() {
+    return Dom.div()(
+      props.customRenderer(props, state, this),
+      props.parameterizedCustomRenderer(props, state, this),
+    );
+  }
+}

--- a/test/over_react/component/fixtures/prop_typedef_fixtures/component_with_custom_render_prop.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures/component_with_custom_render_prop.dart
@@ -1,0 +1,48 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of prop_tyepdef_test_fixtures;
+
+@Factory()
+UiFactory<TestCustomRendererComponentProps> TestCustomRendererComponent = _$TestCustomRendererComponent;
+
+@Props()
+class _$TestCustomRendererComponentProps extends UiProps {
+  CustomRenderFunction customRenderer;
+  CustomRenderFunction<TestCustomRendererComponentProps,
+                       TestCustomRendererComponentState,
+                       TestCustomRendererComponentComponent> parameterizedCustomRenderer;
+  String somePropKey;
+  String someInitialStateKeyValue;
+}
+
+@State()
+class _$TestCustomRendererComponentState extends UiState {
+  String someStateKey;
+}
+
+@Component()
+class TestCustomRendererComponentComponent
+    extends UiStatefulComponent<TestCustomRendererComponentProps, TestCustomRendererComponentState> {
+  @override
+  Map getInitialState() => (newState()..someStateKey = props.someInitialStateKeyValue);
+
+  @override
+  render() {
+    return Dom.div()(
+      props.customRenderer(props, state, this),
+      props.parameterizedCustomRenderer(props, state, this),
+    );
+  }
+}

--- a/test/over_react/component/prop_typedefs_test.dart
+++ b/test/over_react/component/prop_typedefs_test.dart
@@ -1,0 +1,59 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('browser')
+library prop_typedefs_test.dart;
+
+import 'package:test/test.dart';
+import 'package:over_react_test/over_react_test.dart';
+import './fixtures/prop_typedef_fixtures.dart';
+
+main() {
+  // Regression tests for https://github.com/dart-lang/sdk/issues/38880
+  group('CustomRenderFunction typedef', () {
+    TestJacket jacket;
+
+    tearDown(() {
+      jacket = null;
+    });
+
+    void sharedTest() {
+      final customRendererContainerNode =
+          queryByTestId(jacket.getInstance(), 'customRendererContainer');
+      expect(customRendererContainerNode, isNotNull, reason: 'test setup sanity check');
+      final parameterizedCustomRendererContainerNode =
+          queryByTestId(jacket.getInstance(), 'parameterizedCustomRendererContainer');
+      expect(parameterizedCustomRendererContainerNode, isNotNull, reason: 'test setup sanity check');
+
+      expect(customRendererContainerNode.text, 'props.somePropKey: foo \nprops.someStateKey: bar');
+      expect(parameterizedCustomRendererContainerNode.text, 'props.somePropKey: foo \nprops.someStateKey: bar');
+    }
+
+    test('works as expected when the custom render prop is defined in a concrete class', () {
+      jacket = mount((TestConsumingCustomRendererComponent()
+        ..propKeyValueToTest = 'foo'
+        ..stateKeyValueToTest = 'bar'
+      )());
+      sharedTest();
+    });
+
+    test('works as expected when the custom render prop is defined in an abstract class', () {
+      jacket = mount((TestConsumingAbstractCustomRendererComponent()
+        ..propKeyValueToTest = 'foo'
+        ..stateKeyValueToTest = 'bar'
+      )());
+      sharedTest();
+    });
+  });
+}

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -27,6 +27,7 @@ import 'over_react/component/abstract_transition_test.dart' as abstract_transiti
 import 'over_react/component/dom_components_test.dart' as dom_components_test;
 import 'over_react/component/error_boundary_test.dart' as error_boundary_test;
 import 'over_react/component/prop_mixins_test.dart' as prop_mixins_test;
+import 'over_react/component/prop_typedefs_test.dart' as prop_typedefs_test;
 import 'over_react/component/resize_sensor_test.dart' as resize_sensor_test;
 
 
@@ -39,5 +40,6 @@ void main() {
   error_boundary_test.main();
   dom_components_test.main();
   prop_mixins_test.main();
+  prop_typedefs_test.main();
   resize_sensor_test.main();
 }


### PR DESCRIPTION
This Dart 2 stable release of over_react is a hotfix to update prop typedef to work around a [Dart 2.6 compiler regression](https://github.com/dart-lang/sdk/issues/38880)