### PR TITLE
RM-60877 Release over_react 3.0.0+dart1 (stable)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0-alpha.6+dart1
+version: 3.0.0+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:
@@ -16,7 +16,7 @@ dependencies:
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^5.0.0-alpha
+  react: ^5.0.0
   source_span: ^1.4.1
   transformer_utils: ^0.1.5
   w_common: ^1.13.0


### PR DESCRIPTION
This Dart 1 only stable, __major__ release of over_react includes:

### ReactJS 16.x Support

- The underlying `.js` files provided by this package are now ReactJS version `16.10.1`.
- Support for the new / updated lifecycle methods from ReactJS 16 [will be released in version `3.1.0`](https://github.com/Workiva/over_react/milestone/3). __These new lifecycle methods will only be supported in Dart 2.__

> See: [The over_react 3.0.0+dart2 release](https://github.com/Workiva/over_react/pull/408) for more details about breaking changes, etc.

---

🚨 __NOTE: This will be the last release of over_react that supports the Dart 1 SDK.__   🚨