### PR TITLE
CPLAT-8499 OverReactRedux: fix bug and make error messages more verbose

### DIFF
--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -63,7 +63,7 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
       log.warning(e);
       log.warning(
         'You must implement a `toJson` method in your state and actions in order to view state changes in the redux dev tools.\n'
-        'If you are not sure what is causing this issue in DevTools, you can use "pause on caught exceptions" to pinpoint which part of your state/action is no able to be converted to json.'
+        'If you are not sure what is causing this issue in DevTools, you can use "pause on caught exceptions" to pinpoint which part of your state/action is not able to be converted to json.'
       );
       if (shouldRethrow) rethrow;
     }

--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -38,12 +38,13 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
     try {
       devToolsExt = reduxExtConnect();
       devToolsExt.subscribe(handleEventFromRemote);
-    } catch(_) {
+    } catch (e) {
+      log.warning(e);
       log.warning(
         'Unable to connect to the redux dev tools browser extension.\n'
         'Please install it...\n'
         'Chrome: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en\n'
-        'Firefox: https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/\n'
+        'Firefox: https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/'
       );
     }
   }
@@ -58,8 +59,12 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
   dynamic _encodeForTransit(dynamic content, {bool shouldRethrow = false}) {
     try {
       return jsify(jsonDecode(jsonEncode(content)));
-    } catch (_) {
-      log.warning('You must implement a `toJson` method in your state and actions in order to view state changes in the redux dev tools.');
+    } catch (e) {
+      log.warning(e);
+      log.warning(
+        'You must implement a `toJson` method in your state and actions in order to view state changes in the redux dev tools.\n'
+        'If you are not sure what is causing this issue in DevTools, you can use "pause on caught exceptions" to pinpoint which part of your state/action is no able to be converted to json.'
+      );
       if (shouldRethrow) rethrow;
     }
   }

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -215,7 +215,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
         areMergedPropsEqual(jsPropsToTProps(jsNext), jsPropsToTProps(jsPrev));
 
     final hoc = mockableJsConnect(
-      mapStateToProps != null ? allowInteropWithArgCount(handleMapStateToProps, 1) : mapDispatchToPropsWithOwnProps != null ? allowInteropWithArgCount(handleMapStateToPropsWithOwnProps, 2) : null,
+      mapStateToProps != null ? allowInteropWithArgCount(handleMapStateToProps, 1) : mapStateToPropsWithOwnProps != null ? allowInteropWithArgCount(handleMapStateToPropsWithOwnProps, 2) : null,
       mapDispatchToProps != null ? allowInteropWithArgCount(handleMapDispatchToProps, 1) : mapDispatchToPropsWithOwnProps != null ? allowInteropWithArgCount(handleMapDispatchToPropsWithOwnProps, 2) : null,
       mergeProps != null ? allowInterop(handleMergeProps) : null,
       JsConnectOptions(

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -131,6 +131,47 @@ main() {
       });
     });
 
+    group('mapStateToPropsWithOwnProps properly maps the state to the components props', (){
+      test('on inital load', () {
+        ConnectedCounter = connect<CounterState, CounterProps>(mapStateToPropsWithOwnProps: (state, ownProps){
+          return Counter()..currentCount = state.count;
+        }, forwardRef: true)(Counter);
+
+        jacket = mount(
+          (ReduxProvider()..store = store1)(
+            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+          ),
+        );
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
+        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+      });
+
+      test('after dispatch', () async {
+        ConnectedCounter = connect<CounterState, CounterProps>(mapStateToPropsWithOwnProps: (state, ownProps){
+          return Counter()..currentCount = state.count;
+        }, forwardRef: true)(Counter);
+
+        jacket = mount(
+          (ReduxProvider()..store = store1)(
+            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+          ),
+        );
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
+        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+
+        var dispatchButton = getByTestId(jacket.getInstance(), 'button-increment');
+        click(dispatchButton);
+
+        // wait for the next tick for the async dispatch to propagate
+        await Future(() {});
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 1);
+        expect(jacket.getNode().innerHtml, contains('Count: 1'));
+      });
+    });
+
     group('mapDispatchToProps', (){
       test('maps dispatcher to props correctly', () async {
         ConnectedCounter = connect<CounterState, CounterProps>(
@@ -139,6 +180,42 @@ main() {
             return Counter()..currentCount = state.count;
           },
           mapDispatchToProps: (dispatch){
+            return Counter()..decrement = () => dispatch(DecrementAction());
+          },
+          forwardRef: true,
+        )(Counter);
+
+        jacket = mount(
+          (ReduxProvider()..store = store1)(
+            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+          ),
+        );
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.decrement, isA<Function>());
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
+        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+
+        // Click button mapped to trigger `propFromDispatch` prop.
+        var dispatchButton = getByTestId(jacket.getInstance(), 'button-decrement');
+        click(dispatchButton);
+
+        // wait for the next tick for the async dispatch to propagate
+        await Future(() {});
+
+        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, -1);
+        expect(jacket.getNode().innerHtml, contains('Count: -1'));
+      });
+    });
+
+    group('mapDispatchToPropsWithOwnProps', (){
+      test('maps dispatcher to props correctly', () async {
+        ConnectedCounter = connect<CounterState, CounterProps>(
+          mapStateToProps: (state){
+            expect(state, isA<CounterState>());
+            return Counter()..currentCount = state.count;
+          },
+          mapDispatchToPropsWithOwnProps: (dispatch, ownProps){
             return Counter()..decrement = () => dispatch(DecrementAction());
           },
           forwardRef: true,


### PR DESCRIPTION


## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
1. Issue was encountered with mapStateToPropsWithOwnProps.
2. Gitter chat revealed a desire to have errors reveal more information about the issue during errors thrown via json encoding.

## Changes
  <!-- What this PR changes to fix the problem. -->
1. Fix typo that cause mapStateToPropsWithOwnProps to not fire correctly
2. Update error messages to provide more guidance and log out the error encountered for more context.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
