### PR TITLE
CPLAT-7471 Refactor Prop Type Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - pub run build_runner build --delete-conflicting-outputs
   - git diff --exit-code
   - pub run dart_dev analyze
-  - pub run dependency_validator --no-fatal-pins -i analyzer,build_runner,build_web_compilers,built_value_generator
+  - pub run dependency_validator --no-fatal-pins -i analyzer,build_runner,build_web_compilers,built_value_generator,front_end
 
 script:
   - pub run dart_dev test -P vm

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dev_dependencies:
   dart2_constant: ^1.0.0
   dart_dev: ^3.0.0
   dependency_validator: ^1.4.0
+  front_end: ^0.1.27
   glob: ^1.2.0
   mockito: ^4.1.1
   over_react_test: ^2.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dev_dependencies:
   dart2_constant: ^1.0.0
   dart_dev: ^3.0.0
   dependency_validator: ^1.4.0
+  # front_end is necessary because of a change in build_vm_compilers starting with version 1.0.3, and it should be
+  # removed when build_vm_compilers no longer requires it to be specified
   front_end: ^0.1.27
   glob: ^1.2.0
   mockito: ^4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,6 @@ dev_dependencies:
   dependency_validator: ^1.4.0
   glob: ^1.2.0
   mockito: ^4.1.1
