### PR TITLE
CPLAT-8834 fix tests for redux 7.1.3

### DIFF
--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -29,7 +29,7 @@ main() {
   group('connect', () {
     UiFactory<CounterProps> ConnectedCounter;
     TestJacket<CounterComponent> jacket;
-    Ref<CounterComponent> counterRef = createRef();
+    final counterRef = createRef<CounterComponent>();
 
     JsConnectOptions connectOptions;
     var originalConnect = mockableJsConnect;
@@ -299,13 +299,13 @@ main() {
       group('areOwnPropsEqual', () {
         test('', () {
           ConnectedCounter = connect<CounterState, CounterProps>(
-            areOwnPropsEqual: (next, prev) {
+            areOwnPropsEqual: expectAsync2((next, prev) {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
               expect(next.id, 'test');
               expect(prev.id, 'test2');
               return true;
-            },
+            }),
           )(Counter);
 
           var whatever = connectOptions.areOwnPropsEqual(
@@ -329,7 +329,7 @@ main() {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
               methodsCalled.add('areStatePropsEqual');
-              // Force it to always betrue, meaing it shouldnt re-render if they change.
+              // Force it to always be true, meaing it shouldnt re-render if they change.
               return true;
             },
             forwardRef: true,
@@ -359,13 +359,13 @@ main() {
       group('areMergedPropsEqual', () {
         test('', () {
           ConnectedCounter = connect<CounterState, CounterProps>(
-            areMergedPropsEqual: (next, prev) {
+            areMergedPropsEqual: expectAsync2((next, prev) {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
               expect(next.id, 'test');
               expect(prev.id, 'test2');
               return true;
-            },
+            }),
             pure: false,
           )(Counter);
 
@@ -401,7 +401,8 @@ main() {
             ),
           );
 
-          expect(methodsCalled, ['mapStateToProps', 'areStatesEqual']);
+          expect(methodsCalled, contains('mapStateToProps'));
+          expect(methodsCalled, contains('areStatesEqual'));
           methodsCalled.clear();
 
           var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -29,7 +29,7 @@ main() {
   group('connect', () {
     UiFactory<CounterProps> ConnectedCounter;
     TestJacket<CounterComponent> jacket;
-    dynamic counterRef;
+    Ref<CounterComponent> counterRef = createRef();
 
     JsConnectOptions connectOptions;
     var originalConnect = mockableJsConnect;
@@ -83,10 +83,10 @@ main() {
 
         render(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref=(ref){counterRef = ref;})('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
-        expect(getDartComponent(counterRef), isA<CounterComponent>());
+        expect(counterRef.current, isA<CounterComponent>());
       });
     });
 
@@ -98,12 +98,12 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
       });
 
       test('after dispatch', () async {
@@ -113,21 +113,21 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
-        var dispatchButton = getByTestId(jacket.getInstance(), 'button-increment');
+        var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
         click(dispatchButton);
 
         // wait for the next tick for the async dispatch to propagate
         await Future(() {});
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 1);
-        expect(jacket.getNode().innerHtml, contains('Count: 1'));
+        expect(counterRef.current.props.currentCount, 1);
+        expect(jacket.mountNode.innerHtml, contains('Count: 1'));
       });
     });
 
@@ -139,12 +139,12 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
       });
 
       test('after dispatch', () async {
@@ -154,21 +154,21 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
-        var dispatchButton = getByTestId(jacket.getInstance(), 'button-increment');
+        var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
         click(dispatchButton);
 
         // wait for the next tick for the async dispatch to propagate
         await Future(() {});
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 1);
-        expect(jacket.getNode().innerHtml, contains('Count: 1'));
+        expect(counterRef.current.props.currentCount, 1);
+        expect(jacket.mountNode.innerHtml, contains('Count: 1'));
       });
     });
 
@@ -187,24 +187,24 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.decrement, isA<Function>());
+        expect(counterRef.current.props.decrement, isA<Function>());
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
         // Click button mapped to trigger `propFromDispatch` prop.
-        var dispatchButton = getByTestId(jacket.getInstance(), 'button-decrement');
+        var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
         click(dispatchButton);
 
         // wait for the next tick for the async dispatch to propagate
         await Future(() {});
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, -1);
-        expect(jacket.getNode().innerHtml, contains('Count: -1'));
+        expect(counterRef.current.props.currentCount, -1);
+        expect(jacket.mountNode.innerHtml, contains('Count: -1'));
       });
     });
 
@@ -223,24 +223,24 @@ main() {
 
         jacket = mount(
           (ReduxProvider()..store = store1)(
-            (ConnectedCounter()..ref = (ref){ counterRef = ref; })('test'),
+            (ConnectedCounter()..ref = counterRef)('test'),
           ),
         );
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.decrement, isA<Function>());
+        expect(counterRef.current.props.decrement, isA<Function>());
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 0);
-        expect(jacket.getNode().innerHtml, contains('Count: 0'));
+        expect(counterRef.current.props.currentCount, 0);
+        expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
         // Click button mapped to trigger `propFromDispatch` prop.
