### PR TITLE
Revert Typing of Type and Labal to dynamic

### DIFF
--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -78,12 +78,12 @@ abstract class _$DomPropsMixin {
   Map<String, dynamic> style;
 
   String accept, acceptCharset, accessKey, action, alt, autoComplete, charSet, classID, className, content, contextMenu,
-    coords, crossOrigin, data, dateTime, dir, encType, form, href, hrefLang, htmlFor, httpEquiv, id, label, lang, list, manifest, media, mediaGroup,
+    coords, crossOrigin, data, dateTime, dir, encType, form, href, hrefLang, htmlFor, httpEquiv, id, lang, list, manifest, media, mediaGroup,
     method, name, pattern, placeholder, poster, preload, radioGroup, rel, role, sandbox, scope, scrolling, shape, sizes, src,
-    srcDoc, srcSet, target, title, type, useMap, wmode;
+    srcDoc, srcSet, target, title, useMap, wmode;
 
-  dynamic allowTransparency, cellPadding, cellSpacing, colSpan, contentEditable, download, draggable, frameBorder, height, icon,
-    max, maxLength, min, rowSpan, spellCheck, step, tabIndex, value, width;
+  dynamic allowTransparency, cellPadding, cellSpacing, colSpan, contentEditable, download, draggable, frameBorder, height, icon, label,
+    max, maxLength, min, rowSpan, spellCheck, step, tabIndex, type, value, width;
 
   AnimationEventCallback onAnimationEnd, onAnimationIteration, onAnimationStart;
   ClipboardEventCallback onCopy, onCut, onPaste;

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -509,15 +509,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set id(String value) => props[_$key__id___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.label] -->
-  @override
-  String get label =>
-      props[_$key__label___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.label] -->
-  @override
-  set label(String value) => props[_$key__label___$DomPropsMixin] = value;
-
   /// <!-- Generated from [_$DomPropsMixin.lang] -->
   @override
   String get lang =>
@@ -738,15 +729,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set title(String value) => props[_$key__title___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.type] -->
-  @override
-  String get type =>
-      props[_$key__type___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.type] -->
-  @override
-  set type(String value) => props[_$key__type___$DomPropsMixin] = value;
-
   /// <!-- Generated from [_$DomPropsMixin.useMap] -->
   @override
   String get useMap =>
@@ -862,6 +844,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set icon(dynamic value) => props[_$key__icon___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.label] -->
+  @override
+  dynamic get label =>
+      props[_$key__label___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.label] -->
+  @override
+  set label(dynamic value) => props[_$key__label___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
   dynamic get max =>
@@ -927,6 +918,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set tabIndex(dynamic value) =>
       props[_$key__tabIndex___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.type] -->
+  @override
+  dynamic get type =>
+      props[_$key__type___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.type] -->
+  @override
+  set type(dynamic value) => props[_$key__type___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
@@ -1935,8 +1935,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__httpEquiv___$DomPropsMixin);
   static const PropDescriptor _$prop__id___$DomPropsMixin =
       const PropDescriptor(_$key__id___$DomPropsMixin);
-  static const PropDescriptor _$prop__label___$DomPropsMixin =
-      const PropDescriptor(_$key__label___$DomPropsMixin);
   static const PropDescriptor _$prop__lang___$DomPropsMixin =
       const PropDescriptor(_$key__lang___$DomPropsMixin);
   static const PropDescriptor _$prop__list___$DomPropsMixin =
@@ -1985,8 +1983,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__target___$DomPropsMixin);
   static const PropDescriptor _$prop__title___$DomPropsMixin =
       const PropDescriptor(_$key__title___$DomPropsMixin);
-  static const PropDescriptor _$prop__type___$DomPropsMixin =
-      const PropDescriptor(_$key__type___$DomPropsMixin);
   static const PropDescriptor _$prop__useMap___$DomPropsMixin =
       const PropDescriptor(_$key__useMap___$DomPropsMixin);
   static const PropDescriptor _$prop__wmode___$DomPropsMixin =
@@ -2011,6 +2007,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__height___$DomPropsMixin);
   static const PropDescriptor _$prop__icon___$DomPropsMixin =
       const PropDescriptor(_$key__icon___$DomPropsMixin);
+  static const PropDescriptor _$prop__label___$DomPropsMixin =
+      const PropDescriptor(_$key__label___$DomPropsMixin);
   static const PropDescriptor _$prop__max___$DomPropsMixin =
       const PropDescriptor(_$key__max___$DomPropsMixin);
   static const PropDescriptor _$prop__maxLength___$DomPropsMixin =
@@ -2025,6 +2023,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__step___$DomPropsMixin);
   static const PropDescriptor _$prop__tabIndex___$DomPropsMixin =
       const PropDescriptor(_$key__tabIndex___$DomPropsMixin);
+  static const PropDescriptor _$prop__type___$DomPropsMixin =
+      const PropDescriptor(_$key__type___$DomPropsMixin);
   static const PropDescriptor _$prop__value___$DomPropsMixin =
       const PropDescriptor(_$key__value___$DomPropsMixin);
   static const PropDescriptor _$prop__width___$DomPropsMixin =
