### PR TITLE
CPLAT-9715 Fix accidental jsification of Map/Function Dart props when using `connect`

### DIFF
--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -229,10 +229,15 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
       ),
     )(dartComponentClass);
 
-    final hocJsFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
+    /// Use a Dart proxy instead of a JS one since we're treating it like a Dart component:
+    /// props values should be passed to the underlying component (e.g., those returned by mapStateToProps)
+    /// without any conversion needed by JS Components, and props are are fed directly
+    /// into Dart code (e.g., those passed into mapStateToPropsWithOwnProps/areOwnPropsEqual)
+    /// without needing unwrapping/conversion.
+    final hocFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
 
     TProps connectedFactory([Map props]) {
-      return (factory(props)..componentFactory = hocJsFactoryProxy);
+      return (factory(props)..componentFactory = hocFactoryProxy);
     }
 
     return connectedFactory;

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -229,7 +229,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
       ),
     )(dartComponentClass);
 
-    final hocJsFactoryProxy = ReactJsComponentFactoryProxy(hoc, shouldConvertDomProps: false, alwaysReturnChildrenAsList: true);
+    final hocJsFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
 
     TProps connectedFactory([Map props]) {
       return (factory(props)..componentFactory = hocJsFactoryProxy);

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -129,6 +129,53 @@ main() {
         expect(counterRef.current.props.currentCount, 1);
         expect(jacket.mountNode.innerHtml, contains('Count: 1'));
       });
+
+      test('without converting the props whatsoever', () {
+        // Test functions/Maps to ensure they're not allowInterop'd,
+        // test event handlers to ensure they're not oterwise converted
+        testFunction() => 'foo';
+        const testMap = {'foo': 'bar'};
+        testEventHandler(SyntheticMouseEvent e) {}
+
+        ConnectedCounter = connect<CounterState, CounterProps>(mapStateToProps: (state){
+          return (Counter()
+            ..currentCount = state.count
+            ..['functionPropSetInsideHoc'] = testFunction
+            ..['mapPropSetInsideHoc'] = testMap
+            // We need to set a real event prop key to properly test this
+            ..onMouseDown = testEventHandler
+          );
+        }, forwardRef: true)(Counter);
+
+        jacket = mount(
+          (ReduxProvider()..store = store1)(
+            (ConnectedCounter()
+              ..ref = counterRef
+              ..['functionPropSetOnHoc'] = testFunction
+              ..['mapPropSetOnHoc'] = testMap
+              // We need to set a real event prop key to properly test this
+              ..onMouseUp = testEventHandler
+            )('test'),
+          ),
+        );
+
+        final actualProps = counterRef.current.props;
+        final expectedProps = {
+          'functionPropSetInsideHoc': same(testFunction),
+          'mapPropSetInsideHoc': same(testMap),
+          'onMouseDown': same(testEventHandler),
+
+          'functionPropSetOnHoc': same(testFunction),
+          'mapPropSetOnHoc': same(testMap),
+          'onMouseUp': same(testEventHandler),
+        };
+        // Filter out unrelated props that prevent us from using the default Map matcher
+        final relevantPropKeys = {...actualProps}
+            ..removeWhere((key, value) => !expectedProps.containsKey(key));
+
+        expect(relevantPropKeys, expectedProps,
+            reason: 'functions/maps should not be jsified, and event handlers should not be converted');
+      });
     });
 
     group('mapStateToPropsWithOwnProps properly maps the state to the components props', (){


### PR DESCRIPTION
## Motivation
Wrapping Dart components in `connect` unexpectedly jsified props, causing `Map` props to show up as JS Objects when read by the component.

## Changes
- Use a ReactDartComponent2FactoryProxy instead of a JSComponentFactoryProxy, since the connect component really behaves more like a Dart component (see code comment in connect).
- Add regression test

#### Release Notes
- Fix accidental jsification of Map/Function Dart props in certain cases when using `connect`

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @aaronlademann-wf @joebingham-wk @sydneyjodon-wk 
FYI: @matthewnitschke-wk @kealjones-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