-        var dispatchButton = getByTestId(jacket.getInstance(), 'button-decrement');
+        var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
         click(dispatchButton);
 
         // wait for the next tick for the async dispatch to propagate
         await Future(() {});
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, -1);
-        expect(jacket.getNode().innerHtml, contains('Count: -1'));
+        expect(counterRef.current.props.currentCount, -1);
+        expect(jacket.mountNode.innerHtml, contains('Count: -1'));
       });
     });
 
@@ -268,7 +268,7 @@ main() {
         jacket = mount(
           (ReduxProvider()..store = store1)(
             (ConnectedCounter()
-                ..ref = (ref){ counterRef = ref; }
+                ..ref = counterRef
                 // make `decrement` increment
                 ..decrement = () {store1.dispatch(IncrementAction());}
                 ..currentCount = 900
@@ -276,13 +276,13 @@ main() {
           ),
         );
         // `button-decrement` will be incrementing now
-        var dispatchButton = getByTestId(jacket.getInstance(), 'button-decrement');
+        var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.decrement, isA<Function>());
+        expect(counterRef.current.props.decrement, isA<Function>());
 
         // state.count is at 0
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 900);
-        expect(jacket.getNode().innerHtml, contains('Count: 900'));
+        expect(counterRef.current.props.currentCount, 900);
+        expect(jacket.mountNode.innerHtml, contains('Count: 900'));
 
         // Click button mapped to trigger `propFromDispatch` prop.
         click(dispatchButton); // state.count is now equal to 1
@@ -290,8 +290,8 @@ main() {
         // wait for the next tick for the async dispatch to propagate
         await Future(() {});
 
-        expect(getDartComponent<CounterComponent>(counterRef).props.currentCount, 1);
-        expect(jacket.getNode().innerHtml, contains('Count: 1'));
+        expect(counterRef.current.props.currentCount, 1);
+        expect(jacket.mountNode.innerHtml, contains('Count: 1'));
       });
     });
 
@@ -299,13 +299,13 @@ main() {
       group('areOwnPropsEqual', () {
         test('', () {
           ConnectedCounter = connect<CounterState, CounterProps>(
-            areOwnPropsEqual: expectAsync2((next, prev) {
+            areOwnPropsEqual: (next, prev) {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
               expect(next.id, 'test');
               expect(prev.id, 'test2');
               return true;
-            }),
+            },
           )(Counter);
 
           var whatever = connectOptions.areOwnPropsEqual(
@@ -328,9 +328,8 @@ main() {
             areStatePropsEqual: (next, prev) {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
-              expect(next.currentCount, 1);
               methodsCalled.add('areStatePropsEqual');
-              // Force it to always be true, meaing it shouldnt re-render if they change.
+              // Force it to always betrue, meaing it shouldnt re-render if they change.
               return true;
             },
             forwardRef: true,
@@ -338,13 +337,13 @@ main() {
 
           jacket = mount(
             (ReduxProvider()..store = store1)(
-              (ConnectedCounter()..ref = (ref){ counterRef = ref; }..currentCount = 0)('test'),
+              (ConnectedCounter()..ref = counterRef..currentCount = 0)('test'),
             ),
           );
           expect(methodsCalled, ['mapStateToProps']);
           methodsCalled.clear();
 
-          var dispatchButton = getByTestId(jacket.getInstance(), 'button-increment');
+          var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
@@ -353,20 +352,20 @@ main() {
           // store.state.count should be 1 but does not re-render due to override in `areStatePropsEqual`
 
           expect(methodsCalled, ['mapStateToProps', 'areStatePropsEqual']);
-          expect(jacket.getNode().innerHtml, contains('Count: 0'));
+          expect(jacket.mountNode.innerHtml, contains('Count: 0'));
         });
       });
 
       group('areMergedPropsEqual', () {
         test('', () {
           ConnectedCounter = connect<CounterState, CounterProps>(
-            areMergedPropsEqual: expectAsync2((next, prev) {
+            areMergedPropsEqual: (next, prev) {
               expect(next, isA<CounterProps>());
               expect(prev, isA<CounterProps>());
               expect(next.id, 'test');
               expect(prev.id, 'test2');
               return true;
-            }),
+            },
             pure: false,
           )(Counter);
 
@@ -398,24 +397,23 @@ main() {
 
           jacket = mount(
             (ReduxProvider()..store = store1)(
-              (ConnectedCounter()..ref = (ref){ counterRef = ref; }..currentCount = 0)('test'),
+              (ConnectedCounter()..ref = counterRef..currentCount = 0)('test'),
             ),
           );
 
-          // `mapStateToProps` is called once,
-          // then `areStatesEqual` shows up 2 times due to `initialState`.
-          expect(methodsCalled, ['mapStateToProps', 'areStatesEqual', 'areStatesEqual']);
+          expect(methodsCalled, ['mapStateToProps', 'areStatesEqual']);
           methodsCalled.clear();
 
-          var dispatchButton = getByTestId(jacket.getInstance(), 'button-increment');
+          var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
           await Future(() {});
 
-          // only checks `areStatesEqual` and does not call `mapStateToProps` since it returned `true`.
-          expect(methodsCalled, ['areStatesEqual']);
-          expect(jacket.getNode().innerHtml, contains('Count: 0'));
+          // only calls `areStatesEqual` and does not call `mapStateToProps` since it returned `true`.
+          expect(methodsCalled, isNot(contains('mapStateToProps')));
+          expect(methodsCalled, contains('areStatesEqual'));
+          expect(jacket.mountNode.innerHtml, contains('Count: 0'));
         });
       });
     });
@@ -449,13 +447,13 @@ main() {
           ),
         ));
 
-        var bigCounter = getDartComponent(getByTestId(jacket.getInstance(), 'big-counter'));
-        var dispatchButton = queryByTestId(findDomNode(bigCounter), 'button-increment');
+        var bigCounter = queryByTestId(jacket.mountNode, 'big-counter');
+        var dispatchButton = queryByTestId(bigCounter, 'button-increment');
         click(dispatchButton);
 
         await Future((){});
 
-        expect(findDomNode(bigCounter).innerHtml, contains('Count: 100'));
+        expect(bigCounter.innerHtml, contains('Count: 100'));
       });
 
       test('correctly renderes when contexts are nested', () async {
@@ -492,11 +490,11 @@ main() {
           )
         );
 
-        var bigCounter = getDartComponent(getByTestId(jacket.getInstance(), 'big-counter'));
-        var smallCounter = getDartComponent(getByTestId(jacket.getInstance(), 'small-counter'));
+        var bigCounter = queryByTestId(jacket.mountNode, 'big-counter');
+        var smallCounter = queryByTestId(jacket.mountNode, 'small-counter');
 
-        var smallDispatchButton = queryByTestId(findDomNode(smallCounter), 'button-increment');
-        var dispatchButton = queryByTestId(findDomNode(bigCounter), 'button-increment');
+        var smallDispatchButton = queryByTestId(smallCounter, 'button-increment');
+        var dispatchButton = queryByTestId(bigCounter, 'button-increment');
 
         click(dispatchButton);
         click(smallDispatchButton);
@@ -507,7 +505,7 @@ main() {
         expect(findDomNode(bigCounter).innerHtml, contains('Count: 100'), reason: 'Should have a count of 100');
 
         // Normal counter incremented only 1 at both instances
-        expect(findDomNode(getByTestId(jacket.getInstance(), 'outside')).innerHtml, contains('Count: 1</div>'));
+        expect(findDomNode(queryByTestId(jacket.mountNode, 'outside')).innerHtml, contains('Count: 1</div>'));
         expect(findDomNode(bigCounter).innerHtml, contains('Count: 1</div>'));
       });
     });

