### PR TITLE
RM-66264 RM-66263 Release over_react 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## [3.2.1](https://github.com/Workiva/over_react/compare/3.2.0...3.2.1)
+- #461 Fix accidental jsification of `Map`/`Function` Dart props in certain cases when using `connect`
+
 ## [3.2.0](https://github.com/Workiva/over_react/compare/3.1.7...3.2.0)
 
 - [#439] Add `over_react_redux` example app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # OverReact Changelog
 
 ## [3.2.1](https://github.com/Workiva/over_react/compare/3.2.0...3.2.1)
-- #461 Fix accidental jsification of `Map`/`Function` Dart props in certain cases when using `connect`
+- [#461] Fix accidental jsification of `Map`/`Function` Dart props in certain cases when using `connect`
 
 ## [3.2.0](https://github.com/Workiva/over_react/compare/3.1.7...3.2.0)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.2.0
+version: 3.2.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-9715 Fix accidental jsification of Map/Function Dart props when using `connect`](https://github.com/Workiva/over_react/pull/461)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/3.2.0...Workiva:release_over_react_3.2.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/3.2.0...3.2.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)