@@ -2255,7 +2255,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__htmlFor___$DomPropsMixin = 'htmlFor';
   static const String _$key__httpEquiv___$DomPropsMixin = 'httpEquiv';
   static const String _$key__id___$DomPropsMixin = 'id';
-  static const String _$key__label___$DomPropsMixin = 'label';
   static const String _$key__lang___$DomPropsMixin = 'lang';
   static const String _$key__list___$DomPropsMixin = 'list';
   static const String _$key__manifest___$DomPropsMixin = 'manifest';
@@ -2280,7 +2279,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__srcSet___$DomPropsMixin = 'srcSet';
   static const String _$key__target___$DomPropsMixin = 'target';
   static const String _$key__title___$DomPropsMixin = 'title';
-  static const String _$key__type___$DomPropsMixin = 'type';
   static const String _$key__useMap___$DomPropsMixin = 'useMap';
   static const String _$key__wmode___$DomPropsMixin = 'wmode';
   static const String _$key__allowTransparency___$DomPropsMixin =
@@ -2295,6 +2293,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__frameBorder___$DomPropsMixin = 'frameBorder';
   static const String _$key__height___$DomPropsMixin = 'height';
   static const String _$key__icon___$DomPropsMixin = 'icon';
+  static const String _$key__label___$DomPropsMixin = 'label';
   static const String _$key__max___$DomPropsMixin = 'max';
   static const String _$key__maxLength___$DomPropsMixin = 'maxLength';
   static const String _$key__min___$DomPropsMixin = 'min';
@@ -2302,6 +2301,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__spellCheck___$DomPropsMixin = 'spellCheck';
   static const String _$key__step___$DomPropsMixin = 'step';
   static const String _$key__tabIndex___$DomPropsMixin = 'tabIndex';
+  static const String _$key__type___$DomPropsMixin = 'type';
   static const String _$key__value___$DomPropsMixin = 'value';
   static const String _$key__width___$DomPropsMixin = 'width';
   static const String _$key__onAnimationEnd___$DomPropsMixin = 'onAnimationEnd';
@@ -2472,7 +2472,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__htmlFor___$DomPropsMixin,
     _$prop__httpEquiv___$DomPropsMixin,
     _$prop__id___$DomPropsMixin,
-    _$prop__label___$DomPropsMixin,
     _$prop__lang___$DomPropsMixin,
     _$prop__list___$DomPropsMixin,
     _$prop__manifest___$DomPropsMixin,
@@ -2497,7 +2496,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__srcSet___$DomPropsMixin,
     _$prop__target___$DomPropsMixin,
     _$prop__title___$DomPropsMixin,
-    _$prop__type___$DomPropsMixin,
     _$prop__useMap___$DomPropsMixin,
     _$prop__wmode___$DomPropsMixin,
     _$prop__allowTransparency___$DomPropsMixin,
@@ -2510,6 +2508,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__frameBorder___$DomPropsMixin,
     _$prop__height___$DomPropsMixin,
     _$prop__icon___$DomPropsMixin,
+    _$prop__label___$DomPropsMixin,
     _$prop__max___$DomPropsMixin,
     _$prop__maxLength___$DomPropsMixin,
     _$prop__min___$DomPropsMixin,
@@ -2517,6 +2516,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__spellCheck___$DomPropsMixin,
     _$prop__step___$DomPropsMixin,
     _$prop__tabIndex___$DomPropsMixin,
+    _$prop__type___$DomPropsMixin,
     _$prop__value___$DomPropsMixin,
     _$prop__width___$DomPropsMixin,
     _$prop__onAnimationEnd___$DomPropsMixin,
@@ -2657,7 +2657,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__htmlFor___$DomPropsMixin,
     _$key__httpEquiv___$DomPropsMixin,
     _$key__id___$DomPropsMixin,
-    _$key__label___$DomPropsMixin,
     _$key__lang___$DomPropsMixin,
     _$key__list___$DomPropsMixin,
     _$key__manifest___$DomPropsMixin,
@@ -2682,7 +2681,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__srcSet___$DomPropsMixin,
     _$key__target___$DomPropsMixin,
     _$key__title___$DomPropsMixin,
-    _$key__type___$DomPropsMixin,
     _$key__useMap___$DomPropsMixin,
     _$key__wmode___$DomPropsMixin,
     _$key__allowTransparency___$DomPropsMixin,
@@ -2695,6 +2693,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__frameBorder___$DomPropsMixin,
     _$key__height___$DomPropsMixin,
     _$key__icon___$DomPropsMixin,
+    _$key__label___$DomPropsMixin,
     _$key__max___$DomPropsMixin,
     _$key__maxLength___$DomPropsMixin,
     _$key__min___$DomPropsMixin,
@@ -2702,6 +2701,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__spellCheck___$DomPropsMixin,
     _$key__step___$DomPropsMixin,
     _$key__tabIndex___$DomPropsMixin,
+    _$key__type___$DomPropsMixin,
     _$key__value___$DomPropsMixin,
     _$key__width___$DomPropsMixin,
     _$key__onAnimationEnd___$DomPropsMixin,


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Same as https://github.com/Workiva/over_react/pull/391 but for `3.1.0-wip`.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Update DomPropsMixin and set label and type back to `dynamic` instead of `String`.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@greglittlefield-wf @aaronlademann-wf @kealjones-wk @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
