### PR TITLE
CPLAT-8011 Add SafeRenderManager (Dart 1)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,6 @@ analyzer:
 linter:
   rules:
     - annotate_overrides
-    - avoid_as
     - avoid_empty_else
     - avoid_init_to_null
     - avoid_return_types_on_setters

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,3 +26,4 @@ linter:
     - type_init_formals
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
+    - unnecessary_statements

--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -61,6 +61,7 @@ export 'src/util/react_util.dart';
 export 'src/util/react_wrappers.dart';
 export 'src/util/rem_util.dart';
 export 'src/util/string_util.dart';
+export 'src/util/safe_render_manager/safe_render_manager.dart';
 export 'src/util/test_mode.dart';
 export 'src/util/typed_default_props_for.dart';
 export 'src/util/validation_util.dart';

--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:html';
+
+import 'package:meta/meta.dart';
+import 'package:over_react/over_react.dart';
+import 'package:over_react/react_dom.dart' as react_dom;
+import 'package:w_common/disposable.dart';
+
+import './safe_render_manager_helper.dart';
+
+/// A class that manages the top-level rendering of a [ReactElement] into a given node,
+/// with support for safely rendering/updating via [render] and safely unmounting via [tryUnmount].
+///
+/// Content is also unmounted when this object is [dispose]d.
+///
+/// This is useful in cases where [react_dom.render] or [react_dom.unmountComponentAtNode]
+/// may or may not be called from React events or lifecycle methods, which can have
+/// undesirable/unintended side effects.
+///
+/// For instance, calling [react_dom.unmountComponentAtNode] can unmount a component
+/// while an event is being propagated through a component, which normally would never happen.
+/// This could result in null errors in the component as the event logic continues.
+///
+/// SafeRenderManager uses a helper component under the hood to manage the rendering of content
+/// via Component state changes, ensuring that the content is mounted/unmounted as it
+/// normally would be.
+class SafeRenderManager extends Disposable {
+  SafeRenderManagerHelperComponent _helper;
+
+  /// Whether to automatically add [mountNode] to the document body when
+  /// rendered, and remove it when unmounted.
+  ///
+  /// Useful when manually managing the mount node isn't necessary.
+  final bool autoAttachMountNode;
+
+  /// The mount node for content rendered by [render].
+  ///
+  /// If not specified, a new div will be used.
+  final Element mountNode;
+
+  /// The ref to the component rendered by [render].
+  ///
+  /// Due to react_dom.render calls not being guaranteed to be synchronous.
+  /// this may not be populated until later than expected.
+  dynamic contentRef;
+
+  _RenderState _state = _RenderState.unmounted;
+
+  /// A list of [render] calls queued up while the component is in the process
+  /// of rendering.
+  List<ReactElement> _renderQueue = [];
+
+  SafeRenderManager({Element mountNode, this.autoAttachMountNode = false})
+      : mountNode = mountNode ?? new DivElement();
+
+  /// Renders [content]into [mountNode], chaining existing callback refs to
+  /// provide access to the rendered component via [contentRef].
+  void render(ReactElement content) {
+    _checkDisposalState();
+
+    switch (_state) {
+      case _RenderState.mounting:
+        _renderQueue.add(content);
+        break;
+      case _RenderState.mountedOrErrored:
+        // Handle if _helper was unmounted due to an uncaught error.
+        if (_helper == null) {
+          _mountContent(content);
+        } else {
+          _helper.renderContent(content);
+        }
+        break;
+      case _RenderState.unmounted:
+        _mountContent(content);
+        break;
+    }
+  }
+
+  void _mountContent(ReactElement content) {
+    try {
+      _state = _RenderState.mounting;
+      // Use document.contains since `.isConnected` isn't supported in IE11.
+      if (autoAttachMountNode && !document.contains(mountNode)) {
+        document.body.append(mountNode);
+      }
+      react_dom.render((SafeRenderManagerHelper()
+        ..ref = _helperRef
+        ..getInitialContent = () {
+          final value = content;
+          // Clear this closure variable out so it isn't retained.
+          content = null;
+          return value;
+        }
+        ..contentRef = _contentCallbackRef
+      )(), mountNode);
+    } catch (_) {
+      _state = _RenderState.unmounted;
+      rethrow;
+    }
+  }
+
+  /// Attempts to unmount the rendered component, calling [onMaybeUnmounted]
+  /// with whether the component was actually unmounted.
+  ///
+  /// Unmounting could fail if a call to [render] is batched in with this
+  /// unmount during the propagation of this event. In that case, something
+  /// other call wanted something rendered and trumped the unmount request.
+  ///
+  /// This behavior allows the same SafeRenderManager instance to be used to
+  /// render/unmount a single content area without calls interfering with each
+  /// other.
+  ///
+  /// If nothing is currently rendered, [onMaybeUnmounted] will be called immediately.
+  void tryUnmount({void onMaybeUnmounted(bool isUnmounted)}) {
+    // Check here since we call _tryUnmountContent in this class's disposal logic.
+    _checkDisposalState();
+    _safeUnmountContent(onMaybeUnmounted: onMaybeUnmounted, force: false);
+  }
+
+  void _unmountContent() {
+    try {
+      _state = _RenderState.unmounted;
+      _renderQueue = [];
+      react_dom.unmountComponentAtNode(mountNode);
+    } finally {
+      if (autoAttachMountNode) {
+        mountNode.remove();
+      }
+    }
+  }
+
+  void _safeUnmountContent(
+      {void onMaybeUnmounted(bool isUnmounted), @required bool force}) {
+    var _hasBeenCalled = false;
+    /// Helper to call onMaybeUnmounted at most one time, for cases
+    /// where there have to be error handlers at multiple levels
+    void callOnMaybeUnmounted(bool value) {
+      if (!_hasBeenCalled) {
+        _hasBeenCalled = true;
+        onMaybeUnmounted?.call(true);
+      }
+    }
+
+    if (_state == _RenderState.unmounted) {
+      callOnMaybeUnmounted(true);
+    } else if (_state == _RenderState.mountedOrErrored && _helper != null) {
+      try {
+        _helper.tryUnmountContent(onMaybeUnmounted: (isUnmounted) {
+          if (isUnmounted || force) {
+            try {
+              _unmountContent();
+            } finally {
+              callOnMaybeUnmounted(true);
+            }
+          } else {
+            callOnMaybeUnmounted(false);
+          }
+        });
+      } catch (_) {
+        // Handle _helper.tryUnmountContent throwing synchronously without
+        // calling onMaybeUnmounted.
+        // Don't do this in a finally since onMaybeUnmounted can get called async.
+        callOnMaybeUnmounted(true);
+        rethrow;
+      }
+    } else {
+      try {
+        _unmountContent();
+      } finally {
+        callOnMaybeUnmounted(true);
+      }
+    }
+  }
+
+  void _checkDisposalState() {
+    if (isOrWillBeDisposed) {
+      throw new ObjectDisposedException();
+    }
+  }
+
+  void _helperRef(ref) {
+    _helper = ref;
+    if (_helper != null) {
+      if (_state == _RenderState.mounting) {
+        _state = _RenderState.mountedOrErrored;
+      }
+      _renderQueue.forEach(_helper.renderContent);
+      _renderQueue = [];
+    }
+  }
+
+  void _contentCallbackRef(ref) {
+    contentRef = ref;
+  }
+
+  @override
+  Future<Null> onDispose() async {
+    var completer = new Completer<Null>();
+    final completerFuture = completer.future;
+
+    // Set up an onError handler in case onMaybeUnmounted isn't called due to
+    // an error, and an async error is thrown instead.
+    runZoned(() {
+      // Attempt to unmount the content safely
+      _safeUnmountContent(force: true, onMaybeUnmounted: (_) {
+        completer?.complete();
+        // Clear out to not retain it in the onError closure, which has
+        // an indefinitely long lifetime.
+        completer = null;
+      });
+    }, onError: (error, stackTrace) {
+      completer?.completeError(error, stackTrace);
+      // Clear out to not retain it in the onError closure, which has
+      // an indefinitely long lifetime.
+      completer = null;
+    });
+
+    await completerFuture;
+
+    await super.onDispose();
+  }
+}
+
+enum _RenderState { mounting, mountedOrErrored, unmounted }

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
@@ -1,0 +1,70 @@
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'safe_render_manager_helper.over_react.g.dart';
+
+/// A component that allows for safe unmounting of its single child by waiting for state changes
+/// sometimes queued by ReactJS to be applied.
+@Factory()
+UiFactory<SafeRenderManagerHelperProps> SafeRenderManagerHelper =
+    // ignore: undefined_identifier
+    _$SafeRenderManagerHelper;
+
+typedef ReactElement _GetInitialContent();
+
+@Props()
+class _$SafeRenderManagerHelperProps extends UiProps {
+  @requiredProp
+  _GetInitialContent getInitialContent;
+
+  CallbackRef contentRef;
+}
+
+@State()
+class _$SafeRenderManagerHelperState extends UiState {
+  ReactElement content;
+}
+
+@Component()
+class SafeRenderManagerHelperComponent extends UiStatefulComponent<SafeRenderManagerHelperProps, SafeRenderManagerHelperState> {
+  @override
+  getInitialState() => (newState()..content = props.getInitialContent());
+
+  void renderContent(ReactElement content) {
+    setState(newState()..content = content);
+  }
+
+  void tryUnmountContent({void onMaybeUnmounted(bool isUnmounted)}) {
+    setState(newState()..content = null, () {
+      onMaybeUnmounted?.call(state.content == null);
+    });
+  }
+
+  bool get hasContent => state.content != null;
+
+  @override
+  render() {
+    final content = state.content;
+    if (content == null) return null;
+
+    return cloneElement(content, domProps()..ref = chainRef(content, _contentRef));
+  }
+
+  void _contentRef(ref) {
+    props.contentRef?.call(ref);
+  }
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class SafeRenderManagerHelperProps extends _$SafeRenderManagerHelperProps with _$SafeRenderManagerHelperPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForSafeRenderManagerHelperProps;
+}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class SafeRenderManagerHelperState extends _$SafeRenderManagerHelperState with _$SafeRenderManagerHelperStateAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const StateMeta meta = _$metaForSafeRenderManagerHelperState;
+}

