### PR TITLE
RM-61377 Release over_react 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [3.1.2](https://github.com/Workiva/over_react/compare/3.1.1...3.1.2)
+
+- Restore the public `getPropKey` function that was accidentally made private in the 3.1.0 release.
+
 ## [3.1.1](https://github.com/Workiva/over_react/compare/3.1.0...3.1.1)
 
 - Restore the `xmlLang`, `xmlSpace`, `y1`, `y2`, `y` members that were accidentally removed from `SvgProps` in the 3.1.0 release.

--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -70,6 +70,7 @@ export 'src/util/key_constants.dart';
 export 'src/util/map_util.dart';
 export 'src/util/pretty_print.dart';
 export 'src/util/prop_errors.dart';
+export 'src/util/prop_key_util.dart';
 export 'src/util/react_util.dart';
 export 'src/util/react_wrappers.dart';
 export 'src/util/rem_util.dart';

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -255,6 +255,13 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
 
   /// Returns the string key of the [factory] prop accessed in [accessProp], including the namespace if one exists.
   ///
+  /// __DEPRECATED__: This method had to be deprecated and replaced with [keyForProp] because of the way
+  /// that shadowing works in Dart when a top-level function name matches the name of an instance method.
+  @Deprecated('4.0.0')
+  String getPropKey(void Function(TProps props) accessProp) => keyForProp(accessProp);
+
+  /// Returns the string key of the [factory] prop accessed in [accessProp], including the namespace if one exists.
+  ///
   /// Intended for use within [propTypes].
   ///
   /// __Example:__
@@ -277,7 +284,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///   }
   /// }
   /// ```
-  String getPropKey(void Function(TProps props) accessProp) => prop_key_util.getPropKey(accessProp, typedPropsFactory);
+  String keyForProp(void Function(TProps props) accessProp) => prop_key_util.getPropKey(accessProp, typedPropsFactory);
 
   // ***************************************************************************
   //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.1.1
+version: 3.1.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -252,7 +252,7 @@ class _$ComponentTestProps extends UiProps {
 class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
   @override
   get propTypes => {
-      getPropKey((p) => p.requiredAndLengthLimited): (props, info) {
+      this.getPropKey((p) => p.requiredAndLengthLimited): (props, info) {
         final length = props.requiredAndLengthLimited?.length;
         if (length != 2) {
           return PropError.value(length, info.propName, 'must have a length of 2');

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
@@ -256,7 +256,7 @@ class _$ComponentTestProps extends UiProps {
 class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
   @override
   get propTypes => {
-      getPropKey((p) => p.requiredAndLengthLimited): (props, info) {
+      keyForProp((p) => p.requiredAndLengthLimited): (props, info) {
         final length = props.requiredAndLengthLimited?.length;
         if (length != 2) {
           return PropError.value(length, info.propName, 'must have a length of 2');

--- a/web/component2/src/demo_components/prop_validation.dart
+++ b/web/component2/src/demo_components/prop_validation.dart
@@ -33,7 +33,7 @@ class PropTypesTestComponent extends UiComponent2<PropTypesTestProps> {
   // This is closer to what it looks like in JS, but might be confusing syntax.
   @override
   get propTypes => {
-        getPropKey((p) => p.twoObjects): (props, info) {
+        keyForProp((p) => p.twoObjects): (props, info) {
           final length = props.twoObjects?.length;
           if (length != 2) {
             return PropError.value(length, info.propName, 'must have a length of 2');


### PR DESCRIPTION
This hotfix of over_react restores the `getPropKey` function that was accidentally made private in the 3.1.0 release.

---

@greglittlefield-wf @jimhotchkin-wf 