--- a/test/over_react_redux/fixtures/counter.dart
+++ b/test/over_react_redux/fixtures/counter.dart
@@ -22,29 +22,32 @@ class _$CounterProps extends UiProps with ConnectPropsMixin {
 class CounterComponent extends UiComponent2<CounterProps> {
   @override
   render() {
-    return (Dom.div()..style = props.wrapperStyles)(
-        Dom.div()('Count: ${props.currentCount}'),
-        (Dom.button()
-          ..addTestId('button-increment')
-          ..onClick = (_) {
-            if (props.increment != null) {
-              props.increment();
-            } else if (props.dispatch != null) {
-              props.dispatch(IncrementAction());
-            }
+    return (Dom.div()
+      ..modifyProps(addUnconsumedProps)
+      ..style = props.wrapperStyles
+    )(
+      Dom.div()('Count: ${props.currentCount}'),
+      (Dom.button()
+        ..addTestId('button-increment')
+        ..onClick = (_) {
+          if (props.increment != null) {
+            props.increment();
+          } else if (props.dispatch != null) {
+            props.dispatch(IncrementAction());
           }
-        )('+'),
-        (Dom.button()
-          ..addTestId('button-decrement')
-          ..onClick = (_) {
-            if (props.decrement != null) {
-              props.decrement();
-            } else if (props.dispatch != null) {
-              props.dispatch(DecrementAction());
-            }
+        }
+      )('+'),
+      (Dom.button()
+        ..addTestId('button-decrement')
+        ..onClick = (_) {
+          if (props.decrement != null) {
+            props.decrement();
+          } else if (props.dispatch != null) {
+            props.dispatch(DecrementAction());
           }
-        )('-'),
-        props.children
+        }
+      )('-'),
+      props.children
     );
   }
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The NPM package `react-redux` that over_react consumes from react-dart [changed its "Provider" component from a class based component to a function component](https://github.com/reduxjs/react-redux/pull/1377) in the 7.1.1 __patch__ version. This broke some expectations that our tests had in place for over_react_redux.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Remove usage of Class only features from over_react_redux Provider tests  

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
      - [ ] open react-dart and update `packages.json`'s `react-redux` version to `"7.1.3"`
      - [ ] run `npm run build` and publink react-dart to over_react.
      - [ ] run `pub run dart_dev test -P dartdevc` and make sure all tests pass.
      - [ ] run `pub run dart_dev test --build-args="-r" -P dart2js` and make sure all tests pass.
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
