### PR TITLE
RM-60450 Release over_react 3.0.0-alpha.6+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 3.0.0 (alpha)
 
+- __3.0.0-alpha.6__
+
+  * [#404] Clean up Dart 2 lints
+  * [#371] Fix `manageAndReturnTypedDisposable` null exception
+  
+  > Complete `3.0.0-alpha.6` Changesets:
+  >
+  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.5+dart2...3.0.0-alpha.6+dart2)
+  > - Dart 1 (no changes)
+
 - __3.0.0-alpha.5__
 
   * [#390] Add new SafeRenderManager utility

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.5+dart2
+version: 3.0.0-alpha.6+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
This Dart 2 only __alpha__ release of over_react includes:

* #404 Clean up Dart 2 lints
* #371 Fix `manageAndReturnTypedDisposable` null exception

---

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 