### PR TITLE
CPLAT-9174: Fix bug in TDC when, document doesn't fully expand

### DIFF
--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -26,8 +26,19 @@ import 'package:over_react/src/util/css_value_util.dart';
 import 'package:over_react/react_dom.dart' as react_dom;
 import 'package:platform_detect/platform_detect.dart';
 
+// The computed font size of the HTML node isn't reliable in Chrome when the page is refreshed while zoomed.
+// Instead, measure a container to determine how big 1rem is.
 double _computeRootFontSize() {
-  return CssValue.parse(document.documentElement.getComputedStyle().fontSize).number.toDouble();
+  final remMeasurer = DivElement();
+  remMeasurer.style
+    ..width = '1rem'
+    ..height = '0'
+    ..position = 'absolute'
+    ..zIndex = '-1';
+  document.body.append(remMeasurer);
+  final rem = CssValue.parse(remMeasurer.getComputedStyle().width).number.toDouble();
+  remMeasurer.remove();
+  return rem;
 }
 
 double _rootFontSize = _computeRootFontSize();

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -28,6 +28,8 @@ import 'package:platform_detect/platform_detect.dart';
 
 // The computed font size of the HTML node isn't reliable in Chrome when the page is refreshed while zoomed.
 // Instead, measure a container to determine how big 1rem is.
+//
+// See: https://bugs.chromium.org/p/chromium/issues/detail?id=1043349
 double _computeRootFontSize() {
   final remMeasurer = DivElement();
   remMeasurer.style

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -9,6 +9,7 @@ part of over_react.component_declaration.redux_component.reducer;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$BaseActions extends BaseActions {
   factory _$BaseActions() => new _$BaseActions._();


### PR DESCRIPTION
## Motivation
Computed font size of the HTML node being calculated incorrectly when the page is refreshed while zoomed. See: https://bugs.chromium.org/p/chromium/issues/detail?id=1043349. 

## Changes
Measure a container to determine how big 1rem is.
This update fixes issue in our product when document/spreadsheet doesn't fully expand after page refresh while zoomed.
#### Release Notes
<!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
       - [ ] passing CI
       - [ ] Use this branch wdesk_sdk example locally
          - [ ] Open document/spreadsheet
          - [ ] Assuming you current zoom set at 100%, reduce it to 80% or lower
          - [ ] Refresh the page
          - [ ] Ensure main content rendered correctly, aka you don't see any random empty space between scrollbar and gutter.
          - [ ] Open 2 documents side-by-side and make sure that as you resize document splitter follows your mouse.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
