### PR TITLE
Allow redux.dart version 4

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -26,3 +26,7 @@ dev_dependencies:
   test_html_builder: ^1.0.0
   time: ^1.2.0
   w_common: ^1.20.0
+
+dependency_overrides:
+  over_react:
+    path: '../../../'

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -9,8 +9,8 @@ dependencies:
   memoize: ^2.0.0
   meta: ^1.0.0
   over_react: ^3.1.5
-  redux: ^3.0.0
-  redux_dev_tools: 0.4.0
+  redux: ">=3.0.0 <5.0.0"
+  redux_dev_tools: ">=0.4.0 <0.6.0"
   uuid: ^1.0.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,14 +20,14 @@ dependencies:
   meta: ^1.1.6
   path: ^1.5.1
   react: ^5.3.0
-  redux: ^3.0.0
+  redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0
   w_flux: ^2.10.4
   platform_detect: ^1.3.4
   quiver: ">=0.25.0 <3.0.0"
-  redux_dev_tools: ^0.4.0
+  redux_dev_tools: ">=0.4.0 <0.6.0"
 
 dev_dependencies:
   build_resolvers: ^1.0.5


### PR DESCRIPTION
## Motivation
#448 pointed out that our current version constraint for `redux` disallows the latest major release (`4.0.0`).

## Changes
Open up the upper bound of the `redux` and `redux_dev_tools` dependencies.

  * There do not appear to be any breaking changes in the [release notes for redux.dart 4.0.0](https://github.com/johnpryan/redux.dart/blob/master/CHANGELOG.md#400).
  * No breakages are apparent when testing the todo app locally
  * Tests passed locally 

#### Release Notes
Allow redux.dart version 4

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @sydneyjodon-wk @kealjones-wk @UnHumbleBen 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
