### PR TITLE
CPLAT-2276 Finalize UiComponent2 test coverage

### DIFF
--- a/test/over_react/component/dom_components_test.dart
+++ b/test/over_react/component/dom_components_test.dart
@@ -83,7 +83,7 @@ main() {
       if (expectedTagName == 'missingGlyph') expectedTagName = 'missing-glyph';
       if (expectedTagName.startsWith(RegExp('svg.'))) expectedTagName = expectedTagName.substring(3);
 
-      test('${method.toString()} generates the correct type', () {
+      test('Dom.$methodName() generates the correct type', () {
         DomProps builder = method();
         ReactElement component = builder();
         expect(component.type, equalsIgnoringCase(expectedTagName));

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -818,6 +818,15 @@ main() {
     group('UiComponent2', () {
       TestComponent2Component component2;
 
+      test('newProps() returns a new UiProps instance backed by a new Map', () {
+        component2 = TestComponent2Component();
+        var newProps1 = component2.newProps();
+        var newProps2 = component2.newProps();
+        expect(newProps1, isA<TestComponent2Props>());
+        expect(newProps2, isA<TestComponent2Props>());
+        expect(newProps1, isNot(same(newProps2)));
+      });
+
       group('copyUnconsumedProps()', () {
         test('copies props, omitting keys from `consumedProps`, as well as reserved react props', () {
           component2 = TestComponent2Component(testConsumedProps: [
@@ -985,6 +994,166 @@ main() {
           }));
         });
       });
+
+      group('on unmount', () {
+        TestComponent2Component component2;
+        ReactElement instance;
+        Duration longDuration = const Duration(milliseconds: 200);
+        Duration shortDuration = const Duration(milliseconds: 100);
+
+        setUp(() {
+          instance = render(TestComponent2()());
+          component2 = getDartComponent(instance);
+        });
+
+        Future<Null> unmountAndDisposal() async {
+          unmount(instance);
+          // Provide timers a window to fire
+          await Future.delayed(longDuration);
+        }
+
+        test('should await future before disposing', () async {
+          // ignore: close_sinks
+          var streamController = StreamController<String>.broadcast();
+          var completer = Completer<String>();
+
+          // Manage pending future
+          unawaited(component2.awaitBeforeDispose(completer.future));
+
+          // Add events to stream
+          component2.manageDisposer(() async => streamController.add('disposalFuture'));
+          unawaited(completer.future.then(streamController.add));
+
+          // Perform events out of order
+          await unmountAndDisposal();
+          completer.complete('awaitedFuture');
+
+          // Ensure events resolve in the correct order
+          expect(streamController.stream, emitsInOrder([
+            'awaitedFuture',
+            'disposalFuture',
+          ]));
+        });
+
+        test('should complete delayed Future with ObjectDisposedException', () async {
+          expect(component2.getManagedDelayedFuture(shortDuration,
+              expectAsync0(() {}, count: 0, reason: 'Did not expect callback to be invoked.')),
+              throwsA(isA<ObjectDisposedException>()));
+
+          await unmountAndDisposal();
+        });
+
+        test('should call managed disposer returned by getManagedDisposer', () async {
+          var disposerCalled = false;
+          var disposer = component2.getManagedDisposer(() async => disposerCalled = true);
+          expect(disposer, isA<ManagedDisposer>());
+
+          expect(disposerCalled, isFalse);
+          await unmountAndDisposal();
+          expect(disposerCalled, isTrue);
+          expect(disposer.isDisposed, isTrue);
+        });
+
+        test('should cancel periodic timer', () async {
+          var timer = component2.getManagedPeriodicTimer(shortDuration,
+              expectAsync1((_) {}, count: 0, reason: 'Did not expect callback to be invoked.'));
+
+          expect(timer.isActive, isTrue);
+          await unmountAndDisposal();
+          expect(timer.isActive, isFalse);
+        });
+
+        test('should cancel timer', () async {
+          var timer = component2.getManagedTimer(shortDuration,
+              expectAsync1((_){}, count: 0, reason: 'Did not expect callback to be invoked.'));
+
+          expect(timer.isActive, isTrue);
+          await unmountAndDisposal();
+          expect(timer.isActive, isFalse);
+        });
+
+        test('should cancel stream subscription returned by listenToStream', () async{
+          var streamController = StreamController<Null>.broadcast();
+          // ignore: cancel_subscriptions
+          var streamSubscription = component2.listenToStream(streamController.stream, expectAsync1((_) {},
+              count: 0,
+              reason: 'Did not expect event after cancelling subscription'));
+          expect(streamSubscription, isA<StreamSubscription>());
+
+          await unmountAndDisposal();
+
+          streamController.add(null);
+          await streamController.close();
+        });
+
+        test('should dispose managed Disposable returned by manageAndReturnDisposable', () async {
+          var disposable = Disposable();
+          expect(component2.manageAndReturnDisposable(disposable), same(disposable));
+          expect(disposable.isDisposed, isFalse);
+          await unmountAndDisposal();
+          expect(disposable.isDisposed, isTrue);
+        });
+
+        test('should dispose managed Disposable returned by manageAndReturnTypedDisposable', () async {
+          var disposable = Disposable();
+          expect(component2.manageAndReturnTypedDisposable(disposable), same(disposable));
+          expect(disposable.isDisposed, isFalse);
+          await unmountAndDisposal();
+          expect(disposable.isDisposed, isTrue);
+        });
+
+        test('should complete uncompleted managed Completer with ObjectDisposedException', () async {
+          var completer = Completer<Null>();
+          component2.manageCompleter(completer);
+          unawaited(completer.future.catchError(expectAsync1((err) {
+            expect(err, isA<ObjectDisposedException>());
+          })));
+
+          expect(completer.isCompleted, isFalse);
+          await unmountAndDisposal();
+          expect(completer.isCompleted, isTrue);
+        });
+
+        test('should dispose managed Disposable', () async {
+          var disposable = Disposable();
+          component2.manageDisposable(disposable);
+          expect(disposable.isDisposed, isFalse);
+          await unmountAndDisposal();
+          expect(disposable.isDisposed, isTrue);
+        });
+
+        test('should call managed disposers', () async {
+          var disposerCalled = false;
+          component2.manageDisposer(() async => disposerCalled = true); // ignore: deprecated_member_use
+          expect(disposerCalled, isFalse);
+          await unmountAndDisposal();
+          expect(disposerCalled, isTrue);
+        });
+
+        test('should close managed StreamController', () async {
+          //ignore: close_sinks
+          var streamController = StreamController<Null>.broadcast();
+          component2.manageStreamController(streamController);
+          expect(streamController.isClosed, isFalse);
+          await unmountAndDisposal();
+          expect(streamController.isClosed, isTrue);
+        });
+
+        test('should cancel managed StreamSubscription', () async{
+          var streamController = StreamController<Null>.broadcast();
+          // ignore: cancel_subscriptions
+          var streamSubscription = streamController.stream
+              .listen(expectAsync1((_) {},
+              count: 0,
+              reason: 'Did not expect event after cancelling subscription'));
+
+          component2.manageStreamSubscription(streamSubscription); // ignore: deprecated_member_use
+          await unmountAndDisposal();
+
+          streamController.add(null);
+          await streamController.close();
+        });
+      }, timeout: Timeout(const Duration(milliseconds: 250)));
     });
 
     group('UiStatefulComponent', () {
@@ -1240,8 +1409,10 @@ class TestComponentComponent extends UiComponent<TestComponentProps> {
   }
 }
 
+UiFactory<TestComponent2Props> TestComponent2 = ([props]) => TestComponent2Props(props);
+
 class TestComponent2Props extends over_react.UiProps {
-  @override final ReactComponentFactoryProxy componentFactory = _TestComponentComponentFactory;
+  @override final ReactComponentFactoryProxy componentFactory = _TestComponent2ComponentFactory;
   TestComponent2Props(JsBackedMap backingMap)
       : this._props = JsBackedMap() {
     this._props = backingMap ?? JsBackedMap();
@@ -1258,6 +1429,7 @@ class TestComponent2Props extends over_react.UiProps {
   String get propKeyNamespace => null;
 }
 
+final _TestComponent2ComponentFactory = registerComponent2(() => TestComponent2Component());
 class TestComponent2Component extends UiComponent2<TestComponent2Props> {
   @override
   final List<ConsumedProps> consumedProps;

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -102,11 +102,11 @@ main() {
   component2_abstract_accessor_integration_test.main();
   component2_accessor_mixin_integration_test.main();
   annotation_error_integration_test.main();
-  component2_do_not_generate_accessor_integration_test.main();
   component2_component_integration_test.main();
   component2_constant_required_accessor_integration_test.main();
-  component2_private_props_ddc_bug.main();
+  component2_do_not_generate_accessor_integration_test.main();
   component2_namespaced_accessor_integration_test.main();
+  component2_private_props_ddc_bug.main();
   component2_required_accessor_integration_test.main();
   component2_stateful_component_integration_test.main();
   component2_unassigned_prop_integration_test.main();


### PR DESCRIPTION
## Motivation
After many rounds of changes and test additions, we needed to do a final sweep to ensure UiComponent2 was fully tested. 

## Changes
- Add missing tests for `newProps` and disposal behavior
- Add tests for typed `setStateWithUpdater`

Boyscouting:
- Re-sort of Component2 tests, making it easier to visually compare the… …
- Fix Dom.* function source getting emitted in test names

#### Release Notes
- Add additional UiComponent2 test coverage

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