--- a/test/over_react/util/safe_render_manager/safe_render_manager_helper_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_helper_test.dart
@@ -1,0 +1,119 @@
+@TestOn('browser')
+library safe_unmounter_test;
+
+import 'dart:async';
+
+import 'package:over_react/over_react.dart';
+import 'package:over_react/src/util/safe_render_manager/safe_render_manager_helper.dart';
+import 'package:over_react_test/over_react_test.dart';
+import 'package:test/test.dart';
+
+/// Main entry point for SafeRenderManagerHelper testing
+main() {
+  setClientConfiguration();
+  enableTestMode();
+
+  group('SafeRenderManagerHelper component', () {
+    test('renders with the single child initially mounted', () {
+      var renderedInstance = render((SafeRenderManagerHelper()
+        ..getInitialContent = () {
+          return (Dom.div()..addTestId('singleChild'))();
+        }
+      )());
+
+      expect(getByTestId(renderedInstance, 'singleChild'), isNotNull);
+    });
+
+    group('renderContent', () {
+      dynamic renderedInstance;
+      SafeRenderManagerHelperComponent component;
+
+      setUp(() {
+        renderedInstance = render((SafeRenderManagerHelper()
+          ..getInitialContent = () {
+            return (Dom.div()..addTestId('singleChild'))();
+          }
+        )());
+        component = getDartComponent(renderedInstance);
+      });
+
+      tearDown(() {
+        renderedInstance = null;
+        component = null;
+      });
+
+      test('renders new content', () {
+        component.renderContent((Dom.div()..addTestId('singleChild2'))());
+
+        expect(getByTestId(renderedInstance, 'singleChild'), isNull);
+        expect(getByTestId(renderedInstance, 'singleChild2'), isNotNull);
+      });
+    });
+
+    group('tryUnmountContent()', () {
+      dynamic renderedInstance;
+      SafeRenderManagerHelperComponent component;
+
+      setUp(() {
+        renderedInstance = render((SafeRenderManagerHelper()
+          ..getInitialContent = () {
+            return (Dom.div()..addTestId('singleChild'))();
+          }
+        )());
+        component = getDartComponent(renderedInstance);
+      });
+
+      tearDown(() {
+        renderedInstance = null;
+        component = null;
+      });
+
+      test('causes a rerender with the child unmounted', () {
+        expect(getByTestId(renderedInstance, 'singleChild'), isNotNull, reason: 'test setup sanity check');
+
+        component.tryUnmountContent();
+
+        expect(getByTestId(renderedInstance, 'singleChild'), isNull);
+      });
+
+      test('causes a rerender and calls the specified callback', () async {
+        expect(getByTestId(renderedInstance, 'singleChild'), isNotNull, reason: 'test setup sanity check');
+
+        final onUnmountCompleter = new Completer();
+
+        storeZone();
+        component.tryUnmountContent(onMaybeUnmounted: (isUnmounted) {
+          zonedExpect(getByTestId(renderedInstance, 'singleChild'), isNull);
+          zonedExpect(isUnmounted, isTrue);
+
+          onUnmountCompleter.complete();
+        });
+
+        await onUnmountCompleter.future;
+      });
+
+      test('does not throw when called more than once', () {
+        component.tryUnmountContent();
+        expect(() => component.tryUnmountContent(), returnsNormally);
+      });
+
+      test('calls the specified callback if no content is rendered', () async {
+        expect(getByTestId(renderedInstance, 'singleChild'), isNotNull, reason: 'test setup sanity check');
+
+        final onUnmountCompleter = new Completer();
+
+        storeZone();
+        component.tryUnmountContent();
+        zonedExpect(getByTestId(renderedInstance, 'singleChild'), isNull);
+
+        component.tryUnmountContent(onMaybeUnmounted: (isUnmounted) {
+          zonedExpect(getByTestId(renderedInstance, 'singleChild'), isNull);
+          zonedExpect(isUnmounted, isTrue);
+          onUnmountCompleter.complete();
+        });
+
+        await onUnmountCompleter.future;
+      });
+    });
+  });
+}

