### PR TITLE
RM-61380 Release over_react 3.1.3 (Allow UiComponent2 to subtype UiComponent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## [3.1.3](https://github.com/Workiva/over_react/compare/3.1.2...3.1.3)
+
+- Fixes an issue that prevents `UiComponent` instances from being declared as sub-types of `UiComponent2` instances
+  via the `subtypeOf` argument in a `Component2()` annotation.
+
 ## [3.1.2](https://github.com/Workiva/over_react/compare/3.1.1...3.1.2)
 
 - Restore the public `getPropKey` function that was accidentally made private in the 3.1.0 release.

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -54,7 +54,8 @@ ReactDartComponentFactoryProxy2 registerAbstractComponent2(Type abstractComponen
 /// * [displayName]: the name of the component for use when debugging.
 ReactDartComponentFactoryProxy2 registerComponent2(react.Component2 Function() dartComponentFactory, {
     bool isWrapper = false,
-    ReactDartComponentFactoryProxy2 parentType,
+    // This must remain typed in a way that both UiComponent and UiComponent2 classes can be passed as the `subtypeOf` value.
+    ReactDartComponentFactoryProxy parentType,
     UiFactory builderFactory,
     Type componentClass,
     String displayName,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.1.2
+version: 3.1.3
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.dart
@@ -1,0 +1,30 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+import './subtype_of_component1.dart';
+
+part 'subsubtype_of_component1.over_react.g.dart';
+
+@Factory()
+UiFactory<TestSubsubtypeOfComponent1Props> TestSubsubtypeOfComponent1 = _$TestSubsubtypeOfComponent1;
+
+@Props()
+class _$TestSubsubtypeOfComponent1Props extends UiProps {}
+
+@Component2(subtypeOf: TestSubtypeOfComponent1Component)
+class TestSubsubtypeOfComponent1Component extends UiComponent2<TestSubsubtypeOfComponent1Props> {
+  @override
+  render() => Dom.div()();
+}

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
@@ -1,0 +1,159 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'subsubtype_of_component1.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestSubsubtypeOfComponent1ComponentFactory = registerComponent2(
+  () => _$TestSubsubtypeOfComponent1Component(),
+  builderFactory: TestSubsubtypeOfComponent1,
+  componentClass: TestSubsubtypeOfComponent1Component,
+  isWrapper: false,
+  parentType: $TestSubtypeOfComponent1ComponentFactory,
+  /* from `subtypeOf: TestSubtypeOfComponent1Component` */
+  displayName: 'TestSubsubtypeOfComponent1',
+);
+
+abstract class _$TestSubsubtypeOfComponent1PropsAccessorsMixin
+    implements _$TestSubsubtypeOfComponent1Props {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForTestSubsubtypeOfComponent1Props = PropsMeta(
+  fields: _$TestSubsubtypeOfComponent1PropsAccessorsMixin.$props,
+  keys: _$TestSubsubtypeOfComponent1PropsAccessorsMixin.$propKeys,
+);
+
+class TestSubsubtypeOfComponent1Props extends _$TestSubsubtypeOfComponent1Props
+    with _$TestSubsubtypeOfComponent1PropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForTestSubsubtypeOfComponent1Props;
+}
+
+_$$TestSubsubtypeOfComponent1Props _$TestSubsubtypeOfComponent1(
+        [Map backingProps]) =>
+    backingProps == null
+        ? _$$TestSubsubtypeOfComponent1Props$JsMap(JsBackedMap())
+        : _$$TestSubsubtypeOfComponent1Props(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+abstract class _$$TestSubsubtypeOfComponent1Props
+    extends _$TestSubsubtypeOfComponent1Props
+    with _$TestSubsubtypeOfComponent1PropsAccessorsMixin
+    implements TestSubsubtypeOfComponent1Props {
+  _$$TestSubsubtypeOfComponent1Props._();
+
+  factory _$$TestSubsubtypeOfComponent1Props(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestSubsubtypeOfComponent1Props$JsMap(backingMap);
+    } else {
+      return _$$TestSubsubtypeOfComponent1Props$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $TestSubsubtypeOfComponent1ComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TestSubsubtypeOfComponent1Props.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$TestSubsubtypeOfComponent1Props$PlainMap
+    extends _$$TestSubsubtypeOfComponent1Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubsubtypeOfComponent1Props$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$TestSubsubtypeOfComponent1Props$JsMap
+    extends _$$TestSubsubtypeOfComponent1Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubsubtypeOfComponent1Props$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestSubsubtypeOfComponent1Component
+    extends TestSubsubtypeOfComponent1Component {
+  _$$TestSubsubtypeOfComponent1Props$JsMap _cachedTypedProps;
+
+  @override
+  _$$TestSubsubtypeOfComponent1Props$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$TestSubsubtypeOfComponent1Props$JsMap typedPropsFactoryJs(
+          JsBackedMap backingMap) =>
+      _$$TestSubsubtypeOfComponent1Props$JsMap(backingMap);
+
+  @override
+  _$$TestSubsubtypeOfComponent1Props typedPropsFactory(Map backingMap) =>
+      _$$TestSubsubtypeOfComponent1Props(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestSubsubtypeOfComponent1Props.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestSubsubtypeOfComponent1Props
+  ];
+}

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+import '../../component_type_checking_test/type_inheritance/parent.dart';
+
+part 'subtype_of_component1.over_react.g.dart';
+
+@Factory()
+UiFactory<TestSubtypeOfComponent1Props> TestSubtypeOfComponent1 = _$TestSubtypeOfComponent1;
+
+@Props()
+class _$TestSubtypeOfComponent1Props extends UiProps {}
+
+@Component2(subtypeOf: TestParentComponent)
+class TestSubtypeOfComponent1Component extends UiComponent2<TestSubtypeOfComponent1Props> {
+  @override
+  render() => Dom.div()();
+}

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
@@ -1,0 +1,158 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'subtype_of_component1.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestSubtypeOfComponent1ComponentFactory = registerComponent2(
+  () => _$TestSubtypeOfComponent1Component(),
+  builderFactory: TestSubtypeOfComponent1,
+  componentClass: TestSubtypeOfComponent1Component,
+  isWrapper: false,
+  parentType: $TestParentComponentFactory,
+  /* from `subtypeOf: TestParentComponent` */
+  displayName: 'TestSubtypeOfComponent1',
+);
+
+abstract class _$TestSubtypeOfComponent1PropsAccessorsMixin
+    implements _$TestSubtypeOfComponent1Props {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForTestSubtypeOfComponent1Props = PropsMeta(
+  fields: _$TestSubtypeOfComponent1PropsAccessorsMixin.$props,
+  keys: _$TestSubtypeOfComponent1PropsAccessorsMixin.$propKeys,
+);
+
+class TestSubtypeOfComponent1Props extends _$TestSubtypeOfComponent1Props
+    with _$TestSubtypeOfComponent1PropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForTestSubtypeOfComponent1Props;
+}
+
+_$$TestSubtypeOfComponent1Props _$TestSubtypeOfComponent1([Map backingProps]) =>
+    backingProps == null
+        ? _$$TestSubtypeOfComponent1Props$JsMap(JsBackedMap())
+        : _$$TestSubtypeOfComponent1Props(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+abstract class _$$TestSubtypeOfComponent1Props
+    extends _$TestSubtypeOfComponent1Props
+    with _$TestSubtypeOfComponent1PropsAccessorsMixin
+    implements TestSubtypeOfComponent1Props {
+  _$$TestSubtypeOfComponent1Props._();
+
+  factory _$$TestSubtypeOfComponent1Props(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestSubtypeOfComponent1Props$JsMap(backingMap);
+    } else {
+      return _$$TestSubtypeOfComponent1Props$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $TestSubtypeOfComponent1ComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TestSubtypeOfComponent1Props.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$TestSubtypeOfComponent1Props$PlainMap
+    extends _$$TestSubtypeOfComponent1Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubtypeOfComponent1Props$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$TestSubtypeOfComponent1Props$JsMap
+    extends _$$TestSubtypeOfComponent1Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubtypeOfComponent1Props$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestSubtypeOfComponent1Component
+    extends TestSubtypeOfComponent1Component {
+  _$$TestSubtypeOfComponent1Props$JsMap _cachedTypedProps;
+
+  @override
+  _$$TestSubtypeOfComponent1Props$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$TestSubtypeOfComponent1Props$JsMap typedPropsFactoryJs(
+          JsBackedMap backingMap) =>
+      _$$TestSubtypeOfComponent1Props$JsMap(backingMap);
+
+  @override
+  _$$TestSubtypeOfComponent1Props typedPropsFactory(Map backingMap) =>
+      _$$TestSubtypeOfComponent1Props(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestSubtypeOfComponent1Props.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestSubtypeOfComponent1Props
+  ];
+}

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -40,6 +40,8 @@ import 'component2_type_checking_test/type_inheritance/abstract_inheritance/exte
 import 'component2_type_checking_test/type_inheritance/parent2.dart';
 import 'component2_type_checking_test/type_inheritance/subsubtype2.dart';
 import 'component2_type_checking_test/type_inheritance/subtype2.dart';
+import 'component2_type_checking_test/type_inheritance/subsubtype_of_component1.dart';
+import 'component2_type_checking_test/type_inheritance/subtype_of_component1.dart';
 
 main() {
   group('Component1', () {
@@ -64,6 +66,23 @@ main() {
       TestParent: TestParent2,
       TestSubtype: TestSubtype2,
       TestSubsubtype: TestSubsubtype2,
+      TestExtendtype: TestExtendtype2,
+      TestExtendtypeComponent: TestExtendtype2Component,
+      TestAbstractComponent: TestAbstract2Component,
+      TestA: TestA2,
+      TestAComponent: TestA2Component,
+      TestB: TestB2,
+      TestBComponent: TestB2Component,
+      OneLevelWrapper: OneLevelWrapper2,
+      TwoLevelWrapper: TwoLevelWrapper2,
+    );
+  });
+  group('Component2 (subtypeOf: Component1)', () {
+    testComponentTypeChecking(
+      isComponent2: true,
+      TestParent: TestParent,
+      TestSubtype: TestSubtypeOfComponent1,
+      TestSubsubtype: TestSubsubtypeOfComponent1,
       TestExtendtype: TestExtendtype2,
       TestExtendtypeComponent: TestExtendtype2Component,
       TestAbstractComponent: TestAbstract2Component,


### PR DESCRIPTION
This patch release of over_react includes a hotfix for an issue that prevents `UiComponent` instances from being declared as sub-types of `UiComponent2` instances via the `subtypeOf` argument in a `Component2()` annotation:

__Causes RTEs:__

```dart
@Component2(subtypeOf: SomeVersion1Component)
class MyComponent2Instance extends UiComponent2<MyComponent2Props> {}
```

This patch prevents the above code from throwing at runtime.

---

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 