### PR TITLE
CPLAT-8603 Add Multiple Error Check to ErrorBoundary

### DIFF
--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -279,10 +279,12 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
     // ----- [2] ----- //
     else {
       bool sameErrorWasThrownTwiceConsecutively = false;
+      final errorString = error.toString();
 
       for (var i = 0; i < _errorLog.length; i++) {
-        if (_errorLog[i] == error.toString() && _callStackLog[i].componentStack == info.componentStack) {
+        if (_errorLog[i] == errorString && _callStackLog[i].componentStack == info.componentStack) {
           sameErrorWasThrownTwiceConsecutively = true;
+          break;
         }
       }
 

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -205,7 +205,7 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
   @override
   render() {
     if (state.hasError && state.showFallbackUIOnError) {
-      return (props.fallbackUIRenderer ?? _renderStringDomAfterUnrecoverableErrors)(_lastError, _lastErrorInfo);
+      return (props.fallbackUIRenderer ?? _renderStringDomAfterUnrecoverableErrors)(_errorLog.last, _callStackLog.last);
     }
 
     return props.children;
@@ -260,23 +260,24 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
   // ---------------------------------------------- /\ ----------------------------------------------
 
   String _domAtTimeOfError;
-  /*Error||Exception*/dynamic _lastError;
-  ReactErrorInfo _lastErrorInfo;
+  List<String> _errorLog = [];
+  List<ReactErrorInfo> _callStackLog = [];
   Timer _identicalErrorTimer;
 
   /// Called by [componentDidCatch].
   void _handleErrorInComponentTree(/*Error||Exception*/dynamic error, ReactErrorInfo info) {
     // ----- [1] ----- //
     if (props.fallbackUIRenderer != null) {
-      _lastError = error;
-      _lastErrorInfo = info;
+      _errorLog.add(error.toString());
+      _callStackLog.add(info);
       _logErrorCaughtByErrorBoundary(error, info); // [3]
       return;
     }
     // ----- [2] ----- //
     else {
       bool sameErrorWasThrownTwiceConsecutively =
-          error.toString() == _lastError?.toString() && info.componentStack == _lastErrorInfo.componentStack;
+          _errorLog.contains(error.toString()) &&
+              (_callStackLog.where((i) => i.componentStack == info.componentStack)).isNotEmpty;
 
       if (sameErrorWasThrownTwiceConsecutively) { // [2.1]
         try { // [2.2.2]
@@ -289,8 +290,8 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
 
         _logErrorCaughtByErrorBoundary(error, info, isRecoverable: false); // [3]
       } else {
-        _lastError = error;
-        _lastErrorInfo = info;
+        _errorLog.add(error.toString());
+        _callStackLog.add(info);
         _logErrorCaughtByErrorBoundary(error, info); // [3]
       }
 
@@ -334,8 +335,8 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
   /// into an "unrecoverable" error state.
   void _resetInternalErrorTracking() {
     _domAtTimeOfError = null;
-    _lastError = null;
-    _lastErrorInfo = null;
+    _errorLog = [];
+    _callStackLog = [];
     _identicalErrorTimer?.cancel();
     _identicalErrorTimer = null;
   }

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -205,7 +205,10 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
   @override
   render() {
     if (state.hasError && state.showFallbackUIOnError) {
-      return (props.fallbackUIRenderer ?? _renderStringDomAfterUnrecoverableErrors)(_errorLog.last, _callStackLog.last);
+      return (props.fallbackUIRenderer ?? _renderStringDomAfterUnrecoverableErrors)(
+          _errorLog.isNotEmpty ? _errorLog.last : null,
+          _callStackLog.isNotEmpty ? _callStackLog.last : null,
+      );
     }
 
     return props.children;

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -278,9 +278,13 @@ mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBound
     }
     // ----- [2] ----- //
     else {
-      bool sameErrorWasThrownTwiceConsecutively =
-          _errorLog.contains(error.toString()) &&
-              (_callStackLog.where((i) => i.componentStack == info.componentStack)).isNotEmpty;
+      bool sameErrorWasThrownTwiceConsecutively = false;
+
+      for (var i = 0; i < _errorLog.length; i++) {
+        if (_errorLog[i] == error.toString() && _callStackLog[i].componentStack == info.componentStack) {
+          sameErrorWasThrownTwiceConsecutively = true;
+        }
+      }
 
       if (sameErrorWasThrownTwiceConsecutively) { // [2.1]
         try { // [2.2.2]

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -295,6 +295,8 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory builder) {
         expect(calls.length, 1, reason: 'test setup sanity check');
         expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
 
+        getFlawedButtonThatThrowsADifferentErrorNode().click();
+
         calls.clear();
         await Future.delayed(const Duration(milliseconds: identicalErrorFrequencyToleranceInMs ~/ 2));
 

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -290,7 +290,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory builder) {
     });
 
     group('and consecutive errors are thrown from the same component', () {
-      Future<Null> triggerErrorsViaButtonClickThatSignifyAnUnrecoverableComponent({throwExtraError = false}) async {
+      Future<Null> triggerErrorsViaButtonClickThatSignifyAnUnrecoverableComponent({bool throwExtraError = false}) async {
         getFlawedButtonNode().click();
         expect(calls.length, 1, reason: 'test setup sanity check');
         expect(calls.single.keys.single, isNot('onComponentIsUnrecoverable'), reason: 'test setup sanity check');
@@ -496,45 +496,45 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory builder) {
       });
 
       group('and there are two twin errors with a different one being caught in between them', () {
-          String errorBoundaryInnerHtmlBeforeUnrecoverableError;
+        String errorBoundaryInnerHtmlBeforeUnrecoverableError;
 
-          tearDown(() {
-            errorBoundaryInnerHtmlBeforeUnrecoverableError = null;
+        tearDown(() {
+          errorBoundaryInnerHtmlBeforeUnrecoverableError = null;
+        });
+
+        group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance '
+            'and `_domAtTimeOfError` is not null:', () {
+          setUp(() async {
+            sharedSetup();
+
+            expect(jacket.getNode(),
+                isNot(hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')),
+                reason: 'test setup sanity check');
+            errorBoundaryInnerHtmlBeforeUnrecoverableError = jacket.getNode().innerHtml;
+            await triggerErrorsViaButtonClickThatSignifyAnUnrecoverableComponent(throwExtraError: true);
           });
 
-          group('and they occurred more frequently than the value of props.identicalErrorFrequencyTolerance '
-              'and `_domAtTimeOfError` is not null:', () {
-            setUp(() async {
-              sharedSetup();
+          test('the components wrapped by the ErrorBoundary get unmounted', () {
+            expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
+                reason: 'The flawed component should have been unmounted');
+            expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
+                reason: 'Fallback UI should be rendered instead of the flawed component tree');
+            expect(jacket.getNode(),
+                hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
+            expect(jacket.getNode().innerHtml, errorBoundaryInnerHtmlBeforeUnrecoverableError);
+          });
 
-              expect(jacket.getNode(),
-                  isNot(hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')),
-                  reason: 'test setup sanity check');
-              errorBoundaryInnerHtmlBeforeUnrecoverableError = jacket.getNode().innerHtml;
-              await triggerErrorsViaButtonClickThatSignifyAnUnrecoverableComponent(throwExtraError: true);
-            });
+          test('the correct callbacks are called with the correct arguments', () {
+            expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
+                reason: 'onComponentIsUnrecoverable should have been called');
 
-            test('the components wrapped by the ErrorBoundary get unmounted', () {
-              expect(getByTestId(jacket.getInstance(), 'flawedComponent'), isNull,
-                  reason: 'The flawed component should have been unmounted');
-              expect(jacket.getDartInstance().state.showFallbackUIOnError, isTrue,
-                  reason: 'Fallback UI should be rendered instead of the flawed component tree');
-              expect(jacket.getNode(),
-                  hasAttr(defaultTestIdKey, 'ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode'));
-              expect(jacket.getNode().innerHtml, errorBoundaryInnerHtmlBeforeUnrecoverableError);
-            });
+            expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
+            expect(errorSentToComponentIsUnrecoverableCallback, isA<FlawedComponentException>());
+            expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
 
-            test('the correct callbacks are called with the correct arguments', () {
-              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isTrue,
-                  reason: 'onComponentIsUnrecoverable should have been called');
-
-              expect(errorSentToComponentDidCatchCallback, isA<FlawedComponentException>());
-              expect(errorSentToComponentIsUnrecoverableCallback, isA<FlawedComponentException>());
-              expect(errorSentToComponentDidCatchCallback, errorSentToComponentIsUnrecoverableCallback);
-
-              expect(errorInfoSentToComponentDidCatchCallback, isA<ReactErrorInfo>());
-              expect(errorInfoSentToComponentIsUnrecoverableCallback, isA<ReactErrorInfo>());
-              expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
+            expect(errorInfoSentToComponentDidCatchCallback, isA<ReactErrorInfo>());
+            expect(errorInfoSentToComponentIsUnrecoverableCallback, isA<ReactErrorInfo>());
+            expect(errorInfoSentToComponentDidCatchCallback, errorInfoSentToComponentIsUnrecoverableCallback);
           });
         });
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Currently, an `ErrorBoundary` can be fooled to think that the UI is recoverable by a call stack varying even though the same two or three call stack repeatedly occurs.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Keep track of all errors thrown in the same 5 second interval.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Add `ErrorBoundary` fix that helps to prevent recovery attempts after the UI is unrecoverable.
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @greglittlefield-wf @sydneyjodon-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Test in wdesk_sdk to ensure an infinite loop can no longer occur
      - Add a virtualized list as the content to a side panel element (I was using header_footer_properties_panel_content.dart). You can override that file with [this gist](https://gist.github.com/joebingham-wk/0600617c72c9eee9f90ce4634e4fe454) that has a virtual list.
      - Override web_skin_dart and add an error that gets thrown on mount in `RegionComponent`
      - Override over_react with this branch
      - Run the wdesk_sdk app, clicking into a document, the side panel, and the second tab within the panel navigation. For the purposes of this test, the document should unmount and not enter an infinite loop. Removing the over_react override and doing the same test _should_ result in an infinite loop
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
