### PR TITLE
RM-60869 Release over_react 3.0.0+dart2 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,15 @@
   > - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...3.0.0-alpha.0+dart2)
   > - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.0+dart1...3.0.0-alpha.0+dart1)
 
+## 2.7.0
+
+> Complete `2.7.0` Changsets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.6.1+dart2...2.7.0+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.6.1+dart1...2.7.0+dart1)
+
+* This release brings in the `SafeRenderManager` utilities added to the 3.x alpha line-of-release via [#390]  
+
 ## 2.6.1
 
 > Complete `2.6.1` Changsets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,81 +1,17 @@
 # OverReact Changelog
 
-## 3.0.0 (alpha)
+## 3.0.0
 
-- __3.0.0-alpha.6__
+__ReactJS 16.x Support__
 
-  * [#404] Clean up Dart 2 lints
-  * [#371] Fix `manageAndReturnTypedDisposable` null exception
-  
-  > Complete `3.0.0-alpha.6` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.5+dart2...3.0.0-alpha.6+dart2)
-  > - Dart 1 (no changes)
+- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).
 
-- __3.0.0-alpha.5__
+> Complete `3.0.0` Changesets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/2.7.0+dart2...3.0.0+dart2)
+> - [Dart 1](https://github.com/Workiva/over_react/compare/2.7.0+dart1...3.0.0+dart1)
 
-  * [#390] Add new SafeRenderManager utility
-  
-  > Complete `3.0.0-alpha.5` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.4+dart2...3.0.0-alpha.5+dart2)
-  > - [Dart 1](https://github.com/Workiva/over_react/compare/3.0.0-alpha.4+dart1...3.0.0-alpha.5+dart1)
-
-- __3.0.0-alpha.4__
-
-  * [#383] Update prop typedef to work around [Dart 2.6 compiler regression](https://github.com/dart-lang/sdk/issues/38880)
-
-  > Complete `3.0.0-alpha.4` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.3+dart2...3.0.0-alpha.4+dart2)
-  > - Dart 1 (no changes)
-
-- __3.0.0-alpha.3__
-
-  * [#370] Add error logging to ErrorBoundary
-
-  > Complete `3.0.0-alpha.3` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.2+dart2...3.0.0-alpha.3+dart2)
-  > - [Dart 1](https://github.com/Workiva/over_react/compare/3.0.0-alpha.2+dart1...3.0.0-alpha.3+dart1)
-
-- __3.0.0-alpha.2__
-
-  * [#363] Dart 2 Widen `analyzer` dependency range
-
-  > Complete `3.0.0-alpha.2` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.1+dart2...3.0.0-alpha.2+dart2)
-  > - Dart 1 (no changes)
-
-- __3.0.0-alpha.1__
-
-  * [#350] Improve handling of “repeat” errors thrown from components wrapped by an `ErrorBoundary`.
-
-  > Complete `3.0.0-alpha.1` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0-alpha.0+dart2...3.0.0-alpha.1+dart2)
-  > - [Dart 1](https://github.com/Workiva/over_react/compare/3.0.0-alpha.0+dart1...3.0.0-alpha.1+dart1)
-
-- __3.0.0-alpha.0__
-
-  __ReactJS 16.x Support__ _(and Dart 1 compatible)_
-
-  * The underlying `react` dependency ([version 5.0.0](https://github.com/cleandart/react-dart/pull/214)) now provides ReactJS version 16 `.js` source files.
-  * Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).
-
-  __Breaking Changes__
-
-  * [#314] The `.over_react.g.dart` part directive is required on Dart 2. The
-    builder now logs at the `SEVERE` level (which causes the build to fail) when
-    a missing part directive is detected. Previously, the builder only logged this
-    as a warning. In other words, the issue has been promoted from a runtime
-    exception to a build-time error.
-
-  > Complete `3.0.0-alpha.0` Changesets:
-  >
-  > - [Dart 2](https://github.com/Workiva/over_react/compare/2.5.2+dart2...3.0.0-alpha.0+dart2)
-  > - [Dart 1](https://github.com/Workiva/over_react/compare/2.5.0+dart1...3.0.0-alpha.0+dart1)
+> __[Full List of Breaking Changes](https://github.com/Workiva/over_react/pull/408)__
 
 ## 2.7.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OverReact
 
 [![Pub](https://img.shields.io/pub/v/over_react.svg)](https://pub.dartlang.org/packages/over_react)
-[![Documentation](https://img.shields.io/badge/docs-over_react-blue.svg)](https://pub.dev/documentation/react/latest/)
+[![Documentation](https://img.shields.io/badge/docs-over_react-blue.svg)](https://pub.dev/documentation/over_react/latest/)
 [![Join the chat at https://gitter.im/over_react/Lobby](https://badges.gitter.im/over_react/Lobby.svg)](https://gitter.im/over_react/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Build Status](https://travis-ci.org/Workiva/over_react.svg?branch=master)](https://travis-ci.org/Workiva/over_react)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OverReact
 
 [![Pub](https://img.shields.io/pub/v/over_react.svg)](https://pub.dartlang.org/packages/over_react)
-[![Documentation](https://img.shields.io/badge/docs-over__react-blue.svg)](https://workiva.github.io/over_react)
+[![Documentation](https://img.shields.io/badge/docs-over_react-blue.svg)](https://pub.dev/documentation/react/latest/)
 [![Join the chat at https://gitter.im/over_react/Lobby](https://badges.gitter.im/over_react/Lobby.svg)](https://gitter.im/over_react/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Build Status](https://travis-ci.org/Workiva/over_react.svg?branch=master)](https://travis-ci.org/Workiva/over_react)
@@ -50,7 +50,7 @@
 
     ```yaml
     dependencies:
-      over_react: ^2.0.0
+      over_react: ^3.0.0
     ```
 
 2. Include the native JavaScript `react` and `react_dom` libraries in your app’s `index.html` file,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.6+dart2
+version: 3.0.0+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
@@ -18,7 +18,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^5.0.0-alpha
+  react: ^5.0.0
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0


### PR DESCRIPTION
This stable, __major__ release of over_react includes:

### ReactJS 16.x Support

- The underlying `.js` files provided by this package are now ReactJS version `16.10.1`.
- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3).

> Full List of `3.0.0` Changes:
>
> - [Dart 2](https://github.com/Workiva/over_react/compare/2.7.0+dart2...3.0.0+dart2)
> - [Dart 1](https://github.com/Workiva/over_react/compare/2.7.0+dart1...3.0.0+dart1)

---

### Breaking Changes

__ReactJS 16 breaking changes__

> Source: https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes

Breakage | Migration path
-- | --
Errors in the render and lifecycle methods now unmount the component tree by default. | To prevent this, add error boundaries to the appropriate places in the UI.This can be done easily via the OverReact `ErrorBoundary` utility component.
Unitless `props.style` string values are no longer auto-converted to `px`.This has been a warning since React 15.0.0. | Change values from Strings to nums, or add a unit explicitly to string
`react_dom.render` calls within React lifecycle methods are no longer guaranteed to be synchronous, and may return `null` | Either: Use Portals to render content in a different DOM treeUpdate code to handle async mounting
`setState` callbacks (second argument) now fire immediately after componentDidMount / componentDidUpdate instead of after all components have rendered. | Transfer callback logic into `componentDidUpdate`.
It is not safe to re-render into a container that was modified by something other than React. This worked previously in some cases but was never supported. We now emit a warning in this case. | Instead you should clean up your component trees using `unmountComponentAtNode`.
Bool values used in non-bool props are no longer stringified, and are ignored. In most cases, passing bool values to these props is a programmer error, and should be replaced with the correct attribute values. | `.toString()` the value in any places where "false" or "true" are needed.
Previously, changing the `ref` to a component would always detach the ref before that component’s render is called. Now, we change the `ref` later, when applying the changes to the DOM. | Should not affect most usages.
When replacing `<A />` with `<B />`, `B.componentWillMount` now always happens before `A.componentWillUnmount`. Previously, `A.componentWillUnmount` could fire first in some cases. | Should not affect most usages. If it does, switching from `componentWillMount` to `componentDidMount` should resolve the issue, and will be functionally equivalent in most cases.

__Dart API breaking changes__

All of the Dart API breaking changes come from re-exports of members of the `react` package. Check out the [react 5.0.0 breaking changes](https://github.com/cleandart/react-dart/pull/224) for more information.