### PR TITLE
Fixed typo in builder README.md

### DIFF
--- a/lib/src/builder/README.md
+++ b/lib/src/builder/README.md
@@ -62,8 +62,6 @@ getters/setters (via the `_$FooPropsAccessorsMixin` class)
     ```
     
 3. The builder creates a concrete props implementation class
-    ```
-
     ```dart
     // Concrete props implementation.
     //


### PR DESCRIPTION
## Motivation
The code markdown was not rendering properly due to a misplaced "```"
## Changes
Remove the extra "```"
#### Release Notes
Remove typo in builder README.md

## Review
Please review: @Workiva/app-frameworks

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
