### PR TITLE
Localstorage reducer/middleware cleanup

### DIFF
--- a/app/over_react_redux/todo_client/lib/src/actions.dart
+++ b/app/over_react_redux/todo_client/lib/src/actions.dart
@@ -6,112 +6,115 @@ import 'package:todo_client/src/store.dart';
 
 part 'actions.g.dart';
 
-class Action</*JsonSerializable*/T> {
-  Action({this.type, this.value});
+class _Action</*JsonSerializable*/T> {
+  _Action(this.value);
 
-  final String type;
   final T value;
 
-  Map<String, dynamic> toJson() {
-    return {'value': this.value};
+  dynamic toJson() {
+    // JSON-encodable objects need to be either nested in a JSON primitive (map/list)
+    // or returned as a primitive.
+    // Try calling `toJson`.
+    try {
+      return (value as dynamic).toJson();
+    } catch (_) {}
+
+    // Otherwise, assume it's a JSON primitive
+    return value;
   }
 }
 
-class LoadStateFromLocalStorageAction extends Action<String> {
-  LoadStateFromLocalStorageAction([String value]) : super(type: 'LOAD_STATE_FROM_LOCAL_STORAGE', value: value);
+class LoadStateFromLocalStorageAction extends _Action<String> {
+  LoadStateFromLocalStorageAction(String value) : super(value);
+}
+
+class LocalStorageStateLoadedAction extends _Action<AppState> {
+  LocalStorageStateLoadedAction(AppState value) : super(value);
 }
 
 @JsonSerializable()
-class SaveLocalStorageStateAsPayload {
+class SaveLocalStorageStateAsAction {
   final String name;
   final String previousName;
 
-  SaveLocalStorageStateAsPayload(this.name, {this.previousName});
+  SaveLocalStorageStateAsAction(this.name, {this.previousName});
 
-  factory SaveLocalStorageStateAsPayload.fromJson(Map<String, dynamic> json) => _$SaveLocalStorageStateAsPayloadFromJson(json);
-  Map<String, dynamic> toJson() => _$SaveLocalStorageStateAsPayloadToJson(this);
-}
-
-class SaveLocalStorageStateAsAction extends Action<SaveLocalStorageStateAsPayload> {
-  SaveLocalStorageStateAsAction([SaveLocalStorageStateAsPayload value]) : super(type: 'SAVE_LOCAL_STORAGE_STATE_AS', value: value);
-}
-
-class LocalStorageStateLoadedAction extends Action<AppState> {
-  LocalStorageStateLoadedAction(AppState value) : super(type: 'LOCAL_STORAGE_STATE_LOADED', value: value);
+  factory SaveLocalStorageStateAsAction.fromJson(Map<String, dynamic> json) => _$SaveLocalStorageStateAsActionFromJson(json);
+  Map<String, dynamic> toJson() => _$SaveLocalStorageStateAsActionToJson(this);
 }
 
 // ------------ ITEM ACTIONS ------------------
 
-class SelectTodoAction extends Action<String> {
-  SelectTodoAction([String value]) : super(type: 'SELECT_TODO', value: value);
+class SelectTodoAction extends _Action<String> {
+  SelectTodoAction(String value) : super(value);
 }
 
-class DeselectTodoAction extends Action<String> {
-  DeselectTodoAction([String value]) : super(type: 'DESELECT_TODO', value: value);
+class DeselectTodoAction extends _Action<String> {
+  DeselectTodoAction(String value) : super(value);
 }
 
-class BeginEditTodoAction extends Action<String> {
-  BeginEditTodoAction([String value]) : super(type: 'EDIT_TODO_BEGIN', value: value);
+class BeginEditTodoAction extends _Action<String> {
+  BeginEditTodoAction(String value) : super(value);
 }
 
-class FinishEditTodoAction extends Action<String> {
-  FinishEditTodoAction([String value]) : super(type: 'EDIT_TODO_FINISH', value: value);
+class FinishEditTodoAction extends _Action<String> {
+  FinishEditTodoAction(String value) : super(value);
 }
 
-class HighlightTodosAction extends Action<List<String>> {
-  HighlightTodosAction([List<String> value]) : super(type: 'HIGHLIGHT_TODOS', value: value);
+class HighlightTodosAction extends _Action<List<String>> {
+  HighlightTodosAction(List<String> value) : super(value);
 }
 
-class UnHighlightTodosAction extends Action<List<String>> {
-  UnHighlightTodosAction([List<String> value]) : super(type: 'UNHIGHLIGHT_TODOS', value: value);
+class UnHighlightTodosAction extends _Action<List<String>> {
+  UnHighlightTodosAction(List<String> value) : super(value);
 }
 
-class AddTodoAction extends Action<Todo> {
-  AddTodoAction([Todo value]) : super(type: 'ADD_TODO', value: value);
+class AddTodoAction extends _Action<Todo> {
+  AddTodoAction(Todo value) : super(value);
 }
 
-class RemoveTodoAction extends Action<String> {
-  RemoveTodoAction([String value]) : super(type: 'REMOVE_TODO', value: value);
+class RemoveTodoAction extends _Action<String> {
+  RemoveTodoAction(String value) : super(value);
 }
 
-class UpdateTodoAction extends Action<Todo> {
-  UpdateTodoAction([Todo value]) : super(type: 'UPDATE_TODO', value: value);
+class UpdateTodoAction extends _Action<Todo> {
+  UpdateTodoAction(Todo value) : super(value);
 }
 
 // ------------ USER ACTIONS ------------------
 
-class SelectUserAction extends Action<String> {
-  SelectUserAction([String value]) : super(type: 'SELECT_USER', value: value);
+class SelectUserAction extends _Action<String> {
+  SelectUserAction(String value) : super(value);
 }
 
-class DeselectUserAction extends Action<String> {
-  DeselectUserAction([String value]) : super(type: 'DESELECT_USER', value: value);
+class DeselectUserAction extends _Action<String> {
+  DeselectUserAction(String value) : super(value);
 }
 
-class BeginEditUserAction extends Action<String> {
-  BeginEditUserAction([String value]) : super(type: 'EDIT_USER_BEGIN', value: value);
+class BeginEditUserAction extends _Action<String> {
+  BeginEditUserAction(String value) : super(value);
 }
 
-class FinishEditUserAction extends Action<String> {
-  FinishEditUserAction([String value]) : super(type: 'EDIT_USER_FINISH', value: value);
+class FinishEditUserAction extends _Action<String> {
+  FinishEditUserAction(String value) : super(value);
 }
 
-class HighlightUsersAction extends Action<List<String>> {
-  HighlightUsersAction([List<String> value]) : super(type: 'HIGHLIGHT_USERS', value: value);
+class HighlightUsersAction extends _Action<List<String>> {
+  HighlightUsersAction(List<String> value) : super(value);
 }
 
-class UnHighlightUsersAction extends Action<List<String>> {
-  UnHighlightUsersAction([List<String> value]) : super(type: 'UNHIGHLIGHT_USERS', value: value);
+class UnHighlightUsersAction extends _Action<List<String>> {
+  UnHighlightUsersAction(List<String> value) : super(value);
 }
 
-class AddUserAction extends Action<User> {
-  AddUserAction([User value]) : super(type: 'ADD_USER', value: value);
+class AddUserAction extends _Action<User> {
+  AddUserAction(User value) : super(value);
 }
 
-class RemoveUserAction extends Action<String> {
-  RemoveUserAction([String value]) : super(type: 'REMOVE_USER', value: value);
+class RemoveUserAction extends _Action<String> {
+  RemoveUserAction(String value) : super(value);
 }
 
-class UpdateUserAction extends Action<User> {
-  UpdateUserAction([User value]) : super(type: 'UPDATE_USER', value: value);
+class UpdateUserAction extends _Action<User> {
+  UpdateUserAction(User value) : super(value);
 }

--- a/app/over_react_redux/todo_client/lib/src/actions.dart
+++ b/app/over_react_redux/todo_client/lib/src/actions.dart
@@ -2,6 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import 'package:todo_client/src/models/todo.dart';
 import 'package:todo_client/src/models/user.dart';
+import 'package:todo_client/src/store.dart';
 
 part 'actions.g.dart';
 
@@ -33,6 +34,10 @@ class SaveLocalStorageStateAsPayload {
 
 class SaveLocalStorageStateAsAction extends Action<SaveLocalStorageStateAsPayload> {
   SaveLocalStorageStateAsAction([SaveLocalStorageStateAsPayload value]) : super(type: 'SAVE_LOCAL_STORAGE_STATE_AS', value: value);
+}
+
+class LocalStorageStateLoadedAction extends Action<AppState> {
+  LocalStorageStateLoadedAction(AppState value) : super(type: 'LOCAL_STORAGE_STATE_LOADED', value: value);
 }
 
 // ------------ ITEM ACTIONS ------------------

--- a/app/over_react_redux/todo_client/lib/src/actions.g.dart
+++ b/app/over_react_redux/todo_client/lib/src/actions.g.dart
@@ -6,16 +6,16 @@ part of 'actions.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-SaveLocalStorageStateAsPayload _$SaveLocalStorageStateAsPayloadFromJson(
+SaveLocalStorageStateAsAction _$SaveLocalStorageStateAsActionFromJson(
     Map<String, dynamic> json) {
-  return SaveLocalStorageStateAsPayload(
+  return SaveLocalStorageStateAsAction(
     json['name'] as String,
     previousName: json['previousName'] as String,
   );
 }
 
-Map<String, dynamic> _$SaveLocalStorageStateAsPayloadToJson(
-        SaveLocalStorageStateAsPayload instance) =>
+Map<String, dynamic> _$SaveLocalStorageStateAsActionToJson(
+        SaveLocalStorageStateAsAction instance) =>
     <String, dynamic>{
       'name': instance.name,
       'previousName': instance.previousName,

--- a/app/over_react_redux/todo_client/lib/src/components/app_bar/app_bar_local_storage_menu.dart
+++ b/app/over_react_redux/todo_client/lib/src/components/app_bar/app_bar_local_storage_menu.dart
@@ -123,12 +123,11 @@ class AppBarLocalStorageMenuComponent extends UiComponent2<AppBarLocalStorageMen
   }
 
   void _handleLocalStorageStateRename(String newStateName, {String renamedFrom}) {
-    props.dispatch(SaveLocalStorageStateAsAction(
-        SaveLocalStorageStateAsPayload(newStateName, previousName: renamedFrom)));
+    props.dispatch(SaveLocalStorageStateAsAction(newStateName, previousName: renamedFrom));
   }
 
   void _handleCurrentLocalStorageStateSaveAs({String newStateName}) {
-    props.dispatch(SaveLocalStorageStateAsAction(SaveLocalStorageStateAsPayload(newStateName)));
+    props.dispatch(SaveLocalStorageStateAsAction(newStateName));
     _loadFromLocalStorage(newStateName);
     _overlayRef.current.close();
   }

--- a/app/over_react_redux/todo_client/lib/src/components/app_bar/save_as_menu_item.dart
+++ b/app/over_react_redux/todo_client/lib/src/components/app_bar/save_as_menu_item.dart
@@ -45,9 +45,7 @@ class SaveAsMenuItemComponent extends UiStatefulComponent2<SaveAsMenuItemProps, 
     return (LocalStorageMenuItemInput()
       ..initialValue = props.initialValue
       ..onSave = (newValue) {
-        if (newValue != props.initialValue) {
-          props.onSave(newValue);
-        }
+        props.onSave(newValue);
         setState(newState()..isEditable = false);
       }
     )();

--- a/app/over_react_redux/todo_client/lib/src/local_storage.dart
+++ b/app/over_react_redux/todo_client/lib/src/local_storage.dart
@@ -10,14 +10,12 @@ TodoAppLocalStorage localTodoAppStorage;
 /// A map interface for mutating `window.localStorage` values
 /// used to persist [AppState] values across browser refreshes.
 class TodoAppLocalStorage extends MapBase<String, /*encodable*/Object> {
-  final AppState initialState;
-
-  TodoAppLocalStorage([this.initialState]) {
+  TodoAppLocalStorage([AppState initialState]) {
     if (isInitialized()) return;
 
     window.localStorage[localStorageKey] = json.encode({
-      currentStateKey: this.initialState?.toJson() ?? {},
-      defaultStateKey: this.initialState?.toJson() ?? {},
+      currentStateKey: initialState?.toJson() ?? {},
+      defaultStateKey: initialState?.toJson() ?? {},
       emptyStateKey: emptyState.toJson(),
     });
   }

--- a/app/over_react_redux/todo_client/lib/src/store.dart
+++ b/app/over_react_redux/todo_client/lib/src/store.dart
@@ -29,7 +29,10 @@ AppState initializeState() {
 DevToolsStore<AppState> getStore() => DevToolsStore<AppState>(
   appStateReducer,
   initialState: initializeState(),
-  middleware: [overReactReduxDevToolsMiddleware],
+  middleware: [
+    overReactReduxDevToolsMiddleware,
+    localStorageMiddleware(),
+  ],
 );
 
 @JsonSerializable(explicitToJson: true)
@@ -53,10 +56,7 @@ class AppState {
     this.selectedUserIds,
     this.editableUserIds,
     this.highlightedUserIds,
-  }) {
-    assert(name != null && name.isNotEmpty);
-    localTodoAppStorage?.updateCurrentState(this);
-  }
+  }) : assert(name != null && name.isNotEmpty);
 
   factory AppState.fromJson(Map<String, dynamic> json) => _$AppStateFromJson(json);
   Map<String, dynamic> toJson() => _$AppStateToJson(this);
@@ -64,24 +64,11 @@ class AppState {
 
 @visibleForTesting
 AppState appStateReducer(AppState state, dynamic action) {
-  var stateName = localTodoAppStorage.currentStateJson['name'];
-
-  if (action is SaveLocalStorageStateAsAction) {
-    if (action.value.previousName != null && action.value.previousName == action.value.name) {
-      // Overwrite
-      localTodoAppStorage.remove(action.value.previousName);
-    }
-
-    stateName = action.value.name;
-    localTodoAppStorage[stateName] =
-        (AppState.fromJson(localTodoAppStorage.currentStateJson)..name = stateName).toJson();
+  if (action is LocalStorageStateLoadedAction) {
+    return action.value;
   }
 
-  if (action is LoadStateFromLocalStorageAction) {
-    return AppState.fromJson(localTodoAppStorage[action.value]);
-  }
-
-  return AppState(stateName,
+  return AppState(stateNameReducer(state.name, action),
     todos: todosReducer(state.todos, action),
     users: usersReducer(state.users, action),
     editableTodoIds: editableTodosReducer(state.editableTodoIds, action),
@@ -93,7 +80,37 @@ AppState appStateReducer(AppState state, dynamic action) {
   );
 }
 
+
+// todo inject localTodoAppStorage as an arg instead of using a global variable
+Middleware<AppState> localStorageMiddleware() {
+  return (store, action, next) {
+    next(action);
+
+    if (action is LoadStateFromLocalStorageAction) {
+      final localStorageState = AppState.fromJson(localTodoAppStorage[action.value]);
+      store.dispatch(LocalStorageStateLoadedAction(localStorageState));
+    } else if (action is SaveLocalStorageStateAsAction) {
+      if (action.value.previousName != null) {
+        // This is a rename; remove the old entry
+        localTodoAppStorage.remove(action.value.previousName);
+      }
+
+      final stateName = action.value.name;
+      // Run the reducer here so that the name is updated in response to the
+      // current action before saving.
+      final stateWithUpdatedName = store.reducer(store.state, action);
+      localTodoAppStorage[stateName] = stateWithUpdatedName.toJson();
+    } else {
+      localTodoAppStorage?.updateCurrentState(store.state);
+    }
+  };
+}
+
 // ------------ ITEM REDUCERS ------------------
+
+final stateNameReducer = TypedReducer<String, SaveLocalStorageStateAsAction>((name, action) {
+  return action.value.name;
+});
 
 final todosReducer = combineReducers<List<Todo>>([
   TypedReducer<List<Todo>, AddTodoAction>((todos, action) {

--- a/app/over_react_redux/todo_client/lib/src/store.dart
+++ b/app/over_react_redux/todo_client/lib/src/store.dart
@@ -101,9 +101,9 @@ Middleware<AppState> localStorageMiddleware() {
       // TODO use store.reducer once null DevToolsStore.reducer bug is fixed
       final stateWithUpdatedName = appStateReducer(store.state, action);
       localTodoAppStorage[stateName] = stateWithUpdatedName.toJson();
-    } else {
-      localTodoAppStorage?.updateCurrentState(store.state);
     }
+
+    localTodoAppStorage?.updateCurrentState(store.state);
   };
 }
 

--- a/app/over_react_redux/todo_client/lib/src/store.dart
+++ b/app/over_react_redux/todo_client/lib/src/store.dart
@@ -90,15 +90,16 @@ Middleware<AppState> localStorageMiddleware() {
       final localStorageState = AppState.fromJson(localTodoAppStorage[action.value]);
       store.dispatch(LocalStorageStateLoadedAction(localStorageState));
     } else if (action is SaveLocalStorageStateAsAction) {
-      if (action.value.previousName != null) {
+      if (action.previousName != null) {
         // This is a rename; remove the old entry
-        localTodoAppStorage.remove(action.value.previousName);
+        localTodoAppStorage.remove(action.previousName);
       }
 
-      final stateName = action.value.name;
+      final stateName = action.name;
       // Run the reducer here so that the name is updated in response to the
       // current action before saving.
-      final stateWithUpdatedName = store.reducer(store.state, action);
+      // TODO use store.reducer once null DevToolsStore.reducer bug is fixed
+      final stateWithUpdatedName = appStateReducer(store.state, action);
       localTodoAppStorage[stateName] = stateWithUpdatedName.toJson();
     } else {
       localTodoAppStorage?.updateCurrentState(store.state);
@@ -109,7 +110,7 @@ Middleware<AppState> localStorageMiddleware() {
 // ------------ ITEM REDUCERS ------------------
 
 final stateNameReducer = TypedReducer<String, SaveLocalStorageStateAsAction>((name, action) {
-  return action.value.name;
+  return action.name;
 });
 
 final todosReducer = combineReducers<List<Todo>>([

--- a/app/over_react_redux/todo_client/lib/src/store.dart
+++ b/app/over_react_redux/todo_client/lib/src/store.dart
@@ -13,17 +13,9 @@ part 'store.g.dart';
 
 @visibleForTesting
 AppState initializeState() {
-  AppState initialState;
-  if (!TodoAppLocalStorage.isInitialized()) {
-    // First load - give the user some data to work with, and set up our default / empty states.
-    initialState = AppState.fromJson(defaultAppState);
-    localTodoAppStorage = TodoAppLocalStorage(initialState);
-  } else {
-    localTodoAppStorage ??= TodoAppLocalStorage();
-    initialState = AppState.fromJson(localTodoAppStorage.currentStateJson);
-  }
-
-  return initialState;
+  // Initialize local storage with the default state, unless state is already saved in local storage.
+  localTodoAppStorage = TodoAppLocalStorage(AppState.fromJson(defaultAppState));
+  return AppState.fromJson(localTodoAppStorage.currentStateJson);
 }
 
 DevToolsStore<AppState> getStore() => DevToolsStore<AppState>(

--- a/app/over_react_redux/todo_client/test/unit/browser/redux/store_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/redux/store_test.dart
@@ -364,9 +364,8 @@ main() {
           // Update the "current" persisted data set so that it differs from the default
           testStore.dispatch(AddTodoAction(newTodo));
 
-          final addCustomPersistedSetPayload = SaveLocalStorageStateAsPayload(customPersistedDataSetName);
           // Save a custom set based on the "current" persisted data set
-          testStore.dispatch(SaveLocalStorageStateAsAction(addCustomPersistedSetPayload));
+          testStore.dispatch(SaveLocalStorageStateAsAction(customPersistedDataSetName));
 
           expect(getLocalStorageSetByKey(customPersistedDataSetName), testStore.state.toJson());
           expect(getCurrentLocalStorageSet(), getLocalStorageSetByKey(customPersistedDataSetName),
@@ -386,10 +385,9 @@ main() {
           // Update the "current" persisted data set so that it differs from the custom persisted set
           testStore.dispatch(AddTodoAction(newTodo));
 
-          final overwriteCustomPersistedSetPayload =
-              SaveLocalStorageStateAsPayload(customPersistedDataSetName, previousName: customPersistedDataSetName);
           // Save the existing custom set based on the "current" persisted data set
-          testStore.dispatch(SaveLocalStorageStateAsAction(overwriteCustomPersistedSetPayload));
+          testStore.dispatch(
+              SaveLocalStorageStateAsAction(customPersistedDataSetName, previousName: customPersistedDataSetName));
 
           expect(getLocalStorageSetByKey(customPersistedDataSetName), isNot(initialCustomPersistedDataSetValue));
           expect(getLocalStorageSetByKey(customPersistedDataSetName), testStore.state.toJson());
@@ -402,10 +400,9 @@ main() {
           const newCustomPersistedDataSetName = 'Copy of $customPersistedDataSetName';
           final initialCustomPersistedDataSetValue = getLocalStorageSetByKey(customPersistedDataSetName);
 
-          final overwriteCustomPersistedSetPayload =
-              SaveLocalStorageStateAsPayload(newCustomPersistedDataSetName, previousName: customPersistedDataSetName);
           // Save a copy of the existing custom set based on the "current" persisted data set
-          testStore.dispatch(SaveLocalStorageStateAsAction(overwriteCustomPersistedSetPayload));
+          testStore.dispatch(
+              SaveLocalStorageStateAsAction(newCustomPersistedDataSetName, previousName: customPersistedDataSetName));
 
           expect(getLocalStorageSetByKey(newCustomPersistedDataSetName), testStore.state.toJson());
           expect(getCurrentLocalStorageSet(), getLocalStorageSetByKey(newCustomPersistedDataSetName),
@@ -429,10 +426,9 @@ main() {
           // Update the "current" persisted data set so that it differs from the custom persisted set
           testStore.dispatch(AddTodoAction(newTodo));
 
-          final overwriteCustomPersistedSetPayload =
-              SaveLocalStorageStateAsPayload(newCustomPersistedDataSetName, previousName: customPersistedDataSetName);
           // Save a copy of the existing custom set based on the "current" persisted data set
-          testStore.dispatch(SaveLocalStorageStateAsAction(overwriteCustomPersistedSetPayload));
+          testStore.dispatch(
+              SaveLocalStorageStateAsAction(newCustomPersistedDataSetName, previousName: customPersistedDataSetName));
 
           expect(getLocalStorageSetByKey(newCustomPersistedDataSetName), testStore.state.toJson());
           expect(getCurrentLocalStorageSet(), getLocalStorageSetByKey(newCustomPersistedDataSetName),


### PR DESCRIPTION
## Ultimate Problem
The reducer was not pure, which is a big no-no in Redux: https://redux.js.org/style-guide/style-guide#reducers-must-not-have-side-effects

## Solution
- 00a1cd0 Move local storage state manipulation into middleware to make reducer pure
   - c2ec75a Fix save menu not detecting changes (fix to a bug introduced in the first commit)

#### Other cleanup while working through this:
- 73f2538 Remove unused type from actions, simplify JSON representation and payloads
    - The `type` field wasn't used, and the Action class name is already retrieved from the middleware, so I removed it.
    - This removes the extra `{"value": ...}` object that clutters up each action for the dev tools

        <table><thead><tr><th>Before</th><th>After</th></thead><tbody><tr>
        <td><img width="361" alt="Screen Shot 2020-01-16 at 3 21 52 PM" src="https://user-images.githubusercontent.com/1713967/72568124-a7c09780-3874-11ea-8ffc-466ed048b130.png"></td><td><img width="351" alt="Screen Shot 2020-01-16 at 3 21 12 PM" src="https://user-images.githubusercontent.com/1713967/72567898-1b15d980-3874-11ea-9061-3b022db800e6.png"></td></tr></tbody></table>
- dd01aec Fix "Save As" not working for default value
    - This may have been intentional, but hitting "enter" to "save as" with the default "Copy of ..." name did nothing, even though it seemed like it had changed
- 863df28  Simplify LocalStorage initialization
     - This code is equivalent, just removed some redundant logic