### PR TITLE
RM-60496 RM-60495 Release over_react 3.0.2+dart2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OverReact Changelog
 
+## 3.0.2
+
+Dependency updates:
+- Lower the dart_style constraint from ^1.3.1 to ^1.2.5 to help avoid version lock in downstream packages
+- Open up built_value range to include 8.0.0
+
+> Complete `3.0.2` Changesets:
+>
+> - [Dart 2](https://github.com/Workiva/over_react/compare/3.0.1+dart2...3.0.2+dart2)
+> - Dart 1 (No Changes)
+
 ## 3.0.1
 
 - Lower the Dart SDK lower-bound to `2.4.0`. It was accidentally raised to `2.4.1` in the 3.0.0 release.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.1+dart2
+version: 3.0.2+dart2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   build: ^1.0.0
   built_redux: ^7.4.2
   built_value: '>=5.4.4 <7.0.0'
-  dart_style: ^1.3.1
+  dart_style: ^1.2.5
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   meta: ^1.1.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   analyzer: '>=0.35.0 <0.39.0'
   build: ^1.0.0
   built_redux: ^7.4.2
-  built_value: '>=5.4.4 <7.0.0'
+  built_value: '>=5.4.4 <8.0.0'
   dart_style: ^1.2.5
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
@@ -32,7 +32,7 @@ dev_dependencies:
   build_test: ^0.10.9
   build_vm_compilers: ^1.0.3
   build_web_compilers: ^2.5.1
-  built_value_generator: ^6.0.0
+  built_value_generator: '>=6.0.0 <8.0.0'
   dart2_constant: ^1.0.0
   dart_dev: ^3.0.0
   dependency_validator: ^1.4.0


### PR DESCRIPTION
Dependency updates:
- Lower the dart_style constraint from ^1.3.1 to ^1.2.5 to help avoid version lock in downstream packages
- Open up built_value range to include 8.0.0
