### PR TITLE
RM-61406 Release over_react 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OverReact Changelog
 
+## [3.1.4](https://github.com/Workiva/over_react/compare/3.1.3...3.1.4)
+
+- Replace usage / mention of `UiComponent2.getPropKey` which had to be deprecated in [the 3.1.2 release](https://github.com/Workiva/over_react/pull/418).
+- Add a stub for `UiComponent2.redraw` with a deprecated annotation so that consumers would correctly see it as being deprecated.
+  - Previously, this method would not show up as deprecated because certain IDEs would default to the base implementation (`Component.redraw`) - instead of the newer, deprecated `Component2.redraw`.
+
 ## [3.1.3](https://github.com/Workiva/over_react/compare/3.1.2...3.1.3)
 
 - Fixes an issue that prevents `UiComponent` instances from being declared as sub-types of `UiComponent2` instances

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -207,7 +207,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// class MyComponent extends UiComponent2<MyProps> {
   ///   @override
   ///   get propTypes => {
-  ///     getPropKey((p) => p.foo): (props, info) {
+  ///     keyForProp((p) => p.foo): (props, info) {
   ///       final length = props.foo?.length;
   ///       if (length != 2) {
   ///         return PropError.value(length, info.propName, 'must have a length of 2');
@@ -218,7 +218,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// }
   /// ```
   ///
-  /// * [getPropKey] - as shown in the example above - is a statically typed helper to get the string key for a prop.
+  /// * [keyForProp] - as shown in the example above - is a statically typed helper to get the string key for a prop.
   /// * The second argument (`info`) of the function used to return a value for the key contains metadata about
   ///   the prop specified by the key.
   ///     * `propName`, `componentName`, `location` and `propFullName` are available.
@@ -239,7 +239,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   ///   @override
   ///   get propTypes => {
-  ///     getPropKey((p) => p.mustHaveAnotherPropValue): (props, info) {
+  ///     keyForProp((p) => p.mustHaveAnotherPropValue): (props, info) {
   ///       if (props.mustHaveAnotherPropValue && props.anotherProp == null) {
   ///         return PropError.combination(info.propName, 'anotherProp',
   ///             'must have a non-null value when ${info.propName} is true.');
@@ -280,8 +280,8 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// @Component2()
   /// class MyComponent extends UiComponent2<MyProps> {
   ///   void someInstanceMethod() {
-  ///     print(getPropKey((p) => p.somePropKey)); // Prints "MyProps.somePropKey"
-  ///     print(getPropKey((p) => p.id)); // Prints "id"
+  ///     print(keyForProp((p) => p.somePropKey)); // Prints "MyProps.somePropKey"
+  ///     print(keyForProp((p) => p.id)); // Prints "id"
   ///   }
   /// }
   /// ```
@@ -479,7 +479,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   /// class MyComponent extends UiComponent2<MyProps> {
   ///   @override
   ///   get propTypes => {
-  ///     getPropKey((p) => p.listThatMustHaveAnEvenNumberOfItems): (props, info) {
+  ///     keyForProp((p) => p.listThatMustHaveAnEvenNumberOfItems): (props, info) {
   ///       if (props.listThatMustHaveAnEvenNumberOfItems?.length.isOdd) {
   ///         return PropError.value(
   ///             tProps.listThatMustHaveAnEvenNumberOfItems,

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -436,6 +436,10 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
     return copyProps(onlyCopyDomProps: true, keySetsToOmit: consumedPropKeys);
   }
 
+  @Deprecated('4.0.0')
+  @override
+  void redraw([Function() callback]) => super.redraw(callback);
+
   // ***************************************************************************
   //
   // Deprecated and unsupported members

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -96,7 +96,7 @@ void forwardUnconsumedProps(Map props, {
   for (String key in props.keys) {
     if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
-    if (keySetsToOmit != null) {
+    if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
       /// If the passed in value of [keySetsToOmit] comes from
       /// [addUnconsumedProps], there should only be a single index.
       /// Consequently, this case exists to give the opportunity for the loop

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.1.3
+version: 3.1.4
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -252,7 +252,7 @@ class _$ComponentTestProps extends UiProps {
 class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
   @override
   get propTypes => {
-      this.getPropKey((p) => p.requiredAndLengthLimited): (props, info) {
+      keyForProp((p) => p.requiredAndLengthLimited): (props, info) {
         final length = props.requiredAndLengthLimited?.length;
         if (length != 2) {
           return PropError.value(length, info.propName, 'must have a length of 2');

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -209,6 +209,30 @@ main() {
 
         expect(actual, equals(expected));
       });
+      
+      test('when keySetsToOmit is empty', () {
+        var actual = {};
+
+        forwardUnconsumedProps({
+          'prop 1': 'my prop #1',
+          'prop 2': 'my prop #2',
+          'prop 3': 'my prop #3',
+          'prop 4': 'my prop #4',
+          'prop 5': 'my prop #5',
+          'prop 6': 'my prop #6',
+        }, keySetsToOmit: [], propsToUpdate: actual);
+
+        var expected = {
+          'prop 1': 'my prop #1',
+          'prop 2': 'my prop #2',
+          'prop 3': 'my prop #3',
+          'prop 4': 'my prop #4',
+          'prop 5': 'my prop #5',
+          'prop 6': 'my prop #6',
+        };
+
+        expect(actual, equals(expected));
+      });
 
       test('with only valid DOM/SVG props', () {
         var actual = {};


### PR DESCRIPTION
This patch release of over_react includes:

- [x] https://github.com/Workiva/over_react/pull/421/commits/0e7b6fb116874f4aea7498552f457acca4b7cbc5 replace usage / mention of `UiComponent2.getPropKey` which had to be deprecated in [the 3.1.2 release](https://github.com/Workiva/over_react/pull/418).
- [x] https://github.com/Workiva/over_react/pull/421/commits/c571caa49279274e91963f6abe0a7a5ce9be68ba Add a stub for `UiComponent2.redraw` with a deprecated annotation so that consumers would correctly see it as being deprecated.
    - Previously, this method would not show up as deprecated because certain IDEs would default to the base implementation (`Component.redraw`) - instead of the newer, deprecated `Component2.redraw`.
- [x] https://github.com/Workiva/over_react/pull/421/commits/f2b6441403c7a02bbaa79409d614cae3b4673373 Fix `UiComponent2.consumedProps` regression that caused runtime exceptions when a `UiComponent2` instance attempted to forward unconsumed props to a descendant:
  ```dart
  class FooComponent extends UiComponent<FooProps> {
    @override
    get consumedProps => const [];

    @override
    render() {
      return (SomethingElse()
        // This does not cause a runtime exception
        ..addProps(copyUnconsumedProps())
      )(props.children);
    }
  }

  class FooComponent extends UiComponent2<FooProps> {
    @override
    get consumedProps => const [];

    @override
    render() {
      return (SomethingElse()
        // This was throwing a runtime exception
        ..modifyProps(addUnconsumedProps)
      )(props.children);
    }
  }
  ```

---

@greglittlefield-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 