--- a/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
@@ -1,0 +1,707 @@
+@TestOn('browser')
+library top_level_render_manager_test;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:meta/meta.dart';
+import 'package:react/react.dart' as react;
+import 'package:over_react/over_react.dart';
+import 'package:over_react/src/util/safe_render_manager/safe_render_manager.dart';
+import 'package:over_react_test/over_react_test.dart';
+import 'package:test/test.dart';
+import 'package:w_common/disposable.dart';
+
+import 'test_component.dart';
+
+/// Main entry point for TopLevelRenderManager testing
+main() {
+  setClientConfiguration();
+  enableTestMode();
+
+  group('SafeRenderManager', () {
+    Element mountNode;
+    SafeRenderManager renderManager;
+
+    setUp(() {
+      mountNode = new DivElement();
+      renderManager = new SafeRenderManager(mountNode: mountNode);
+    });
+
+    tearDown(() async {
+      await renderManager?.dispose();
+      mountNode.remove();
+    });
+
+    group('render()', () {
+      test('renders a component into the specified `mountNode`', () {
+        renderManager.render(Dom.div()('foo'));
+        expect(mountNode.text, 'foo');
+      });
+
+      test('rerenders a component into the specified `mountNode`', () {
+        renderManager.render(Dom.div()('foo'));
+        renderManager.render(Dom.div()('bar'));
+
+        expect(mountNode.text, 'bar');
+      });
+
+      group('renders a component and exposes a ref to it via `contentRef`', () {
+        test('when there is no existing ref', () {
+          renderManager.render(Wrapper()());
+
+          expect(renderManager.contentRef, isNotNull);
+          expect(renderManager.contentRef, const isInstanceOf<WrapperComponent>());
+        });
+
+        test('by chaining any existing callback ref', () {
+          WrapperComponent existingWrapperRef;
+
+          renderManager.render((Wrapper()..ref = ((ref) => existingWrapperRef = ref))());
+
+          expect(renderManager.contentRef, isNotNull);
+          expect(existingWrapperRef, same(renderManager.contentRef));
+        });
+      });
+    });
+
+    group('tryUnmount()', () {
+      group('unmounts the rendered component', () {
+        setUp(() {
+          renderManager.render(Wrapper()());
+          expect(mountNode.children, isNotEmpty);
+        });
+
+        test('', () async {
+          renderManager.tryUnmount();
+          expect(mountNode.children, isEmpty);
+        });
+
+        test('and calls the provided callback when complete', () async {
+          renderManager.render(Wrapper()());
+
+          expect(mountNode.children, isNotEmpty);
+
+          final onUnmountCompleter = new Completer();
+
+          renderManager.tryUnmount(onMaybeUnmounted: bind1Guarded((isUnmounted) {
+            expect(mountNode.children, isEmpty);
+            expect(isUnmounted, isTrue);
+
+            onUnmountCompleter.complete();
+          }));
+
+          await onUnmountCompleter.future;
+        });
+      });
+
+      test('invokes the provided callback immediately when nothing has been rendered', () async {
+        expect(mountNode.children, isEmpty, reason: 'test setup sanity check');
+
+        bool onUnmountCalledSynchronously = false;
+
+        renderManager.tryUnmount(onMaybeUnmounted: bind1Guarded((isUnmounted) {
+          expect(isUnmounted, isTrue);
+          onUnmountCalledSynchronously = true;
+        }));
+
+        expect(onUnmountCalledSynchronously, isTrue);
+      });
+    });
+
+    group('automatically attaches and detached the mount node', () {
+      setUp(() async {
+        // Clean up the manager from the above setUp block.
+        await renderManager?.dispose();
+        renderManager = null;
+      });
+
+      test('when autoAttachMountNode is true', () {
+        renderManager = new SafeRenderManager(autoAttachMountNode: true);
+        expect(document.contains(renderManager.mountNode), isFalse, reason: 'test setup check');
+
+        renderManager.render(Dom.div()());
+        expect(renderManager.mountNode.parent, document.body);
+
+        renderManager.tryUnmount();
+        expect(renderManager.mountNode.parent, isNull);
+      });
+
+      test('unless autoAttachMountNode is false', () {
+        renderManager = new SafeRenderManager(autoAttachMountNode: false);
+        expect(renderManager.mountNode.parent, isNull, reason: 'test setup check');
+
+        renderManager.render(Dom.div()());
+        expect(renderManager.mountNode.parent, isNull);
+
+        // Attach the node manually
+        document.body.append(renderManager.mountNode);
+        addTearDown(renderManager.mountNode.remove);
+
+        renderManager.tryUnmount();
+        expect(renderManager.mountNode.parent, document.body, reason: 'should not have removed the mount node');
+      });
+    });
+
+    group('throws when the object is interacted with after disposal:', () {
+      final throwsObjectDisposedException = throwsA(const isInstanceOf<ObjectDisposedException>());
+
+      setUp(() async {
+        await renderManager.dispose();
+      });
+
+      test('render', () {
+        expect(() => renderManager.render(Dom.div()()), throwsObjectDisposedException);
+      });
+
+      test('tryUnmount', () {
+        expect(() => renderManager.tryUnmount(), throwsObjectDisposedException);
+      });
+    });
+
+    group('gracefully handles uncaught component lifecycle errors', () {
+      void sharedTests() {
+        group('recovers,', () {
+          test('and can dispose properly', () async {
+            // Should not throw
+            await renderManager.dispose();
+          });
+
+          test('and can render content again and then dispose properly', () async {
+            renderManager.render(Dom.div()('second render'));
+            expect(renderManager.mountNode.text, 'second render');
+
+            // Should not throw
+            await renderManager.dispose();
+            expect(renderManager.mountNode.text, isEmpty);
+          });
+        });
+      }
+
+      group('on initial mount,', () {
+        setUp(() {
+          try {
+            renderManager.render((Test()
+              ..onComponentDidMount = bind0(expectAsync0(() {
+                throw new TestExceptionThrownFromLifecycle();
+              }, id: 'onComponentDidMount'))
+            )());
+          } on TestExceptionThrownFromLifecycle catch (_) {}
+        });
+
+        sharedTests();
+      });
+
+      // rerender and unmount are tested below
+    });
+
+    group('edge-cases:', () {
+      group('rerenders content correctly when when initial and second render happen synchronously and', () {
+        LifecycleCallback onRender;
+
+        setUp(() {
+          onRender = null;
+        });
+
+        // ---------------------------------------------------------------------
+        // Begin unmount sharedTests
+        void sharedRerenderTests({@required bool isThrowingTest}) {
+          group('calls come from', () {
+            const render1Text = 'render1';
+            const render2Text = 'render2';
+
+            bool onMaybeUnmountedCalled;
+
+            setUp(() {
+              onMaybeUnmountedCalled = false;
+            });
+
+            tearDown(() async {
+              const additionalRenderText = 'additionalRenderText';
+              renderManager.render(Test()(additionalRenderText));
+              expect(mountNode.text, additionalRenderText,
+                  reason: 'should be able to render additional content properly afterwards');
+
+              // Should not throw
+              await renderManager.dispose();
+              expect(renderManager.mountNode.text, isEmpty,
+                  reason: 'should be able to dispose properly afterwards');
+            });
+
+            Future<Null> sharedTest({@required void Function() setUpAndReturnTriggerRender(void doRenders()),
+              @required bool verifyImmediateRender,
+              @required bool verifyDeferredRender,
+            }) async {
+              if (verifyImmediateRender && verifyDeferredRender) {
+                throw new ArgumentError('verifyImmediateRender and verifyDeferredRender '
+                    'are mutually exclusive and cannot both be set to true');
+              }
+
+              // Bind guarded so that any failing `expect`s, which result in synchronous errors,
+              // are handled by the test zone's error handler and not swallowed
+              // by whichever zone they end up being run in
+              // (e.g., the root zone in the case of event handlers).
+              final doRenders = bind0Guarded(expectAsync0(() {
+                renderManager.render(Test()(render1Text));
+                // Catch any errors thrown synchronously by this call, which will
+                // happen only when rendering is not deferred...
+                try {
+                  renderManager.render((Test()..onRender = onRender)(render2Text));
+                } on TestExceptionThrownFromLifecycle catch (_) {
+                  // ...but rethrow them if we're not expecting them so they aren't swallowed.
+                  if (!isThrowingTest) rethrow;
+                }
+
+                if (!isThrowingTest) {
+                  if (verifyImmediateRender) {
+                    expect(mountNode.text, render2Text, reason: 'should have updated synchronously');
+                  }
+
+                  if (verifyDeferredRender) {
+                    expect(mountNode.text, isNot(anyOf(render1Text, render2Text)),
+                        reason: 'should have updated synchronously');
+                  }
+                }
+              }, id: 'doRenders', reason: 'needs to be called as part of test'));
+
+              final triggerRenders = setUpAndReturnTriggerRender(doRenders);
+
+              await pumpEventQueue();
+              expect(onMaybeUnmountedCalled, isFalse,
+                  reason: 'test setup: content should still be mounted before doRenders is called');
+              expect(mountNode.text, isNot(anyOf(render1Text, render2Text)),
+                  reason: 'test setup: content should still be mounted before doRenders is called');
+
+              // Catch any errors thrown synchronously by this call, which will
+              // happen only when rendering is deferred...
+              try {
+                triggerRenders();
+              } on TestExceptionThrownFromLifecycle catch (_) {
+                // ...but rethrow them if we're not expecting them so they aren't swallowed.
+                if (!isThrowingTest) rethrow;
+              }
+
+              if (isThrowingTest) {
+                expect(mountNode.text, isEmpty, reason: 'test setup check: React should have unmounted throwing component tree');
+              } else {
+                expect(mountNode.text, render2Text, reason: 'should have updated by now');
+              }
+            }
+
+            group('the same React tree (rerenders only, not mounting), from a', () {
+              test('event handler', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    document.body.append(renderManager.mountNode);
+                    renderManager.render((Wrapper()
+                      ..onClick = (_) {
+                        doRenders();
+                      }
+                    )('setup render'));
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => findDomNode(renderManager.contentRef).click();
+                  },
+                );
+              });
+
+              test('callback of setState performed within event handler', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    document.body.append(renderManager.mountNode);
+                    renderManager.render((Wrapper()
+                      ..onClick = (_) {
+                        (renderManager.contentRef as react.Component).setState({}, doRenders);
+                      }
+                    )('setup render'));
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => findDomNode(renderManager.contentRef).click();
+                  },
+                );
+              });
+
+              test('lifecycle method (pre-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    renderManager.render((Test()
+                      ..onComponentWillUpdate = doRenders
+                    )());
+
+                    return () => (renderManager.contentRef as react.Component).redraw();
+                  },
+                );
+              });
+
+              test('lifecycle method (post-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    renderManager.render((Test()
+                      ..onComponentDidUpdate = doRenders
+                    )());
+
+                    return () => (renderManager.contentRef as react.Component).redraw();
+                  },
+                );
+              });
+            });
+
+            group('another React tree, from a', () {
+              test('event handler', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: false,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    final jacket = mount((Wrapper()
+                      ..onClick = (_) {
+                        doRenders();
+                      }
+                    )(), attachedToDocument: true);
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => jacket.getNode().click();
+                  },
+                );
+              });
+
+              test('callback of setState performed within event handler', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    TestJacket jacket;
+                    jacket = mount((Wrapper()
+                      ..onClick = (_) {
+                        jacket.getDartInstance().setState({}, doRenders);
+                      }
+                    )(), attachedToDocument: true);
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => jacket.getNode().click();
+                  },
+                );
+              });
+
+              test('lifecycle method (pre-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    final jacket = mount((Test()
+                      ..onComponentWillUpdate = doRenders
+                    )());
+
+                    return () => jacket.getDartInstance().redraw();
+                  },
+                );
+              });
+
+              test('lifecycle method (post-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateRender: false,
+                  verifyDeferredRender: true,
+                  setUpAndReturnTriggerRender: (doRenders) {
+                    final jacket = mount((Test()
+                      ..onComponentDidUpdate = doRenders
+                    )());
+
+                    return () => jacket.getDartInstance().redraw();
+                  },
+                );
+              });
+            });
+          });
+        }
+        // End rerender sharedTests
+        // ---------------------------------------------------------------------
+
+        group('second render occurs normally and', () {
+          sharedRerenderTests(isThrowingTest: false);
+        });
+
+        group('second render throws and', () {
+          setUp(() {
+            onRender = bind0(expectAsync0(() {
+              throw new TestExceptionThrownFromLifecycle();
+            }, id: 'onRender', max: 2)); // `max: 2` since React will call this more than once for some reason.
+          });
+
+          sharedRerenderTests(isThrowingTest: true);
+        });
+      });
+
+      group('unmounts content safely when', () {
+        LifecycleCallback onComponentWillUnmount;
+
+        setUp(() {
+          onComponentWillUnmount = null;
+        });
+
+        tearDown(() async {
+          const additionalRenderText = 'additionalRenderText';
+          renderManager.render(Test()(additionalRenderText));
+          expect(mountNode.text, additionalRenderText,
+              reason: 'should be able to render additional content properly afterwards');
+
+          // Should not throw
+          await renderManager.dispose();
+          expect(renderManager.mountNode.text, isEmpty,
+              reason: 'should be able to dispose properly afterwards');
+        });
+
+        // ---------------------------------------------------------------------
+        // Begin unmount sharedTests
+        void sharedUnmountTests({@required bool isThrowingTest}) {
+          group('unmount calls come from', () {
+            bool onMaybeUnmountedCalled;
+
+            setUp(() {
+              onMaybeUnmountedCalled = false;
+            });
+
+            Future<Null> sharedTest({@required void Function() setUpAndReturnUnmounter(void doUnmount()),
+              @required bool verifyImmediateUnmount,
+              @required bool verifyDeferredUnmount,
+            }) async {
+              if (verifyImmediateUnmount && verifyDeferredUnmount) {
+                throw new ArgumentError('verifyImmediateUnmount and verifyDeferredUnmount '
+                    'are mutually exclusive and cannot both be set to true');
+              }
+
+              void _doUnmount() {
+                expect(mountNode.text, '1', reason: 'test setup check; should not have unmounted yet');
+
+                renderManager.tryUnmount(onMaybeUnmounted: bind1Guarded(expectAsync1((isUnmounted) {
+                  onMaybeUnmountedCalled = true;
+                  expect(isUnmounted, isTrue, reason: 'should have unmounted');
+                }, id: 'onMaybeUnmounted', reason: 'should always be called on unmount')));
+
+                if (verifyDeferredUnmount) {
+                  expect(onMaybeUnmountedCalled, isFalse, reason: 'should not have unmounted yet');
+                  expect(mountNode.text, '1', reason: 'should not have unmounted yet');
+                }
+                if (verifyImmediateUnmount) {
+                  expect(onMaybeUnmountedCalled, isTrue, reason: 'should have unmounted by now');
+                  expect(mountNode.text, '', reason: 'should have unmounted by now');
+                }
+              }
+              // Bind guarded so that any failing `expect`s, which result in synchronous errors,
+              // are handled by the test zone's error handler and not swallowed
+              // by whichever zone they end up being run in
+              // (e.g., the root zone in the case of event handlers).
+              final doUnmount = bind0Guarded(expectAsync0(_doUnmount,
+                  id: 'doUnmount', reason: 'must to be called as part of test'));
+
+              final triggerUnmount = setUpAndReturnUnmounter(doUnmount);
+
+              await pumpEventQueue();
+              expect(onMaybeUnmountedCalled, isFalse,
+                  reason: 'test setup: content should still be mounted before doUnmount is called');
+              expect(mountNode.text, '1',
+                  reason: 'test setup: content should still be mounted before doUnmount is called');
+
+              // Catch any errors thrown synchronously by this call, which will
+              // happen in some cases where mounting is synchronous...
+              try {
+                triggerUnmount();
+              } on TestExceptionThrownFromLifecycle catch (_) {
+                // ..but rethrow them if we're not expecting them so they aren't swallowed.
+                if (!isThrowingTest) rethrow;
+              }
+
+              expect(onMaybeUnmountedCalled, isTrue,
+                  reason: 'should have unmounted by now');
+              expect(mountNode.text, '', reason: 'should have unmounted by now');
+            }
+
+            group('the same React tree, from a', () {
+              test('event handler', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    document.body.append(renderManager.mountNode);
+                    renderManager.render((Test()
+                      ..onClick = (_) {
+                        callUnmount();
+                      }
+                      ..onComponentWillUnmount = onComponentWillUnmount
+                    )('1'));
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => findDomNode(renderManager.contentRef).click();
+                  },
+                );
+              });
+
+              test('callback of setState performed within event handler', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    document.body.append(renderManager.mountNode);
+                    renderManager.render((Test()
+                      ..onClick = (_) {
+                        (renderManager.contentRef as react.Component).setState({}, callUnmount);
+                      }
+                      ..onComponentWillUnmount = onComponentWillUnmount
+                    )('1'));
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => findDomNode(renderManager.contentRef).click();
+                  },
+                );
+              });
+
+              test('lifecycle method (pre-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    renderManager.render((Test()
+                      ..onComponentWillUpdate = callUnmount
+                      ..onComponentWillUnmount = onComponentWillUnmount
+                    )('1'));
+
+                    return () => (renderManager.contentRef as react.Component).redraw();
+                  },
+                );
+              });
+
+              test('lifecycle method (post-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    renderManager.render((Test()
+                      ..onComponentDidUpdate = callUnmount
+                      ..onComponentWillUnmount = onComponentWillUnmount
+                    )('1'));
+
+                    return () => (renderManager.contentRef as react.Component).redraw();
+                  },
+                );
+              });
+            });
+
+            group('another React tree, from a', () {
+              setUp(() {
+                renderManager.render((Test()
+                  ..onComponentWillUnmount = onComponentWillUnmount
+                )('1'));
+                expect(mountNode.text, '1', reason: 'test setup check');
+              });
+
+              test('event handler', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    final jacket = mount((Test()
+                      ..onClick = (_) {
+                        callUnmount();
+                      }
+                    )(), attachedToDocument: true);
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => jacket.getNode().click();
+                  },
+                );
+              });
+
+              test('callback of setState performed within event handler', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    TestJacket jacket;
+                    jacket = mount((Test()
+                      ..onClick = (_) {
+                        jacket.getDartInstance().setState({}, callUnmount);
+                      }
+                    )(), attachedToDocument: true);
+
+                    // Use a real click since simulated clicks don't trigger this async behavior
+                    return () => jacket.getNode().click();
+                  },
+                );
+              });
+
+              test('lifecycle method (pre-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    final jacket = mount((Test()
+                      ..onComponentWillUpdate = callUnmount
+                    )());
+
+                    return () => jacket.getDartInstance().redraw();
+                  },
+                );
+              });
+
+              test('lifecycle method (post-commit phase)', () async {
+                await sharedTest(
+                  verifyImmediateUnmount: false,
+                  verifyDeferredUnmount: true,
+                  setUpAndReturnUnmounter: (callUnmount) {
+                    final jacket = mount((Test()
+                      ..onComponentDidUpdate = callUnmount
+                    )());
+
+                    return () => jacket.getDartInstance().redraw();
+                  },
+                );
+              });
+            });
+          });
+        }
+        // End unmount sharedTests
+        // ---------------------------------------------------------------------
+
+        group('unmounting occurs normally and', () {
+          sharedUnmountTests(isThrowingTest: false);
+        });
+
+        group('unmounting throws and', () {
+          setUp(() {
+            onComponentWillUnmount = bind0(expectAsync0(() {
+              throw new TestExceptionThrownFromLifecycle();
+            }, id: 'onComponentWillUnmount'));
+          });
+
+          sharedUnmountTests(isThrowingTest: true);
+        });
+      });
+    });
+  }, timeout: const Timeout(const Duration(seconds: 1)));
+}
+
+/// Shorthand for [Zone.bindCallback] on the current zone.
+ZoneCallback<R> bind0<R>(ZoneCallback<R> callback) =>
+    Zone.current.bindCallback(callback);
+
+/// Shorthand for [Zone.bindUnaryCallback] on the current zone.
+ZoneUnaryCallback<R, T> bind1<R, T>(ZoneUnaryCallback<R, T> callback) =>
+    Zone.current.bindUnaryCallback(callback);
+
+/// Shorthand for [Zone.bindCallbackGuarded] on the current zone.
+ZoneCallback<void> bind0Guarded(ZoneCallback<void> callback) =>
+    Zone.current.bindCallbackGuarded(callback);
+
+/// Shorthand for [Zone.bindUnaryCallbackGuarded] on the current zone.
+ZoneUnaryCallback<void, T> bind1Guarded<T>(ZoneUnaryCallback<void, T> callback) =>
+    Zone.current.bindUnaryCallbackGuarded(callback);
+
+/// An exception used for testing, which we can tell apart from
+/// other arbitrary exceptions via type-checking.
+class TestExceptionThrownFromLifecycle implements Exception {}

