### PR TITLE
RM-63989 RM-63988 Release over_react 3.1.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.1.7
+version: 3.1.8
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -9,7 +9,6 @@ part of over_react.component_declaration.redux_component.reducer;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
-// ignore_for_file: type_annotate_public_apis
 
 class _$BaseActions extends BaseActions {
   factory _$BaseActions() => new _$BaseActions._();

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -9,13 +9,14 @@ part of over_react.component_declaration.redux_component.reducer;
 // ignore_for_file: avoid_classes_with_only_static_members
 // ignore_for_file: annotate_overrides
 // ignore_for_file: overridden_fields
+// ignore_for_file: type_annotate_public_apis
 
 class _$BaseActions extends BaseActions {
-  factory _$BaseActions() => new _$BaseActions._();
+  factory _$BaseActions() => _$BaseActions._();
   _$BaseActions._() : super._();
 
-  final trigger1 = new ActionDispatcher<Null>('BaseActions-trigger1');
-  final trigger2 = new ActionDispatcher<Null>('BaseActions-trigger2');
+  final trigger1 = ActionDispatcher<Null>('BaseActions-trigger1');
+  final trigger2 = ActionDispatcher<Null>('BaseActions-trigger2');
 
   @override
   void setDispatcher(Dispatcher dispatcher) {
@@ -25,8 +26,8 @@ class _$BaseActions extends BaseActions {
 }
 
 class BaseActionsNames {
-  static final trigger1 = new ActionName<Null>('BaseActions-trigger1');
-  static final trigger2 = new ActionName<Null>('BaseActions-trigger2');
+  static final trigger1 = ActionName<Null>('BaseActions-trigger1');
+  static final trigger2 = ActionName<Null>('BaseActions-trigger2');
 }
 
 // **************************************************************************


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-6104 Add over_react_redux example app](https://github.com/Workiva/over_react/pull/439)
* [CPLAT-9057: Implement StrictMode component](https://github.com/Workiva/over_react/pull/447)
* [CPLAT-9092 Add built_redux to Redux Docs](https://github.com/Workiva/over_react/pull/452)
* [CPLAT-9174: Fix bug in TDC when, document doesn't fully expand](https://github.com/Workiva/over_react/pull/453)


Requested by: @olesiathoms-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/3.1.7...Workiva:release_over_react_3.1.8
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/3.1.7...3.1.8

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)