### PR TITLE
Change order of generated declarations

### DIFF
--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -18,6 +18,10 @@ class OverReactBuilder extends Builder {
     '.dart': [outputExtension],
   };
 
+  /// The generation order of boilerplate declarations.
+  ///
+  /// Changing the order of this iterable changes the order in which
+  /// the builder will write the generated code to the output file.
   static const generationOrder = [
     DeclarationType.classComponentDeclaration,
     DeclarationType.legacyClassComponentDeclaration,

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -28,7 +28,6 @@ class OverReactBuilder extends Builder {
     DeclarationType.functionComponentDeclaration,
   ];
 
-
   @override
   FutureOr<void> build(BuildStep buildStep) async {
     final source = await buildStep.readAsString(buildStep.inputId);

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -61,9 +61,10 @@ class OverReactBuilder extends Builder {
       final generator = ImplGenerator(log, sourceFile);
 
       final members = BoilerplateMembers.detect(unit);
-      final declarations = getBoilerplateDeclarations(members, errorCollector).toList()..sort((a, b) {
-        return generationOrder.indexOf(a.type).compareTo(generationOrder.indexOf(b.type));
-      });
+      final declarations = getBoilerplateDeclarations(members, errorCollector).toList()
+        ..sort((a, b) {
+          return generationOrder.indexOf(a.type).compareTo(generationOrder.indexOf(b.type));
+        });
 
       if (hasErrors) {
         // Log the members that weren't grouped into declarations.

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -58,7 +58,22 @@ class OverReactBuilder extends Builder {
         hasErrors = false;
       }
 
-      for (final declaration in declarations) {
+      const generationOrder = [
+        DeclarationTypes.classComponentDeclaration,
+        DeclarationTypes.legacyClassComponentDeclaration,
+        DeclarationTypes.propsMixinDeclaration,
+        DeclarationTypes.stateMixinDeclaration,
+        DeclarationTypes.propsMapViewDeclaration,
+        DeclarationTypes.legacyAbstractClassComponentDeclaration,
+        DeclarationTypes.functionComponentDeclaration,
+      ];
+
+      final sortedDeclarations = declarations.toList()..sort((a, b) {
+        return generationOrder
+            .indexOf(a.type).compareTo(generationOrder.indexOf(b.type));
+      });
+
+      for (final declaration in sortedDeclarations) {
         hasErrors = false;
         declaration.validate(errorCollector);
         if (!hasErrors) {

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -61,7 +61,7 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
   //
   // Legacy abstract props/state classes
   //
-  // They be declared stand-alone without needing other abstract component members, so grouping
+  // They can be declared stand-alone without needing other abstract component members, so grouping
   // them isn't helpful, and can actually cause issues for edge cases where there are other
   // `noGenerate` members with similar names.
   //
@@ -321,8 +321,19 @@ AstNode fuzzyMatch(BoilerplateMember member, Iterable<BoilerplateMember> members
 
 class BoilerplateGenerator {}
 
+enum DeclarationTypes {
+  functionComponentDeclaration,
+  classComponentDeclaration,
+  legacyClassComponentDeclaration,
+  legacyAbstractClassComponentDeclaration,
+  propsMixinDeclaration,
+  stateMixinDeclaration,
+  propsMapViewDeclaration,
+}
+
 abstract class BoilerplateDeclaration {
   final BoilerplateVersion version;
+  DeclarationTypes type;
 
   BoilerplateDeclaration(this.version);
 
@@ -359,6 +370,9 @@ class LegacyClassComponentDeclaration extends BoilerplateDeclaration {
 
   @override
   get _members => [factory, component, props, if (state != null) state];
+
+  @override
+  get type => DeclarationTypes.legacyClassComponentDeclaration;
 
   LegacyClassComponentDeclaration({
     @required BoilerplateVersion version,
@@ -398,6 +412,9 @@ class LegacyAbstractClassComponentDeclaration extends BoilerplateDeclaration {
 
   @override
   get _members => [component, props, state].whereNotNull();
+
+  @override
+  final type = DeclarationTypes.legacyAbstractClassComponentDeclaration;
 
   LegacyAbstractClassComponentDeclaration({
     @required BoilerplateVersion version,
@@ -447,6 +464,9 @@ class ClassComponentDeclaration extends BoilerplateDeclaration {
   @override
   get _members => [factory, component, props.either, if (state != null) state?.either];
 
+  @override
+  get type => DeclarationTypes.classComponentDeclaration;
+
   ClassComponentDeclaration({
     @required BoilerplateVersion version,
     @required this.factory,
@@ -466,6 +486,9 @@ class PropsMapViewDeclaration extends BoilerplateDeclaration {
   @override
   get _members => [factory, props.either];
 
+  @override
+  get type => DeclarationTypes.propsMapViewDeclaration;
+
   PropsMapViewDeclaration({
     @required BoilerplateVersion version,
     @required this.factory,
@@ -483,6 +506,9 @@ class FunctionComponentDeclaration extends BoilerplateDeclaration {
   @override
   get _members => [factory, props.either];
 
+  @override
+  get type => DeclarationTypes.functionComponentDeclaration;
+
   FunctionComponentDeclaration({
     @required BoilerplateVersion version,
     @required this.factory,
@@ -496,6 +522,9 @@ class PropsMixinDeclaration extends BoilerplateDeclaration {
   @override
   get _members => [propsMixin];
 
+  @override
+  get type => DeclarationTypes.propsMixinDeclaration;
+
   PropsMixinDeclaration({
     @required BoilerplateVersion version,
     @required this.propsMixin,
@@ -507,6 +536,9 @@ class StateMixinDeclaration extends BoilerplateDeclaration {
 
   @override
   get _members => [stateMixin];
+
+  @override
+  get type => DeclarationTypes.stateMixinDeclaration;
 
   StateMixinDeclaration({
     @required BoilerplateVersion version,

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -321,7 +321,7 @@ AstNode fuzzyMatch(BoilerplateMember member, Iterable<BoilerplateMember> members
 
 class BoilerplateGenerator {}
 
-enum DeclarationTypes {
+enum DeclarationType {
   functionComponentDeclaration,
   classComponentDeclaration,
   legacyClassComponentDeclaration,
@@ -333,7 +333,7 @@ enum DeclarationTypes {
 
 abstract class BoilerplateDeclaration {
   final BoilerplateVersion version;
-  DeclarationTypes type;
+  DeclarationType type;
 
   BoilerplateDeclaration(this.version);
 
@@ -372,7 +372,7 @@ class LegacyClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, component, props, if (state != null) state];
 
   @override
-  get type => DeclarationTypes.legacyClassComponentDeclaration;
+  get type => DeclarationType.legacyClassComponentDeclaration;
 
   LegacyClassComponentDeclaration({
     @required BoilerplateVersion version,
@@ -414,7 +414,7 @@ class LegacyAbstractClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [component, props, state].whereNotNull();
 
   @override
-  final type = DeclarationTypes.legacyAbstractClassComponentDeclaration;
+  final type = DeclarationType.legacyAbstractClassComponentDeclaration;
 
   LegacyAbstractClassComponentDeclaration({
     @required BoilerplateVersion version,
@@ -465,7 +465,7 @@ class ClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, component, props.either, if (state != null) state?.either];
 
   @override
-  get type => DeclarationTypes.classComponentDeclaration;
+  get type => DeclarationType.classComponentDeclaration;
 
   ClassComponentDeclaration({
     @required BoilerplateVersion version,
@@ -487,7 +487,7 @@ class PropsMapViewDeclaration extends BoilerplateDeclaration {
   get _members => [factory, props.either];
 
   @override
-  get type => DeclarationTypes.propsMapViewDeclaration;
+  get type => DeclarationType.propsMapViewDeclaration;
 
   PropsMapViewDeclaration({
     @required BoilerplateVersion version,
@@ -507,7 +507,7 @@ class FunctionComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, props.either];
 
   @override
-  get type => DeclarationTypes.functionComponentDeclaration;
+  get type => DeclarationType.functionComponentDeclaration;
 
   FunctionComponentDeclaration({
     @required BoilerplateVersion version,
@@ -523,7 +523,7 @@ class PropsMixinDeclaration extends BoilerplateDeclaration {
   get _members => [propsMixin];
 
   @override
-  get type => DeclarationTypes.propsMixinDeclaration;
+  get type => DeclarationType.propsMixinDeclaration;
 
   PropsMixinDeclaration({
     @required BoilerplateVersion version,
@@ -538,7 +538,7 @@ class StateMixinDeclaration extends BoilerplateDeclaration {
   get _members => [stateMixin];
 
   @override
-  get type => DeclarationTypes.stateMixinDeclaration;
+  get type => DeclarationType.stateMixinDeclaration;
 
   StateMixinDeclaration({
     @required BoilerplateVersion version,

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -321,6 +321,7 @@ AstNode fuzzyMatch(BoilerplateMember member, Iterable<BoilerplateMember> members
 
 class BoilerplateGenerator {}
 
+/// The possible declaration types that the builder will look for.
 enum DeclarationType {
   functionComponentDeclaration,
   classComponentDeclaration,
@@ -333,6 +334,8 @@ enum DeclarationType {
 
 abstract class BoilerplateDeclaration {
   final BoilerplateVersion version;
+
+  /// The explicit type of declaration this class is tied to.
   DeclarationType type;
 
   BoilerplateDeclaration(this.version);


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Add a generation order and sort the declarations by that list.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a `type` getter that explicitly states what type of declaration it is.
- Sort the declarations by a defined order.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@greglittlefield-wf 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
