### PR TITLE
Revert DOM Props Typing

### DIFF
--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -77,13 +77,14 @@ abstract class _$DomPropsMixin {
 
   Map<String, dynamic> style;
 
-  String accept, acceptCharset, accessKey, action, alt, autoComplete, charSet, classID, className, content, contextMenu,
-    coords, crossOrigin, data, dateTime, dir, encType, form, href, hrefLang, htmlFor, httpEquiv, id, lang, list, manifest, media, mediaGroup,
-    method, name, pattern, placeholder, poster, preload, radioGroup, rel, role, sandbox, scope, scrolling, shape, sizes, src,
-    srcDoc, srcSet, target, title, useMap, wmode;
+  String className, title, id;
 
-  dynamic allowTransparency, cellPadding, cellSpacing, colSpan, contentEditable, download, draggable, frameBorder, height, icon, label,
-    max, maxLength, min, rowSpan, spellCheck, step, tabIndex, type, value, width;
+  dynamic accept, acceptCharset, accessKey, action, allowTransparency, alt, autoComplete, cellPadding, cellSpacing,
+    charSet, classID, colSpan, content, contentEditable, contextMenu, coords, crossOrigin, data, dateTime,
+    dir, download, draggable, encType, form, frameBorder, height, href, hrefLang, htmlFor, httpEquiv, icon, label,
+    lang, list, manifest, max, maxLength, media, mediaGroup, method, min, name, pattern, placeholder,
+    poster, preload, radioGroup, rel, role, rowSpan, sandbox, scope, scrolling, shape, sizes, spellCheck, src, srcDoc,
+    srcSet, step, tabIndex, target, type, useMap, value, width, wmode;
 
   AnimationEventCallback onAnimationEnd, onAnimationIteration, onAnimationStart;
   ClipboardEventCallback onCopy, onCut, onPaste;
@@ -127,13 +128,11 @@ abstract class $SvgPropsMixin {}
 abstract class _$SvgPropsMixin {
   Map get props;
 
-  String clipPath, d, fill, fontFamily, gradientTransform, gradientUnits, markerEnd, markerMid, markerStart,
-    patternContentUnits, patternUnits, points, preserveAspectRatio, spreadMethod, stopColor, stroke,
-    strokeLinecap, textAnchor, transform, version, viewBox, xlinkActuate, xlinkArcrole, xlinkHref, xlinkRole,
-    xlinkShow, xlinkTitle, xlinkType, xmlBase, xmlLang, xmlSpace;
-
-  dynamic cx, cy, dx, dy, fillOpacity, fontSize, fx, fy, offset, opacity, r, rx, ry, stopOpacity, strokeDasharray,
-    strokeOpacity, strokeWidth, x1, x2, x, y1, y2, y;
+  dynamic clipPath, cx, cy, d, dx, dy, fill, fillOpacity, fontFamily, fontSize, fx, fy, gradientTransform,
+    gradientUnits, markerEnd, markerMid, markerStart, offset, opacity, patternContentUnits, patternUnits, points,
+    preserveAspectRatio, r, rx, ry, spreadMethod, stopColor, stopOpacity, stroke, strokeDasharray, strokeLinecap,
+    strokeOpacity, strokeWidth, textAnchor, transform, version, viewBox, x1, x2, x, xlinkActuate, xlinkArcrole,
+    xlinkHref, xlinkRole, xlinkShow, xlinkTitle, xlinkType, xmlBase, xmlLang, xmlSpace, y1, y2, y;
 }
 /// This class is only present to allow for consumers which have used the
 /// --backwards-compat flag with over_react_codemod to statically analyze:

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -295,81 +295,6 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set style(Map<String, dynamic> value) =>
       props[_$key__style___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.accept] -->
-  @override
-  String get accept =>
-      props[_$key__accept___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.accept] -->
-  @override
-  set accept(String value) => props[_$key__accept___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
-  @override
-  String get acceptCharset =>
-      props[_$key__acceptCharset___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
-  @override
-  set acceptCharset(String value) =>
-      props[_$key__acceptCharset___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
-  @override
-  String get accessKey =>
-      props[_$key__accessKey___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
-  @override
-  set accessKey(String value) =>
-      props[_$key__accessKey___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.action] -->
-  @override
-  String get action =>
-      props[_$key__action___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.action] -->
-  @override
-  set action(String value) => props[_$key__action___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.alt] -->
-  @override
-  String get alt =>
-      props[_$key__alt___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.alt] -->
-  @override
-  set alt(String value) => props[_$key__alt___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
-  @override
-  String get autoComplete =>
-      props[_$key__autoComplete___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
-  @override
-  set autoComplete(String value) =>
-      props[_$key__autoComplete___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
-  @override
-  String get charSet =>
-      props[_$key__charSet___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
-  @override
-  set charSet(String value) => props[_$key__charSet___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.classID] -->
-  @override
-  String get classID =>
-      props[_$key__classID___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.classID] -->
-  @override
-  set classID(String value) => props[_$key__classID___$DomPropsMixin] = value;
-
   /// <!-- Generated from [_$DomPropsMixin.className] -->
   @override
   String get className =>
@@ -380,125 +305,14 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set className(String value) =>
       props[_$key__className___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.content] -->
+  /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
-  String get content =>
-      props[_$key__content___$DomPropsMixin] ??
+  String get title =>
+      props[_$key__title___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.content] -->
+  /// <!-- Generated from [_$DomPropsMixin.title] -->
   @override
-  set content(String value) => props[_$key__content___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
-  @override
-  String get contextMenu =>
-      props[_$key__contextMenu___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
-  @override
-  set contextMenu(String value) =>
-      props[_$key__contextMenu___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.coords] -->
-  @override
-  String get coords =>
-      props[_$key__coords___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.coords] -->
-  @override
-  set coords(String value) => props[_$key__coords___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
-  @override
-  String get crossOrigin =>
-      props[_$key__crossOrigin___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
-  @override
-  set crossOrigin(String value) =>
-      props[_$key__crossOrigin___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.data] -->
-  @override
-  String get data =>
-      props[_$key__data___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.data] -->
-  @override
-  set data(String value) => props[_$key__data___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
-  @override
-  String get dateTime =>
-      props[_$key__dateTime___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
-  @override
-  set dateTime(String value) => props[_$key__dateTime___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.dir] -->
-  @override
-  String get dir =>
-      props[_$key__dir___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.dir] -->
-  @override
-  set dir(String value) => props[_$key__dir___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.encType] -->
-  @override
-  String get encType =>
-      props[_$key__encType___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.encType] -->
-  @override
-  set encType(String value) => props[_$key__encType___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.form] -->
-  @override
-  String get form =>
-      props[_$key__form___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.form] -->
-  @override
-  set form(String value) => props[_$key__form___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.href] -->
-  @override
-  String get href =>
-      props[_$key__href___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.href] -->
-  @override
-  set href(String value) => props[_$key__href___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
-  @override
-  String get hrefLang =>
-      props[_$key__hrefLang___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
-  @override
-  set hrefLang(String value) => props[_$key__hrefLang___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
-  @override
-  String get htmlFor =>
-      props[_$key__htmlFor___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
-  @override
-  set htmlFor(String value) => props[_$key__htmlFor___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
-  @override
-  String get httpEquiv =>
-      props[_$key__httpEquiv___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
-  @override
-  set httpEquiv(String value) =>
-      props[_$key__httpEquiv___$DomPropsMixin] = value;
+  set title(String value) => props[_$key__title___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.id] -->
   @override
@@ -509,243 +323,43 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set id(String value) => props[_$key__id___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.lang] -->
+  /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
-  String get lang =>
-      props[_$key__lang___$DomPropsMixin] ??
+  dynamic get accept =>
+      props[_$key__accept___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.lang] -->
+  /// <!-- Generated from [_$DomPropsMixin.accept] -->
   @override
-  set lang(String value) => props[_$key__lang___$DomPropsMixin] = value;
+  set accept(dynamic value) => props[_$key__accept___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.list] -->
+  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
-  String get list =>
-      props[_$key__list___$DomPropsMixin] ??
+  dynamic get acceptCharset =>
+      props[_$key__acceptCharset___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.list] -->
+  /// <!-- Generated from [_$DomPropsMixin.acceptCharset] -->
   @override
-  set list(String value) => props[_$key__list___$DomPropsMixin] = value;
+  set acceptCharset(dynamic value) =>
+      props[_$key__acceptCharset___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
+  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
-  String get manifest =>
-      props[_$key__manifest___$DomPropsMixin] ??
+  dynamic get accessKey =>
+      props[_$key__accessKey___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
+  /// <!-- Generated from [_$DomPropsMixin.accessKey] -->
   @override
-  set manifest(String value) => props[_$key__manifest___$DomPropsMixin] = value;
+  set accessKey(dynamic value) =>
+      props[_$key__accessKey___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.media] -->
+  /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
-  String get media =>
-      props[_$key__media___$DomPropsMixin] ??
+  dynamic get action =>
+      props[_$key__action___$DomPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.media] -->
+  /// <!-- Generated from [_$DomPropsMixin.action] -->
   @override
-  set media(String value) => props[_$key__media___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
-  @override
-  String get mediaGroup =>
-      props[_$key__mediaGroup___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
-  @override
-  set mediaGroup(String value) =>
-      props[_$key__mediaGroup___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.method] -->
-  @override
-  String get method =>
-      props[_$key__method___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.method] -->
-  @override
-  set method(String value) => props[_$key__method___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.name] -->
-  @override
-  String get name =>
-      props[_$key__name___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.name] -->
-  @override
-  set name(String value) => props[_$key__name___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
-  @override
-  String get pattern =>
-      props[_$key__pattern___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
-  @override
-  set pattern(String value) => props[_$key__pattern___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
-  @override
-  String get placeholder =>
-      props[_$key__placeholder___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
-  @override
-  set placeholder(String value) =>
-      props[_$key__placeholder___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.poster] -->
-  @override
-  String get poster =>
-      props[_$key__poster___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.poster] -->
-  @override
-  set poster(String value) => props[_$key__poster___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.preload] -->
-  @override
-  String get preload =>
-      props[_$key__preload___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.preload] -->
-  @override
-  set preload(String value) => props[_$key__preload___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
-  @override
-  String get radioGroup =>
-      props[_$key__radioGroup___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
-  @override
-  set radioGroup(String value) =>
-      props[_$key__radioGroup___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.rel] -->
-  @override
-  String get rel =>
-      props[_$key__rel___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.rel] -->
-  @override
-  set rel(String value) => props[_$key__rel___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.role] -->
-  @override
-  String get role =>
-      props[_$key__role___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.role] -->
-  @override
-  set role(String value) => props[_$key__role___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
-  @override
-  String get sandbox =>
-      props[_$key__sandbox___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
-  @override
-  set sandbox(String value) => props[_$key__sandbox___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.scope] -->
-  @override
-  String get scope =>
-      props[_$key__scope___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.scope] -->
-  @override
-  set scope(String value) => props[_$key__scope___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
-  @override
-  String get scrolling =>
-      props[_$key__scrolling___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
-  @override
-  set scrolling(String value) =>
-      props[_$key__scrolling___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.shape] -->
-  @override
-  String get shape =>
-      props[_$key__shape___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.shape] -->
-  @override
-  set shape(String value) => props[_$key__shape___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
-  @override
-  String get sizes =>
-      props[_$key__sizes___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
-  @override
-  set sizes(String value) => props[_$key__sizes___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.src] -->
-  @override
-  String get src =>
-      props[_$key__src___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.src] -->
-  @override
-  set src(String value) => props[_$key__src___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
-  @override
-  String get srcDoc =>
-      props[_$key__srcDoc___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
-  @override
-  set srcDoc(String value) => props[_$key__srcDoc___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
-  @override
-  String get srcSet =>
-      props[_$key__srcSet___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
-  @override
-  set srcSet(String value) => props[_$key__srcSet___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.target] -->
-  @override
-  String get target =>
-      props[_$key__target___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.target] -->
-  @override
-  set target(String value) => props[_$key__target___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.title] -->
-  @override
-  String get title =>
-      props[_$key__title___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.title] -->
-  @override
-  set title(String value) => props[_$key__title___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
-  @override
-  String get useMap =>
-      props[_$key__useMap___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
-  @override
-  set useMap(String value) => props[_$key__useMap___$DomPropsMixin] = value;
-
-  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
-  @override
-  String get wmode =>
-      props[_$key__wmode___$DomPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
-  @override
-  set wmode(String value) => props[_$key__wmode___$DomPropsMixin] = value;
+  set action(dynamic value) => props[_$key__action___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.allowTransparency] -->
   @override
@@ -756,6 +370,25 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set allowTransparency(dynamic value) =>
       props[_$key__allowTransparency___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.alt] -->
+  @override
+  dynamic get alt =>
+      props[_$key__alt___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.alt] -->
+  @override
+  set alt(dynamic value) => props[_$key__alt___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
+  @override
+  dynamic get autoComplete =>
+      props[_$key__autoComplete___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.autoComplete] -->
+  @override
+  set autoComplete(dynamic value) =>
+      props[_$key__autoComplete___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.cellPadding] -->
   @override
@@ -777,6 +410,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set cellSpacing(dynamic value) =>
       props[_$key__cellSpacing___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
+  @override
+  dynamic get charSet =>
+      props[_$key__charSet___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.charSet] -->
+  @override
+  set charSet(dynamic value) => props[_$key__charSet___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.classID] -->
+  @override
+  dynamic get classID =>
+      props[_$key__classID___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.classID] -->
+  @override
+  set classID(dynamic value) => props[_$key__classID___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
   dynamic get colSpan =>
@@ -785,6 +436,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.colSpan] -->
   @override
   set colSpan(dynamic value) => props[_$key__colSpan___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.content] -->
+  @override
+  dynamic get content =>
+      props[_$key__content___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.content] -->
+  @override
+  set content(dynamic value) => props[_$key__content___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.contentEditable] -->
   @override
@@ -795,6 +455,63 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set contentEditable(dynamic value) =>
       props[_$key__contentEditable___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
+  @override
+  dynamic get contextMenu =>
+      props[_$key__contextMenu___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.contextMenu] -->
+  @override
+  set contextMenu(dynamic value) =>
+      props[_$key__contextMenu___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.coords] -->
+  @override
+  dynamic get coords =>
+      props[_$key__coords___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.coords] -->
+  @override
+  set coords(dynamic value) => props[_$key__coords___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
+  @override
+  dynamic get crossOrigin =>
+      props[_$key__crossOrigin___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.crossOrigin] -->
+  @override
+  set crossOrigin(dynamic value) =>
+      props[_$key__crossOrigin___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.data] -->
+  @override
+  dynamic get data =>
+      props[_$key__data___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.data] -->
+  @override
+  set data(dynamic value) => props[_$key__data___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
+  @override
+  dynamic get dateTime =>
+      props[_$key__dateTime___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.dateTime] -->
+  @override
+  set dateTime(dynamic value) =>
+      props[_$key__dateTime___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.dir] -->
+  @override
+  dynamic get dir =>
+      props[_$key__dir___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.dir] -->
+  @override
+  set dir(dynamic value) => props[_$key__dir___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.download] -->
   @override
@@ -816,6 +533,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set draggable(dynamic value) =>
       props[_$key__draggable___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.encType] -->
+  @override
+  dynamic get encType =>
+      props[_$key__encType___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.encType] -->
+  @override
+  set encType(dynamic value) => props[_$key__encType___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.form] -->
+  @override
+  dynamic get form =>
+      props[_$key__form___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.form] -->
+  @override
+  set form(dynamic value) => props[_$key__form___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.frameBorder] -->
   @override
   dynamic get frameBorder =>
@@ -835,6 +570,44 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set height(dynamic value) => props[_$key__height___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.href] -->
+  @override
+  dynamic get href =>
+      props[_$key__href___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.href] -->
+  @override
+  set href(dynamic value) => props[_$key__href___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
+  @override
+  dynamic get hrefLang =>
+      props[_$key__hrefLang___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.hrefLang] -->
+  @override
+  set hrefLang(dynamic value) =>
+      props[_$key__hrefLang___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
+  @override
+  dynamic get htmlFor =>
+      props[_$key__htmlFor___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.htmlFor] -->
+  @override
+  set htmlFor(dynamic value) => props[_$key__htmlFor___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
+  @override
+  dynamic get httpEquiv =>
+      props[_$key__httpEquiv___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.httpEquiv] -->
+  @override
+  set httpEquiv(dynamic value) =>
+      props[_$key__httpEquiv___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.icon] -->
   @override
   dynamic get icon =>
@@ -852,6 +625,34 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.label] -->
   @override
   set label(dynamic value) => props[_$key__label___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.lang] -->
+  @override
+  dynamic get lang =>
+      props[_$key__lang___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.lang] -->
+  @override
+  set lang(dynamic value) => props[_$key__lang___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.list] -->
+  @override
+  dynamic get list =>
+      props[_$key__list___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.list] -->
+  @override
+  set list(dynamic value) => props[_$key__list___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
+  @override
+  dynamic get manifest =>
+      props[_$key__manifest___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.manifest] -->
+  @override
+  set manifest(dynamic value) =>
+      props[_$key__manifest___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.max] -->
   @override
@@ -872,6 +673,34 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set maxLength(dynamic value) =>
       props[_$key__maxLength___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.media] -->
+  @override
+  dynamic get media =>
+      props[_$key__media___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.media] -->
+  @override
+  set media(dynamic value) => props[_$key__media___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
+  @override
+  dynamic get mediaGroup =>
+      props[_$key__mediaGroup___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.mediaGroup] -->
+  @override
+  set mediaGroup(dynamic value) =>
+      props[_$key__mediaGroup___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.method] -->
+  @override
+  dynamic get method =>
+      props[_$key__method___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.method] -->
+  @override
+  set method(dynamic value) => props[_$key__method___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
   dynamic get min =>
@@ -880,6 +709,80 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.min] -->
   @override
   set min(dynamic value) => props[_$key__min___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.name] -->
+  @override
+  dynamic get name =>
+      props[_$key__name___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.name] -->
+  @override
+  set name(dynamic value) => props[_$key__name___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
+  @override
+  dynamic get pattern =>
+      props[_$key__pattern___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.pattern] -->
+  @override
+  set pattern(dynamic value) => props[_$key__pattern___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
+  @override
+  dynamic get placeholder =>
+      props[_$key__placeholder___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.placeholder] -->
+  @override
+  set placeholder(dynamic value) =>
+      props[_$key__placeholder___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.poster] -->
+  @override
+  dynamic get poster =>
+      props[_$key__poster___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.poster] -->
+  @override
+  set poster(dynamic value) => props[_$key__poster___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.preload] -->
+  @override
+  dynamic get preload =>
+      props[_$key__preload___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.preload] -->
+  @override
+  set preload(dynamic value) => props[_$key__preload___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
+  @override
+  dynamic get radioGroup =>
+      props[_$key__radioGroup___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.radioGroup] -->
+  @override
+  set radioGroup(dynamic value) =>
+      props[_$key__radioGroup___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.rel] -->
+  @override
+  dynamic get rel =>
+      props[_$key__rel___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.rel] -->
+  @override
+  set rel(dynamic value) => props[_$key__rel___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.role] -->
+  @override
+  dynamic get role =>
+      props[_$key__role___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.role] -->
+  @override
+  set role(dynamic value) => props[_$key__role___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.rowSpan] -->
   @override
@@ -890,6 +793,52 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set rowSpan(dynamic value) => props[_$key__rowSpan___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
+  @override
+  dynamic get sandbox =>
+      props[_$key__sandbox___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.sandbox] -->
+  @override
+  set sandbox(dynamic value) => props[_$key__sandbox___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.scope] -->
+  @override
+  dynamic get scope =>
+      props[_$key__scope___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.scope] -->
+  @override
+  set scope(dynamic value) => props[_$key__scope___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
+  @override
+  dynamic get scrolling =>
+      props[_$key__scrolling___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.scrolling] -->
+  @override
+  set scrolling(dynamic value) =>
+      props[_$key__scrolling___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.shape] -->
+  @override
+  dynamic get shape =>
+      props[_$key__shape___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.shape] -->
+  @override
+  set shape(dynamic value) => props[_$key__shape___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
+  @override
+  dynamic get sizes =>
+      props[_$key__sizes___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.sizes] -->
+  @override
+  set sizes(dynamic value) => props[_$key__sizes___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.spellCheck] -->
   @override
   dynamic get spellCheck =>
@@ -899,6 +848,33 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set spellCheck(dynamic value) =>
       props[_$key__spellCheck___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.src] -->
+  @override
+  dynamic get src =>
+      props[_$key__src___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.src] -->
+  @override
+  set src(dynamic value) => props[_$key__src___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
+  @override
+  dynamic get srcDoc =>
+      props[_$key__srcDoc___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.srcDoc] -->
+  @override
+  set srcDoc(dynamic value) => props[_$key__srcDoc___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
+  @override
+  dynamic get srcSet =>
+      props[_$key__srcSet___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.srcSet] -->
+  @override
+  set srcSet(dynamic value) => props[_$key__srcSet___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.step] -->
   @override
@@ -919,6 +895,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   set tabIndex(dynamic value) =>
       props[_$key__tabIndex___$DomPropsMixin] = value;
 
+  /// <!-- Generated from [_$DomPropsMixin.target] -->
+  @override
+  dynamic get target =>
+      props[_$key__target___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.target] -->
+  @override
+  set target(dynamic value) => props[_$key__target___$DomPropsMixin] = value;
+
   /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
   dynamic get type =>
@@ -927,6 +912,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.type] -->
   @override
   set type(dynamic value) => props[_$key__type___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
+  @override
+  dynamic get useMap =>
+      props[_$key__useMap___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.useMap] -->
+  @override
+  set useMap(dynamic value) => props[_$key__useMap___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.value] -->
   @override
@@ -945,6 +939,15 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   /// <!-- Generated from [_$DomPropsMixin.width] -->
   @override
   set width(dynamic value) => props[_$key__width___$DomPropsMixin] = value;
+
+  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
+  @override
+  dynamic get wmode =>
+      props[_$key__wmode___$DomPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$DomPropsMixin.wmode] -->
+  @override
+  set wmode(dynamic value) => props[_$key__wmode___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.onAnimationEnd] -->
   @override
@@ -1789,6 +1792,12 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__selected___$DomPropsMixin);
   static const PropDescriptor _$prop__style___$DomPropsMixin =
       const PropDescriptor(_$key__style___$DomPropsMixin);
+  static const PropDescriptor _$prop__className___$DomPropsMixin =
+      const PropDescriptor(_$key__className___$DomPropsMixin);
+  static const PropDescriptor _$prop__title___$DomPropsMixin =
+      const PropDescriptor(_$key__title___$DomPropsMixin);
+  static const PropDescriptor _$prop__id___$DomPropsMixin =
+      const PropDescriptor(_$key__id___$DomPropsMixin);
   static const PropDescriptor _$prop__accept___$DomPropsMixin =
       const PropDescriptor(_$key__accept___$DomPropsMixin);
   static const PropDescriptor _$prop__acceptCharset___$DomPropsMixin =
@@ -1797,18 +1806,26 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__accessKey___$DomPropsMixin);
   static const PropDescriptor _$prop__action___$DomPropsMixin =
       const PropDescriptor(_$key__action___$DomPropsMixin);
+  static const PropDescriptor _$prop__allowTransparency___$DomPropsMixin =
+      const PropDescriptor(_$key__allowTransparency___$DomPropsMixin);
   static const PropDescriptor _$prop__alt___$DomPropsMixin =
       const PropDescriptor(_$key__alt___$DomPropsMixin);
   static const PropDescriptor _$prop__autoComplete___$DomPropsMixin =
       const PropDescriptor(_$key__autoComplete___$DomPropsMixin);
+  static const PropDescriptor _$prop__cellPadding___$DomPropsMixin =
+      const PropDescriptor(_$key__cellPadding___$DomPropsMixin);
+  static const PropDescriptor _$prop__cellSpacing___$DomPropsMixin =
+      const PropDescriptor(_$key__cellSpacing___$DomPropsMixin);
   static const PropDescriptor _$prop__charSet___$DomPropsMixin =
       const PropDescriptor(_$key__charSet___$DomPropsMixin);
   static const PropDescriptor _$prop__classID___$DomPropsMixin =
       const PropDescriptor(_$key__classID___$DomPropsMixin);
-  static const PropDescriptor _$prop__className___$DomPropsMixin =
-      const PropDescriptor(_$key__className___$DomPropsMixin);
+  static const PropDescriptor _$prop__colSpan___$DomPropsMixin =
+      const PropDescriptor(_$key__colSpan___$DomPropsMixin);
   static const PropDescriptor _$prop__content___$DomPropsMixin =
       const PropDescriptor(_$key__content___$DomPropsMixin);
+  static const PropDescriptor _$prop__contentEditable___$DomPropsMixin =
+      const PropDescriptor(_$key__contentEditable___$DomPropsMixin);
   static const PropDescriptor _$prop__contextMenu___$DomPropsMixin =
       const PropDescriptor(_$key__contextMenu___$DomPropsMixin);
   static const PropDescriptor _$prop__coords___$DomPropsMixin =
@@ -1821,10 +1838,18 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__dateTime___$DomPropsMixin);
   static const PropDescriptor _$prop__dir___$DomPropsMixin =
       const PropDescriptor(_$key__dir___$DomPropsMixin);
+  static const PropDescriptor _$prop__download___$DomPropsMixin =
+      const PropDescriptor(_$key__download___$DomPropsMixin);
+  static const PropDescriptor _$prop__draggable___$DomPropsMixin =
+      const PropDescriptor(_$key__draggable___$DomPropsMixin);
   static const PropDescriptor _$prop__encType___$DomPropsMixin =
       const PropDescriptor(_$key__encType___$DomPropsMixin);
   static const PropDescriptor _$prop__form___$DomPropsMixin =
       const PropDescriptor(_$key__form___$DomPropsMixin);
+  static const PropDescriptor _$prop__frameBorder___$DomPropsMixin =
+      const PropDescriptor(_$key__frameBorder___$DomPropsMixin);
+  static const PropDescriptor _$prop__height___$DomPropsMixin =
+      const PropDescriptor(_$key__height___$DomPropsMixin);
   static const PropDescriptor _$prop__href___$DomPropsMixin =
       const PropDescriptor(_$key__href___$DomPropsMixin);
   static const PropDescriptor _$prop__hrefLang___$DomPropsMixin =
@@ -1833,20 +1858,28 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__htmlFor___$DomPropsMixin);
   static const PropDescriptor _$prop__httpEquiv___$DomPropsMixin =
       const PropDescriptor(_$key__httpEquiv___$DomPropsMixin);
-  static const PropDescriptor _$prop__id___$DomPropsMixin =
-      const PropDescriptor(_$key__id___$DomPropsMixin);
+  static const PropDescriptor _$prop__icon___$DomPropsMixin =
+      const PropDescriptor(_$key__icon___$DomPropsMixin);
+  static const PropDescriptor _$prop__label___$DomPropsMixin =
+      const PropDescriptor(_$key__label___$DomPropsMixin);
   static const PropDescriptor _$prop__lang___$DomPropsMixin =
       const PropDescriptor(_$key__lang___$DomPropsMixin);
   static const PropDescriptor _$prop__list___$DomPropsMixin =
       const PropDescriptor(_$key__list___$DomPropsMixin);
   static const PropDescriptor _$prop__manifest___$DomPropsMixin =
       const PropDescriptor(_$key__manifest___$DomPropsMixin);
+  static const PropDescriptor _$prop__max___$DomPropsMixin =
+      const PropDescriptor(_$key__max___$DomPropsMixin);
+  static const PropDescriptor _$prop__maxLength___$DomPropsMixin =
+      const PropDescriptor(_$key__maxLength___$DomPropsMixin);
   static const PropDescriptor _$prop__media___$DomPropsMixin =
       const PropDescriptor(_$key__media___$DomPropsMixin);
   static const PropDescriptor _$prop__mediaGroup___$DomPropsMixin =
       const PropDescriptor(_$key__mediaGroup___$DomPropsMixin);
   static const PropDescriptor _$prop__method___$DomPropsMixin =
       const PropDescriptor(_$key__method___$DomPropsMixin);
+  static const PropDescriptor _$prop__min___$DomPropsMixin =
+      const PropDescriptor(_$key__min___$DomPropsMixin);
   static const PropDescriptor _$prop__name___$DomPropsMixin =
       const PropDescriptor(_$key__name___$DomPropsMixin);
   static const PropDescriptor _$prop__pattern___$DomPropsMixin =
@@ -1863,6 +1896,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__rel___$DomPropsMixin);
   static const PropDescriptor _$prop__role___$DomPropsMixin =
       const PropDescriptor(_$key__role___$DomPropsMixin);
+  static const PropDescriptor _$prop__rowSpan___$DomPropsMixin =
+      const PropDescriptor(_$key__rowSpan___$DomPropsMixin);
   static const PropDescriptor _$prop__sandbox___$DomPropsMixin =
       const PropDescriptor(_$key__sandbox___$DomPropsMixin);
   static const PropDescriptor _$prop__scope___$DomPropsMixin =
@@ -1873,62 +1908,30 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       const PropDescriptor(_$key__shape___$DomPropsMixin);
   static const PropDescriptor _$prop__sizes___$DomPropsMixin =
       const PropDescriptor(_$key__sizes___$DomPropsMixin);
+  static const PropDescriptor _$prop__spellCheck___$DomPropsMixin =
+      const PropDescriptor(_$key__spellCheck___$DomPropsMixin);
   static const PropDescriptor _$prop__src___$DomPropsMixin =
       const PropDescriptor(_$key__src___$DomPropsMixin);
   static const PropDescriptor _$prop__srcDoc___$DomPropsMixin =
       const PropDescriptor(_$key__srcDoc___$DomPropsMixin);
   static const PropDescriptor _$prop__srcSet___$DomPropsMixin =
       const PropDescriptor(_$key__srcSet___$DomPropsMixin);
-  static const PropDescriptor _$prop__target___$DomPropsMixin =
-      const PropDescriptor(_$key__target___$DomPropsMixin);
-  static const PropDescriptor _$prop__title___$DomPropsMixin =
-      const PropDescriptor(_$key__title___$DomPropsMixin);
-  static const PropDescriptor _$prop__useMap___$DomPropsMixin =
-      const PropDescriptor(_$key__useMap___$DomPropsMixin);
-  static const PropDescriptor _$prop__wmode___$DomPropsMixin =
-      const PropDescriptor(_$key__wmode___$DomPropsMixin);
-  static const PropDescriptor _$prop__allowTransparency___$DomPropsMixin =
-      const PropDescriptor(_$key__allowTransparency___$DomPropsMixin);
-  static const PropDescriptor _$prop__cellPadding___$DomPropsMixin =
-      const PropDescriptor(_$key__cellPadding___$DomPropsMixin);
-  static const PropDescriptor _$prop__cellSpacing___$DomPropsMixin =
-      const PropDescriptor(_$key__cellSpacing___$DomPropsMixin);
-  static const PropDescriptor _$prop__colSpan___$DomPropsMixin =
-      const PropDescriptor(_$key__colSpan___$DomPropsMixin);
-  static const PropDescriptor _$prop__contentEditable___$DomPropsMixin =
-      const PropDescriptor(_$key__contentEditable___$DomPropsMixin);
-  static const PropDescriptor _$prop__download___$DomPropsMixin =
-      const PropDescriptor(_$key__download___$DomPropsMixin);
-  static const PropDescriptor _$prop__draggable___$DomPropsMixin =
-      const PropDescriptor(_$key__draggable___$DomPropsMixin);
-  static const PropDescriptor _$prop__frameBorder___$DomPropsMixin =
-      const PropDescriptor(_$key__frameBorder___$DomPropsMixin);
-  static const PropDescriptor _$prop__height___$DomPropsMixin =
-      const PropDescriptor(_$key__height___$DomPropsMixin);
-  static const PropDescriptor _$prop__icon___$DomPropsMixin =
-      const PropDescriptor(_$key__icon___$DomPropsMixin);
-  static const PropDescriptor _$prop__label___$DomPropsMixin =
-      const PropDescriptor(_$key__label___$DomPropsMixin);
-  static const PropDescriptor _$prop__max___$DomPropsMixin =
-      const PropDescriptor(_$key__max___$DomPropsMixin);
-  static const PropDescriptor _$prop__maxLength___$DomPropsMixin =
-      const PropDescriptor(_$key__maxLength___$DomPropsMixin);
-  static const PropDescriptor _$prop__min___$DomPropsMixin =
-      const PropDescriptor(_$key__min___$DomPropsMixin);
-  static const PropDescriptor _$prop__rowSpan___$DomPropsMixin =
-      const PropDescriptor(_$key__rowSpan___$DomPropsMixin);
-  static const PropDescriptor _$prop__spellCheck___$DomPropsMixin =
-      const PropDescriptor(_$key__spellCheck___$DomPropsMixin);
   static const PropDescriptor _$prop__step___$DomPropsMixin =
       const PropDescriptor(_$key__step___$DomPropsMixin);
   static const PropDescriptor _$prop__tabIndex___$DomPropsMixin =
       const PropDescriptor(_$key__tabIndex___$DomPropsMixin);
+  static const PropDescriptor _$prop__target___$DomPropsMixin =
+      const PropDescriptor(_$key__target___$DomPropsMixin);
   static const PropDescriptor _$prop__type___$DomPropsMixin =
       const PropDescriptor(_$key__type___$DomPropsMixin);
+  static const PropDescriptor _$prop__useMap___$DomPropsMixin =
+      const PropDescriptor(_$key__useMap___$DomPropsMixin);
   static const PropDescriptor _$prop__value___$DomPropsMixin =
       const PropDescriptor(_$key__value___$DomPropsMixin);
   static const PropDescriptor _$prop__width___$DomPropsMixin =
       const PropDescriptor(_$key__width___$DomPropsMixin);
+  static const PropDescriptor _$prop__wmode___$DomPropsMixin =
+      const PropDescriptor(_$key__wmode___$DomPropsMixin);
   static const PropDescriptor _$prop__onAnimationEnd___$DomPropsMixin =
       const PropDescriptor(_$key__onAnimationEnd___$DomPropsMixin);
   static const PropDescriptor _$prop__onAnimationIteration___$DomPropsMixin =
@@ -2112,35 +2115,52 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__seamless___$DomPropsMixin = 'seamless';
   static const String _$key__selected___$DomPropsMixin = 'selected';
   static const String _$key__style___$DomPropsMixin = 'style';
+  static const String _$key__className___$DomPropsMixin = 'className';
+  static const String _$key__title___$DomPropsMixin = 'title';
+  static const String _$key__id___$DomPropsMixin = 'id';
   static const String _$key__accept___$DomPropsMixin = 'accept';
   static const String _$key__acceptCharset___$DomPropsMixin = 'acceptCharset';
   static const String _$key__accessKey___$DomPropsMixin = 'accessKey';
   static const String _$key__action___$DomPropsMixin = 'action';
+  static const String _$key__allowTransparency___$DomPropsMixin =
+      'allowTransparency';
   static const String _$key__alt___$DomPropsMixin = 'alt';
   static const String _$key__autoComplete___$DomPropsMixin = 'autoComplete';
+  static const String _$key__cellPadding___$DomPropsMixin = 'cellPadding';
+  static const String _$key__cellSpacing___$DomPropsMixin = 'cellSpacing';
   static const String _$key__charSet___$DomPropsMixin = 'charSet';
   static const String _$key__classID___$DomPropsMixin = 'classID';
-  static const String _$key__className___$DomPropsMixin = 'className';
+  static const String _$key__colSpan___$DomPropsMixin = 'colSpan';
   static const String _$key__content___$DomPropsMixin = 'content';
+  static const String _$key__contentEditable___$DomPropsMixin =
+      'contentEditable';
   static const String _$key__contextMenu___$DomPropsMixin = 'contextMenu';
   static const String _$key__coords___$DomPropsMixin = 'coords';
   static const String _$key__crossOrigin___$DomPropsMixin = 'crossOrigin';
   static const String _$key__data___$DomPropsMixin = 'data';
   static const String _$key__dateTime___$DomPropsMixin = 'dateTime';
   static const String _$key__dir___$DomPropsMixin = 'dir';
+  static const String _$key__download___$DomPropsMixin = 'download';
+  static const String _$key__draggable___$DomPropsMixin = 'draggable';
   static const String _$key__encType___$DomPropsMixin = 'encType';
   static const String _$key__form___$DomPropsMixin = 'form';
+  static const String _$key__frameBorder___$DomPropsMixin = 'frameBorder';
+  static const String _$key__height___$DomPropsMixin = 'height';
   static const String _$key__href___$DomPropsMixin = 'href';
   static const String _$key__hrefLang___$DomPropsMixin = 'hrefLang';
   static const String _$key__htmlFor___$DomPropsMixin = 'htmlFor';
   static const String _$key__httpEquiv___$DomPropsMixin = 'httpEquiv';
-  static const String _$key__id___$DomPropsMixin = 'id';
+  static const String _$key__icon___$DomPropsMixin = 'icon';
+  static const String _$key__label___$DomPropsMixin = 'label';
   static const String _$key__lang___$DomPropsMixin = 'lang';
   static const String _$key__list___$DomPropsMixin = 'list';
   static const String _$key__manifest___$DomPropsMixin = 'manifest';
+  static const String _$key__max___$DomPropsMixin = 'max';
+  static const String _$key__maxLength___$DomPropsMixin = 'maxLength';
   static const String _$key__media___$DomPropsMixin = 'media';
   static const String _$key__mediaGroup___$DomPropsMixin = 'mediaGroup';
   static const String _$key__method___$DomPropsMixin = 'method';
+  static const String _$key__min___$DomPropsMixin = 'min';
   static const String _$key__name___$DomPropsMixin = 'name';
   static const String _$key__pattern___$DomPropsMixin = 'pattern';
   static const String _$key__placeholder___$DomPropsMixin = 'placeholder';
@@ -2149,41 +2169,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__radioGroup___$DomPropsMixin = 'radioGroup';
   static const String _$key__rel___$DomPropsMixin = 'rel';
   static const String _$key__role___$DomPropsMixin = 'role';
+  static const String _$key__rowSpan___$DomPropsMixin = 'rowSpan';
   static const String _$key__sandbox___$DomPropsMixin = 'sandbox';
   static const String _$key__scope___$DomPropsMixin = 'scope';
   static const String _$key__scrolling___$DomPropsMixin = 'scrolling';
   static const String _$key__shape___$DomPropsMixin = 'shape';
   static const String _$key__sizes___$DomPropsMixin = 'sizes';
+  static const String _$key__spellCheck___$DomPropsMixin = 'spellCheck';
   static const String _$key__src___$DomPropsMixin = 'src';
   static const String _$key__srcDoc___$DomPropsMixin = 'srcDoc';
   static const String _$key__srcSet___$DomPropsMixin = 'srcSet';
-  static const String _$key__target___$DomPropsMixin = 'target';
-  static const String _$key__title___$DomPropsMixin = 'title';
-  static const String _$key__useMap___$DomPropsMixin = 'useMap';
-  static const String _$key__wmode___$DomPropsMixin = 'wmode';
-  static const String _$key__allowTransparency___$DomPropsMixin =
-      'allowTransparency';
-  static const String _$key__cellPadding___$DomPropsMixin = 'cellPadding';
-  static const String _$key__cellSpacing___$DomPropsMixin = 'cellSpacing';
-  static const String _$key__colSpan___$DomPropsMixin = 'colSpan';
-  static const String _$key__contentEditable___$DomPropsMixin =
-      'contentEditable';
-  static const String _$key__download___$DomPropsMixin = 'download';
-  static const String _$key__draggable___$DomPropsMixin = 'draggable';
-  static const String _$key__frameBorder___$DomPropsMixin = 'frameBorder';
-  static const String _$key__height___$DomPropsMixin = 'height';
-  static const String _$key__icon___$DomPropsMixin = 'icon';
-  static const String _$key__label___$DomPropsMixin = 'label';
-  static const String _$key__max___$DomPropsMixin = 'max';
-  static const String _$key__maxLength___$DomPropsMixin = 'maxLength';
-  static const String _$key__min___$DomPropsMixin = 'min';
-  static const String _$key__rowSpan___$DomPropsMixin = 'rowSpan';
-  static const String _$key__spellCheck___$DomPropsMixin = 'spellCheck';
   static const String _$key__step___$DomPropsMixin = 'step';
   static const String _$key__tabIndex___$DomPropsMixin = 'tabIndex';
+  static const String _$key__target___$DomPropsMixin = 'target';
   static const String _$key__type___$DomPropsMixin = 'type';
+  static const String _$key__useMap___$DomPropsMixin = 'useMap';
   static const String _$key__value___$DomPropsMixin = 'value';
   static const String _$key__width___$DomPropsMixin = 'width';
+  static const String _$key__wmode___$DomPropsMixin = 'wmode';
   static const String _$key__onAnimationEnd___$DomPropsMixin = 'onAnimationEnd';
   static const String _$key__onAnimationIteration___$DomPropsMixin =
       'onAnimationIteration';
@@ -2316,35 +2319,50 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__seamless___$DomPropsMixin,
     _$prop__selected___$DomPropsMixin,
     _$prop__style___$DomPropsMixin,
+    _$prop__className___$DomPropsMixin,
+    _$prop__title___$DomPropsMixin,
+    _$prop__id___$DomPropsMixin,
     _$prop__accept___$DomPropsMixin,
     _$prop__acceptCharset___$DomPropsMixin,
     _$prop__accessKey___$DomPropsMixin,
     _$prop__action___$DomPropsMixin,
+    _$prop__allowTransparency___$DomPropsMixin,
     _$prop__alt___$DomPropsMixin,
     _$prop__autoComplete___$DomPropsMixin,
+    _$prop__cellPadding___$DomPropsMixin,
+    _$prop__cellSpacing___$DomPropsMixin,
     _$prop__charSet___$DomPropsMixin,
     _$prop__classID___$DomPropsMixin,
-    _$prop__className___$DomPropsMixin,
+    _$prop__colSpan___$DomPropsMixin,
     _$prop__content___$DomPropsMixin,
+    _$prop__contentEditable___$DomPropsMixin,
     _$prop__contextMenu___$DomPropsMixin,
     _$prop__coords___$DomPropsMixin,
     _$prop__crossOrigin___$DomPropsMixin,
     _$prop__data___$DomPropsMixin,
     _$prop__dateTime___$DomPropsMixin,
     _$prop__dir___$DomPropsMixin,
+    _$prop__download___$DomPropsMixin,
+    _$prop__draggable___$DomPropsMixin,
     _$prop__encType___$DomPropsMixin,
     _$prop__form___$DomPropsMixin,
+    _$prop__frameBorder___$DomPropsMixin,
+    _$prop__height___$DomPropsMixin,
     _$prop__href___$DomPropsMixin,
     _$prop__hrefLang___$DomPropsMixin,
     _$prop__htmlFor___$DomPropsMixin,
     _$prop__httpEquiv___$DomPropsMixin,
-    _$prop__id___$DomPropsMixin,
+    _$prop__icon___$DomPropsMixin,
+    _$prop__label___$DomPropsMixin,
     _$prop__lang___$DomPropsMixin,
     _$prop__list___$DomPropsMixin,
     _$prop__manifest___$DomPropsMixin,
+    _$prop__max___$DomPropsMixin,
+    _$prop__maxLength___$DomPropsMixin,
     _$prop__media___$DomPropsMixin,
     _$prop__mediaGroup___$DomPropsMixin,
     _$prop__method___$DomPropsMixin,
+    _$prop__min___$DomPropsMixin,
     _$prop__name___$DomPropsMixin,
     _$prop__pattern___$DomPropsMixin,
     _$prop__placeholder___$DomPropsMixin,
@@ -2353,39 +2371,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__radioGroup___$DomPropsMixin,
     _$prop__rel___$DomPropsMixin,
     _$prop__role___$DomPropsMixin,
+    _$prop__rowSpan___$DomPropsMixin,
     _$prop__sandbox___$DomPropsMixin,
     _$prop__scope___$DomPropsMixin,
     _$prop__scrolling___$DomPropsMixin,
     _$prop__shape___$DomPropsMixin,
     _$prop__sizes___$DomPropsMixin,
+    _$prop__spellCheck___$DomPropsMixin,
     _$prop__src___$DomPropsMixin,
     _$prop__srcDoc___$DomPropsMixin,
     _$prop__srcSet___$DomPropsMixin,
-    _$prop__target___$DomPropsMixin,
-    _$prop__title___$DomPropsMixin,
-    _$prop__useMap___$DomPropsMixin,
-    _$prop__wmode___$DomPropsMixin,
-    _$prop__allowTransparency___$DomPropsMixin,
-    _$prop__cellPadding___$DomPropsMixin,
-    _$prop__cellSpacing___$DomPropsMixin,
-    _$prop__colSpan___$DomPropsMixin,
-    _$prop__contentEditable___$DomPropsMixin,
-    _$prop__download___$DomPropsMixin,
-    _$prop__draggable___$DomPropsMixin,
-    _$prop__frameBorder___$DomPropsMixin,
-    _$prop__height___$DomPropsMixin,
-    _$prop__icon___$DomPropsMixin,
-    _$prop__label___$DomPropsMixin,
-    _$prop__max___$DomPropsMixin,
-    _$prop__maxLength___$DomPropsMixin,
-    _$prop__min___$DomPropsMixin,
-    _$prop__rowSpan___$DomPropsMixin,
-    _$prop__spellCheck___$DomPropsMixin,
     _$prop__step___$DomPropsMixin,
     _$prop__tabIndex___$DomPropsMixin,
+    _$prop__target___$DomPropsMixin,
     _$prop__type___$DomPropsMixin,
+    _$prop__useMap___$DomPropsMixin,
     _$prop__value___$DomPropsMixin,
     _$prop__width___$DomPropsMixin,
+    _$prop__wmode___$DomPropsMixin,
     _$prop__onAnimationEnd___$DomPropsMixin,
     _$prop__onAnimationIteration___$DomPropsMixin,
     _$prop__onAnimationStart___$DomPropsMixin,
@@ -2491,35 +2494,50 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__seamless___$DomPropsMixin,
     _$key__selected___$DomPropsMixin,
     _$key__style___$DomPropsMixin,
+    _$key__className___$DomPropsMixin,
+    _$key__title___$DomPropsMixin,
+    _$key__id___$DomPropsMixin,
     _$key__accept___$DomPropsMixin,
     _$key__acceptCharset___$DomPropsMixin,
     _$key__accessKey___$DomPropsMixin,
     _$key__action___$DomPropsMixin,
+    _$key__allowTransparency___$DomPropsMixin,
     _$key__alt___$DomPropsMixin,
     _$key__autoComplete___$DomPropsMixin,
+    _$key__cellPadding___$DomPropsMixin,
+    _$key__cellSpacing___$DomPropsMixin,
     _$key__charSet___$DomPropsMixin,
     _$key__classID___$DomPropsMixin,
-    _$key__className___$DomPropsMixin,
+    _$key__colSpan___$DomPropsMixin,
     _$key__content___$DomPropsMixin,
+    _$key__contentEditable___$DomPropsMixin,
     _$key__contextMenu___$DomPropsMixin,
     _$key__coords___$DomPropsMixin,
     _$key__crossOrigin___$DomPropsMixin,
     _$key__data___$DomPropsMixin,
     _$key__dateTime___$DomPropsMixin,
     _$key__dir___$DomPropsMixin,
+    _$key__download___$DomPropsMixin,
+    _$key__draggable___$DomPropsMixin,
     _$key__encType___$DomPropsMixin,
     _$key__form___$DomPropsMixin,
+    _$key__frameBorder___$DomPropsMixin,
+    _$key__height___$DomPropsMixin,
     _$key__href___$DomPropsMixin,
     _$key__hrefLang___$DomPropsMixin,
     _$key__htmlFor___$DomPropsMixin,
     _$key__httpEquiv___$DomPropsMixin,
-    _$key__id___$DomPropsMixin,
+    _$key__icon___$DomPropsMixin,
+    _$key__label___$DomPropsMixin,
     _$key__lang___$DomPropsMixin,
     _$key__list___$DomPropsMixin,
     _$key__manifest___$DomPropsMixin,
+    _$key__max___$DomPropsMixin,
+    _$key__maxLength___$DomPropsMixin,
     _$key__media___$DomPropsMixin,
     _$key__mediaGroup___$DomPropsMixin,
     _$key__method___$DomPropsMixin,
+    _$key__min___$DomPropsMixin,
     _$key__name___$DomPropsMixin,
     _$key__pattern___$DomPropsMixin,
     _$key__placeholder___$DomPropsMixin,
@@ -2528,39 +2546,24 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__radioGroup___$DomPropsMixin,
     _$key__rel___$DomPropsMixin,
     _$key__role___$DomPropsMixin,
+    _$key__rowSpan___$DomPropsMixin,
     _$key__sandbox___$DomPropsMixin,
     _$key__scope___$DomPropsMixin,
     _$key__scrolling___$DomPropsMixin,
     _$key__shape___$DomPropsMixin,
     _$key__sizes___$DomPropsMixin,
+    _$key__spellCheck___$DomPropsMixin,
     _$key__src___$DomPropsMixin,
     _$key__srcDoc___$DomPropsMixin,
     _$key__srcSet___$DomPropsMixin,
-    _$key__target___$DomPropsMixin,
-    _$key__title___$DomPropsMixin,
-    _$key__useMap___$DomPropsMixin,
-    _$key__wmode___$DomPropsMixin,
-    _$key__allowTransparency___$DomPropsMixin,
-    _$key__cellPadding___$DomPropsMixin,
-    _$key__cellSpacing___$DomPropsMixin,
-    _$key__colSpan___$DomPropsMixin,
-    _$key__contentEditable___$DomPropsMixin,
-    _$key__download___$DomPropsMixin,
-    _$key__draggable___$DomPropsMixin,
-    _$key__frameBorder___$DomPropsMixin,
-    _$key__height___$DomPropsMixin,
-    _$key__icon___$DomPropsMixin,
-    _$key__label___$DomPropsMixin,
-    _$key__max___$DomPropsMixin,
-    _$key__maxLength___$DomPropsMixin,
-    _$key__min___$DomPropsMixin,
-    _$key__rowSpan___$DomPropsMixin,
-    _$key__spellCheck___$DomPropsMixin,
     _$key__step___$DomPropsMixin,
     _$key__tabIndex___$DomPropsMixin,
+    _$key__target___$DomPropsMixin,
     _$key__type___$DomPropsMixin,
+    _$key__useMap___$DomPropsMixin,
     _$key__value___$DomPropsMixin,
     _$key__width___$DomPropsMixin,
+    _$key__wmode___$DomPropsMixin,
     _$key__onAnimationEnd___$DomPropsMixin,
     _$key__onAnimationIteration___$DomPropsMixin,
     _$key__onAnimationStart___$DomPropsMixin,
@@ -2656,303 +2659,13 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
 
   /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
-  String get clipPath =>
+  dynamic get clipPath =>
       props[_$key__clipPath___$SvgPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   /// <!-- Generated from [_$SvgPropsMixin.clipPath] -->
   @override
-  set clipPath(String value) => props[_$key__clipPath___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.d] -->
-  @override
-  String get d =>
-      props[_$key__d___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.d] -->
-  @override
-  set d(String value) => props[_$key__d___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
-  @override
-  String get fill =>
-      props[_$key__fill___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
-  @override
-  set fill(String value) => props[_$key__fill___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
-  @override
-  String get fontFamily =>
-      props[_$key__fontFamily___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
-  @override
-  set fontFamily(String value) =>
-      props[_$key__fontFamily___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
-  @override
-  String get gradientTransform =>
-      props[_$key__gradientTransform___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
-  @override
-  set gradientTransform(String value) =>
-      props[_$key__gradientTransform___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
-  @override
-  String get gradientUnits =>
-      props[_$key__gradientUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
-  @override
-  set gradientUnits(String value) =>
-      props[_$key__gradientUnits___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
-  @override
-  String get markerEnd =>
-      props[_$key__markerEnd___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
-  @override
-  set markerEnd(String value) =>
-      props[_$key__markerEnd___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
-  @override
-  String get markerMid =>
-      props[_$key__markerMid___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
-  @override
-  set markerMid(String value) =>
-      props[_$key__markerMid___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
-  @override
-  String get markerStart =>
-      props[_$key__markerStart___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
-  @override
-  set markerStart(String value) =>
-      props[_$key__markerStart___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
-  @override
-  String get patternContentUnits =>
-      props[_$key__patternContentUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
-  @override
-  set patternContentUnits(String value) =>
-      props[_$key__patternContentUnits___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
-  @override
-  String get patternUnits =>
-      props[_$key__patternUnits___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
-  @override
-  set patternUnits(String value) =>
-      props[_$key__patternUnits___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.points] -->
-  @override
-  String get points =>
-      props[_$key__points___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.points] -->
-  @override
-  set points(String value) => props[_$key__points___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
-  @override
-  String get preserveAspectRatio =>
-      props[_$key__preserveAspectRatio___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
-  @override
-  set preserveAspectRatio(String value) =>
-      props[_$key__preserveAspectRatio___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
-  @override
-  String get spreadMethod =>
-      props[_$key__spreadMethod___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
-  @override
-  set spreadMethod(String value) =>
-      props[_$key__spreadMethod___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
-  @override
-  String get stopColor =>
-      props[_$key__stopColor___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
-  @override
-  set stopColor(String value) =>
-      props[_$key__stopColor___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
-  @override
-  String get stroke =>
-      props[_$key__stroke___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
-  @override
-  set stroke(String value) => props[_$key__stroke___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
-  @override
-  String get strokeLinecap =>
-      props[_$key__strokeLinecap___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
-  @override
-  set strokeLinecap(String value) =>
-      props[_$key__strokeLinecap___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
-  @override
-  String get textAnchor =>
-      props[_$key__textAnchor___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
-  @override
-  set textAnchor(String value) =>
-      props[_$key__textAnchor___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
-  @override
-  String get transform =>
-      props[_$key__transform___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
-  @override
-  set transform(String value) =>
-      props[_$key__transform___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.version] -->
-  @override
-  String get version =>
-      props[_$key__version___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.version] -->
-  @override
-  set version(String value) => props[_$key__version___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
-  @override
-  String get viewBox =>
-      props[_$key__viewBox___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
-  @override
-  set viewBox(String value) => props[_$key__viewBox___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
-  @override
-  String get xlinkActuate =>
-      props[_$key__xlinkActuate___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
-  @override
-  set xlinkActuate(String value) =>
-      props[_$key__xlinkActuate___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
-  @override
-  String get xlinkArcrole =>
-      props[_$key__xlinkArcrole___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
-  @override
-  set xlinkArcrole(String value) =>
-      props[_$key__xlinkArcrole___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
-  @override
-  String get xlinkHref =>
-      props[_$key__xlinkHref___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
-  @override
-  set xlinkHref(String value) =>
-      props[_$key__xlinkHref___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
-  @override
-  String get xlinkRole =>
-      props[_$key__xlinkRole___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
-  @override
-  set xlinkRole(String value) =>
-      props[_$key__xlinkRole___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
-  @override
-  String get xlinkShow =>
-      props[_$key__xlinkShow___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
-  @override
-  set xlinkShow(String value) =>
-      props[_$key__xlinkShow___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
-  @override
-  String get xlinkTitle =>
-      props[_$key__xlinkTitle___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
-  @override
-  set xlinkTitle(String value) =>
-      props[_$key__xlinkTitle___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
-  @override
-  String get xlinkType =>
-      props[_$key__xlinkType___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
-  @override
-  set xlinkType(String value) =>
-      props[_$key__xlinkType___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
-  @override
-  String get xmlBase =>
-      props[_$key__xmlBase___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
-  @override
-  set xmlBase(String value) => props[_$key__xmlBase___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
-  @override
-  String get xmlLang =>
-      props[_$key__xmlLang___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
-  @override
-  set xmlLang(String value) => props[_$key__xmlLang___$SvgPropsMixin] = value;
-
-  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
-  @override
-  String get xmlSpace =>
-      props[_$key__xmlSpace___$SvgPropsMixin] ??
-      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
-  @override
-  set xmlSpace(String value) => props[_$key__xmlSpace___$SvgPropsMixin] = value;
+  set clipPath(dynamic value) =>
+      props[_$key__clipPath___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.cx] -->
   @override
@@ -2972,6 +2685,15 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set cy(dynamic value) => props[_$key__cy___$SvgPropsMixin] = value;
 
+  /// <!-- Generated from [_$SvgPropsMixin.d] -->
+  @override
+  dynamic get d =>
+      props[_$key__d___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.d] -->
+  @override
+  set d(dynamic value) => props[_$key__d___$SvgPropsMixin] = value;
+
   /// <!-- Generated from [_$SvgPropsMixin.dx] -->
   @override
   dynamic get dx =>
@@ -2990,6 +2712,15 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set dy(dynamic value) => props[_$key__dy___$SvgPropsMixin] = value;
 
+  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
+  @override
+  dynamic get fill =>
+      props[_$key__fill___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.fill] -->
+  @override
+  set fill(dynamic value) => props[_$key__fill___$SvgPropsMixin] = value;
+
   /// <!-- Generated from [_$SvgPropsMixin.fillOpacity] -->
   @override
   dynamic get fillOpacity =>
@@ -2999,6 +2730,16 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set fillOpacity(dynamic value) =>
       props[_$key__fillOpacity___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
+  @override
+  dynamic get fontFamily =>
+      props[_$key__fontFamily___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.fontFamily] -->
+  @override
+  set fontFamily(dynamic value) =>
+      props[_$key__fontFamily___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.fontSize] -->
   @override
@@ -3028,6 +2769,56 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set fy(dynamic value) => props[_$key__fy___$SvgPropsMixin] = value;
 
+  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
+  @override
+  dynamic get gradientTransform =>
+      props[_$key__gradientTransform___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.gradientTransform] -->
+  @override
+  set gradientTransform(dynamic value) =>
+      props[_$key__gradientTransform___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
+  @override
+  dynamic get gradientUnits =>
+      props[_$key__gradientUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.gradientUnits] -->
+  @override
+  set gradientUnits(dynamic value) =>
+      props[_$key__gradientUnits___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
+  @override
+  dynamic get markerEnd =>
+      props[_$key__markerEnd___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.markerEnd] -->
+  @override
+  set markerEnd(dynamic value) =>
+      props[_$key__markerEnd___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
+  @override
+  dynamic get markerMid =>
+      props[_$key__markerMid___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.markerMid] -->
+  @override
+  set markerMid(dynamic value) =>
+      props[_$key__markerMid___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
+  @override
+  dynamic get markerStart =>
+      props[_$key__markerStart___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.markerStart] -->
+  @override
+  set markerStart(dynamic value) =>
+      props[_$key__markerStart___$SvgPropsMixin] = value;
+
   /// <!-- Generated from [_$SvgPropsMixin.offset] -->
   @override
   dynamic get offset =>
@@ -3045,6 +2836,45 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// <!-- Generated from [_$SvgPropsMixin.opacity] -->
   @override
   set opacity(dynamic value) => props[_$key__opacity___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
+  @override
+  dynamic get patternContentUnits =>
+      props[_$key__patternContentUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.patternContentUnits] -->
+  @override
+  set patternContentUnits(dynamic value) =>
+      props[_$key__patternContentUnits___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
+  @override
+  dynamic get patternUnits =>
+      props[_$key__patternUnits___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.patternUnits] -->
+  @override
+  set patternUnits(dynamic value) =>
+      props[_$key__patternUnits___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.points] -->
+  @override
+  dynamic get points =>
+      props[_$key__points___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.points] -->
+  @override
+  set points(dynamic value) => props[_$key__points___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
+  @override
+  dynamic get preserveAspectRatio =>
+      props[_$key__preserveAspectRatio___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.preserveAspectRatio] -->
+  @override
+  set preserveAspectRatio(dynamic value) =>
+      props[_$key__preserveAspectRatio___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.r] -->
   @override
@@ -3073,6 +2903,26 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set ry(dynamic value) => props[_$key__ry___$SvgPropsMixin] = value;
 
+  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
+  @override
+  dynamic get spreadMethod =>
+      props[_$key__spreadMethod___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.spreadMethod] -->
+  @override
+  set spreadMethod(dynamic value) =>
+      props[_$key__spreadMethod___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
+  @override
+  dynamic get stopColor =>
+      props[_$key__stopColor___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.stopColor] -->
+  @override
+  set stopColor(dynamic value) =>
+      props[_$key__stopColor___$SvgPropsMixin] = value;
+
   /// <!-- Generated from [_$SvgPropsMixin.stopOpacity] -->
   @override
   dynamic get stopOpacity =>
@@ -3083,6 +2933,15 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   set stopOpacity(dynamic value) =>
       props[_$key__stopOpacity___$SvgPropsMixin] = value;
 
+  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
+  @override
+  dynamic get stroke =>
+      props[_$key__stroke___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.stroke] -->
+  @override
+  set stroke(dynamic value) => props[_$key__stroke___$SvgPropsMixin] = value;
+
   /// <!-- Generated from [_$SvgPropsMixin.strokeDasharray] -->
   @override
   dynamic get strokeDasharray =>
@@ -3092,6 +2951,16 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set strokeDasharray(dynamic value) =>
       props[_$key__strokeDasharray___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
+  @override
+  dynamic get strokeLinecap =>
+      props[_$key__strokeLinecap___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.strokeLinecap] -->
+  @override
+  set strokeLinecap(dynamic value) =>
+      props[_$key__strokeLinecap___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.strokeOpacity] -->
   @override
@@ -3112,6 +2981,44 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   @override
   set strokeWidth(dynamic value) =>
       props[_$key__strokeWidth___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
+  @override
+  dynamic get textAnchor =>
+      props[_$key__textAnchor___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.textAnchor] -->
+  @override
+  set textAnchor(dynamic value) =>
+      props[_$key__textAnchor___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
+  @override
+  dynamic get transform =>
+      props[_$key__transform___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.transform] -->
+  @override
+  set transform(dynamic value) =>
+      props[_$key__transform___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.version] -->
+  @override
+  dynamic get version =>
+      props[_$key__version___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.version] -->
+  @override
+  set version(dynamic value) => props[_$key__version___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
+  @override
+  dynamic get viewBox =>
+      props[_$key__viewBox___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.viewBox] -->
+  @override
+  set viewBox(dynamic value) => props[_$key__viewBox___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.x1] -->
   @override
@@ -3139,6 +3046,104 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /// <!-- Generated from [_$SvgPropsMixin.x] -->
   @override
   set x(dynamic value) => props[_$key__x___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
+  @override
+  dynamic get xlinkActuate =>
+      props[_$key__xlinkActuate___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkActuate] -->
+  @override
+  set xlinkActuate(dynamic value) =>
+      props[_$key__xlinkActuate___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
+  @override
+  dynamic get xlinkArcrole =>
+      props[_$key__xlinkArcrole___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkArcrole] -->
+  @override
+  set xlinkArcrole(dynamic value) =>
+      props[_$key__xlinkArcrole___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
+  @override
+  dynamic get xlinkHref =>
+      props[_$key__xlinkHref___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkHref] -->
+  @override
+  set xlinkHref(dynamic value) =>
+      props[_$key__xlinkHref___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
+  @override
+  dynamic get xlinkRole =>
+      props[_$key__xlinkRole___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkRole] -->
+  @override
+  set xlinkRole(dynamic value) =>
+      props[_$key__xlinkRole___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
+  @override
+  dynamic get xlinkShow =>
+      props[_$key__xlinkShow___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkShow] -->
+  @override
+  set xlinkShow(dynamic value) =>
+      props[_$key__xlinkShow___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
+  @override
+  dynamic get xlinkTitle =>
+      props[_$key__xlinkTitle___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkTitle] -->
+  @override
+  set xlinkTitle(dynamic value) =>
+      props[_$key__xlinkTitle___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
+  @override
+  dynamic get xlinkType =>
+      props[_$key__xlinkType___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xlinkType] -->
+  @override
+  set xlinkType(dynamic value) =>
+      props[_$key__xlinkType___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
+  @override
+  dynamic get xmlBase =>
+      props[_$key__xmlBase___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xmlBase] -->
+  @override
+  set xmlBase(dynamic value) => props[_$key__xmlBase___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
+  @override
+  dynamic get xmlLang =>
+      props[_$key__xmlLang___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xmlLang] -->
+  @override
+  set xmlLang(dynamic value) => props[_$key__xmlLang___$SvgPropsMixin] = value;
+
+  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
+  @override
+  dynamic get xmlSpace =>
+      props[_$key__xmlSpace___$SvgPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$SvgPropsMixin.xmlSpace] -->
+  @override
+  set xmlSpace(dynamic value) =>
+      props[_$key__xmlSpace___$SvgPropsMixin] = value;
 
   /// <!-- Generated from [_$SvgPropsMixin.y1] -->
   @override
@@ -3169,12 +3174,28 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   /* GENERATED CONSTANTS */
   static const PropDescriptor _$prop__clipPath___$SvgPropsMixin =
       const PropDescriptor(_$key__clipPath___$SvgPropsMixin);
+  static const PropDescriptor _$prop__cx___$SvgPropsMixin =
+      const PropDescriptor(_$key__cx___$SvgPropsMixin);
+  static const PropDescriptor _$prop__cy___$SvgPropsMixin =
+      const PropDescriptor(_$key__cy___$SvgPropsMixin);
   static const PropDescriptor _$prop__d___$SvgPropsMixin =
       const PropDescriptor(_$key__d___$SvgPropsMixin);
+  static const PropDescriptor _$prop__dx___$SvgPropsMixin =
+      const PropDescriptor(_$key__dx___$SvgPropsMixin);
+  static const PropDescriptor _$prop__dy___$SvgPropsMixin =
+      const PropDescriptor(_$key__dy___$SvgPropsMixin);
   static const PropDescriptor _$prop__fill___$SvgPropsMixin =
       const PropDescriptor(_$key__fill___$SvgPropsMixin);
+  static const PropDescriptor _$prop__fillOpacity___$SvgPropsMixin =
+      const PropDescriptor(_$key__fillOpacity___$SvgPropsMixin);
   static const PropDescriptor _$prop__fontFamily___$SvgPropsMixin =
       const PropDescriptor(_$key__fontFamily___$SvgPropsMixin);
+  static const PropDescriptor _$prop__fontSize___$SvgPropsMixin =
+      const PropDescriptor(_$key__fontSize___$SvgPropsMixin);
+  static const PropDescriptor _$prop__fx___$SvgPropsMixin =
+      const PropDescriptor(_$key__fx___$SvgPropsMixin);
+  static const PropDescriptor _$prop__fy___$SvgPropsMixin =
+      const PropDescriptor(_$key__fy___$SvgPropsMixin);
   static const PropDescriptor _$prop__gradientTransform___$SvgPropsMixin =
       const PropDescriptor(_$key__gradientTransform___$SvgPropsMixin);
   static const PropDescriptor _$prop__gradientUnits___$SvgPropsMixin =
@@ -3185,6 +3206,10 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
       const PropDescriptor(_$key__markerMid___$SvgPropsMixin);
   static const PropDescriptor _$prop__markerStart___$SvgPropsMixin =
       const PropDescriptor(_$key__markerStart___$SvgPropsMixin);
+  static const PropDescriptor _$prop__offset___$SvgPropsMixin =
+      const PropDescriptor(_$key__offset___$SvgPropsMixin);
+  static const PropDescriptor _$prop__opacity___$SvgPropsMixin =
+      const PropDescriptor(_$key__opacity___$SvgPropsMixin);
   static const PropDescriptor _$prop__patternContentUnits___$SvgPropsMixin =
       const PropDescriptor(_$key__patternContentUnits___$SvgPropsMixin);
   static const PropDescriptor _$prop__patternUnits___$SvgPropsMixin =
@@ -3193,14 +3218,28 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
       const PropDescriptor(_$key__points___$SvgPropsMixin);
   static const PropDescriptor _$prop__preserveAspectRatio___$SvgPropsMixin =
       const PropDescriptor(_$key__preserveAspectRatio___$SvgPropsMixin);
+  static const PropDescriptor _$prop__r___$SvgPropsMixin =
+      const PropDescriptor(_$key__r___$SvgPropsMixin);
+  static const PropDescriptor _$prop__rx___$SvgPropsMixin =
+      const PropDescriptor(_$key__rx___$SvgPropsMixin);
+  static const PropDescriptor _$prop__ry___$SvgPropsMixin =
+      const PropDescriptor(_$key__ry___$SvgPropsMixin);
   static const PropDescriptor _$prop__spreadMethod___$SvgPropsMixin =
       const PropDescriptor(_$key__spreadMethod___$SvgPropsMixin);
   static const PropDescriptor _$prop__stopColor___$SvgPropsMixin =
       const PropDescriptor(_$key__stopColor___$SvgPropsMixin);
+  static const PropDescriptor _$prop__stopOpacity___$SvgPropsMixin =
+      const PropDescriptor(_$key__stopOpacity___$SvgPropsMixin);
   static const PropDescriptor _$prop__stroke___$SvgPropsMixin =
       const PropDescriptor(_$key__stroke___$SvgPropsMixin);
+  static const PropDescriptor _$prop__strokeDasharray___$SvgPropsMixin =
+      const PropDescriptor(_$key__strokeDasharray___$SvgPropsMixin);
   static const PropDescriptor _$prop__strokeLinecap___$SvgPropsMixin =
       const PropDescriptor(_$key__strokeLinecap___$SvgPropsMixin);
+  static const PropDescriptor _$prop__strokeOpacity___$SvgPropsMixin =
+      const PropDescriptor(_$key__strokeOpacity___$SvgPropsMixin);
+  static const PropDescriptor _$prop__strokeWidth___$SvgPropsMixin =
+      const PropDescriptor(_$key__strokeWidth___$SvgPropsMixin);
   static const PropDescriptor _$prop__textAnchor___$SvgPropsMixin =
       const PropDescriptor(_$key__textAnchor___$SvgPropsMixin);
   static const PropDescriptor _$prop__transform___$SvgPropsMixin =
@@ -3209,6 +3248,12 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
       const PropDescriptor(_$key__version___$SvgPropsMixin);
   static const PropDescriptor _$prop__viewBox___$SvgPropsMixin =
       const PropDescriptor(_$key__viewBox___$SvgPropsMixin);
+  static const PropDescriptor _$prop__x1___$SvgPropsMixin =
+      const PropDescriptor(_$key__x1___$SvgPropsMixin);
+  static const PropDescriptor _$prop__x2___$SvgPropsMixin =
+      const PropDescriptor(_$key__x2___$SvgPropsMixin);
+  static const PropDescriptor _$prop__x___$SvgPropsMixin =
+      const PropDescriptor(_$key__x___$SvgPropsMixin);
   static const PropDescriptor _$prop__xlinkActuate___$SvgPropsMixin =
       const PropDescriptor(_$key__xlinkActuate___$SvgPropsMixin);
   static const PropDescriptor _$prop__xlinkArcrole___$SvgPropsMixin =
@@ -3229,46 +3274,6 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
       const PropDescriptor(_$key__xmlLang___$SvgPropsMixin);
   static const PropDescriptor _$prop__xmlSpace___$SvgPropsMixin =
       const PropDescriptor(_$key__xmlSpace___$SvgPropsMixin);
-  static const PropDescriptor _$prop__cx___$SvgPropsMixin =
-      const PropDescriptor(_$key__cx___$SvgPropsMixin);
-  static const PropDescriptor _$prop__cy___$SvgPropsMixin =
-      const PropDescriptor(_$key__cy___$SvgPropsMixin);
-  static const PropDescriptor _$prop__dx___$SvgPropsMixin =
-      const PropDescriptor(_$key__dx___$SvgPropsMixin);
-  static const PropDescriptor _$prop__dy___$SvgPropsMixin =
-      const PropDescriptor(_$key__dy___$SvgPropsMixin);
-  static const PropDescriptor _$prop__fillOpacity___$SvgPropsMixin =
-      const PropDescriptor(_$key__fillOpacity___$SvgPropsMixin);
-  static const PropDescriptor _$prop__fontSize___$SvgPropsMixin =
-      const PropDescriptor(_$key__fontSize___$SvgPropsMixin);
-  static const PropDescriptor _$prop__fx___$SvgPropsMixin =
-      const PropDescriptor(_$key__fx___$SvgPropsMixin);
-  static const PropDescriptor _$prop__fy___$SvgPropsMixin =
-      const PropDescriptor(_$key__fy___$SvgPropsMixin);
-  static const PropDescriptor _$prop__offset___$SvgPropsMixin =
-      const PropDescriptor(_$key__offset___$SvgPropsMixin);
-  static const PropDescriptor _$prop__opacity___$SvgPropsMixin =
-      const PropDescriptor(_$key__opacity___$SvgPropsMixin);
-  static const PropDescriptor _$prop__r___$SvgPropsMixin =
-      const PropDescriptor(_$key__r___$SvgPropsMixin);
-  static const PropDescriptor _$prop__rx___$SvgPropsMixin =
-      const PropDescriptor(_$key__rx___$SvgPropsMixin);
-  static const PropDescriptor _$prop__ry___$SvgPropsMixin =
-      const PropDescriptor(_$key__ry___$SvgPropsMixin);
-  static const PropDescriptor _$prop__stopOpacity___$SvgPropsMixin =
-      const PropDescriptor(_$key__stopOpacity___$SvgPropsMixin);
-  static const PropDescriptor _$prop__strokeDasharray___$SvgPropsMixin =
-      const PropDescriptor(_$key__strokeDasharray___$SvgPropsMixin);
-  static const PropDescriptor _$prop__strokeOpacity___$SvgPropsMixin =
-      const PropDescriptor(_$key__strokeOpacity___$SvgPropsMixin);
-  static const PropDescriptor _$prop__strokeWidth___$SvgPropsMixin =
-      const PropDescriptor(_$key__strokeWidth___$SvgPropsMixin);
-  static const PropDescriptor _$prop__x1___$SvgPropsMixin =
-      const PropDescriptor(_$key__x1___$SvgPropsMixin);
-  static const PropDescriptor _$prop__x2___$SvgPropsMixin =
-      const PropDescriptor(_$key__x2___$SvgPropsMixin);
-  static const PropDescriptor _$prop__x___$SvgPropsMixin =
-      const PropDescriptor(_$key__x___$SvgPropsMixin);
   static const PropDescriptor _$prop__y1___$SvgPropsMixin =
       const PropDescriptor(_$key__y1___$SvgPropsMixin);
   static const PropDescriptor _$prop__y2___$SvgPropsMixin =
@@ -3276,29 +3281,50 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   static const PropDescriptor _$prop__y___$SvgPropsMixin =
       const PropDescriptor(_$key__y___$SvgPropsMixin);
   static const String _$key__clipPath___$SvgPropsMixin = 'clipPath';
+  static const String _$key__cx___$SvgPropsMixin = 'cx';
+  static const String _$key__cy___$SvgPropsMixin = 'cy';
   static const String _$key__d___$SvgPropsMixin = 'd';
+  static const String _$key__dx___$SvgPropsMixin = 'dx';
+  static const String _$key__dy___$SvgPropsMixin = 'dy';
   static const String _$key__fill___$SvgPropsMixin = 'fill';
+  static const String _$key__fillOpacity___$SvgPropsMixin = 'fillOpacity';
   static const String _$key__fontFamily___$SvgPropsMixin = 'fontFamily';
+  static const String _$key__fontSize___$SvgPropsMixin = 'fontSize';
+  static const String _$key__fx___$SvgPropsMixin = 'fx';
+  static const String _$key__fy___$SvgPropsMixin = 'fy';
   static const String _$key__gradientTransform___$SvgPropsMixin =
       'gradientTransform';
   static const String _$key__gradientUnits___$SvgPropsMixin = 'gradientUnits';
   static const String _$key__markerEnd___$SvgPropsMixin = 'markerEnd';
   static const String _$key__markerMid___$SvgPropsMixin = 'markerMid';
   static const String _$key__markerStart___$SvgPropsMixin = 'markerStart';
+  static const String _$key__offset___$SvgPropsMixin = 'offset';
+  static const String _$key__opacity___$SvgPropsMixin = 'opacity';
   static const String _$key__patternContentUnits___$SvgPropsMixin =
       'patternContentUnits';
   static const String _$key__patternUnits___$SvgPropsMixin = 'patternUnits';
   static const String _$key__points___$SvgPropsMixin = 'points';
   static const String _$key__preserveAspectRatio___$SvgPropsMixin =
       'preserveAspectRatio';
+  static const String _$key__r___$SvgPropsMixin = 'r';
+  static const String _$key__rx___$SvgPropsMixin = 'rx';
+  static const String _$key__ry___$SvgPropsMixin = 'ry';
   static const String _$key__spreadMethod___$SvgPropsMixin = 'spreadMethod';
   static const String _$key__stopColor___$SvgPropsMixin = 'stopColor';
+  static const String _$key__stopOpacity___$SvgPropsMixin = 'stopOpacity';
   static const String _$key__stroke___$SvgPropsMixin = 'stroke';
+  static const String _$key__strokeDasharray___$SvgPropsMixin =
+      'strokeDasharray';
   static const String _$key__strokeLinecap___$SvgPropsMixin = 'strokeLinecap';
+  static const String _$key__strokeOpacity___$SvgPropsMixin = 'strokeOpacity';
+  static const String _$key__strokeWidth___$SvgPropsMixin = 'strokeWidth';
   static const String _$key__textAnchor___$SvgPropsMixin = 'textAnchor';
   static const String _$key__transform___$SvgPropsMixin = 'transform';
   static const String _$key__version___$SvgPropsMixin = 'version';
   static const String _$key__viewBox___$SvgPropsMixin = 'viewBox';
+  static const String _$key__x1___$SvgPropsMixin = 'x1';
+  static const String _$key__x2___$SvgPropsMixin = 'x2';
+  static const String _$key__x___$SvgPropsMixin = 'x';
   static const String _$key__xlinkActuate___$SvgPropsMixin = 'xlinkActuate';
   static const String _$key__xlinkArcrole___$SvgPropsMixin = 'xlinkArcrole';
   static const String _$key__xlinkHref___$SvgPropsMixin = 'xlinkHref';
@@ -3309,53 +3335,52 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
   static const String _$key__xmlBase___$SvgPropsMixin = 'xmlBase';
   static const String _$key__xmlLang___$SvgPropsMixin = 'xmlLang';
   static const String _$key__xmlSpace___$SvgPropsMixin = 'xmlSpace';
-  static const String _$key__cx___$SvgPropsMixin = 'cx';
-  static const String _$key__cy___$SvgPropsMixin = 'cy';
-  static const String _$key__dx___$SvgPropsMixin = 'dx';
-  static const String _$key__dy___$SvgPropsMixin = 'dy';
-  static const String _$key__fillOpacity___$SvgPropsMixin = 'fillOpacity';
-  static const String _$key__fontSize___$SvgPropsMixin = 'fontSize';
-  static const String _$key__fx___$SvgPropsMixin = 'fx';
-  static const String _$key__fy___$SvgPropsMixin = 'fy';
-  static const String _$key__offset___$SvgPropsMixin = 'offset';
-  static const String _$key__opacity___$SvgPropsMixin = 'opacity';
-  static const String _$key__r___$SvgPropsMixin = 'r';
-  static const String _$key__rx___$SvgPropsMixin = 'rx';
-  static const String _$key__ry___$SvgPropsMixin = 'ry';
-  static const String _$key__stopOpacity___$SvgPropsMixin = 'stopOpacity';
-  static const String _$key__strokeDasharray___$SvgPropsMixin =
-      'strokeDasharray';
-  static const String _$key__strokeOpacity___$SvgPropsMixin = 'strokeOpacity';
-  static const String _$key__strokeWidth___$SvgPropsMixin = 'strokeWidth';
-  static const String _$key__x1___$SvgPropsMixin = 'x1';
-  static const String _$key__x2___$SvgPropsMixin = 'x2';
-  static const String _$key__x___$SvgPropsMixin = 'x';
   static const String _$key__y1___$SvgPropsMixin = 'y1';
   static const String _$key__y2___$SvgPropsMixin = 'y2';
   static const String _$key__y___$SvgPropsMixin = 'y';
 
   static const List<PropDescriptor> $props = const [
     _$prop__clipPath___$SvgPropsMixin,
+    _$prop__cx___$SvgPropsMixin,
+    _$prop__cy___$SvgPropsMixin,
     _$prop__d___$SvgPropsMixin,
+    _$prop__dx___$SvgPropsMixin,
+    _$prop__dy___$SvgPropsMixin,
     _$prop__fill___$SvgPropsMixin,
+    _$prop__fillOpacity___$SvgPropsMixin,
     _$prop__fontFamily___$SvgPropsMixin,
+    _$prop__fontSize___$SvgPropsMixin,
+    _$prop__fx___$SvgPropsMixin,
+    _$prop__fy___$SvgPropsMixin,
     _$prop__gradientTransform___$SvgPropsMixin,
     _$prop__gradientUnits___$SvgPropsMixin,
     _$prop__markerEnd___$SvgPropsMixin,
     _$prop__markerMid___$SvgPropsMixin,
     _$prop__markerStart___$SvgPropsMixin,
+    _$prop__offset___$SvgPropsMixin,
+    _$prop__opacity___$SvgPropsMixin,
     _$prop__patternContentUnits___$SvgPropsMixin,
     _$prop__patternUnits___$SvgPropsMixin,
     _$prop__points___$SvgPropsMixin,
     _$prop__preserveAspectRatio___$SvgPropsMixin,
+    _$prop__r___$SvgPropsMixin,
+    _$prop__rx___$SvgPropsMixin,
+    _$prop__ry___$SvgPropsMixin,
     _$prop__spreadMethod___$SvgPropsMixin,
     _$prop__stopColor___$SvgPropsMixin,
+    _$prop__stopOpacity___$SvgPropsMixin,
     _$prop__stroke___$SvgPropsMixin,
+    _$prop__strokeDasharray___$SvgPropsMixin,
     _$prop__strokeLinecap___$SvgPropsMixin,
+    _$prop__strokeOpacity___$SvgPropsMixin,
+    _$prop__strokeWidth___$SvgPropsMixin,
     _$prop__textAnchor___$SvgPropsMixin,
     _$prop__transform___$SvgPropsMixin,
     _$prop__version___$SvgPropsMixin,
     _$prop__viewBox___$SvgPropsMixin,
+    _$prop__x1___$SvgPropsMixin,
+    _$prop__x2___$SvgPropsMixin,
+    _$prop__x___$SvgPropsMixin,
     _$prop__xlinkActuate___$SvgPropsMixin,
     _$prop__xlinkArcrole___$SvgPropsMixin,
     _$prop__xlinkHref___$SvgPropsMixin,
@@ -3366,52 +3391,52 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
     _$prop__xmlBase___$SvgPropsMixin,
     _$prop__xmlLang___$SvgPropsMixin,
     _$prop__xmlSpace___$SvgPropsMixin,
-    _$prop__cx___$SvgPropsMixin,
-    _$prop__cy___$SvgPropsMixin,
-    _$prop__dx___$SvgPropsMixin,
-    _$prop__dy___$SvgPropsMixin,
-    _$prop__fillOpacity___$SvgPropsMixin,
-    _$prop__fontSize___$SvgPropsMixin,
-    _$prop__fx___$SvgPropsMixin,
-    _$prop__fy___$SvgPropsMixin,
-    _$prop__offset___$SvgPropsMixin,
-    _$prop__opacity___$SvgPropsMixin,
-    _$prop__r___$SvgPropsMixin,
-    _$prop__rx___$SvgPropsMixin,
-    _$prop__ry___$SvgPropsMixin,
-    _$prop__stopOpacity___$SvgPropsMixin,
-    _$prop__strokeDasharray___$SvgPropsMixin,
-    _$prop__strokeOpacity___$SvgPropsMixin,
-    _$prop__strokeWidth___$SvgPropsMixin,
-    _$prop__x1___$SvgPropsMixin,
-    _$prop__x2___$SvgPropsMixin,
-    _$prop__x___$SvgPropsMixin,
     _$prop__y1___$SvgPropsMixin,
     _$prop__y2___$SvgPropsMixin,
     _$prop__y___$SvgPropsMixin
   ];
   static const List<String> $propKeys = const [
     _$key__clipPath___$SvgPropsMixin,
+    _$key__cx___$SvgPropsMixin,
+    _$key__cy___$SvgPropsMixin,
     _$key__d___$SvgPropsMixin,
+    _$key__dx___$SvgPropsMixin,
+    _$key__dy___$SvgPropsMixin,
     _$key__fill___$SvgPropsMixin,
+    _$key__fillOpacity___$SvgPropsMixin,
     _$key__fontFamily___$SvgPropsMixin,
+    _$key__fontSize___$SvgPropsMixin,
+    _$key__fx___$SvgPropsMixin,
+    _$key__fy___$SvgPropsMixin,
     _$key__gradientTransform___$SvgPropsMixin,
     _$key__gradientUnits___$SvgPropsMixin,
     _$key__markerEnd___$SvgPropsMixin,
     _$key__markerMid___$SvgPropsMixin,
     _$key__markerStart___$SvgPropsMixin,
+    _$key__offset___$SvgPropsMixin,
+    _$key__opacity___$SvgPropsMixin,
     _$key__patternContentUnits___$SvgPropsMixin,
     _$key__patternUnits___$SvgPropsMixin,
     _$key__points___$SvgPropsMixin,
     _$key__preserveAspectRatio___$SvgPropsMixin,
+    _$key__r___$SvgPropsMixin,
+    _$key__rx___$SvgPropsMixin,
+    _$key__ry___$SvgPropsMixin,
     _$key__spreadMethod___$SvgPropsMixin,
     _$key__stopColor___$SvgPropsMixin,
+    _$key__stopOpacity___$SvgPropsMixin,
     _$key__stroke___$SvgPropsMixin,
+    _$key__strokeDasharray___$SvgPropsMixin,
     _$key__strokeLinecap___$SvgPropsMixin,
+    _$key__strokeOpacity___$SvgPropsMixin,
+    _$key__strokeWidth___$SvgPropsMixin,
     _$key__textAnchor___$SvgPropsMixin,
     _$key__transform___$SvgPropsMixin,
     _$key__version___$SvgPropsMixin,
     _$key__viewBox___$SvgPropsMixin,
+    _$key__x1___$SvgPropsMixin,
+    _$key__x2___$SvgPropsMixin,
+    _$key__x___$SvgPropsMixin,
     _$key__xlinkActuate___$SvgPropsMixin,
     _$key__xlinkArcrole___$SvgPropsMixin,
     _$key__xlinkHref___$SvgPropsMixin,
@@ -3422,26 +3447,6 @@ abstract class SvgPropsMixin implements _$SvgPropsMixin {
     _$key__xmlBase___$SvgPropsMixin,
     _$key__xmlLang___$SvgPropsMixin,
     _$key__xmlSpace___$SvgPropsMixin,
-    _$key__cx___$SvgPropsMixin,
-    _$key__cy___$SvgPropsMixin,
-    _$key__dx___$SvgPropsMixin,
-    _$key__dy___$SvgPropsMixin,
-    _$key__fillOpacity___$SvgPropsMixin,
-    _$key__fontSize___$SvgPropsMixin,
-    _$key__fx___$SvgPropsMixin,
-    _$key__fy___$SvgPropsMixin,
-    _$key__offset___$SvgPropsMixin,
-    _$key__opacity___$SvgPropsMixin,
-    _$key__r___$SvgPropsMixin,
-    _$key__rx___$SvgPropsMixin,
-    _$key__ry___$SvgPropsMixin,
-    _$key__stopOpacity___$SvgPropsMixin,
-    _$key__strokeDasharray___$SvgPropsMixin,
-    _$key__strokeOpacity___$SvgPropsMixin,
-    _$key__strokeWidth___$SvgPropsMixin,
-    _$key__x1___$SvgPropsMixin,
-    _$key__x2___$SvgPropsMixin,
-    _$key__x___$SvgPropsMixin,
     _$key__y1___$SvgPropsMixin,
     _$key__y2___$SvgPropsMixin,
     _$key__y___$SvgPropsMixin


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Reverting typing to remove errors in consumer repos.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Revert `props_mixin.dart` to SHA 756a01af
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Revert DOM Prop and SVG prop typing changes back to `dynamic`
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @kealjones-wk @greglittlefield-wf @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
