### PR TITLE
CPLAT-8600: Unrecoverable ErrorBoundary Fix

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -40,7 +40,7 @@ export 'src/component/abstract_transition_props.dart';
 export 'src/component/aria_mixin.dart';
 export 'src/component/callback_typedefs.dart';
 export 'src/component/error_boundary.dart';
-export 'src/component/error_boundary_mixins.dart';
+export 'src/component/error_boundary_mixins.dart' hide ErrorBoundaryApi;
 export 'src/component/dom_components.dart';
 export 'src/component/ref_util.dart';
 export 'src/component/fragment_component.dart';

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -57,14 +57,16 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   //
   //     [2.1] If we have `props.fallbackUIRenderer` we present that.
   //
-  //     [2.2] Present nothing instead of the broken children.
+  //     [2.2] Due to this ErrorBoundary only catching during "unrecoverable" render cycle errors
+  //           there is never any DOM created that can be used, and because `props.fallbackUIRenderer`
+  //           is not set we have no content to display, so we present an empty div instead.
   // ---------------------------------------------- /\ ----------------------------------------------
 
   ReactErrorInfo _errorInfo;
   dynamic _error;
 
   @override
-  Map get defaultProps => (newProps()
+  get defaultProps => (newProps()
     ..identicalErrorFrequencyTolerance = Duration(seconds: 5)
     ..loggerName = defaultErrorBoundaryLoggerName
     ..shouldLogErrors = true
@@ -110,7 +112,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
         )(); // [2.2]
       }
     }
-    return (RecoverableErrorBoundary()..addProps(props))(props.children); // [1]
+    return (RecoverableErrorBoundary()..modifyProps(addUnconsumedProps))(props.children); // [1]
   }
 
   @override
@@ -120,6 +122,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     if (state.hasError) {
       final childThatCausedError = typedPropsFactory(prevProps).children.single;
       if (childThatCausedError != props.children.single) {
+        print('children are different!');
         reset();
       }
     }

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,6 +1,7 @@
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_mixins.dart';
 import 'package:over_react/src/component/error_boundary_recoverable.dart';
 
 part 'error_boundary.over_react.g.dart';
@@ -25,7 +26,7 @@ class _$ErrorBoundaryState extends UiState with ErrorBoundaryStateMixin {}
 
 @Component2(isWrapper: true, isErrorBoundary: true)
 class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBoundaryState>
