### PR TITLE
CPLAT-9650 Add base mixins for flux props classes

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -27,9 +27,62 @@ import 'annotations.dart' as annotations;
 import 'builder_helpers.dart';
 import 'component_base_2.dart';
 
-/// Builds on top of [UiProps], adding typed props for [Action]s and [Store]s in order to integrate with w_flux.
+/// Builds on top of [UiProps], adding typed [Action] and [Store] props for use with [FluxUiComponent2].
 ///
-/// Use with the over_react builder via the `@Props()` ([annotations.Props]) annotation.
+/// __Example:__
+///
+/// ```dart
+/// class YourComponentProps extends UiProps with FluxUiPropsMixin<YourFluxActionsClass, YourFluxStoreClass> {
+///   // Additional arbitrary props for your component can go here
+/// }
+/// ```
+mixin FluxUiPropsMixin<ActionsT, StoresT> on UiProps implements FluxUiProps<ActionsT, StoresT> {
+  @override
+  String get _actionsPropKey => '${propKeyNamespace}actions';
+  @override
+  String get _storePropKey => '${propKeyNamespace}store';
+
+  /// The prop defined by [ActionsT] that holds all [Action]s that
+  /// this component needs access to.
+  ///
+  /// There is no strict rule on the [ActionsT] type. Depending on application
+  /// structure, there may be [Action]s available directly on this object, or
+  /// this object may represent a hierarchy of actions.
+  @override
+  ActionsT get actions => props[_actionsPropKey] as ActionsT;
+  @override
+  set actions(ActionsT value) => props[_actionsPropKey] = value;
+
+  /// The flux [Store] instance(s) to be used by a [FluxUiComponent2] instance, or a reference to one.
+  ///
+  /// __Instead of storing state within this component via `setState`, it is recommended that data be
+  /// pulled directly from these stores.__ This ensures that the data being used is always up to date
+  /// and leaves the state management logic to the stores.
+  ///
+  /// If this component only needs data from a single [Store], then [StoresT]
+  /// should be an instance of [Store]. This allows the default implementation
+  /// of `redrawOn` to automatically subscribe to the store.
+  ///
+  /// If this component needs data from multiple [Store] instances, then
+  /// [StoresT] should be a class that provides access to these multiple stores.
+  /// Then, you can explicitly select the [Store] instances that should be
+  /// listened to by overriding [_FluxComponentMixin.redrawOn].
+  @override
+  StoresT get store => props[_storePropKey] as StoresT;
+  @override
+  set store(StoresT value) => props[_storePropKey] = value;
+}
+
+/// __Deprecated.__ Use [FluxUiPropsMixin] instead.
+///
+///  The latest over_react component boilerplate does not allow props classes to extend from anything except UiProps.
+///  You can upgrade your usage automatically by running:
+///
+///  ```
+///  pub global activate over_react_codemod
+///  pub global run over_react_codemod:boilerplate_upgrade
+///  ```
+@Deprecated('Use FluxUiPropsMixin instead. See the documentation for this class for detailed migration instructions.')
 abstract class FluxUiProps<ActionsT, StoresT> extends UiProps {
   String get _actionsPropKey => '${propKeyNamespace}actions';
   String get _storePropKey => '${propKeyNamespace}store';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,6 @@ dev_dependencies:
 dependency_overrides:
   react:
     git:
-      url: git@github.com:cleandart/react-dart.git
-      ref: 5.2.0-wip
+      url: https://github.com/cleandart/react-dart.git
+      ref: 5.4.0-wip
 

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
@@ -34,6 +34,10 @@ void main() {
       await window.animationFrame;
     }
 
+    group('FluxUiPropsMixin', () {
+      // TODO: Add tests / fixtures once the new boilerplate is ready
+    });
+
     group('FluxUiProps', () {
       test('exposes an actions getter', () {
         var props = TestBasic();


### PR DESCRIPTION
## Motivation
As part of the new boilerplate work, consumers will no longer be able to extend props classes from anything other than `UiProps`. This means that `FluxUiProps` will need to exist in the form of a mixin.

## Changes
1. Deprecate `FluxUiProps`
2. Add `FluxUiPropsMixin`

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @joebingham-wk @sydneyjodon-wk @greglittlefield-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
