### PR TITLE
RM-59676 Release over_react 2.6.1+dart1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 2.6.0+dart1
+version: 2.6.1+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This Dart 1 only stable release contains no functional changes, and is merely a version bump for the analogous [Dart 2 release](https://github.com/Workiva/over_react/pull/382).