-    extends UiStatefulComponent2<T, S> {
+    extends UiStatefulComponent2<T, S> with ErrorBoundaryApi<T, S> {
 
   // ---------------------------------------------- \/ ----------------------------------------------
   // How This ErrorBoundary Works:

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,4 +1,6 @@
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_recoverable.dart';
 
 part 'error_boundary.over_react.g.dart';
 
@@ -22,4 +24,35 @@ class _$ErrorBoundaryState extends UiState with ErrorBoundaryStateMixin {}
 
 @Component2(isWrapper: true, isErrorBoundary: true)
 class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBoundaryState>
-    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S> {}
+    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S> {
+
+  @override
+  Map getDerivedStateFromError(error) {
+    return (newState()
+      ..hasError = true
+      ..showFallbackUIOnError = true
+    );
+  }
+
+  @override
+  void componentDidCatch(error, ReactErrorInfo info) {
+    if (props.onComponentDidCatch != null) {
+      props.onComponentDidCatch(error, info);
+    }
+
+    if (props.onComponentIsUnrecoverable != null) {
+      props.onComponentIsUnrecoverable(error, info);
+    }
+  }
+
+  @override
+  void componentDidUpdate(Map prevProps, Map prevState, [dynamic snapshot]) {}
+
+  @override
+  render() {
+    if (state.hasError) {
+      return super.render();
+    }
+    return (RecoverableErrorBoundary()..addProps(props))(props.children);
+  }
+}

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,4 +1,4 @@
-import 'package:meta/meta.dart';
+import 'package:logging/logging.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component/error_boundary_recoverable.dart';
 
@@ -24,10 +24,60 @@ class _$ErrorBoundaryState extends UiState with ErrorBoundaryStateMixin {}
 
 @Component2(isWrapper: true, isErrorBoundary: true)
 class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBoundaryState>
-    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S> {
+    extends UiStatefulComponent2<T, S> {
+
+  // ---------------------------------------------- \/ ----------------------------------------------
+  // How This ErrorBoundary Works:
+  //
+  //   Background Info:
+  //     React gives each Error Boundary one chance to handle or recover when an error is throws, if
+  //     the Error Boundary's children throw again on its next render after React calls
+  //     `getDerivedStateFromError` and `componentDidCatch`, React will ascend the tree to the next
+  //     Error Boundary above it and rerender offering it a chance to handle the error. If none of
+  //     the parent Error Boundaries have a successful render cycle, React unmounts the entire tree.
+  //       __Note:__ When an Error Boundary remounts its children React clears all child components
+  //       previous state, including child ErrorBoundaries meaning they lose all previous knowledge
+  //       of any errors thrown.
+  //
+  //   Solution:
+  //     To prevent unmounting the entire tree when React cannot find an Error Boundary that is able
+  //     to handle the error we wrap an Error Boundary with another Error Boundary (this one!). The
+  //     child Error Boundary will handle errors that are "recoverable", so if an error gets to this
+  //     Error Boundary we know it is "unrecoverable" and can present a fallback.
+  //
+  // -----------------------------------------------------------------------------------------------
+  // Implementation:
+  //
+  // [1] Renders a child Error Boundary that is able to handle Errors thrown outside of the initial
+  //     render cycle, allowing it a chance to "recover".
+  //
+  // [2] If we catch an error in this Error Boundary that indicates that the child Error Boundary was
+  //     unable to handle or recover from the error, so we know that it was "unrecoverable" and we
+  //     haven't had a successful render.
+  //
+  //     [2.1] If we have `props.fallbackUIRenderer` we present that.
+  //
+  //     [2.2] Present nothing instead of the broken children.
+  // ---------------------------------------------- /\ ----------------------------------------------
+
+  ReactErrorInfo _errorInfo;
+  String _error;
+
+  @override
+  Map get defaultProps => (newProps()
+    ..identicalErrorFrequencyTolerance = Duration(seconds: 5)
+    ..loggerName = defaultErrorBoundaryLoggerName
+    ..shouldLogErrors = true
+  );
+
+  @override
+  get initialState => newState()
+    ..hasError = false
+    ..showFallbackUIOnError = true;
 
   @override
   Map getDerivedStateFromError(error) {
+    _error = error;
     return (newState()
       ..hasError = true
       ..showFallbackUIOnError = true
@@ -36,9 +86,14 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
 
   @override
   void componentDidCatch(error, ReactErrorInfo info) {
+    _error = error;
+    _errorInfo = info;
+
     if (props.onComponentDidCatch != null) {
       props.onComponentDidCatch(error, info);
     }
+
+    _logErrorCaughtByErrorBoundary(error, info);
 
     if (props.onComponentIsUnrecoverable != null) {
       props.onComponentIsUnrecoverable(error, info);
@@ -46,13 +101,55 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   }
 
   @override
-  void componentDidUpdate(Map prevProps, Map prevState, [dynamic snapshot]) {}
+  render() {
+    if (state.hasError) { // [2]
+      if (props.fallbackUIRenderer != null) {
+        return ErrorBoundary()(props.fallbackUIRenderer(_error, _errorInfo)); // [2.1]
+      } else {
+        return (Dom.div()
+          ..key = 'ohnoes'
+          ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
+        )(); // [2.2]
+      }
+    }
+    return (RecoverableErrorBoundary()..addProps(props))(props.children); // [1]
+  }
 
   @override
-  render() {
+  void componentDidUpdate(Map prevProps, Map prevState, [dynamic snapshot]) {
+    // If the child is different, and the error boundary is currently in an error state,
+    // give the child a chance to remount itself and "recover" from the previous error.
     if (state.hasError) {
-      return super.render();
+      final childThatCausedError = typedPropsFactory(prevProps).children.single;
+      if (childThatCausedError != props.children.single) {
+        reset();
+      }
     }
-    return (RecoverableErrorBoundary()..addProps(props))(props.children);
+  }
+
+    /// Resets the [ErrorBoundary] to a non-error state.
+  ///
+  /// This can be called manually on the component instance using a `ref` -
+  /// or by passing in a new child instance after a child has thrown an error.
+  void reset() {
+    setState(initialState);
+  }
+
+  String get _loggerName {
+    if (props.logger != null) return props.logger.name;
+
+    return props.loggerName ?? defaultErrorBoundaryLoggerName;
+  }
+
+  void _logErrorCaughtByErrorBoundary(
+    /*Error|Exception*/ dynamic error,
+    ReactErrorInfo info, {
+    bool isRecoverable = true,
+  }) {
+    if (!props.shouldLogErrors) return;
+
+    String message = 'An unrecoverable error was caught by an ErrorBoundary (attempting to remount it was unsuccessful): \nInfo: ${info.componentStack}';
+
+    (props.logger ?? Logger(_loggerName)).severe(message, error, info.dartStackTrace);
   }
 }

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -139,7 +139,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   }) {
     if (!props.shouldLogErrors) return;
 
-    String message = 'An unrecoverable error was caught by an ErrorBoundary (attempting to remount it was unsuccessful): \nInfo: ${info.componentStack}';
+    final message = 'An unrecoverable error was caught by an ErrorBoundary (attempting to remount it was unsuccessful): \nInfo: ${info.componentStack}';
 
     (props.logger ?? Logger(_loggerName)).severe(message, error, info.dartStackTrace);
   }

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -61,7 +61,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   // ---------------------------------------------- /\ ----------------------------------------------
 
   ReactErrorInfo _errorInfo;
-  String _error;
+  dynamic _error;
 
   @override
   Map get defaultProps => (newProps()
@@ -71,18 +71,16 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   );
 
   @override
-  get initialState => newState()
+  get initialState => (newState()
     ..hasError = false
-    ..showFallbackUIOnError = true;
+    ..showFallbackUIOnError = true
+  );
 
   @override
-  Map getDerivedStateFromError(error) {
-    _error = error;
-    return (newState()
-      ..hasError = true
-      ..showFallbackUIOnError = true
-    );
-  }
+  Map getDerivedStateFromError(error) => (newState()
+    ..hasError = true
+    ..showFallbackUIOnError = true
+  );
 
   @override
   void componentDidCatch(error, ReactErrorInfo info) {
@@ -104,7 +102,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   render() {
     if (state.hasError) { // [2]
       if (props.fallbackUIRenderer != null) {
-        return ErrorBoundary()(props.fallbackUIRenderer(_error, _errorInfo)); // [2.1]
+        return props.fallbackUIRenderer(_error, _errorInfo); // [2.1]
       } else {
         return (Dom.div()
           ..key = 'ohnoes'
@@ -118,7 +116,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   @override
   void componentDidUpdate(Map prevProps, Map prevState, [dynamic snapshot]) {
     // If the child is different, and the error boundary is currently in an error state,
-    // give the child a chance to remount itself and "recover" from the previous error.
+    // give the children a chance to mount.
     if (state.hasError) {
       final childThatCausedError = typedPropsFactory(prevProps).children.single;
       if (childThatCausedError != props.children.single) {
@@ -127,7 +125,7 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     }
   }
 
-    /// Resets the [ErrorBoundary] to a non-error state.
+  /// Resets the [ErrorBoundary] to a non-error state.
   ///
   /// This can be called manually on the component instance using a `ref` -
   /// or by passing in a new child instance after a child has thrown an error.

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -1,4 +1,5 @@
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component/error_boundary_recoverable.dart';
 
@@ -53,17 +54,10 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   //
   // [2] If we catch an error in this Error Boundary that indicates that the child Error Boundary was
   //     unable to handle or recover from the error, so we know that it was "unrecoverable" and we
-  //     haven't had a successful render.
+  //     haven't had a successful render there is never any DOM created that can used to display,
+  //     so we present an empty div instead.
   //
-  //     [2.1] If we have `props.fallbackUIRenderer` we present that.
-  //
-  //     [2.2] Due to this ErrorBoundary only catching during "unrecoverable" render cycle errors
-  //           there is never any DOM created that can be used, and because `props.fallbackUIRenderer`
-  //           is not set we have no content to display, so we present an empty div instead.
   // ---------------------------------------------- /\ ----------------------------------------------
-
-  ReactErrorInfo _errorInfo;
-  dynamic _error;
 
   @override
   get defaultProps => (newProps()
@@ -86,9 +80,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
 
   @override
   void componentDidCatch(error, ReactErrorInfo info) {
-    _error = error;
-    _errorInfo = info;
-
     if (props.onComponentDidCatch != null) {
       props.onComponentDidCatch(error, info);
     }
@@ -103,16 +94,15 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
   @override
   render() {
     if (state.hasError) { // [2]
-      if (props.fallbackUIRenderer != null) {
-        return props.fallbackUIRenderer(_error, _errorInfo); // [2.1]
-      } else {
-        return (Dom.div()
-          ..key = 'ohnoes'
-          ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
-        )(); // [2.2]
-      }
+      return (Dom.div()
+        ..key = 'ohnoes'
+        ..addTestId('ErrorBoundary.unrecoverableErrorInnerHtmlContainerNode')
+      )();
     }
-    return (RecoverableErrorBoundary()..modifyProps(addUnconsumedProps))(props.children); // [1]
+    return (RecoverableErrorBoundary()
+      ..addTestId('RecoverableErrorBoundary')
+      ..modifyProps(addUnconsumedProps)
+    )(props.children); // [1]
   }
 
   @override

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -122,7 +122,6 @@ class ErrorBoundaryComponent<T extends ErrorBoundaryProps, S extends ErrorBounda
     if (state.hasError) {
       final childThatCausedError = typedPropsFactory(prevProps).children.single;
       if (childThatCausedError != props.children.single) {
-        print('children are different!');
         reset();
       }
     }

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -13,6 +13,8 @@ const String defaultErrorBoundaryLoggerName = 'over_react.ErrorBoundary';
 /// within a custom component.
 ///
 /// > See: [ErrorBoundaryMixin] for a usage example.
+@Deprecated('Building custom error boundaries with this mixin will no longer be supported in version 4.0.0.'
+    'Use ErrorBoundary and its prop API to customize error handling instead.')
 @PropsMixin()
 abstract class _$ErrorBoundaryPropsMixin implements UiProps {
   @override
@@ -109,6 +111,8 @@ abstract class _$ErrorBoundaryPropsMixin implements UiProps {
 /// within a custom component.
 ///
 /// > See: [ErrorBoundaryMixin] for a usage example.
+@Deprecated('Building custom error boundaries with this mixin will no longer be supported in version 4.0.0.'
+    'Use ErrorBoundary and its prop API to customize error handling instead.')
 @StateMixin()
 abstract class _$ErrorBoundaryStateMixin implements UiState {
   @override
@@ -158,9 +162,8 @@ abstract class _$ErrorBoundaryStateMixin implements UiState {
 ///         return Dom.h3()('Error!');
 ///       }
 ///     }
-///
-/// __Deprecated.__ Use `ErrorBoundary` component and its props to handle errors instead.
-@Deprecated('4.0.0')
+@Deprecated('Building custom error boundaries with this mixin will no longer be supported in version 4.0.0.'
+    'Use ErrorBoundary and its prop API to customize error handling instead.')
 mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBoundaryStateMixin>
     on UiStatefulComponent2<T, S> {
   @override

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -158,6 +158,9 @@ abstract class _$ErrorBoundaryStateMixin implements UiState {
 ///         return Dom.h3()('Error!');
 ///       }
 ///     }
+///
+/// __Deprecated.__ Use `ErrorBoundary` component and its props to handle errors instead.
+@Deprecated('4.0.0')
 mixin ErrorBoundaryMixin<T extends ErrorBoundaryPropsMixin, S extends ErrorBoundaryStateMixin>
     on UiStatefulComponent2<T, S> {
   @override

--- a/lib/src/component/error_boundary_mixins.dart
+++ b/lib/src/component/error_boundary_mixins.dart
@@ -9,6 +9,17 @@ part 'error_boundary_mixins.over_react.g.dart';
 @visibleForTesting
 const String defaultErrorBoundaryLoggerName = 'over_react.ErrorBoundary';
 
+/// An API mixin used for shared APIs in ErrorBoundary Components.
+mixin ErrorBoundaryApi<T extends ErrorBoundaryPropsMixin, S extends ErrorBoundaryStateMixin> on UiStatefulComponent2<T, S> {
+  /// Resets the [ErrorBoundary] to a non-error state.
+  ///
+  /// This can be called manually on the component instance using a `ref` -
+  /// or by passing in a new child instance after a child has thrown an error.
+  void reset() {
+    setState(initialState);
+  }
+}
+
 /// A props mixin you can use to implement / extend from the behaviors of an [ErrorBoundary]
 /// within a custom component.
 ///

--- a/lib/src/component/error_boundary_recoverable.dart
+++ b/lib/src/component/error_boundary_recoverable.dart
@@ -2,15 +2,12 @@ import 'package:over_react/over_react.dart';
 
 part 'error_boundary_recoverable.over_react.g.dart';
 
-/// A higher-order component that will catch ReactJS errors anywhere within the child component tree and
-/// display a fallback UI instead of the component tree that crashed.
+/// A higher-order component that will catch "recoverable" ReactJS errors, errors outside of the render/mount cycle,
+/// anywhere within the child component tree and display a fallback UI instead of the component tree that crashed.
 ///
-/// Optionally, use the [ErrorBoundaryProps.onComponentDidCatch]
-/// to send error / stack trace information to a logging endpoint for your application.
-///
-/// To make your own custom error boundaries, you can utilize the [ErrorBoundaryPropsMixin],
-/// [ErrorBoundaryStateMixin] and [ErrorBoundaryMixin]s on any component that is annotated
-/// using `@Component2(isErrorBoundary: true)`. See the [ErrorBoundaryMixin] for an example implementation.
+/// __NOTE:__
+///   1. This component is not / should never be publicly exported.
+///   2. This component should never be used, except as a child of the outer (public) `ErrorBoundary` component.
 @Factory()
 UiFactory<RecoverableErrorBoundaryProps> RecoverableErrorBoundary = _$RecoverableErrorBoundary;
 

--- a/lib/src/component/error_boundary_recoverable.dart
+++ b/lib/src/component/error_boundary_recoverable.dart
@@ -1,4 +1,5 @@
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_mixins.dart';
 
 part 'error_boundary_recoverable.over_react.g.dart';
 
@@ -19,4 +20,4 @@ class _$RecoverableErrorBoundaryState extends UiState with ErrorBoundaryStateMix
 
 @Component2(isWrapper: true, isErrorBoundary: true)
 class RecoverableErrorBoundaryComponent<T extends RecoverableErrorBoundaryProps, S extends RecoverableErrorBoundaryState>
-    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S> {}
+    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S>, ErrorBoundaryApi<T, S> {}

--- a/lib/src/component/error_boundary_recoverable.dart
+++ b/lib/src/component/error_boundary_recoverable.dart
@@ -1,0 +1,25 @@
+import 'package:over_react/over_react.dart';
+
+part 'error_boundary_recoverable.over_react.g.dart';
+
+/// A higher-order component that will catch ReactJS errors anywhere within the child component tree and
+/// display a fallback UI instead of the component tree that crashed.
+///
+/// Optionally, use the [ErrorBoundaryProps.onComponentDidCatch]
+/// to send error / stack trace information to a logging endpoint for your application.
+///
+/// To make your own custom error boundaries, you can utilize the [ErrorBoundaryPropsMixin],
+/// [ErrorBoundaryStateMixin] and [ErrorBoundaryMixin]s on any component that is annotated
+/// using `@Component2(isErrorBoundary: true)`. See the [ErrorBoundaryMixin] for an example implementation.
+@Factory()
+UiFactory<RecoverableErrorBoundaryProps> RecoverableErrorBoundary = _$RecoverableErrorBoundary;
+
+@Props()
+class _$RecoverableErrorBoundaryProps extends UiProps with ErrorBoundaryPropsMixin {}
+
+@State()
+class _$RecoverableErrorBoundaryState extends UiState with ErrorBoundaryStateMixin {}
+
+@Component2(isWrapper: true, isErrorBoundary: true)
+class RecoverableErrorBoundaryComponent<T extends RecoverableErrorBoundaryProps, S extends RecoverableErrorBoundaryState>
+    extends UiStatefulComponent2<T, S> with ErrorBoundaryMixin<T, S> {}

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -1,0 +1,260 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'error_boundary_recoverable.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $RecoverableErrorBoundaryComponentFactory = registerComponent2(
+  () => _$RecoverableErrorBoundaryComponent(),
+  builderFactory: RecoverableErrorBoundary,
+  componentClass: RecoverableErrorBoundaryComponent,
+  isWrapper: true,
+  parentType: null,
+  displayName: 'RecoverableErrorBoundary',
+  skipMethods: const [],
+);
+
+abstract class _$RecoverableErrorBoundaryPropsAccessorsMixin
+    implements _$RecoverableErrorBoundaryProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForRecoverableErrorBoundaryProps = PropsMeta(
+  fields: _$RecoverableErrorBoundaryPropsAccessorsMixin.$props,
+  keys: _$RecoverableErrorBoundaryPropsAccessorsMixin.$propKeys,
+);
+
+class RecoverableErrorBoundaryProps extends _$RecoverableErrorBoundaryProps
+    with _$RecoverableErrorBoundaryPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForRecoverableErrorBoundaryProps;
+}
+
+_$$RecoverableErrorBoundaryProps _$RecoverableErrorBoundary(
+        [Map backingProps]) =>
+    backingProps == null
+        ? _$$RecoverableErrorBoundaryProps$JsMap(JsBackedMap())
+        : _$$RecoverableErrorBoundaryProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+abstract class _$$RecoverableErrorBoundaryProps
+    extends _$RecoverableErrorBoundaryProps
+    with _$RecoverableErrorBoundaryPropsAccessorsMixin
+    implements RecoverableErrorBoundaryProps {
+  _$$RecoverableErrorBoundaryProps._();
+
+  factory _$$RecoverableErrorBoundaryProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$RecoverableErrorBoundaryProps$JsMap(backingMap);
+    } else {
+      return _$$RecoverableErrorBoundaryProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $RecoverableErrorBoundaryComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'RecoverableErrorBoundaryProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$RecoverableErrorBoundaryProps$PlainMap
+    extends _$$RecoverableErrorBoundaryProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$RecoverableErrorBoundaryProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$RecoverableErrorBoundaryProps$JsMap
+    extends _$$RecoverableErrorBoundaryProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$RecoverableErrorBoundaryProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+abstract class _$RecoverableErrorBoundaryStateAccessorsMixin
+    implements _$RecoverableErrorBoundaryState {
+  @override
+  Map get state;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<StateDescriptor> $state = [];
+  static const List<String> $stateKeys = [];
+}
+
+const StateMeta _$metaForRecoverableErrorBoundaryState = StateMeta(
+  fields: _$RecoverableErrorBoundaryStateAccessorsMixin.$state,
+  keys: _$RecoverableErrorBoundaryStateAccessorsMixin.$stateKeys,
+);
+
+class RecoverableErrorBoundaryState extends _$RecoverableErrorBoundaryState
+    with _$RecoverableErrorBoundaryStateAccessorsMixin {
+  static const StateMeta meta = _$metaForRecoverableErrorBoundaryState;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+abstract class _$$RecoverableErrorBoundaryState
+    extends _$RecoverableErrorBoundaryState
+    with _$RecoverableErrorBoundaryStateAccessorsMixin
+    implements RecoverableErrorBoundaryState {
+  _$$RecoverableErrorBoundaryState._();
+
+  factory _$$RecoverableErrorBoundaryState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$RecoverableErrorBoundaryState$JsMap(backingMap);
+    } else {
+      return _$$RecoverableErrorBoundaryState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiState` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+class _$$RecoverableErrorBoundaryState$PlainMap
+    extends _$$RecoverableErrorBoundaryState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$RecoverableErrorBoundaryState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+}
+
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$RecoverableErrorBoundaryState$JsMap
+    extends _$$RecoverableErrorBoundaryState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$RecoverableErrorBoundaryState$JsMap(JsBackedMap backingMap)
+      : this._state = JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$RecoverableErrorBoundaryComponent
+    extends RecoverableErrorBoundaryComponent {
+  _$$RecoverableErrorBoundaryProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$RecoverableErrorBoundaryProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$RecoverableErrorBoundaryProps$JsMap typedPropsFactoryJs(
+          JsBackedMap backingMap) =>
+      _$$RecoverableErrorBoundaryProps$JsMap(backingMap);
+
+  @override
+  _$$RecoverableErrorBoundaryProps typedPropsFactory(Map backingMap) =>
+      _$$RecoverableErrorBoundaryProps(backingMap);
+
+  _$$RecoverableErrorBoundaryState$JsMap _cachedTypedState;
+  @override
+  _$$RecoverableErrorBoundaryState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initialState or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$RecoverableErrorBoundaryState$JsMap typedStateFactoryJs(
+          JsBackedMap backingMap) =>
+      _$$RecoverableErrorBoundaryState$JsMap(backingMap);
+
+  @override
+  _$$RecoverableErrorBoundaryState typedStateFactory(Map backingMap) =>
+      _$$RecoverableErrorBoundaryState(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$RecoverableErrorBoundaryProps.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForRecoverableErrorBoundaryProps
+  ];
+}

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -23,11 +23,11 @@ import 'package:test/test.dart';
 import 'shared_error_boundary_tests.dart';
 
 void main() {
-  group('RecoverableErrorBoundary', () {
-    sharedErrorBoundaryTests(() => RecoverableErrorBoundary());
-  });
+  // group('RecoverableErrorBoundary', () {
+  //   sharedErrorBoundaryTests(() => RecoverableErrorBoundary());
+  // });
 
   group('ErrorBoundary', () {
-    sharedErrorBoundaryTests(() => ErrorBoundary());
+    sharedErrorBoundaryTests(() => ErrorBoundary(), isWrapper: true);
   });
 }

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -17,11 +17,16 @@
 library error_boundary_test;
 
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_recoverable.dart';
 import 'package:test/test.dart';
 
 import 'shared_error_boundary_tests.dart';
 
 void main() {
+  group('RecoverableErrorBoundary', () {
+    sharedErrorBoundaryTests(() => RecoverableErrorBoundary());
+  });
+
   group('ErrorBoundary', () {
     sharedErrorBoundaryTests(() => ErrorBoundary());
   });

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -23,9 +23,9 @@ import 'package:test/test.dart';
 import 'shared_error_boundary_tests.dart';
 
 void main() {
-  // group('RecoverableErrorBoundary', () {
-  //   sharedErrorBoundaryTests(() => RecoverableErrorBoundary());
-  // });
+  group('RecoverableErrorBoundary', () {
+    sharedErrorBoundaryTests(() => RecoverableErrorBoundary());
+  });
 
   group('ErrorBoundary', () {
     sharedErrorBoundaryTests(() => ErrorBoundary(), isWrapper: true);

--- a/test/over_react/component/fixtures/custom_error_boundary_component.dart
+++ b/test/over_react/component/fixtures/custom_error_boundary_component.dart
@@ -1,4 +1,5 @@
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_mixins.dart';
 
 // ignore: uri_has_not_been_generated
 part 'custom_error_boundary_component.over_react.g.dart';
@@ -15,4 +16,6 @@ class _$CustomErrorBoundaryState extends UiState with ErrorBoundaryStateMixin {}
 
 @Component2(isErrorBoundary: true)
 class CustomErrorBoundaryComponent extends UiStatefulComponent2<CustomErrorBoundaryProps, CustomErrorBoundaryState>
-    with ErrorBoundaryMixin<CustomErrorBoundaryProps, CustomErrorBoundaryState> {}
+    with
+        ErrorBoundaryMixin<CustomErrorBoundaryProps, CustomErrorBoundaryState>,
+        ErrorBoundaryApi<CustomErrorBoundaryProps, CustomErrorBoundaryState> {}

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -339,7 +339,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
       if (isWrapper) {
         group('and the errors are during the render cycle', () {
           group('and they occurred on every render', () {
-            setUp(() async {
+            setUp(() {
               sharedSetup(errorBoundaryChildren: FlawedOnMount()());
             });
 
@@ -370,7 +370,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
           });
 
           group('and they occurred on every render and fallbackUIRenderer is set', () {
-            setUp(() async {
+            setUp(() {
               sharedSetup(
                 errorBoundaryChildren: FlawedOnMount()(),
                 errorBoundaryProps: (ErrorBoundaryPropsMapView({})

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -392,6 +392,8 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
             test('the correct callbacks are called with the correct arguments', () {
               expect(calls.any((call) => call.keys.single == 'onComponentDidCatch'), isTrue,
                   reason: 'onComponentDidCatch should have been called');
+              expect(calls.any((call) => call.keys.single == 'onComponentIsUnrecoverable'), isFalse,
+                  reason: 'onComponentIsUnrecoverable should not have been called');
 
               _setCallbackVarValues();
 
@@ -550,7 +552,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -660,7 +662,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -730,7 +732,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -765,7 +767,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -806,7 +808,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -841,7 +843,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -878,7 +880,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 
@@ -913,7 +915,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
                 reason: 'The flawed component should have been remounted');
             if (!isWrapper) {
               expect(jacket.getDartInstance().state.showFallbackUIOnError, isFalse,
-                  reason: 'Fallback UI should be not be rendered');
+                  reason: 'Fallback UI should not be rendered');
             }
           });
 

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -28,7 +28,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
     List<Map<String, List>> calls;
     DivElement mountNode;
 
-    void verifyReact16ErrorHandlingWithoutbuilder() {
+    void verifyReact16ErrorHandlingWithoutErrorBoundary() {
       mountNode = DivElement();
       document.body.append(mountNode);
       var jacketOfFlawedComponentWithNoErrorBoundary = mount(Flawed()(), mountNode: mountNode);
@@ -49,7 +49,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
 
     setUp(() {
       // Verify the behavior of a component that throws when it is not wrapped in an error boundary first
-      verifyReact16ErrorHandlingWithoutbuilder();
+      verifyReact16ErrorHandlingWithoutErrorBoundary();
 
       calls = [];
       jacket = mount(

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -1,6 +1,7 @@
 import 'dart:html';
 import 'package:logging/logging.dart';
 import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/error_boundary_mixins.dart';
 import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
 
@@ -12,7 +13,7 @@ import './fixtures/flawed_component_that_renders_nothing.dart';
 /// `isWrapper` identifies an ErrorBoundary that wraps another Error Boundary in order to handle
 /// render cycle "unrecoverable" errors.
 void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> builder, { bool isWrapper = false }) {
-  TestJacket<UiStatefulComponent2<ErrorBoundaryPropsMixin, ErrorBoundaryStateMixin>> jacket;
+  TestJacket<ErrorBoundaryApi> jacket;
   ReactElement dummyChild;
 
   setUp(() {
@@ -194,8 +195,8 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
         });
 
         test('when reset() is called', () {
-          dynamic component = jacket.getDartInstance();
-          (component as dynamic).reset();
+          var component = jacket.getDartInstance();
+          component.reset();
           expect(component.state.hasError, isFalse);
           expect(component.state.showFallbackUIOnError, isTrue);
           expect(getByTestId(jacket.getInstance(), 'dummyChild'), isNotNull);

--- a/test/over_react/component/shared_error_boundary_tests.dart
+++ b/test/over_react/component/shared_error_boundary_tests.dart
@@ -10,7 +10,7 @@ import './fixtures/flawed_component_on_mount.dart';
 import './fixtures/flawed_component_that_renders_a_string.dart';
 import './fixtures/flawed_component_that_renders_nothing.dart';
 
-/// `isWrapper` identifies an ErrorBoundary that wraps another Error Boundary in order to handle
+/// [isWrapper] identifies an ErrorBoundary that wraps another Error Boundary in order to handle
 /// render cycle "unrecoverable" errors.
 void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> builder, { bool isWrapper = false }) {
   TestJacket<ErrorBoundaryApi> jacket;
@@ -268,7 +268,7 @@ void sharedErrorBoundaryTests(BuilderOnlyUiFactory<ErrorBoundaryPropsMixin> buil
 
       // At this point the component is "Unrecoverable"
       if (calls.length > 1) {
-        expect(calls[calls.length - 1].keys.single, 'onComponentIsUnrecoverable', reason: 'test setup sanity check');
+        expect(calls.last.keys.single, 'onComponentIsUnrecoverable', reason: 'test setup sanity check');
         final componentIsUnrecoverableCallbackArguments = calls[1]['onComponentIsUnrecoverable'];
         if (componentIsUnrecoverableCallbackArguments != null) {
           errorSentToComponentIsUnrecoverableCallback = componentIsUnrecoverableCallbackArguments[0];

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -41,16 +41,16 @@ void main() {
 
   enableTestMode();
 
-  // abstract_transition_test.main();
-  // abstract_transition2_test.main();
-  //error_boundary_mixin_test.main();
+  abstract_transition_test.main();
+  abstract_transition2_test.main();
+  error_boundary_mixin_test.main();
   error_boundary_test.main();
-  // forward_ref_test.main();
-  // dom_components_test.main();
-  // prop_mixins_test.main();
-  // prop_typedefs_test.main();
-  // resize_sensor_test.main();
-  // fragment_component_test.main();
-  // context_test.main();
-  // typed_factory_test.main();
+  forward_ref_test.main();
+  dom_components_test.main();
+  prop_mixins_test.main();
+  prop_typedefs_test.main();
+  resize_sensor_test.main();
+  fragment_component_test.main();
+  context_test.main();
+  typed_factory_test.main();
 }

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -41,16 +41,16 @@ void main() {
 
   enableTestMode();
 
-  abstract_transition_test.main();
-  abstract_transition2_test.main();
-  error_boundary_mixin_test.main();
+  // abstract_transition_test.main();
+  // abstract_transition2_test.main();
+  //error_boundary_mixin_test.main();
   error_boundary_test.main();
-  forward_ref_test.main();
-  dom_components_test.main();
-  prop_mixins_test.main();
-  prop_typedefs_test.main();
-  resize_sensor_test.main();
-  fragment_component_test.main();
-  context_test.main();
-  typed_factory_test.main();
+  // forward_ref_test.main();
+  // dom_components_test.main();
+  // prop_mixins_test.main();
+  // prop_typedefs_test.main();
+  // resize_sensor_test.main();
+  // fragment_component_test.main();
+  // context_test.main();
+  // typed_factory_test.main();
 }

--- a/web/component2/index.dart
+++ b/web/component2/index.dart
@@ -36,6 +36,18 @@ void main() {
   );
 
   react_dom.render(
+    (ErrorBoundary()
+      ..fallbackUIRenderer = (error, info) {
+        return Dom.div()('It totally crashed.');
+      }
+      ..onComponentDidCatch = (error, info) {
+        print('Consumer props.onComponentDidCatch($error, $info)');
+      }
+    )(FaultyOnMount()()),
+    querySelector('$demoMountNodeSelectorPrefix--faulty-on-mount-component'),
+  );
+
+  react_dom.render(
     (CustomErrorBoundary()
       ..onComponentDidCatch = (error, info) {
         print('Consumer props.onComponentDidCatch($error, $info)');

--- a/web/component2/index.dart
+++ b/web/component2/index.dart
@@ -37,9 +37,6 @@ void main() {
 
   react_dom.render(
     (ErrorBoundary()
-      ..fallbackUIRenderer = (error, info) {
-        return Dom.div()('It totally crashed.');
-      }
       ..onComponentDidCatch = (error, info) {
         print('Consumer props.onComponentDidCatch($error, $info)');
       }

--- a/web/component2/index.dart
+++ b/web/component2/index.dart
@@ -45,6 +45,18 @@ void main() {
   );
 
   react_dom.render(
+    (ErrorBoundary()
+      ..onComponentDidCatch = (error, info) {
+        print('Consumer props.onComponentDidCatch($error, $info)');
+      }
+      ..fallbackUIRenderer = (_, __) {
+        return (Dom.div()..id = 'FallbackUi')('I am a fallback.');
+      }
+    )(FaultyOnMount()()),
+    querySelector('$demoMountNodeSelectorPrefix--faulty-on-mount-fallback-component'),
+  );
+
+  react_dom.render(
     (CustomErrorBoundary()
       ..onComponentDidCatch = (error, info) {
         print('Consumer props.onComponentDidCatch($error, $info)');

--- a/web/component2/index.html
+++ b/web/component2/index.html
@@ -59,10 +59,10 @@
                 <div class="component-demo__mount--faulty-component"></div>
             </div>
             <div class="col-xs-12 col-lg-6 p-3">
-                <h2>Component That Throws A Caught Error On Mount (everytime)</h2>
+                <h2>Component That Throws A Caught Error On Mount (every time)</h2>
                 <p><strong>(Default ErrorBoundary Component)</strong></p>
-                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
-                    around with the component rendered below.</p>
+                <p>Modify the source of <code>/web/demos/faulty-on-mount-component.dart</code> to play
+                    around with the component rendered below. By default nothing is rendered except an empty div.</p>
                 <div class="component-demo__mount--faulty-on-mount-component"></div>
             </div>
             <div class="col-xs-12 col-lg-6 p-3">

--- a/web/component2/index.html
+++ b/web/component2/index.html
@@ -59,6 +59,13 @@
                 <div class="component-demo__mount--faulty-component"></div>
             </div>
             <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws A Caught Error On Mount (everytime)</h2>
+                <p><strong>(Default ErrorBoundary Component)</strong></p>
+                <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play
+                    around with the component rendered below.</p>
+                <div class="component-demo__mount--faulty-on-mount-component"></div>
+            </div>
+            <div class="col-xs-12 col-lg-6 p-3">
                 <h2>Component That Throws A Caught Error</h2>
                 <p><strong>(Custom Error Boundary Component)</strong></p>
                 <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play

--- a/web/component2/index.html
+++ b/web/component2/index.html
@@ -66,6 +66,13 @@
                 <div class="component-demo__mount--faulty-on-mount-component"></div>
             </div>
             <div class="col-xs-12 col-lg-6 p-3">
+                <h2>Component That Throws A Caught Error On Mount with Fallback (every time)</h2>
+                <p><strong>(Default ErrorBoundary Component)</strong></p>
+                <p>Modify the source of <code>/web/demos/faulty-on-mount-component.dart</code> to play
+                    around with the component rendered below. By default nothing is rendered except an empty div.</p>
+                <div class="component-demo__mount--faulty-on-mount-fallback-component"></div>
+            </div>
+            <div class="col-xs-12 col-lg-6 p-3">
                 <h2>Component That Throws A Caught Error</h2>
                 <p><strong>(Custom Error Boundary Component)</strong></p>
                 <p>Modify the source of <code>/web/demos/faulty-component.dart</code> to play

--- a/web/component2/src/demos.dart
+++ b/web/component2/src/demos.dart
@@ -13,6 +13,7 @@ export 'demos/custom_error_boundary.dart';
 export '../src/demo_components/prop_validation_wrap.dart';
 
 export '../../src/demos/faulty-component.dart';
+export '../../src/demos/faulty-on-mount-component.dart';
 
 export 'demos/list-group/list-group-basic.dart';
 export 'demos/list-group/list-group-tags.dart';

--- a/web/src/demos/faulty-on-mount-component.dart
+++ b/web/src/demos/faulty-on-mount-component.dart
@@ -1,0 +1,26 @@
+import 'package:over_react/over_react.dart';
+
+part 'faulty-on-mount-component.over_react.g.dart';
+
+
+@Factory()
+// ignore: undefined_identifier
+UiFactory<FaultyOnMountProps> FaultyOnMount = _$FaultyOnMount;
+
+@Props()
+class _$FaultyOnMountProps extends UiProps {}
+
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
+class FaultyOnMountProps extends _$FaultyOnMountProps with _$FaultyOnMountPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  static const PropsMeta meta = _$metaForFaultyOnMountProps;
+}
+
+@Component2()
+class FaultyOnMountComponent extends UiComponent2<FaultyOnMountProps> {
+  @override
+  render() {
+    throw 'lol';
+  }
+}

--- a/web/src/demos/faulty-on-mount-component.dart
+++ b/web/src/demos/faulty-on-mount-component.dart
@@ -21,6 +21,11 @@ class FaultyOnMountProps extends _$FaultyOnMountProps with _$FaultyOnMountPropsA
 class FaultyOnMountComponent extends UiComponent2<FaultyOnMountProps> {
   @override
   render() {
-    throw 'lol';
+    throw Shade();
   }
+}
+
+class Shade extends Error {
+  @override
+  toString() => 'lol';
 }

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -1,0 +1,147 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'faulty-on-mount-component.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $FaultyOnMountComponentFactory = registerComponent2(
+  () => _$FaultyOnMountComponent(),
+  builderFactory: FaultyOnMount,
+  componentClass: FaultyOnMountComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'FaultyOnMount',
+);
+
+abstract class _$FaultyOnMountPropsAccessorsMixin
+    implements _$FaultyOnMountProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForFaultyOnMountProps = PropsMeta(
+  fields: _$FaultyOnMountPropsAccessorsMixin.$props,
+  keys: _$FaultyOnMountPropsAccessorsMixin.$propKeys,
+);
+
+_$$FaultyOnMountProps _$FaultyOnMount([Map backingProps]) =>
+    backingProps == null
+        ? _$$FaultyOnMountProps$JsMap(JsBackedMap())
+        : _$$FaultyOnMountProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+abstract class _$$FaultyOnMountProps extends _$FaultyOnMountProps
+    with _$FaultyOnMountPropsAccessorsMixin
+    implements FaultyOnMountProps {
+  _$$FaultyOnMountProps._();
+
+  factory _$$FaultyOnMountProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$FaultyOnMountProps$JsMap(backingMap);
+    } else {
+      return _$$FaultyOnMountProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $FaultyOnMountComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'FaultyOnMountProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$FaultyOnMountProps$PlainMap extends _$$FaultyOnMountProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FaultyOnMountProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$FaultyOnMountProps$JsMap extends _$$FaultyOnMountProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FaultyOnMountProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$FaultyOnMountComponent extends FaultyOnMountComponent {
+  _$$FaultyOnMountProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$FaultyOnMountProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$FaultyOnMountProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$FaultyOnMountProps$JsMap(backingMap);
+
+  @override
+  _$$FaultyOnMountProps typedPropsFactory(Map backingMap) =>
+      _$$FaultyOnMountProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$FaultyOnMountProps.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForFaultyOnMountProps
+  ];
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Even with ErrorBoundaries in place, we were seeing issues with the app still entirely unmounting even with the logic for "unrecoverable" errors. It turns out in React if an ErrorBoundary catches an error, it will have its error lifecycle methods called, if on that render cycle the component throws during the render cycle React will move up the tree to a parent ErrorBoundary instead. And due to all the Previous ErrorBoundaries having the same logic none would ever handle the render cycle error.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Updated `ErrorBoundaryComponent` to handle render cycle unrecoverable errors (hopefully this wont happen often.)
- Moved the previous `ErrorBoundary` logic into `RecoverableErrorBoundary` and nested it as the first child of the updated `ErrorBoundary`.
  - This nesting allows us to know that if `RecoverableErrorBoundary` was unable to recover, that the error is "Unrecoverable" and needs to be handled.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Updated ErrorBoundary to better handle Unrecoverable Errors that might be thrown during the render cycle.
- Deprecated ErrorBoundaryMixin as it only handles errors that are able to be "recovered" and recommend using ErrorBoundary with your custom props instead.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
