### PR TITLE
RM-60981 Release over_react 3.0.1+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## 3.0.1
+
+- Lower the Dart SDK lower-bound to `2.4.0`. It was accidentally raised to `2.4.1` in the 3.0.0 release.
+
+> Complete `3.0.1` Changesets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.0+dart2...3.0.1+dart2)
+> - Dart 1 (No Changes)
+
 ## 3.0.0
 
 __ReactJS 16.x Support__

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.0+dart2
+version: 3.0.1+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
   - Workiva UI Platform Chapter <uip@workiva.com>
   - Workiva App Frameworks Team <appframeworks@workiva.com>
 environment:
-  sdk: '>=2.4.1 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   analyzer: '>=0.35.0 <0.39.0'


### PR DESCRIPTION
This Dart 2 only, stable patch release of over_react lowers the Dart SDK lower-bound to `2.4.0`. It was accidentally increased to `2.4.1` in the 3.0.0 release.

---

@greglittlefield-wf 