### PR TITLE
CPLAT-9796 HOC type checking fixes and improvements

### DIFF
--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
 import 'package:over_react/component_base.dart';
@@ -98,6 +99,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
       return wrapperFunction(factory(props), ref);
     }
     ReactComponentFactoryProxy hoc = react_interop.forwardRef(wrapProps);
+    setComponentTypeMeta(hoc, isHoc: true, parentType: factory().componentFactory);
 
     TProps forwardedFactory([Map props]) {
       return factory(props)..componentFactory = hoc;

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -177,12 +177,10 @@ dynamic getComponentTypeFromAlias(dynamic typeAlias) {
 /// Valid types:
 ///
 /// * [String] tag name (DOM components)
-/// * [Function] ([ReactClass]) factory (Dart/JS composite components)
-///
-/// > __NOTE:__ It's impossible to determine know whether something is a [ReactClass] due to type-checking restrictions
-/// for JS-interop classes, so a Function type-check is the best we can do.
+/// * [Function] factory (Dart components)
+/// * [ReactClass] component type (JS composite component classes, JS function component functions, Dart component JS classes)
 bool isPotentiallyValidComponentType(dynamic type) {
-  return type is Function || type is String;
+  return type is Function || type is ReactClass || type is String;
 }
 
 /// Returns an [Iterable] of all component types that are ancestors of [type].

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -17,6 +17,7 @@ library over_react.component_declaration.component_type_checking;
 
 import 'dart:js_util';
 
+import 'package:meta/meta.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' show UiFactory;
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations show Component2;
 import 'package:over_react/src/util/react_wrappers.dart';
@@ -48,14 +49,17 @@ const String _componentTypeMetaKey = '_componentTypeMeta';
 /// the component type of the specified [factory].
 ///
 /// This meta is retrievable via [getComponentTypeMeta].
-// ignore: deprecated_member_use
-void setComponentTypeMeta(ReactDartComponentFactoryProxy factory, {
-    bool isWrapper,
-    // ignore: deprecated_member_use
-    ReactDartComponentFactoryProxy parentType
+void setComponentTypeMeta(ReactComponentFactoryProxy factory, {
+  @required ReactComponentFactoryProxy parentType,
+  bool isWrapper = false,
+  bool isHoc = false,
 }) {
   // ignore: argument_type_not_assignable
-  setProperty(factory.type, _componentTypeMetaKey, ComponentTypeMeta(isWrapper, parentType));
+  setProperty(factory.type, _componentTypeMetaKey, ComponentTypeMeta(
+    parentType: parentType,
+    isWrapper: isWrapper,
+    isHoc: isHoc,
+  ));
 }
 
 /// Returns the [ComponentTypeMeta] associated with the component type [type] in [setComponentTypeMeta],
@@ -75,6 +79,9 @@ class ComponentTypeMeta {
   /// Whether the component clones or passes through its children and needs to be
   /// treated as if it were the wrapped component when passed into [isComponentOfType].
   final bool isWrapper;
+
+  /// Whether the component is a higher-order component that wraps [parentType].
+  final bool isHoc;
 
   /// The factory of this component's "parent type".
   ///
@@ -115,12 +122,17 @@ class ComponentTypeMeta {
   ///
   /// > See: `subtypeOf` (within [annotations.Component2])
   // ignore: deprecated_member_use
-  final ReactDartComponentFactoryProxy parentType;
+  final ReactComponentFactoryProxy parentType;
 
-  ComponentTypeMeta(this.isWrapper, this.parentType);
+  ComponentTypeMeta({
+    @required this.parentType,
+    this.isWrapper = false,
+    this.isHoc = false
+  });
 
   const ComponentTypeMeta.none()
       : this.isWrapper = false,
+        this.isHoc = false,
         this.parentType = null;
 }
 
@@ -231,11 +243,6 @@ bool isComponentOfType(ReactElement instance, dynamic typeAlias, {
     return false;
   }
 
-  // When a component is wrapped in a react.memo, we can gain access to the
-  // original Dart component via the 'WrappedComponent` property.
-  if (instance.type != null && getProperty(instance.type, 'WrappedComponent') != null) {
-    instanceType = getProperty(instance.type, 'WrappedComponent');
-  }
 
   var instanceTypeMeta = getComponentTypeMeta(instanceType);
 

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -16,9 +16,10 @@ library over_react.component_declaration.component_type_checking_test;
 
 import 'package:js/js.dart';
 import 'package:over_react/over_react.dart';
+import 'package:over_react/over_react_redux.dart' show connect;
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react_client.dart';
-import 'package:react/react_client/react_interop.dart';
+import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:test/test.dart';
 
 import '../../test_util/one_level_wrapper.dart';
@@ -368,6 +369,18 @@ testComponentTypeChecking({
             expect(() => isComponentOfType(OneLevelWrapper()(), TestA), returnsNormally);
           });
         });
+
+        group('a higher-order component created by', () {
+          test('forwardRef', () {
+            final hocFactory = forwardRef((props, ref) => null)(TestA);
+            expect(isComponentOfType(hocFactory()(), TestA), isTrue);
+          });
+
+          test('connect', () {
+            final hocFactory = connect(mapStateToProps: (state) => {})(TestA);
+            expect(isComponentOfType(hocFactory()(), TestA), isTrue);
+          });
+        });
       });
     });
 
@@ -393,7 +406,7 @@ testComponentTypeChecking({
   });
 }
 
-ReactClass createTestReactClass() {
+react_interop.ReactClass createTestReactClass() {
   // ignore: deprecated_member_use
-  return React.createClass(ReactClassConfig(render: allowInterop(() => false)))..dartDefaultProps = const {};
+  return react_interop.React.createClass(react_interop.ReactClassConfig(render: allowInterop(() => false)))..dartDefaultProps = const {};
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
- The JS function-component HOCs returned by connect/forwardRef caused a failing assertion since they weren't considered valid `isPotentiallyValidComponentType`
- HOCs didn't have type meta information, meaning that type-checking wouldn't work as expected on them
   - e.g., `isComponentOftype(ConnectedFoo()(), Foo)` would return false

## Changes
  <!-- What this PR changes to fix the problem. -->
- Fix `isPotentiallyValidComponentType` to support function types, fixing failing assertion
- Add regression test that also tests new type checking functionality

#### Release Notes
- `connect`/`forwardRef` HOCs
   - Fix component type-checking error when passing into `isComponentOfType`
   - Match against the type of the wrapped component, as expected.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
