### PR TITLE
CPLAT-9691 Improve HOC Errors

### DIFF
--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -95,13 +95,13 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
     Function(TProps props, Ref ref) wrapperFunction) {
 
   UiFactory<TProps> wrapWithForwardRef(UiFactory<TProps> factory) {
+    enforceMinimumComponentVersionFor(factory().componentFactory);
+
     Object wrapProps(Map props, Ref ref) {
       return wrapperFunction(factory(props), ref);
     }
     ReactComponentFactoryProxy hoc = react_interop.forwardRef(wrapProps);
     setComponentTypeMeta(hoc, isHoc: true, parentType: factory().componentFactory);
-
-    enforceMinimumComponentVersionFor(hoc);
 
     TProps forwardedFactory([Map props]) {
       return factory(props)..componentFactory = hoc;

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -101,6 +101,8 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
     ReactComponentFactoryProxy hoc = react_interop.forwardRef(wrapProps);
     setComponentTypeMeta(hoc, isHoc: true, parentType: factory().componentFactory);
 
+    enforceMinimumComponentVersionFor(hoc);
+
     TProps forwardedFactory([Map props]) {
       return factory(props)..componentFactory = hoc;
     }

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -53,6 +53,8 @@ Ref<T> createRef<T>() {
 
 /// Automatically passes a [Ref] through a component to one of its children.
 ///
+/// > __NOTE:__ This should only be used to wrap components that extend from `Component2`.
+///
 /// __Example__:
 ///
 ///     UiFactory<DomProps> DivForwarded = forwardRef<DomProps>((props, ref) {

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -21,10 +21,9 @@ import 'package:meta/meta.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' show UiFactory;
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations show Component2;
 import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:over_react/src/util/string_util.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
-
-import '../../over_react.dart';
 
 // ----------------------------------------------------------------------
 //   Component type registration and internal type metadata management
@@ -289,8 +288,8 @@ bool isValidElementOfType(dynamic instance, dynamic typeAlias) {
   return isValidElement(instance) && isComponentOfType(instance, typeAlias);
 }
 
-/// Validates that a [ReactComponentFactoryProxy]'s component is not [Component]
-/// or [UiComponent].
+/// Validates that a [ReactComponentFactoryProxy]'s component is not `Component`
+/// or `UiComponent`.
 void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
   if (component.type is String) return;
 

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -244,12 +244,6 @@ bool isComponentOfType(ReactElement instance, dynamic typeAlias, {
     return false;
   }
 
-  // When a component is wrapped in a react.memo, we can gain access to the
-  // original Dart component via the 'WrappedComponent` property.
-  if (instance.type != null && getProperty(instance.type, 'WrappedComponent') != null) {
-    instanceType = getProperty(instance.type, 'WrappedComponent');
-  }
-
   var instanceTypeMeta = getComponentTypeMeta(instanceType);
 
   // Type-check instance wrappers.

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -24,6 +24,8 @@ import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:react/react_client.dart';
 import 'package:react/react_client/react_interop.dart';
 
+import '../../over_react.dart';
+
 // ----------------------------------------------------------------------
 //   Component type registration and internal type metadata management
 // ----------------------------------------------------------------------
@@ -280,4 +282,18 @@ bool isComponentOfType(ReactElement instance, dynamic typeAlias, {
 /// > Related: [isComponentOfType]
 bool isValidElementOfType(dynamic instance, dynamic typeAlias) {
   return isValidElement(instance) && isComponentOfType(instance, typeAlias);
+}
+
+/// Validates that a [ReactComponentFactoryProxy]'s component is not [Component]
+/// or [UiComponent].
+void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
+  // ignore: invalid_use_of_protected_member
+  if (component.type.dartComponentVersion == '1') {
+    throw ArgumentError(unindent('''
+        The UiFactory provided to connect should not be for a UiComponent or Component.
+        
+        Instead, use a different factory (such as UiComponent2 or Component2).
+        '''
+    ));
+  }
 }

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -295,7 +295,7 @@ void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
   if (component.type is String) return;
 
   // ignore: invalid_use_of_protected_member
-  if (component.type?.dartComponentVersion == '1') {
+  if (component.type.dartComponentVersion == '1') {
     throw ArgumentError(unindent('''
         The UiFactory provided should not be for a UiComponent or Component.
         

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -292,8 +292,10 @@ bool isValidElementOfType(dynamic instance, dynamic typeAlias) {
 /// Validates that a [ReactComponentFactoryProxy]'s component is not [Component]
 /// or [UiComponent].
 void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
+  if (component.type is String) return;
+
   // ignore: invalid_use_of_protected_member
-  if (component.type.dartComponentVersion == '1') {
+  if (component.type?.dartComponentVersion == '1') {
     throw ArgumentError(unindent('''
         The UiFactory provided should not be for a UiComponent or Component.
         

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -245,6 +245,11 @@ bool isComponentOfType(ReactElement instance, dynamic typeAlias, {
     return false;
   }
 
+  // When a component is wrapped in a react.memo, we can gain access to the
+  // original Dart component via the 'WrappedComponent` property.
+  if (instance.type != null && getProperty(instance.type, 'WrappedComponent') != null) {
+    instanceType = getProperty(instance.type, 'WrappedComponent');
+  }
 
   var instanceTypeMeta = getComponentTypeMeta(instanceType);
 
@@ -290,10 +295,9 @@ void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
   // ignore: invalid_use_of_protected_member
   if (component.type.dartComponentVersion == '1') {
     throw ArgumentError(unindent('''
-        The UiFactory provided to connect should not be for a UiComponent or Component.
+        The UiFactory provided should not be for a UiComponent or Component.
         
         Instead, use a different factory (such as UiComponent2 or Component2).
-        '''
-    ));
+        '''));
   }
 }

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -290,9 +290,11 @@ bool _shallowMapEquality(Map a, Map b) => const MapEquality().equals(a, b);
 ///
 /// This is primarily for use while transitioning _to_ `connect` and OverReact Redux.
 ///
-/// __NOTE:__ Unlike `connect`, there is no `areStatesEqual` parameter due to the state
-/// update process being impure. It is impure because it involves modification of
-/// the store itself, as opposed to creating a new state object with each change.
+/// > __NOTE:__ This should only be used to wrap components that extend from [Component2].
+/// >
+/// > Additionally, unlike `connect`, there is no `areStatesEqual` parameter due to the state
+/// > update process being impure. It is impure because it involves modification of
+/// > the store itself, as opposed to creating a new state object with each change.
 ///
 /// __Example:__
 /// ```dart

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -45,6 +45,8 @@ typedef dynamic Dispatcher(dynamic action);
 
 /// A wrapper around the JS react-redux `connect` function that supports OverReact components.
 ///
+/// > __NOTE:__ This should only be used to wrap components that extend from [Component2].
+///
 /// __Example:__
 /// ```dart
 ///     UiFactory<CounterProps> ConnectedCounter = connect<CounterState, CounterProps>(

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -239,6 +239,8 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
     final hocFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
     setComponentTypeMeta(hocFactoryProxy, isHoc: true, parentType: dartComponentFactory);
 
+    enforceMinimumComponentVersionFor(hocJsFactoryProxy);
+
     TProps connectedFactory([Map props]) {
       return (factory(props)..componentFactory = hocFactoryProxy);
     }

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -149,6 +149,10 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
   areMergedPropsEqual ??= _shallowMapEquality;
 
   UiFactory<TProps> wrapWithConnect(UiFactory<TProps> factory) {
+    final dartComponentFactory = factory().componentFactory;
+    final dartComponentClass = dartComponentFactory.type;
+    enforceMinimumComponentVersionFor(dartComponentFactory);
+
     JsMap jsMapFromProps(Map props) => jsBackingMapOrJsCopy(props is UiProps ? props.props : props);
 
     TProps jsPropsToTProps(JsMap jsProps) => factory(JsBackedMap.backedBy(jsProps));
@@ -213,9 +217,6 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
     bool handleAreMergedPropsEqual(JsMap jsNext, JsMap jsPrev) =>
         areMergedPropsEqual(jsPropsToTProps(jsNext), jsPropsToTProps(jsPrev));
 
-    final dartComponentFactory = factory().componentFactory;
-    final dartComponentClass = dartComponentFactory.type;
-
     final hoc = mockableJsConnect(
       mapStateToProps != null ? allowInteropWithArgCount(handleMapStateToProps, 1) : mapStateToPropsWithOwnProps != null ? allowInteropWithArgCount(handleMapStateToPropsWithOwnProps, 2) : null,
       mapDispatchToProps != null ? allowInteropWithArgCount(handleMapDispatchToProps, 1) : mapDispatchToPropsWithOwnProps != null ? allowInteropWithArgCount(handleMapDispatchToPropsWithOwnProps, 2) : null,
@@ -238,8 +239,6 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
     /// without needing unwrapping/conversion.
     final hocFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
     setComponentTypeMeta(hocFactoryProxy, isHoc: true, parentType: dartComponentFactory);
-
-    enforceMinimumComponentVersionFor(hocJsFactoryProxy);
 
     TProps connectedFactory([Map props]) {
       return (factory(props)..componentFactory = hocFactoryProxy);

--- a/test/over_react/component/fixtures/basic_ui_component.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.dart
@@ -1,0 +1,29 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+part 'basic_ui_component.over_react.g.dart';
+// ignore_for_file: deprecated_member_use_from_same_package
+@Factory()
+UiFactory<BasicUiComponentProps> BasicUiComponent = _$BasicUiComponent;
+
+@Props()
+class _$BasicUiComponentProps extends UiProps {}
+
+@Component()
+class BasicUiComponentComponent extends UiComponent<BasicUiComponentProps> {
+  @override
+  render() => 'child component';
+}

--- a/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
@@ -1,0 +1,95 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'basic_ui_component.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $BasicUiComponentComponentFactory = registerComponent(
+    () => _$BasicUiComponentComponent(),
+    builderFactory: BasicUiComponent,
+    componentClass: BasicUiComponentComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'BasicUiComponent');
+
+abstract class _$BasicUiComponentPropsAccessorsMixin
+    implements _$BasicUiComponentProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForBasicUiComponentProps = PropsMeta(
+  fields: _$BasicUiComponentPropsAccessorsMixin.$props,
+  keys: _$BasicUiComponentPropsAccessorsMixin.$propKeys,
+);
+
+class BasicUiComponentProps extends _$BasicUiComponentProps
+    with _$BasicUiComponentPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForBasicUiComponentProps;
+}
+
+_$$BasicUiComponentProps _$BasicUiComponent([Map backingProps]) =>
+    _$$BasicUiComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$BasicUiComponentProps extends _$BasicUiComponentProps
+    with _$BasicUiComponentPropsAccessorsMixin
+    implements BasicUiComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicUiComponentProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $BasicUiComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'BasicUiComponentProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$BasicUiComponentComponent extends BasicUiComponentComponent {
+  @override
+  _$$BasicUiComponentProps typedPropsFactory(Map backingMap) =>
+      _$$BasicUiComponentProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$BasicUiComponentProps.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForBasicUiComponentProps
+  ];
+}

--- a/test/over_react/component/forward_ref_test.dart
+++ b/test/over_react/component/forward_ref_test.dart
@@ -22,11 +22,22 @@ import 'package:over_react/src/component/dom_components.dart';
 
 import '../../test_util/test_util.dart';
 import '../component/fixtures/basic_child_component.dart';
+import 'fixtures/basic_ui_component.dart';
 
 part 'forward_ref_test.over_react.g.dart';
 
 main() {
   group('forward ref -', () {
+    test('errors when wrapping a UiComponent', () {
+      final component = forwardRef<BasicUiComponentProps>((props, ref) {
+        return (BasicUiComponent()
+        ..ref = ref
+        )();
+      })(BasicUiComponent);
+
+      expect(() => mount(component()()), throwsArgumentError);
+    });
+
     group('on a component with a dom component child', () {
       forwardRefTest(Dom.span, verifyRefValue: (ref) {
         expect(ref, TypeMatcher<SpanElement>());

--- a/test/over_react/component/forward_ref_test.dart
+++ b/test/over_react/component/forward_ref_test.dart
@@ -29,13 +29,11 @@ part 'forward_ref_test.over_react.g.dart';
 main() {
   group('forward ref -', () {
     test('errors when wrapping a UiComponent', () {
-      final component = forwardRef<BasicUiComponentProps>((props, ref) {
+      expect(() => forwardRef<BasicUiComponentProps>((props, ref) {
         return (BasicUiComponent()
-        ..ref = ref
+          ..ref = ref
         )();
-      })(BasicUiComponent);
-
-      expect(() => mount(component()()), throwsArgumentError);
+      })(BasicUiComponent), throwsArgumentError);
     });
 
     group('on a component with a dom component child', () {

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -371,15 +371,25 @@ testComponentTypeChecking({
         });
 
         group('a higher-order component created by', () {
-          test('forwardRef', () {
-            final hocFactory = forwardRef((props, ref) => null)(TestA);
-            expect(isComponentOfType(hocFactory()(), TestA), isTrue);
-          });
+          if (TestA().componentFactory.type.dartComponentVersion == '1') {
+            test('forwardRef', () {
+              expect(() => forwardRef((props, ref) => null)(TestA), throwsArgumentError);
+            });
 
-          test('connect', () {
-            final hocFactory = connect(mapStateToProps: (state) => {})(TestA);
-            expect(isComponentOfType(hocFactory()(), TestA), isTrue);
-          });
+            test('connect', () {
+              expect(() => connect(mapStateToProps: (state) => {})(TestA), throwsArgumentError);
+            });
+          } else {
+            test('forwardRef', () {
+              final hocFactory = forwardRef((props, ref) => null)(TestA);
+              expect(isComponentOfType(hocFactory()(), TestA), isTrue);
+            });
+
+            test('connect', () {
+              final hocFactory = connect(mapStateToProps: (state) => {})(TestA);
+              expect(isComponentOfType(hocFactory()(), TestA), isTrue);
+            });
+          }
         });
       });
     });

--- a/test/over_react_redux/connect_flux_test.dart
+++ b/test/over_react_redux/connect_flux_test.dart
@@ -21,6 +21,7 @@ import '../test_util/test_util.dart';
 import 'fixtures/connect_flux_counter.dart';
 import 'fixtures/connect_flux_store.dart';
 import 'fixtures/counter.dart';
+import 'fixtures/non_component_two_counter.dart';
 import 'fixtures/redux_actions.dart';
 import 'fixtures/store.dart' as redux_store;
 
@@ -64,6 +65,10 @@ main() {
     });
 
     group('behaves like redux with', () {
+      test('errors when wrapping a UiComponent', (){
+        expect(() => connectFlux<FluxStore, FluxActions, NonComponentTwoCounterProps>()(NonComponentTwoCounter), throwsArgumentError);
+      });
+
       group('Provider Usage', () {
         test('throws without a provider', () {
           ConnectedCounter =

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -19,9 +19,10 @@ import 'package:over_react/over_react_redux.dart';
 import 'package:test/test.dart';
 
 import '../test_util/test_util.dart';
-import './fixtures/counter.dart';
-import './fixtures/redux_actions.dart';
-import './fixtures/store.dart';
+import 'fixtures/counter.dart';
+import 'fixtures/non_component_two_counter.dart';
+import 'fixtures/redux_actions.dart';
+import 'fixtures/store.dart';
 
 // ignore_for_file: avoid_types_on_closure_parameters
 
@@ -61,6 +62,10 @@ main() {
 
       // wait for state to update
       await Future(() {});
+    });
+
+    test('throws when mounting a UiComponent', (){
+        expect(() => connect<CounterState, NonComponentTwoCounterProps>()(NonComponentTwoCounter), throwsArgumentError);
     });
 
     group('Provider Usage', () {

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -64,8 +64,8 @@ main() {
       await Future(() {});
     });
 
-    test('throws when mounting a UiComponent', (){
-        expect(() => connect<CounterState, NonComponentTwoCounterProps>()(NonComponentTwoCounter), throwsArgumentError);
+    test('throws when mounting a UiComponent', () {
+      expect(() => connect<CounterState, NonComponentTwoCounterProps>()(NonComponentTwoCounter), throwsArgumentError);
     });
 
     group('Provider Usage', () {

--- a/test/over_react_redux/fixtures/non_component_two_counter.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.dart
@@ -1,0 +1,18 @@
+import 'package:over_react/over_react.dart';
+import 'package:over_react/over_react_redux.dart';
+
+part 'non_component_two_counter.over_react.g.dart';
+// ignore_for_file: deprecated_member_use_from_same_package
+@Factory()
+UiFactory<NonComponentTwoCounterProps> NonComponentTwoCounter = _$NonComponentTwoCounter;
+
+@Props()
+class _$NonComponentTwoCounterProps extends UiProps with ConnectPropsMixin {}
+
+@Component()
+class NonComponentTwoCounterComponent extends UiComponent<NonComponentTwoCounterProps> {
+  @override
+  render() {
+    return Dom.div()();
+  }
+}

--- a/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'non_component_two_counter.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $NonComponentTwoCounterComponentFactory = registerComponent(
+    () => _$NonComponentTwoCounterComponent(),
+    builderFactory: NonComponentTwoCounter,
+    componentClass: NonComponentTwoCounterComponent,
+    isWrapper: false,
+    parentType: null,
+    displayName: 'NonComponentTwoCounter');
+
+abstract class _$NonComponentTwoCounterPropsAccessorsMixin
+    implements _$NonComponentTwoCounterProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForNonComponentTwoCounterProps = PropsMeta(
+  fields: _$NonComponentTwoCounterPropsAccessorsMixin.$props,
+  keys: _$NonComponentTwoCounterPropsAccessorsMixin.$propKeys,
+);
+
+class NonComponentTwoCounterProps extends _$NonComponentTwoCounterProps
+    with _$NonComponentTwoCounterPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForNonComponentTwoCounterProps;
+}
+
+_$$NonComponentTwoCounterProps _$NonComponentTwoCounter([Map backingProps]) =>
+    _$$NonComponentTwoCounterProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$NonComponentTwoCounterProps extends _$NonComponentTwoCounterProps
+    with _$NonComponentTwoCounterPropsAccessorsMixin
+    implements NonComponentTwoCounterProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$NonComponentTwoCounterProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $NonComponentTwoCounterComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'NonComponentTwoCounterProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$NonComponentTwoCounterComponent
+    extends NonComponentTwoCounterComponent {
+  @override
+  _$$NonComponentTwoCounterProps typedPropsFactory(Map backingMap) =>
+      _$$NonComponentTwoCounterProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$NonComponentTwoCounterProps.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForNonComponentTwoCounterProps
+  ];
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Currently, wrapping a `UiComponent` in one of our HOC utilities (`forwardRef`, `connect`, `connectFlux`) will throw a cryptic error, and there's no mention of that on the utility doc comments.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Update the doc comments for `connect`, `connectFlux`, and `forwardRef` noting that the component being wrapped should extend `Component2`.
- Add a utility that throws when a `Component` is passed in
- Add tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Ensure `connect`, `connectFlux`, and `forwardRef` fail gracefully when an invalid component gets passed in.
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @sydneyjodon-wk  @willdrach-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