-  over_react_test: ^2.5.2
+  over_react_test: ^2.7.0
   pedantic: ^1.8.0
   test: ^1.9.1

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -36,20 +36,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
+        TestJacket jacket;
+
+        expect(() {
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )(),
-          attachedToDocument: true,
-        );
-
-        expect(() {
-          jacket.rerender((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -65,7 +60,7 @@ void main() {
     group('throwing when a prop is required and set to null', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..required = null
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
@@ -74,20 +69,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
-          ..required = true
-          ..nullable = true
-          ..requiredAndLengthLimited = [1,2]
-        )(),
-          attachedToDocument: true,
-        );
+        TestJacket jacket;
 
         expect(() {
-          jacket.rerender((ComponentTest()
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
-          )());
+          )(),
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -103,7 +93,7 @@ void main() {
     group('throwing when a prop is nullable and not set', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..required = true
             ..requiredAndLengthLimited = [1,2]
           )());
@@ -111,16 +101,10 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true,
-        );
+        TestJacket jacket;
 
         expect(() {
-          jacket.rerender((ComponentTest()
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
@@ -139,7 +123,7 @@ void main() {
     group('not throwing when a prop is required and set', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..nullable = true
             ..required = true
             ..requiredAndLengthLimited = [1,2]
@@ -169,7 +153,7 @@ void main() {
     group('not throwing when a prop is nullable and set to null', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..nullable = null
             ..requiredAndLengthLimited = [1,2]
             ..required = true
@@ -178,20 +162,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
+        TestJacket jacket;
+
+        expect(() {
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )(),
-          attachedToDocument: true,
-        );
-
-        expect(() {
-          jacket.rerender((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -207,7 +186,7 @@ void main() {
     group('when a consumer propType function is also provided', () {
       test('required fires', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..nullable = null
             ..required = true
           )());
@@ -216,7 +195,7 @@ void main() {
 
       test('consumer check fires', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1]

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -39,12 +39,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -72,12 +72,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -104,11 +104,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -165,12 +166,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -11,10 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import 'dart:js';
 
 import 'package:over_react/over_react.dart';
-import 'package:react/react_client/react_interop.dart' show PropTypes;
+import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
 
 import '../../../../test_util/test_util.dart';
@@ -23,39 +22,17 @@ part 'constant_required_accessor_integration_test.over_react.g.dart';
 
 void main() {
   group('(Component2) propTypes properly identifies required props by', () {
-    List<String> consoleErrors;
-    JsFunction originalConsoleError;
-
-    setUp(() {
-      // PropTypes by default will only throw a specific error one time per Component Class.
-      // This resets the cache after each test so it throws again.
-      // See: https://www.npmjs.com/package/prop-types#proptypesresetwarningcache
-      PropTypes.resetWarningCache();
-
-      originalConsoleError = context['console']['error'];
-      consoleErrors = [];
-      context['console']['error'] = JsFunction.withThis((self, message) {
-        consoleErrors.add(message);
-        originalConsoleError.apply([message], thisArg: self);
-      });
-    });
-
-    tearDown(() {
-      context['console']['error'] = originalConsoleError;
-    });
     group('throwing when a prop is required and not set', () {
-
       test('on mount', () {
-        mount(
-          (ComponentTest()
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true,
-        );
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
+        expect(() {
+          mount(
+            (ComponentTest()
+              ..nullable = true
+              ..requiredAndLengthLimited = [1,2]
+            )(),
+            attachedToDocument: true,
+          );
+        }, logsPropRequiredError('ComponentTestProps.required'));
       });
 
       test('on re-render', () {
@@ -67,62 +44,70 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
+        expect(() {
+          jacket.rerender((ComponentTest()
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )()
-        );
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
+          );
+        }, logsPropRequiredError('ComponentTestProps.required'));
       });
-
     });
 
     group('throwing when a prop is required and set to null', () {
       test('on mount', () {
-        render((ComponentTest()
+        expect(() {
+          render((ComponentTest()
             ..required = null
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
+        }, logsPropRequiredError('ComponentTestProps.required'));
       });
 
       test('on re-render', () {
         var jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
+          ..required = true
+          ..nullable = true
+          ..requiredAndLengthLimited = [1,2]
+        )(),
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-              ..required = null
-              ..nullable = true
-              ..requiredAndLengthLimited = [1,2]
-            )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = null
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropRequiredError('ComponentTestProps.required'));
       });
     });
 
     group('throwing when a prop is nullable and not set', () {
       test('on mount', () {
-        render((ComponentTest()
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.nullable')]);
+        expect(() {
+          render((ComponentTest()
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropError('ComponentTestProps.nullable'));
       });
 
       test('on re-render', () {
@@ -134,26 +119,32 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.nullable')]);
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropError('ComponentTestProps.nullable'));
       });
     });
 
     group('not throwing when a prop is required and set', () {
       test('on mount', () {
-        render((ComponentTest()
-          ..nullable = true
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          render((ComponentTest()
+            ..nullable = true
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
       });
 
       test('on re-render', () {
@@ -165,26 +156,25 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
-
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..nullable = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
       });
     });
 
     group('not throwing when a prop is nullable and set to null', () {
       test('on mount', () {
-       render((ComponentTest()
-          ..nullable = null
-          ..requiredAndLengthLimited = [1,2]
-          ..required = true
-        )());
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          render((ComponentTest()
+            ..nullable = null
+            ..requiredAndLengthLimited = [1,2]
+            ..required = true
+          )());
+        }, logsNoPropTypeWarnings);
       });
 
       test('on re-render', () {
@@ -196,38 +186,42 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..nullable = null
-          ..requiredAndLengthLimited = [1,2]
-        )());
-
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = null
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
       });
     });
 
     group('when a consumer propType function is also provided', () {
       test('required fires', () {
-       render((ComponentTest()
+        expect(() {
+          render((ComponentTest()
             ..nullable = null
             ..required = true
           )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.requiredAndLengthLimited')]);
+        }, logsPropValueError('null', 'ComponentTestProps.requiredAndLengthLimited'));
       });
 
       test('consumer check fires', () {
-        render((ComponentTest()
+        expect(() {
+          render((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1]
           )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('must have a length of 2')]);
+        }, logsPropValueError('1', 'ComponentTestProps.requiredAndLengthLimited'));
       });
     });
   });

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
@@ -33,21 +33,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
-          ..required = true
-          ..nullable = true
-          ..requiredAndLengthLimited = [1,2]
-        )(),
-          attachedToDocument: true,
-        );
+        TestJacket jacket;
 
         expect(() {
-          jacket.rerender(
-              (ComponentTest()
+          jacket = mount((ComponentTest()
                 ..required = true
                 ..nullable = true
                 ..requiredAndLengthLimited = [1,2]
-              )()
+              )(),
+            attachedToDocument: true
           );
         }, logsNoPropTypeWarnings);
 
@@ -65,7 +59,7 @@ void main() {
     group('throwing when a prop is required and set to null', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..required = null
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
@@ -74,20 +68,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
+        TestJacket jacket;
+
+        expect(() {
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )(),
-          attachedToDocument: true,
-        );
-
-        expect(() {
-          jacket.rerender((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -111,20 +100,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
+        TestJacket jacket;
+
+        expect(() {
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )(),
-          attachedToDocument: true,
-        );
-
-        expect(() {
-          jacket.rerender((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -139,7 +123,7 @@ void main() {
     group('not throwing when a prop is required and set', () {
       test('on mount', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..nullable = true
             ..required = true
             ..requiredAndLengthLimited = [1,2]
@@ -162,8 +146,6 @@ void main() {
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )());
-
-
         }, logsNoPropTypeWarnings);
       });
     });
@@ -180,20 +162,15 @@ void main() {
       });
 
       test('on re-render', () {
-        var jacket = mount((ComponentTest()
+        TestJacket jacket;
+
+        expect(() {
+          jacket = mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )(),
-          attachedToDocument: true,
-        );
-
-        expect(() {
-          jacket.rerender((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )());
+          attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -209,7 +186,7 @@ void main() {
     group('when a consumer propType function is also provided', () {
       test('required fires', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..nullable = null
             ..required = true
           )());
@@ -218,7 +195,7 @@ void main() {
 
       test('consumer check fires', () {
         expect(() {
-          render((ComponentTest()
+          mount((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1]

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
@@ -36,12 +36,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
+          jacket = mount(
+              (ComponentTest()
                 ..required = true
                 ..nullable = true
-                ..requiredAndLengthLimited = [1,2]
-              )(),
-            attachedToDocument: true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true
           );
         }, logsNoPropTypeWarnings);
 
@@ -71,12 +71,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -103,12 +103,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {
@@ -165,12 +165,12 @@ void main() {
         TestJacket jacket;
 
         expect(() {
-          jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
-          attachedToDocument: true);
+          jacket = mount(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2])(),
+              attachedToDocument: true);
         }, logsNoPropTypeWarnings);
 
         expect(() {

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import 'dart:js';
 
 import 'package:over_react/over_react.dart';
+import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
-import 'package:react/react_client/react_interop.dart' show PropTypes;
 
 import '../../../../test_util/test_util.dart';
 
@@ -23,74 +22,55 @@ part 'required_accessor_integration_test.over_react.g.dart';
 
 void main() {
   group('(Component2) propTypes required props', () {
-    List<String> consoleErrors;
-    JsFunction originalConsoleError;
-
-    setUp(() {
-      // PropTypes by default will only throw a specific error one time per Component Class.
-      // This resets the cache after each test so it throws again.
-      // See: https://www.npmjs.com/package/prop-types#proptypesresetwarningcache
-      PropTypes.resetWarningCache();
-
-      originalConsoleError = context['console']['error'];
-      consoleErrors = [];
-      context['console']['error'] = JsFunction.withThis((self, message) {
-        consoleErrors.add(message);
-        originalConsoleError.apply([message], thisArg: self);
-      });
-    });
-
-    tearDown(() {
-      context['console']['error'] = originalConsoleError;
-    });
     group('throwing when a prop is required and not set', () {
-
       test('on mount', () {
-        mount(
-          (ComponentTest()..nullable = true..requiredAndLengthLimited = [1,2])(),
-          attachedToDocument: true,
-        );
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
-        expect(consoleErrors, [contains('This Prop is Required for testing purposes.')]);
+        expect(() {
+          mount(
+            (ComponentTest()..nullable = true..requiredAndLengthLimited = [1,2])(),
+            attachedToDocument: true,
+          );
+        }, logsPropRequiredError('ComponentTestProps.required', 'This Prop is Required for testing purposes.'));
       });
 
       test('on re-render', () {
         var jacket = mount((ComponentTest()
-            ..required = true
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )(),
+          ..required = true
+          ..nullable = true
+          ..requiredAndLengthLimited = [1,2]
+        )(),
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender(
+              (ComponentTest()
+                ..required = true
+                ..nullable = true
+                ..requiredAndLengthLimited = [1,2]
+              )()
+          );
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-            ..nullable = true
-            ..requiredAndLengthLimited = [1,2]
-          )()
-        );
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
-        expect(consoleErrors, [contains('This Prop is Required for testing purposes.')]);
+        expect(() {
+          jacket.rerender((ComponentTest()
+              ..nullable = true
+              ..requiredAndLengthLimited = [1,2]
+            )()
+          );
+        }, logsPropRequiredError('ComponentTestProps.required', 'This Prop is Required for testing purposes.'));
       });
 
     });
 
     group('throwing when a prop is required and set to null', () {
       test('on mount', () {
-        render((ComponentTest()
+        expect(() {
+          render((ComponentTest()
             ..required = null
             ..nullable = true
             ..requiredAndLengthLimited = [1,2]
           )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
-        expect(consoleErrors, [contains('This Prop is Required for testing purposes.')]);
+        }, logsPropRequiredError('ComponentTestProps.required', 'This Prop is Required for testing purposes.'));
       });
 
       test('on re-render', () {
@@ -102,29 +82,32 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-              ..required = null
-              ..nullable = true
-              ..requiredAndLengthLimited = [1,2]
-            )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.required')]);
-        expect(consoleErrors, [contains('This Prop is Required for testing purposes.')]);
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = null
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropRequiredError('ComponentTestProps.required', 'This Prop is Required for testing purposes.'));
       });
     });
 
     group('throwing when a prop is nullable and not set', () {
       test('on mount', () {
-        render((ComponentTest()
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.nullable')]);
-        expect(consoleErrors, [contains('This prop can be set to null!')]);
+        expect(() {
+          render((ComponentTest()
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropRequiredError('ComponentTestProps.nullable', 'This prop can be set to null!'));
       });
 
       test('on re-render', () {
@@ -136,27 +119,32 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.nullable')]);
-        expect(consoleErrors, [contains('This prop can be set to null!')]);
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsPropRequiredError('ComponentTestProps.nullable', 'This prop can be set to null!'));
       });
     });
 
     group('not throwing when a prop is required and set', () {
       test('on mount', () {
-        render((ComponentTest()
-          ..nullable = true
-          ..required = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          render((ComponentTest()
+            ..nullable = true
+            ..required = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
       });
 
       test('on re-render', () {
@@ -168,26 +156,27 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
 
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..nullable = true
-          ..requiredAndLengthLimited = [1,2]
-        )());
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        }, logsNoPropTypeWarnings);
       });
     });
 
     group('not throwing when a prop is nullable and set to null', () {
       test('on mount', () {
-       render((ComponentTest()
-          ..nullable = null
-          ..requiredAndLengthLimited = [1,2]
-          ..required = true
-        )());
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          render((ComponentTest()
+            ..nullable = null
+            ..requiredAndLengthLimited = [1,2]
+            ..required = true
+          )());
+        }, logsNoPropTypeWarnings);
       });
 
       test('on re-render', () {
@@ -199,38 +188,42 @@ void main() {
           attachedToDocument: true,
         );
 
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = true
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
 
-        jacket.rerender((ComponentTest()
-          ..required = true
-          ..nullable = null
-          ..requiredAndLengthLimited = [1,2]
-        )());
-
-        expect(consoleErrors, isEmpty, reason: 'should not have outputted a warning but found: $consoleErrors');
+        expect(() {
+          jacket.rerender((ComponentTest()
+            ..required = true
+            ..nullable = null
+            ..requiredAndLengthLimited = [1,2]
+          )());
+        }, logsNoPropTypeWarnings);
       });
     });
 
     group('when a consumer propType function is also provided', () {
       test('required fires', () {
-       render((ComponentTest()
-          ..nullable = null
-          ..required = true
-        )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('ComponentTestProps.requiredAndLengthLimited')]);
+        expect(() {
+          render((ComponentTest()
+            ..nullable = null
+            ..required = true
+          )());
+        }, logsPropValueError('null', 'ComponentTestProps.requiredAndLengthLimited'));
       });
 
       test('consumer check fires', () {
-        render((ComponentTest()
+        expect(() {
+          render((ComponentTest()
             ..required = true
             ..nullable = true
             ..requiredAndLengthLimited = [1]
           )());
-
-        expect(consoleErrors, isNotEmpty, reason: 'should have outputted a warning');
-        expect(consoleErrors, [contains('must have a length of 2')]);
+        }, logsPropValueError('1', 'ComponentTestProps.requiredAndLengthLimited'));
       });
     });
   });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The prop type tests for over_react were still using the outdated `propType` testing methods. Refactoring the tests keeps them up to date with the latest APIs and helps provide examples of how to use our testing utils.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Refactor any test the tests `propTypes`
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @greglittlefield-wf @sydneyjodon-wk @aaronlademann-wf 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
