### PR TITLE
RM-61028 RM-61027 Release over_react 3.0.2+dart1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.0.1+dart1
+version: 3.0.2+dart1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION
Counterpart to https://github.com/Workiva/over_react/pull/412, no changes for Dart 1