--- a/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
@@ -228,7 +228,7 @@ main() {
                   reason: 'should be able to dispose properly afterwards');
             });
 
-            Future<Null> sharedTest({@required void Function() setUpAndReturnTriggerRender(void doRenders()),
+            Future<Null> sharedTest({@required VoidFunc0 setUpAndReturnTriggerRender(void doRenders()),
               @required bool verifyImmediateRender,
               @required bool verifyDeferredRender,
             }) async {
@@ -467,7 +467,7 @@ main() {
               onMaybeUnmountedCalled = false;
             });
 
-            Future<Null> sharedTest({@required void Function() setUpAndReturnUnmounter(void doUnmount()),
+            Future<Null> sharedTest({@required VoidFunc0 setUpAndReturnUnmounter(void doUnmount()),
               @required bool verifyImmediateUnmount,
               @required bool verifyDeferredUnmount,
             }) async {
@@ -476,7 +476,7 @@ main() {
                     'are mutually exclusive and cannot both be set to true');
               }
 
-              void _doUnmount() {
+              _doUnmount() {
                 expect(mountNode.text, '1', reason: 'test setup check; should not have unmounted yet');
 
                 renderManager.tryUnmount(onMaybeUnmounted: bind1Guarded(expectAsync1((isUnmounted) {
@@ -695,13 +695,15 @@ ZoneUnaryCallback<R, T> bind1<R, T>(ZoneUnaryCallback<R, T> callback) =>
     Zone.current.bindUnaryCallback(callback);
 
 /// Shorthand for [Zone.bindCallbackGuarded] on the current zone.
-ZoneCallback<void> bind0Guarded(ZoneCallback<void> callback) =>
-    Zone.current.bindCallbackGuarded(callback);
+ZoneCallback<Null> bind0Guarded(ZoneCallback<Null> callback) =>
+    Zone.current.bindCallback(callback, runGuarded: true);
 
 /// Shorthand for [Zone.bindUnaryCallbackGuarded] on the current zone.
-ZoneUnaryCallback<void, T> bind1Guarded<T>(ZoneUnaryCallback<void, T> callback) =>
-    Zone.current.bindUnaryCallbackGuarded(callback);
+ZoneUnaryCallback<Null, T> bind1Guarded<T>(ZoneUnaryCallback<Null, T> callback) =>
+    Zone.current.bindUnaryCallback(callback, runGuarded: true);
 
 /// An exception used for testing, which we can tell apart from
 /// other arbitrary exceptions via type-checking.
 class TestExceptionThrownFromLifecycle implements Exception {}
+
+typedef void VoidFunc0();

--- a/test/over_react/util/safe_render_manager/test_component.dart
+++ b/test/over_react/util/safe_render_manager/test_component.dart
@@ -1,0 +1,51 @@
+import 'package:over_react/over_react.dart';
+
+part 'test_component.over_react.g.dart';
+
+@Factory()
+UiFactory<TestProps> Test = _$Test;
+
+@Props()
+class _$TestProps extends UiProps {
+  LifecycleCallback onComponentDidMount;
+  LifecycleCallback onComponentWillUpdate;
+  LifecycleCallback onComponentWillReceiveProps;
+  LifecycleCallback onComponentDidUpdate;
+  LifecycleCallback onComponentWillUnmount;
+  LifecycleCallback onRender;
+}
+
+@Component(isWrapper: true)
+class TestComponent extends UiComponent<TestProps> {
+  @override
+  componentDidMount() {
+    props.onComponentDidMount?.call();
+  }
+
+  @override
+  componentDidUpdate(prevProps, prevState) {
+    props.onComponentDidUpdate?.call();
+  }
+  @override
+  componentWillUpdate(nextProps, nextState) {
+    typedPropsFactory(nextProps).onComponentWillUpdate?.call();
+  }
+  @override
+  componentWillReceiveProps(nextProps) {
+    super.componentWillReceiveProps(nextProps);
+    typedPropsFactory(nextProps).onComponentWillReceiveProps?.call();
+  }
+  @override
+  componentWillUnmount() {
+    super.componentWillUnmount();
+    typedPropsFactory(nextProps).onComponentWillUnmount?.call();
+  }
+
+  @override
+  render() {
+    props.onRender?.call();
+    return (Dom.div()..addProps(copyUnconsumedProps()))(props.children);
+  }
+}
+
+typedef void LifecycleCallback();

--- a/test/over_react/util/safe_render_manager/test_component.dart
+++ b/test/over_react/util/safe_render_manager/test_component.dart
@@ -1,9 +1,12 @@
 import 'package:over_react/over_react.dart';
 
+// ignore: uri_has_not_been_generated
 part 'test_component.over_react.g.dart';
 
 @Factory()
-UiFactory<TestProps> Test = _$Test;
+UiFactory<TestProps> Test =
+    // ignore: undefined_identifier
+    _$Test;
 
 @Props()
 class _$TestProps extends UiProps {
@@ -49,3 +52,11 @@ class TestComponent extends UiComponent<TestProps> {
 }
 
 typedef void LifecycleCallback();
+
+class TestProps extends _$TestProps
+    with
+        // ignore: mixin_of_non_class, undefined_class
+        _$TestPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForTestProps;
+}

--- a/test/over_react_util_test.dart
+++ b/test/over_react_util_test.dart
@@ -38,6 +38,8 @@ import 'over_react/util/prop_key_util_test_dart2.dart' as prop_key_util_test_dar
 import 'over_react/util/react_util_test.dart' as react_util_test;
 import 'over_react/util/react_wrappers_test.dart' as react_wrappers_test;
 import 'over_react/util/rem_util_test.dart' as rem_util_test;
+import 'over_react/util/safe_render_manager/safe_render_manager_test.dart' as safe_render_manager_test;
+import 'over_react/util/safe_render_manager/safe_render_manager_helper_test.dart' as safe_render_manager_helper_test;
 import 'over_react/util/string_util_test.dart' as string_util_test;
 import 'over_react/util/test_mode_test.dart' as test_mode_test;
 
@@ -61,6 +63,8 @@ void main() {
   react_util_test.main();
   react_wrappers_test.main();
   rem_util_test.main();
+  safe_render_manager_test.main();
+  safe_render_manager_helper_test.main();
   string_util_test.main();
   test_mode_test.main();
 }


### PR DESCRIPTION
Dart 1 version of https://github.com/Workiva/over_react/pull/390 —see that PR for details.

All commits from that PR (other than generated code updates) were cherry-picked without merge conflicts.

Two additional commits were added adding Dart 1 compatibility and fixing tests in Dart 1:
https://github.com/Workiva/over_react/pull/396/files/b9f81fb542de38f7cabfb9cf5c2908429b4e7961..0242e043715861d8e0d9f850f5c8ac575598e4ea