### PR TITLE
New boilerplate parser confidence refactor

### DIFF
--- a/lib/src/builder/generation/impl_generation.dart
+++ b/lib/src/builder/generation/impl_generation.dart
@@ -62,13 +62,13 @@ class ImplGenerator {
       } else if (declaration is LegacyAbstractClassComponentDeclaration) {
         generateAbstractComponent(declaration);
       } else if (declaration is PropsMixinDeclaration) {
-        if (declaration.version == BoilerplateVersion.v4_mixinBased) {
+        if (declaration.version == Version.v4_mixinBased) {
           logger.severe('Codegen for new boilerplate is not yet implemented $declaration');
         } else {
           generatePropsMixin(declaration);
         }
       } else if (declaration is StateMixinDeclaration) {
-        if (declaration.version == BoilerplateVersion.v4_mixinBased) {
+        if (declaration.version == Version.v4_mixinBased) {
           logger.severe('Codegen for new boilerplate is not yet implemented $declaration');
         } else {
           generateStateMixin(declaration);

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -252,10 +252,12 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
     if (resolveVersion([stateClass]) == BoilerplateVersion.noGenerate) continue;
     errorCollector.addError('State class is missing factory and/or component.', errorCollector.spanFor(stateClass.node));
   }
-  for (var componentClass in components) {
-    if (resolveVersion([componentClass]) == BoilerplateVersion.noGenerate) continue;
-    errorCollector.addError('componentClass class is missing factory and/or props.', errorCollector.spanFor(componentClass.node));
-  }
+  // ignore components since they don't require any generation if not accompanied by a props class and factory
+  // todo don't ignore components with a sufficiently high confidence
+//  for (var componentClass in components) {
+//    if (resolveVersion([componentClass]) == BoilerplateVersion.noGenerate) continue;
+//    errorCollector.addError('componentClass class is missing factory and/or props.', errorCollector.spanFor(componentClass.node));
+//  }
 }
 
 class FactoryGroup {

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -154,7 +154,7 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
     props.remove(propsClassOrMixin.either);
     states.remove(stateClassOrMixin?.either);
 
-    final component = getComponentFor(factory, components, findOtherInCompilationUnit: true);
+    final component = getComponentFor(factory, components);
     if (component != null) {
       components.remove(component);
 
@@ -252,12 +252,10 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
     if (!resolveVersion([stateClass]).shouldGenerate) continue;
     errorCollector.addError('State class is missing factory and/or component.', errorCollector.spanFor(stateClass.node));
   }
-  // ignore components since they don't require any generation if not accompanied by a props class and factory
-  // todo don't ignore components with a sufficiently high confidence
-//  for (var componentClass in components) {
-//    if (resolveVersion([componentClass]) == BoilerplateVersion.noGenerate) continue;
-//    errorCollector.addError('componentClass class is missing factory and/or props.', errorCollector.spanFor(componentClass.node));
-//  }
+  for (var componentClass in components) {
+    if (!resolveVersion([componentClass]).shouldGenerate) continue;
+    errorCollector.addError('componentClass class is missing factory and/or props.', errorCollector.spanFor(componentClass.node));
+  }
 }
 
 class FactoryGroup {

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -51,6 +51,15 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
 
   // -----------------------------------------------------------------------------------------------
   //
+  // Legacy map views
+  //
+  // Remove them so they don't get grouped with anything else and throw things off.
+  //
+  // TODO do we still need to do this? Write regression test case for this and see if it can be removed
+  props.removeWhere((p) => p.isLegacyMapView);
+
+  // -----------------------------------------------------------------------------------------------
+  //
   // Legacy abstract props/state classes
   //
   // They can be declared stand-alone without needing other abstract component members, so grouping

--- a/lib/src/builder/generation/parsing/declarations.dart
+++ b/lib/src/builder/generation/parsing/declarations.dart
@@ -167,8 +167,8 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
 
       if (version.shouldGenerate) {
         switch (version.version) {
-          case BoilerplateVersion.v2_legacyBackwardsCompat:
-          case BoilerplateVersion.v3_legacyDart2Only:
+          case Version.v2_legacyBackwardsCompat:
+          case Version.v3_legacyDart2Only:
             yield LegacyClassComponentDeclaration(
                 version: version.version,
                 factory: factory,
@@ -176,7 +176,7 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
                 props: propsClassOrMixin.a,
                 state: stateClassOrMixin?.a);
             break;
-          case BoilerplateVersion.v4_mixinBased:
+          case Version.v4_mixinBased:
             yield ClassComponentDeclaration(
                 version: version.version,
                 factory: factory,
@@ -194,7 +194,7 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
 
       if (isFunctionComponent(factory)) {
         yield FunctionComponentDeclaration(
-          version: BoilerplateVersion.v4_mixinBased,
+          version: Version.v4_mixinBased,
           factory: factory,
           props: propsClassOrMixin,
         );
@@ -202,14 +202,14 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
         final version = resolveVersion([factory, propsClassOrMixin.either]);
         if (version.shouldGenerate) {
           switch (version.version) {
-            case BoilerplateVersion.v2_legacyBackwardsCompat:
-            case BoilerplateVersion.v3_legacyDart2Only:
+            case Version.v2_legacyBackwardsCompat:
+            case Version.v3_legacyDart2Only:
               errorCollector.addError(
                   'Missing component for factory/props', errorCollector.spanFor(factory.node));
               break;
-            case BoilerplateVersion.v4_mixinBased:
+            case Version.v4_mixinBased:
               yield PropsMapViewDeclaration(
-                version: BoilerplateVersion.v4_mixinBased,
+                version: Version.v4_mixinBased,
                 factory: factory,
                 props: propsClassOrMixin,
               );
@@ -322,7 +322,7 @@ AstNode fuzzyMatch(BoilerplateMember member, Iterable<BoilerplateMember> members
 class BoilerplateGenerator {}
 
 abstract class BoilerplateDeclaration {
-  final BoilerplateVersion version;
+  final Version version;
 
   BoilerplateDeclaration(this.version);
 
@@ -361,7 +361,7 @@ class LegacyClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, component, props, if (state != null) state];
 
   LegacyClassComponentDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.factory,
     @required this.component,
     @required this.props,
@@ -400,7 +400,7 @@ class LegacyAbstractClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [component, props, state].whereNotNull();
 
   LegacyAbstractClassComponentDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     this.component,
     this.props,
     this.state,
@@ -448,7 +448,7 @@ class ClassComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, component, props.either, if (state != null) state?.either];
 
   ClassComponentDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.factory,
     @required this.component,
     @required this.props,
@@ -467,7 +467,7 @@ class PropsMapViewDeclaration extends BoilerplateDeclaration {
   get _members => [factory, props.either];
 
   PropsMapViewDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.factory,
     @required this.props,
   }) : super(version);
@@ -484,7 +484,7 @@ class FunctionComponentDeclaration extends BoilerplateDeclaration {
   get _members => [factory, props.either];
 
   FunctionComponentDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.factory,
     @required this.props,
   }) : super(version);
@@ -497,7 +497,7 @@ class PropsMixinDeclaration extends BoilerplateDeclaration {
   get _members => [propsMixin];
 
   PropsMixinDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.propsMixin,
   }) : super(version);
 }
@@ -509,7 +509,7 @@ class StateMixinDeclaration extends BoilerplateDeclaration {
   get _members => [stateMixin];
 
   StateMixinDeclaration({
-    @required BoilerplateVersion version,
+    @required Version version,
     @required this.stateMixin,
   }) : super(version);
 }

--- a/lib/src/builder/generation/parsing/member_association.dart
+++ b/lib/src/builder/generation/parsing/member_association.dart
@@ -52,15 +52,12 @@ Union<A, B> _getNameMatchUnion<A extends BoilerplateMember, B extends Boilerplat
   return null;
 }
 
-BoilerplateComponent getComponentFor(
-  BoilerplateMember member,
-  List<BoilerplateComponent> components, {
-  bool findOtherInCompilationUnit = false,
-}) {
+BoilerplateComponent getComponentFor(BoilerplateMember member, List<BoilerplateComponent> components) {
   final match = _getNameMatch(components, normalizeNameAndRemoveSuffix(member)) ??
       getRelatedName(member).mapIfNotNull((name) => _getNameMatch(components, name));
   if (match != null) return match;
 
+  // If there's no match by name, use the props generic parameter
   return components.firstWhere((comp) {
     final propsGenericArgName = comp.nodeHelper.superclass?.typeArguments?.arguments
         ?.firstWhere((arg) => arg.typeNameWithoutPrefix.contains('Props'), orElse: () => null)

--- a/lib/src/builder/generation/parsing/member_association.dart
+++ b/lib/src/builder/generation/parsing/member_association.dart
@@ -1,6 +1,3 @@
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:over_react/src/builder/generation/parsing/version.dart';
-
 import 'ast_util.dart';
 import 'members.dart';
 import 'util.dart';
@@ -64,66 +61,19 @@ BoilerplateComponent getComponentFor(
       getRelatedName(member).mapIfNotNull((name) => _getNameMatch(components, name));
   if (match != null) return match;
 
-  if (findOtherInCompilationUnit) {
-    final componentNode = member.node
-        .thisOrAncestorOfType<CompilationUnit>()
-        .declarations
-        .whereType<NamedCompilationUnitMember>()
-        .where((m) => m is ClassOrMixinDeclaration || m is ClassTypeAlias)
-        .map((m) => m.asClassish())
-        .where(_detectComponent)
-        .firstWhere((comp) {
-      final propsGenericArgName = comp.superclass?.typeArguments?.arguments
-          ?.firstWhere((arg) => arg.typeNameWithoutPrefix.contains('Props'), orElse: () => null)
-          ?.typeNameWithoutPrefix;
-      if (propsGenericArgName != null) {
-        if (_normalizeBoilerplatePropsOrPropsMixinName(propsGenericArgName) ==
-            normalizeNameAndRemoveSuffix(member)) {
-          return true;
-        }
+  return components.firstWhere((comp) {
+    final propsGenericArgName = comp.nodeHelper.superclass?.typeArguments?.arguments
+        ?.firstWhere((arg) => arg.typeNameWithoutPrefix.contains('Props'), orElse: () => null)
+        ?.typeNameWithoutPrefix;
+    if (propsGenericArgName != null) {
+      if (_normalizeBoilerplatePropsOrPropsMixinName(propsGenericArgName) ==
+          normalizeNameAndRemoveSuffix(member)) {
+        return true;
       }
-
-      return false;
-    }, orElse: () => null);
-
-    if (componentNode != null) {
-      return BoilerplateComponent(componentNode, {
-        for (final version in BoilerplateVersion.values) version: Confidence.medium,
-      });
-    }
-  }
-
-  return null;
-}
-
-bool _detectComponent(ClassishDeclaration classish) {
-  // Don't detect react-dart components as boilerplate components, since they cause issues with grouping
-  // if they're in the same file as an OverReact component with non-matching names.
-  if (!const {'Component', 'Component2'}.contains(classish.superclass?.nameWithoutPrefix)) {
-    int confidence = 0;
-    if (classish.name.name.endsWith('Component')) {
-      confidence += Confidence.medium;
-    }
-    if (classish.allSuperTypes.any((type) {
-      final name = type.nameWithoutPrefix;
-      return name == 'UiComponent' || name == 'UiComponent2';
-    })) {
-      confidence += Confidence.high;
     }
 
-    // extending from an abstract component: `FooComponent extends BarComponent<FooProps, FooState>`
-    if (classish.superclass?.typeArguments?.arguments
-            ?.any((arg) => arg.typeNameWithoutPrefix.contains('Props')) ??
-        false) {
-      confidence += Confidence.medium;
-    }
-
-    if (confidence != 0) {
-      return true;
-    }
-  }
-
-  return false;
+    return false;
+  }, orElse: () => null);
 }
 
 Union<BoilerplateProps, BoilerplatePropsMixin> getPropsFor(

--- a/lib/src/builder/generation/parsing/member_detection.dart
+++ b/lib/src/builder/generation/parsing/member_detection.dart
@@ -167,10 +167,10 @@ class BoilerplateMemberDetector {
     } else {
       return VersionConfidence(
         v2_legacyBackwardsCompat:
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.medium : Confidence.veryLow,
+            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.medium : Confidence.low,
         v3_legacyDart2Only:
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.veryLow : Confidence.medium,
-        v4_mixinBased: Confidence.veryLow,
+            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.low : Confidence.medium,
+        v4_mixinBased: Confidence.low,
       );
     }
   }
@@ -187,10 +187,10 @@ class BoilerplateMemberDetector {
 
     return VersionConfidence(
       v2_legacyBackwardsCompat:
-          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.veryLow : Confidence.high),
+          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.low : Confidence.high),
       v3_legacyDart2Only:
-          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.high : Confidence.veryLow),
-      v4_mixinBased: isMixin ? Confidence.high : Confidence.veryLow,
+          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.high : Confidence.low),
+      v4_mixinBased: isMixin ? Confidence.high : Confidence.low,
     );
   }
 

--- a/lib/src/builder/generation/parsing/member_detection.dart
+++ b/lib/src/builder/generation/parsing/member_detection.dart
@@ -90,7 +90,8 @@ class BoilerplateMemberDetector {
         } else {
           onFactory(BoilerplateFactory(node, {
             BoilerplateVersion.v4_mixinBased: Confidence.medium,
-            BoilerplateVersion.noGenerate: Confidence.medium,
+            BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+            BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
           }));
           return;
         }
@@ -148,7 +149,11 @@ class BoilerplateMemberDetector {
     final isAbstractNoGenerate = !hasGeneratedPrefix &&
         (node is! MixinDeclaration && nodeHelper.hasAbstractKeyword && nodeHelper.members.isEmpty);
     if (isAbstractNoGenerate) {
-      return {BoilerplateVersion.noGenerate: Confidence.high};
+      return {
+        BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+        BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
+        BoilerplateVersion.v4_mixinBased: Confidence.none,
+      };
     }
 
     final map = <BoilerplateVersion, int>{};
@@ -187,7 +192,6 @@ class BoilerplateMemberDetector {
       BoilerplateVersion.v3_legacyDart2Only:
           isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.high : Confidence.veryLow),
       BoilerplateVersion.v4_mixinBased: isMixin ? Confidence.high : Confidence.veryLow,
-      BoilerplateVersion.noGenerate: Confidence.veryLow,
     };
   }
 
@@ -219,7 +223,9 @@ class BoilerplateMemberDetector {
         case 'Component':
         case 'Component2':
           final confidence = {
-            for (final version in BoilerplateVersion.values) version: Confidence.high
+            BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.high,
+            BoilerplateVersion.v3_legacyDart2Only: Confidence.high,
+            BoilerplateVersion.v4_mixinBased: Confidence.high,
           };
           onComponent(BoilerplateComponent(classish, confidence));
           return true;
@@ -227,7 +233,11 @@ class BoilerplateMemberDetector {
         // todo should we even use these?
         case 'AbstractComponent':
         case 'AbstractComponent2':
-          final confidence = {BoilerplateVersion.noGenerate: Confidence.high};
+          final confidence = {
+            BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+            BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
+            BoilerplateVersion.v4_mixinBased: Confidence.none,
+          };
           onComponent(BoilerplateComponent(classish, confidence));
           return true;
       }
@@ -251,19 +261,31 @@ class BoilerplateMemberDetector {
     // Thus, it's non-legacy boilerplate.
 
     Map<BoilerplateVersion, int> getConfidence() {
-      final confidence = {BoilerplateVersion.v4_mixinBased: Confidence.high};
+
       final overridesIsClassGenerated = classish.members
           .whereType<MethodDeclaration>()
           .any((member) => member.isGetter && member.name.name == r'$isClassGenerated');
       // Handle classes that look like props but are really just used as interfaces, and aren't extended from or directly used as a component's props
       if (overridesIsClassGenerated || onlyImplementsThings(classish)) {
-        confidence[BoilerplateVersion.noGenerate] = Confidence.certain;
+        return {
+          BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+          BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
+          BoilerplateVersion.v4_mixinBased: Confidence.none,
+        };
       } else if (classish.members.whereType<ConstructorDeclaration>().isNotEmpty) {
         //fixme fix these cases?
-        confidence[BoilerplateVersion.noGenerate] = Confidence.certain;
+        return {
+          BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+          BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
+          BoilerplateVersion.v4_mixinBased: Confidence.none,
+        };
       }
 
-      return confidence;
+      return {
+        BoilerplateVersion.v2_legacyBackwardsCompat: Confidence.none,
+        BoilerplateVersion.v3_legacyDart2Only: Confidence.none,
+        BoilerplateVersion.v4_mixinBased: Confidence.high,
+      };
     }
 
     if (node is MixinDeclaration) {

--- a/lib/src/builder/generation/parsing/member_detection.dart
+++ b/lib/src/builder/generation/parsing/member_detection.dart
@@ -211,9 +211,9 @@ class BoilerplateMemberDetector {
     } else {
       return VersionConfidence(
         v2_legacyBackwardsCompat:
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.medium : Confidence.low,
+            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.high : Confidence.low,
         v3_legacyDart2Only:
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.low : Confidence.medium,
+            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.low : Confidence.high,
         v4_mixinBased: Confidence.low,
       );
     }

--- a/lib/src/builder/generation/parsing/members.dart
+++ b/lib/src/builder/generation/parsing/members.dart
@@ -21,27 +21,21 @@ part 'members/props_and_state_util.dart';
 abstract class BoilerplateMember {
   /// The confidence that, assuming that [node] has been correctly identified as this type of boilerplate member,
   /// it belongs to a boilerplate declaration of a given version.
-  final Map<BoilerplateVersion, int> versionConfidence;
+  final VersionConfidence versionConfidence;
 
-  BoilerplateMember(this.versionConfidence) : assert(versionConfidence != null && versionConfidence.isNotEmpty);
+  BoilerplateMember(this.versionConfidence) : assert(versionConfidence != null);
 
   CompilationUnitMember get node;
 
-  void validate(BoilerplateVersion version, ErrorCollector errorCollector);
+  void validate(Version version, ErrorCollector errorCollector);
 
   SimpleIdentifier get name;
 
   @override
-  String toString() => '${super.toString()} (${name.name}) ${prettyPrintMap(versionConfidence)}';
+  String toString() => '${super.toString()} (${name.name}) ${versionConfidence}';
 
   String get debugString {
-    final confidence = versionConfidence;
-    final sortedKeys = BoilerplateVersion.values.where(confidence.containsKey);
-    final shorthandConfidence = {
-      for (var key in sortedKeys) '${key.toString().split('.').last}': confidence[key],
-    };
-
-    return '${runtimeType.toString()}; confidence:$shorthandConfidence';
+    return '${runtimeType.toString()}; confidence:$versionConfidence';
   }
 }
 

--- a/lib/src/builder/generation/parsing/members.dart
+++ b/lib/src/builder/generation/parsing/members.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:meta/meta.dart';
 import 'package:over_react/src/builder/generation/parsing/meta.dart';
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
 import 'package:over_react/src/util/pretty_print.dart';
@@ -23,7 +22,7 @@ abstract class BoilerplateMember {
   /// it belongs to a boilerplate declaration of a given version.
   final VersionConfidence versionConfidence;
 
-  BoilerplateMember(this.versionConfidence) : assert(versionConfidence != null);
+  BoilerplateMember(this.versionConfidence);
 
   CompilationUnitMember get node;
 
@@ -32,7 +31,7 @@ abstract class BoilerplateMember {
   SimpleIdentifier get name;
 
   @override
-  String toString() => '${super.toString()} (${name.name}) ${versionConfidence}';
+  String toString() => '${super.toString()} (${name.name}) $versionConfidence';
 
   String get debugString {
     return '${runtimeType.toString()}; confidence:$versionConfidence';

--- a/lib/src/builder/generation/parsing/members.dart
+++ b/lib/src/builder/generation/parsing/members.dart
@@ -19,15 +19,13 @@ part 'members/props_and_state_mixins.dart';
 part 'members/props_and_state_util.dart';
 
 abstract class BoilerplateMember {
-  final int declarationConfidence;
-
-  BoilerplateMember(this.declarationConfidence);
-
-  CompilationUnitMember get node;
-
   /// The confidence that, assuming that [node] has been correctly identified as this type of boilerplate member,
   /// it belongs to a boilerplate declaration of a given version.
-  Map<BoilerplateVersion, int> get versionConfidence;
+  final Map<BoilerplateVersion, int> versionConfidence;
+
+  BoilerplateMember(this.versionConfidence) : assert(versionConfidence != null && versionConfidence.isNotEmpty);
+
+  CompilationUnitMember get node;
 
   void validate(BoilerplateVersion version, ErrorCollector errorCollector);
 

--- a/lib/src/builder/generation/parsing/members.dart
+++ b/lib/src/builder/generation/parsing/members.dart
@@ -67,9 +67,14 @@ class BoilerplateMembers {
   bool get isNotEmpty => !isEmpty;
 
   BoilerplateMembers.detect(CompilationUnit unit) {
-    BoilerplateMemberDetector()
-      ..members = this
-      ..detect(unit);
+    BoilerplateMemberDetector(
+      onFactory: factories.add,
+      onProps: props.add,
+      onPropsMixin: propsMixins.add,
+      onComponent: components.add,
+      onState: states.add,
+      onStateMixin: stateMixins.add,
+    ).detect(unit);
   }
 
   toString() => 'BoilerplateMembers:${prettyPrintMap({

--- a/lib/src/builder/generation/parsing/members/component.dart
+++ b/lib/src/builder/generation/parsing/members/component.dart
@@ -9,9 +9,9 @@ class BoilerplateComponent extends BoilerplateMember {
   annotations.Component meta;
   Identifier configSubtypeOf;
 
-  BoilerplateComponent(this.nodeHelper, int declarationConfidence)
+  BoilerplateComponent(this.nodeHelper, Map<BoilerplateVersion, int> confidence)
       : node = nodeHelper.node,
-        super(declarationConfidence) {
+        super(confidence) {
     final meta = InstantiatedComponentMeta<annotations.Component2>(node) ??
         InstantiatedComponentMeta<annotations.Component>(node);
 
@@ -25,35 +25,6 @@ class BoilerplateComponent extends BoilerplateMember {
   TypeAnnotation get propsGenericArg {
     return nodeHelper.superclass.typeArguments?.arguments
         ?.firstWhere((type) => type.typeNameWithoutPrefix.endsWith('Props'), orElse: () => null);
-  }
-
-  @override
-  Map<BoilerplateVersion, int> get versionConfidence {
-    final map = <BoilerplateVersion, int>{};
-
-    // todo do we need this and should we include other confidences in the map in this case?
-    if (nodeHelper.hasAbstractKeyword && !hasComponent1OrAbstractAnnotation) {
-      map[BoilerplateVersion.noGenerate] = Confidence.high;
-      return map;
-    }
-
-    if (hasComponent1OrAbstractAnnotation) {
-      map[BoilerplateVersion.v2_legacyBackwardsCompat] = Confidence.high;
-      map[BoilerplateVersion.v3_legacyDart2Only] = Confidence.high;
-      map[BoilerplateVersion.v4_mixinBased] = Confidence.veryLow;
-      map[BoilerplateVersion.noGenerate] = Confidence.veryLow;
-    } else if (hasComponent2OrAbstractAnnotation) {
-      map[BoilerplateVersion.v2_legacyBackwardsCompat] = Confidence.medium;
-      map[BoilerplateVersion.v3_legacyDart2Only] = Confidence.medium;
-      map[BoilerplateVersion.v3_legacyDart2Only] = Confidence.medium;
-      map[BoilerplateVersion.noGenerate] = Confidence.veryLow;
-    } else {
-      map[BoilerplateVersion.v2_legacyBackwardsCompat] = Confidence.veryLow;
-      map[BoilerplateVersion.v3_legacyDart2Only] = Confidence.veryLow;
-      map[BoilerplateVersion.v4_mixinBased] = Confidence.medium;
-      map[BoilerplateVersion.noGenerate] = Confidence.medium;
-    }
-    return map;
   }
 
   bool get hasAnnotation => hasComponent1OrAbstractAnnotation || hasComponent2OrAbstractAnnotation;

--- a/lib/src/builder/generation/parsing/members/component.dart
+++ b/lib/src/builder/generation/parsing/members/component.dart
@@ -39,8 +39,6 @@ class BoilerplateComponent extends BoilerplateMember {
   @override
   void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.noGenerate:
-        return;
       case BoilerplateVersion.v4_mixinBased:
         final superclass = nodeHelper.superclass;
         if (superclass?.nameWithoutPrefix == 'UiComponent') {

--- a/lib/src/builder/generation/parsing/members/component.dart
+++ b/lib/src/builder/generation/parsing/members/component.dart
@@ -9,7 +9,7 @@ class BoilerplateComponent extends BoilerplateMember {
   annotations.Component meta;
   Identifier configSubtypeOf;
 
-  BoilerplateComponent(this.nodeHelper, Map<BoilerplateVersion, int> confidence)
+  BoilerplateComponent(this.nodeHelper, VersionConfidence confidence)
       : node = nodeHelper.node,
         super(confidence) {
     final meta = InstantiatedComponentMeta<annotations.Component2>(node) ??
@@ -33,21 +33,21 @@ class BoilerplateComponent extends BoilerplateMember {
       node.hasAnnotationWithNames({'Component', 'AbstractComponent'});
   bool get hasComponent2OrAbstractAnnotation =>
       node.hasAnnotationWithNames({'Component2', 'AbstractComponent2'});
-  bool isComponent2(BoilerplateVersion version) =>
-      version == BoilerplateVersion.v4_mixinBased || hasComponent2OrAbstractAnnotation;
+  bool isComponent2(Version version) =>
+      version == Version.v4_mixinBased || hasComponent2OrAbstractAnnotation;
 
   @override
-  void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
+  void validate(Version version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.v4_mixinBased:
+      case Version.v4_mixinBased:
         final superclass = nodeHelper.superclass;
         if (superclass?.nameWithoutPrefix == 'UiComponent') {
           errorCollector.addError(
               'Must extend UiComponent2, not UiComponent.', errorCollector.spanFor(superclass));
         }
         break;
-      case BoilerplateVersion.v2_legacyBackwardsCompat:
-      case BoilerplateVersion.v3_legacyDart2Only:
+      case Version.v2_legacyBackwardsCompat:
+      case Version.v3_legacyDart2Only:
         break;
     }
 

--- a/lib/src/builder/generation/parsing/members/factory.dart
+++ b/lib/src/builder/generation/parsing/members/factory.dart
@@ -19,18 +19,10 @@ class BoilerplateFactory extends BoilerplateMember {
     return null;
   }
 
-  BoilerplateFactory(this.node, int declarationConfidence) : super(declarationConfidence);
-
-  @override
-  Map<BoilerplateVersion, int> get versionConfidence => {
-        BoilerplateVersion.v2_legacyBackwardsCompat:
-            hasFactoryAnnotation ? Confidence.medium : Confidence.veryLow,
-        BoilerplateVersion.v3_legacyDart2Only:
-            hasFactoryAnnotation ? Confidence.medium : Confidence.veryLow,
-        BoilerplateVersion.v4_mixinBased:
-            hasFactoryAnnotation ? Confidence.medium : Confidence.high,
-        BoilerplateVersion.noGenerate: hasFactoryAnnotation ? Confidence.veryLow : Confidence.high,
-      };
+  BoilerplateFactory(
+    this.node,
+    Map<BoilerplateVersion, int> declarationConfidence,
+  ) : super(declarationConfidence);
 
   bool get hasFactoryAnnotation => node.hasAnnotationWithName('Factory');
 

--- a/lib/src/builder/generation/parsing/members/factory.dart
+++ b/lib/src/builder/generation/parsing/members/factory.dart
@@ -29,8 +29,6 @@ class BoilerplateFactory extends BoilerplateMember {
   @override
   void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.noGenerate:
-        return;
       case BoilerplateVersion.v4_mixinBased:
         break;
       case BoilerplateVersion.v2_legacyBackwardsCompat:

--- a/lib/src/builder/generation/parsing/members/factory.dart
+++ b/lib/src/builder/generation/parsing/members/factory.dart
@@ -21,18 +21,18 @@ class BoilerplateFactory extends BoilerplateMember {
 
   BoilerplateFactory(
     this.node,
-    Map<BoilerplateVersion, int> declarationConfidence,
+    VersionConfidence declarationConfidence,
   ) : super(declarationConfidence);
 
   bool get hasFactoryAnnotation => node.hasAnnotationWithName('Factory');
 
   @override
-  void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
+  void validate(Version version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.v4_mixinBased:
+      case Version.v4_mixinBased:
         break;
-      case BoilerplateVersion.v2_legacyBackwardsCompat:
-      case BoilerplateVersion.v3_legacyDart2Only:
+      case Version.v2_legacyBackwardsCompat:
+      case Version.v3_legacyDart2Only:
         if (!hasFactoryAnnotation) {
           errorCollector.addError(
               'Legacy boilerplate factories must be annotated with `@Factory()`.',

--- a/lib/src/builder/generation/parsing/members/factory.dart
+++ b/lib/src/builder/generation/parsing/members/factory.dart
@@ -19,10 +19,7 @@ class BoilerplateFactory extends BoilerplateMember {
     return null;
   }
 
-  BoilerplateFactory(
-    this.node,
-    VersionConfidence declarationConfidence,
-  ) : super(declarationConfidence);
+  BoilerplateFactory(this.node, VersionConfidence confidence) : super(confidence);
 
   bool get hasFactoryAnnotation => node.hasAnnotationWithName('Factory');
 

--- a/lib/src/builder/generation/parsing/members/props_and_state.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state.dart
@@ -13,11 +13,8 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
   @override
   SimpleIdentifier get name => nodeHelper.name;
 
-  BoilerplatePropsOrState(
-    this.nodeHelper, {
-    @required VersionConfidence confidence,
-    @required this.companion,
-  })  : node = nodeHelper.node,
+  BoilerplatePropsOrState(this.nodeHelper, this.companion, VersionConfidence confidence)
+      : node = nodeHelper.node,
         super(confidence) {
     meta = getPropsOrStateAnnotation(isProps, node);
   }
@@ -109,14 +106,8 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
 
 class BoilerplateProps extends BoilerplatePropsOrState {
   BoilerplateProps(
-    ClassishDeclaration nodeHelper,
-      ClassishDeclaration companion,
-    VersionConfidence confidence,
-  ) : super(
-          nodeHelper,
-          confidence: confidence,
-          companion: companion,
-        );
+      ClassishDeclaration nodeHelper, ClassishDeclaration companion, VersionConfidence confidence)
+      : super(nodeHelper, companion, confidence);
 
   @override
   bool get isProps => true;
@@ -124,14 +115,8 @@ class BoilerplateProps extends BoilerplatePropsOrState {
 
 class BoilerplateState extends BoilerplatePropsOrState {
   BoilerplateState(
-    ClassishDeclaration nodeHelper,
-    ClassishDeclaration companion,
-      VersionConfidence confidence,
-  ) : super(
-          nodeHelper,
-          confidence: confidence,
-          companion: companion,
-        );
+      ClassishDeclaration nodeHelper, ClassishDeclaration companion, VersionConfidence confidence)
+      : super(nodeHelper, companion, confidence);
 
   @override
   bool get isProps => false;

--- a/lib/src/builder/generation/parsing/members/props_and_state.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state.dart
@@ -34,8 +34,6 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
   @override
   void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.noGenerate:
-        return;
       case BoilerplateVersion.v4_mixinBased:
         final node = this.node;
         if (node is MixinDeclaration) {

--- a/lib/src/builder/generation/parsing/members/props_and_state.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state.dart
@@ -13,57 +13,17 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
   @override
   SimpleIdentifier get name => nodeHelper.name;
 
-  BoilerplatePropsOrState(this.nodeHelper, int declarationConfidence, {@required this.companion})
-      : node = nodeHelper.node,
-        super(declarationConfidence) {
+  BoilerplatePropsOrState(
+    this.nodeHelper, {
+    @required Map<BoilerplateVersion, int> confidence,
+    @required this.companion,
+  })  : node = nodeHelper.node,
+        super(confidence) {
     meta = getPropsOrStateAnnotation(isProps, node);
   }
 
   @override
   String get debugString => '${super.debugString}, companion: ${companion?.name}';
-
-  @override
-  Map<BoilerplateVersion, int> get versionConfidence {
-    final map = <BoilerplateVersion, int>{};
-
-    final hasGeneratedPrefix = node.name.name.startsWith(r'_$');
-    if (!hasGeneratedPrefix && (node is! MixinDeclaration && nodeHelper.hasAbstractKeyword)) {
-      map[BoilerplateVersion.noGenerate] = Confidence.high;
-      map[BoilerplateVersion.v4_mixinBased] = Confidence.veryLow;
-      return map;
-    }
-
-    if (isLegacyMapView) {
-      map[BoilerplateVersion.noGenerate] = Confidence.high;
-    } else {
-      final isMixin = node is MixinDeclaration;
-      if (isMixin) {
-        // todo might need to rethink these, as well as in the mixin classes, to be able to provide better error messages when people make things mixins
-
-        // It has never been possible to declare a props class with a mixin
-        map[BoilerplateVersion.v2_legacyBackwardsCompat] = Confidence.none;
-        map[BoilerplateVersion.v3_legacyDart2Only] = Confidence.none;
-        // fixme this ain't right
-        map[BoilerplateVersion.v4_mixinBased] = Confidence.high;
-      } else {
-        map[BoilerplateVersion.v2_legacyBackwardsCompat] =
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.medium : Confidence.veryLow;
-        map[BoilerplateVersion.v3_legacyDart2Only] =
-            (hasCompanionClass || !hasGeneratedPrefix) ? Confidence.veryLow : Confidence.medium;
-        map[BoilerplateVersion.v4_mixinBased] = Confidence.veryLow;
-      }
-
-      final overridesIsClassGenerated = nodeHelper.members
-          .whereType<MethodDeclaration>()
-          .any((member) => member.isGetter && member.name.name == r'$isClassGenerated');
-      // Handle classes that look like props but are really just used as interfaces, and aren't extended from or directly used as a component's props
-      if (overridesIsClassGenerated || onlyImplementsThings(nodeHelper)) {
-        map[BoilerplateVersion.noGenerate] = Confidence.certain;
-      }
-    }
-
-    return map;
-  }
 
   bool get isLegacyMapView =>
       name.name.endsWith('MapView') &&
@@ -82,7 +42,8 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
           // It's possible in the future that this may not always
           // be a ClassDeclaration, so fall back to node if it's not one.
           errorCollector.addError(
-              '$propsOrStateClassString implementations must be concrete classes, not mixins', // TODO add versions to error messages
+              '$propsOrStateClassString implementations must be concrete classes, not mixins',
+              // TODO add versions to error messages
               errorCollector.spanFor(node.mixinKeyword));
         } else {
           if (nodeHelper.superclass?.nameWithoutPrefix != propsOrStateBaseClassString) {
@@ -108,7 +69,9 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
       case BoilerplateVersion.v2_legacyBackwardsCompat:
         // It's possible to declare an abstract class without any props/state fields that need to be generated,
         //  so long as it doesn't have the annotation.
-        if (nodeHelper.members.isNotEmpty || node.hasAnnotationWithNames({propsOrStateAnnotationName, propsOrStateAbstractAnnotationName})) {
+        if (nodeHelper.members.isNotEmpty ||
+            node.hasAnnotationWithNames(
+                {propsOrStateAnnotationName, propsOrStateAbstractAnnotationName})) {
           _sharedLegacyValidation(errorCollector);
           if (companion == null) {
             // Don't emit this and the prefix error.
@@ -147,18 +110,30 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
 }
 
 class BoilerplateProps extends BoilerplatePropsOrState {
-  BoilerplateProps(ClassishDeclaration nodeHelper, int declarationConfidence,
-      {ClassishDeclaration companion})
-      : super(nodeHelper, declarationConfidence, companion: companion);
+  BoilerplateProps(
+    ClassishDeclaration nodeHelper,
+      ClassishDeclaration companion,
+    Map<BoilerplateVersion, int> confidence,
+  ) : super(
+          nodeHelper,
+          confidence: confidence,
+          companion: companion,
+        );
 
   @override
   bool get isProps => true;
 }
 
 class BoilerplateState extends BoilerplatePropsOrState {
-  BoilerplateState(ClassishDeclaration nodeHelper, int declarationConfidence,
-      {ClassishDeclaration companion})
-      : super(nodeHelper, declarationConfidence, companion: companion);
+  BoilerplateState(
+    ClassishDeclaration nodeHelper,
+    ClassishDeclaration companion,
+      Map<BoilerplateVersion, int> confidence,
+  ) : super(
+          nodeHelper,
+          confidence: confidence,
+          companion: companion,
+        );
 
   @override
   bool get isProps => false;

--- a/lib/src/builder/generation/parsing/members/props_and_state.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state.dart
@@ -15,7 +15,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
 
   BoilerplatePropsOrState(
     this.nodeHelper, {
-    @required Map<BoilerplateVersion, int> confidence,
+    @required VersionConfidence confidence,
     @required this.companion,
   })  : node = nodeHelper.node,
         super(confidence) {
@@ -32,9 +32,9 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
   bool get hasCompanionClass => companion != null;
 
   @override
-  void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
+  void validate(Version version, ErrorCollector errorCollector) {
     switch (version) {
-      case BoilerplateVersion.v4_mixinBased:
+      case Version.v4_mixinBased:
         final node = this.node;
         if (node is MixinDeclaration) {
           // It's possible in the future that this may not always
@@ -64,7 +64,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
           }
         }
         break;
-      case BoilerplateVersion.v2_legacyBackwardsCompat:
+      case Version.v2_legacyBackwardsCompat:
         // It's possible to declare an abstract class without any props/state fields that need to be generated,
         //  so long as it doesn't have the annotation.
         if (nodeHelper.members.isNotEmpty ||
@@ -81,7 +81,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateMember with PropsState
           }
         }
         break;
-      case BoilerplateVersion.v3_legacyDart2Only:
+      case Version.v3_legacyDart2Only:
         _sharedLegacyValidation(errorCollector);
         if (node is ClassOrMixinDeclaration) {
           checkForMetaPresence(node as ClassOrMixinDeclaration, errorCollector);
@@ -111,7 +111,7 @@ class BoilerplateProps extends BoilerplatePropsOrState {
   BoilerplateProps(
     ClassishDeclaration nodeHelper,
       ClassishDeclaration companion,
-    Map<BoilerplateVersion, int> confidence,
+    VersionConfidence confidence,
   ) : super(
           nodeHelper,
           confidence: confidence,
@@ -126,7 +126,7 @@ class BoilerplateState extends BoilerplatePropsOrState {
   BoilerplateState(
     ClassishDeclaration nodeHelper,
     ClassishDeclaration companion,
-      Map<BoilerplateVersion, int> confidence,
+      VersionConfidence confidence,
   ) : super(
           nodeHelper,
           confidence: confidence,

--- a/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
@@ -34,8 +34,6 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
     }
 
     switch (version) {
-      case BoilerplateVersion.noGenerate:
-        return;
       case BoilerplateVersion.v4_mixinBased:
         final node = this.node;
         if (node is MixinDeclaration) {

--- a/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
@@ -11,41 +11,16 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
   @override
   SimpleIdentifier get name => node.name;
 
-  BoilerplatePropsOrStateMixin(this.node, int declarationConfidence, {@required this.companion})
-      : super(declarationConfidence) {
+  BoilerplatePropsOrStateMixin(
+    this.node, {
+    @required Map<BoilerplateVersion, int> confidence,
+    @required this.companion,
+  }) : super(confidence) {
     meta = getPropsOrStateAnnotation(isProps, node);
   }
 
   @override
   String get debugString => '${super.debugString}, companion: ${companion?.name}';
-
-  @override
-  Map<BoilerplateVersion, int> get versionConfidence {
-    final isMixin = node is MixinDeclaration;
-    final hasGeneratedPrefix = node.name.name.startsWith(r'_$');
-
-    final map = {
-      BoilerplateVersion.v2_legacyBackwardsCompat:
-          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.veryLow : Confidence.high),
-      BoilerplateVersion.v3_legacyDart2Only:
-          isMixin ? Confidence.none : (hasGeneratedPrefix ? Confidence.high : Confidence.veryLow),
-      BoilerplateVersion.v4_mixinBased: isMixin ? Confidence.high : Confidence.veryLow,
-    };
-
-    final nodeHelper = node.asClassish();
-
-    final overridesIsClassGenerated = nodeHelper.members
-        .whereType<MethodDeclaration>()
-        .any((member) => member.isGetter && member.name.name == r'$isClassGenerated');
-    // Handle classes that look like props but are really just used as interfaces, and aren't extended from or directly used as a component's props
-    if (overridesIsClassGenerated || onlyImplementsThings(nodeHelper)) {
-      map[BoilerplateVersion.noGenerate] = Confidence.certain;
-    } else {
-      map[BoilerplateVersion.noGenerate] = Confidence.veryLow;
-    }
-
-    return map;
-  }
 
   @override
   void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
@@ -93,18 +68,30 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
 }
 
 class BoilerplatePropsMixin extends BoilerplatePropsOrStateMixin {
-  BoilerplatePropsMixin(ClassOrMixinDeclaration node, int declarationConfidence,
-      {ClassishDeclaration companion})
-      : super(node, declarationConfidence, companion: companion);
+  BoilerplatePropsMixin(
+    ClassOrMixinDeclaration node,
+    ClassishDeclaration companion,
+    Map<BoilerplateVersion, int> confidence,
+  ) : super(
+          node,
+          confidence: confidence,
+          companion: companion,
+        );
 
   @override
   bool get isProps => true;
 }
 
 class BoilerplateStateMixin extends BoilerplatePropsOrStateMixin {
-  BoilerplateStateMixin(ClassOrMixinDeclaration node, int declarationConfidence,
-      {ClassishDeclaration companion})
-      : super(node, declarationConfidence, companion: companion);
+  BoilerplateStateMixin(
+    ClassOrMixinDeclaration node,
+    ClassishDeclaration companion,
+    Map<BoilerplateVersion, int> confidence,
+  ) : super(
+          node,
+          confidence: confidence,
+          companion: companion,
+        );
 
   @override
   bool get isProps => false;

--- a/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
@@ -13,7 +13,7 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
 
   BoilerplatePropsOrStateMixin(
     this.node, {
-    @required Map<BoilerplateVersion, int> confidence,
+    @required VersionConfidence confidence,
     @required this.companion,
   }) : super(confidence) {
     meta = getPropsOrStateAnnotation(isProps, node);
@@ -23,7 +23,7 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
   String get debugString => '${super.debugString}, companion: ${companion?.name}';
 
   @override
-  void validate(BoilerplateVersion version, ErrorCollector errorCollector) {
+  void validate(Version version, ErrorCollector errorCollector) {
     void _sharedLegacyValidation() {
       if (!node.hasAnnotationWithName(propsOrStateMixinAnnotationName)) {
         errorCollector.addError(
@@ -34,7 +34,7 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
     }
 
     switch (version) {
-      case BoilerplateVersion.v4_mixinBased:
+      case Version.v4_mixinBased:
         final node = this.node;
         if (node is MixinDeclaration) {
           final isOnUiProps = node.onClause?.superclassConstraints
@@ -53,11 +53,11 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
               '$propsOrStateString mixins must be mixins', errorCollector.spanFor(spanNode));
         }
         break;
-      case BoilerplateVersion.v2_legacyBackwardsCompat:
+      case Version.v2_legacyBackwardsCompat:
         _sharedLegacyValidation();
         validateMetaField(node.asClassish(), propsOrStateMetaStructName, errorCollector);
         break;
-      case BoilerplateVersion.v3_legacyDart2Only:
+      case Version.v3_legacyDart2Only:
         _sharedLegacyValidation();
         checkForMetaPresence(node, errorCollector);
         break;
@@ -69,7 +69,7 @@ class BoilerplatePropsMixin extends BoilerplatePropsOrStateMixin {
   BoilerplatePropsMixin(
     ClassOrMixinDeclaration node,
     ClassishDeclaration companion,
-    Map<BoilerplateVersion, int> confidence,
+    VersionConfidence confidence,
   ) : super(
           node,
           confidence: confidence,
@@ -84,7 +84,7 @@ class BoilerplateStateMixin extends BoilerplatePropsOrStateMixin {
   BoilerplateStateMixin(
     ClassOrMixinDeclaration node,
     ClassishDeclaration companion,
-    Map<BoilerplateVersion, int> confidence,
+    VersionConfidence confidence,
   ) : super(
           node,
           confidence: confidence,

--- a/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
+++ b/lib/src/builder/generation/parsing/members/props_and_state_mixins.dart
@@ -11,11 +11,8 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
   @override
   SimpleIdentifier get name => node.name;
 
-  BoilerplatePropsOrStateMixin(
-    this.node, {
-    @required VersionConfidence confidence,
-    @required this.companion,
-  }) : super(confidence) {
+  BoilerplatePropsOrStateMixin(this.node, this.companion, VersionConfidence confidence)
+      : super(confidence) {
     meta = getPropsOrStateAnnotation(isProps, node);
   }
 
@@ -67,14 +64,8 @@ abstract class BoilerplatePropsOrStateMixin extends BoilerplateMember with Props
 
 class BoilerplatePropsMixin extends BoilerplatePropsOrStateMixin {
   BoilerplatePropsMixin(
-    ClassOrMixinDeclaration node,
-    ClassishDeclaration companion,
-    VersionConfidence confidence,
-  ) : super(
-          node,
-          confidence: confidence,
-          companion: companion,
-        );
+      ClassOrMixinDeclaration node, ClassishDeclaration companion, VersionConfidence confidence)
+      : super(node, companion, confidence);
 
   @override
   bool get isProps => true;
@@ -82,14 +73,8 @@ class BoilerplatePropsMixin extends BoilerplatePropsOrStateMixin {
 
 class BoilerplateStateMixin extends BoilerplatePropsOrStateMixin {
   BoilerplateStateMixin(
-    ClassOrMixinDeclaration node,
-    ClassishDeclaration companion,
-    VersionConfidence confidence,
-  ) : super(
-          node,
-          confidence: confidence,
-          companion: companion,
-        );
+      ClassOrMixinDeclaration node, ClassishDeclaration companion, VersionConfidence confidence)
+      : super(node, companion, confidence);
 
   @override
   bool get isProps => false;

--- a/lib/src/builder/generation/parsing/version.dart
+++ b/lib/src/builder/generation/parsing/version.dart
@@ -1,69 +1,36 @@
-import 'dart:math' as math;
 import 'package:meta/meta.dart';
 
 import 'members.dart';
-import 'util.dart';
 
 @sealed
 abstract class Confidence {
   static const none = 0;
   static const veryLow = 1;
-
-//  static const low = 5;
   static const medium = 10;
   static const high = 100;
   static const certain = 100000;
 }
 
-extension VersionConfidenceMap on Map<BoilerplateVersion, int> {
-  Map<BoilerplateVersion, int> operator +(Map<BoilerplateVersion, int> other) {
-    final keys = this.keys.toSet()..addAll(other.keys);
-    return {
-      for (var key in keys) key: (this[key] ?? 0) + (other[key] ?? 0),
-    };
-  }
-
-  List<MapEntry<BoilerplateVersion, int>> get _sortedVersions {
-    final sortedVersionEntries = entries.where((entry) => entry.value != 0).toList()
-      ..sort((a, b) {
-        // Sort highest to lowest for values
-        final compareResult = b.value.compareTo(a.value);
-        // For ties, chose the preferred boilerplate.
-        if (compareResult == 0) {
-          return boilerplateVersionPriority
-              .indexOf(a.key)
-              .compareTo(boilerplateVersionPriority.indexOf(b.key));
-        }
-        return compareResult;
-      });
-
-    return sortedVersionEntries;
-  }
-
-  VersionWithConfidence get maxConfidence {
-    final best = _sortedVersions.firstOrNull;
-    return VersionWithConfidence(
-      // This value shouldn't matter if the confidence is 0; it just needs to be non-null.
-      best?.key ?? boilerplateVersionPriority.first,
-      best.value ?? 0,
-    );
-  }
-}
-
-const boilerplateVersionPriority = [
-  BoilerplateVersion.v4_mixinBased,
-  BoilerplateVersion.v2_legacyBackwardsCompat,
-  BoilerplateVersion.v3_legacyDart2Only,
-];
-
-enum BoilerplateVersion {
+enum Version {
   v2_legacyBackwardsCompat,
   v3_legacyDart2Only,
   v4_mixinBased,
 }
 
+const _versionsInPriorityOrder = [
+  Version.v4_mixinBased,
+  Version.v2_legacyBackwardsCompat,
+  Version.v3_legacyDart2Only,
+];
+
+extension VersionExtension on Version {
+  bool get isLegacy =>
+      this == Version.v2_legacyBackwardsCompat ||
+      this == Version.v3_legacyDart2Only;
+}
+
 class VersionWithConfidence {
-  final BoilerplateVersion version;
+  final Version version;
   final num confidence;
 
   VersionWithConfidence(this.version, this.confidence);
@@ -71,14 +38,9 @@ class VersionWithConfidence {
   bool get shouldGenerate => confidence >= Confidence.medium;
 }
 
-extension BoilerplateVersionExtension on BoilerplateVersion {
-  bool get isLegacy =>
-      this == BoilerplateVersion.v2_legacyBackwardsCompat ||
-      this == BoilerplateVersion.v3_legacyDart2Only;
-}
 
 VersionWithConfidence resolveVersion(Iterable<BoilerplateMember> members) {
-  var totals = <BoilerplateVersion, int>{};
+  var totals = VersionConfidence.none();
   for (var member in members) {
     totals += member.versionConfidence;
   }
@@ -86,5 +48,69 @@ VersionWithConfidence resolveVersion(Iterable<BoilerplateMember> members) {
   return totals.maxConfidence;
 }
 
+class VersionConfidence {
+  final int v2_legacyBackwardsCompat;
+  final int v3_legacyDart2Only;
+  final int v4_mixinBased;
+
+  VersionConfidence({
+    @required this.v2_legacyBackwardsCompat,
+    @required this.v3_legacyDart2Only,
+    @required this.v4_mixinBased,
+  });
+
+  VersionConfidence.all(int value) : this(
+    v2_legacyBackwardsCompat: value,
+    v3_legacyDart2Only: value,
+    v4_mixinBased: value,
+  );
+
+  VersionConfidence.none() : this.all(Confidence.none);
+
+
+  List<VersionWithConfidence> toList() => [
+    VersionWithConfidence(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),
+    VersionWithConfidence(Version.v3_legacyDart2Only, v3_legacyDart2Only),
+    VersionWithConfidence(Version.v4_mixinBased, v4_mixinBased),
+  ];
+
+  VersionConfidence operator +(VersionConfidence other) {
+    return VersionConfidence(
+      v2_legacyBackwardsCompat: v2_legacyBackwardsCompat + other.v2_legacyBackwardsCompat,
+      v3_legacyDart2Only: v3_legacyDart2Only + other.v3_legacyDart2Only,
+      v4_mixinBased: v4_mixinBased + other.v4_mixinBased,
+    );
+  }
+
+  List<VersionWithConfidence> get _sortedVersions {
+    final sortedVersionEntries = toList()
+      ..sort((a, b) {
+        // Sort highest to lowest for values
+        final compareResult = b.confidence.compareTo(a.confidence);
+        // For ties, chose the preferred boilerplate.
+        if (compareResult == 0) {
+          return _versionsInPriorityOrder
+              .indexOf(a.version)
+              .compareTo(_versionsInPriorityOrder.indexOf(b.version));
+        }
+        return compareResult;
+      });
+
+    return sortedVersionEntries;
+  }
+
+  VersionWithConfidence get maxConfidence => _sortedVersions.first;
+
+  @override
+  String toString() {
+    final confidenceMap = {
+      'v2_legacyBackwardsCompat': v2_legacyBackwardsCompat,
+      'v3_legacyDart2Only': v3_legacyDart2Only,
+      'v4_mixinBased': v4_mixinBased,
+    };
+
+    return '${runtimeType.toString()}; confidence:$confidenceMap';
+  }
+}
 
 

--- a/lib/src/builder/generation/parsing/version.dart
+++ b/lib/src/builder/generation/parsing/version.dart
@@ -35,17 +35,20 @@ class VersionConfidencePair {
 
   VersionConfidencePair(this.version, this.confidence);
 
-  bool get shouldGenerate => confidence >= Confidence.medium;
+  bool get shouldGenerate => confidence > Confidence.medium;
 }
 
-
+/// Returns a confidence pair with
+/// - a [VersionConfidencePair.version] equal to the highest-confidence version among all [members]
+/// - a [VersionConfidencePair.confidence] equal to the average of all confidences for that version
 VersionConfidencePair resolveVersion(Iterable<BoilerplateMember> members) {
   var totals = VersionConfidence.none();
   for (var member in members) {
     totals += member.versionConfidence;
   }
+  final max = totals.maxConfidence;
 
-  return totals.maxConfidence;
+  return VersionConfidencePair(max.version, max.confidence / members.length);
 }
 
 class VersionConfidence {
@@ -66,7 +69,6 @@ class VersionConfidence {
   );
 
   VersionConfidence.none() : this.all(Confidence.none);
-
 
   List<VersionConfidencePair> toList() => [
     VersionConfidencePair(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),

--- a/lib/src/builder/generation/parsing/version.dart
+++ b/lib/src/builder/generation/parsing/version.dart
@@ -1,29 +1,74 @@
+import 'dart:math' as math;
 import 'package:meta/meta.dart';
 
 import 'members.dart';
+import 'util.dart';
 
 @sealed
 abstract class Confidence {
   static const none = 0;
   static const veryLow = 1;
+
 //  static const low = 5;
   static const medium = 10;
-  static const high = 20;
+  static const high = 100;
   static const certain = 100000;
+}
+
+extension VersionConfidenceMap on Map<BoilerplateVersion, int> {
+  Map<BoilerplateVersion, int> operator +(Map<BoilerplateVersion, int> other) {
+    final keys = this.keys.toSet()..addAll(other.keys);
+    return {
+      for (var key in keys) key: (this[key] ?? 0) + (other[key] ?? 0),
+    };
+  }
+
+  List<MapEntry<BoilerplateVersion, int>> get _sortedVersions {
+    final sortedVersionEntries = entries.where((entry) => entry.value != 0).toList()
+      ..sort((a, b) {
+        // Sort highest to lowest for values
+        final compareResult = b.value.compareTo(a.value);
+        // For ties, chose the preferred boilerplate.
+        if (compareResult == 0) {
+          return boilerplateVersionPriority
+              .indexOf(a.key)
+              .compareTo(boilerplateVersionPriority.indexOf(b.key));
+        }
+        return compareResult;
+      });
+
+    return sortedVersionEntries;
+  }
+
+  VersionWithConfidence get maxConfidence {
+    final best = _sortedVersions.firstOrNull;
+    return VersionWithConfidence(
+      // This value shouldn't matter if the confidence is 0; it just needs to be non-null.
+      best?.key ?? boilerplateVersionPriority.first,
+      best.value ?? 0,
+    );
+  }
 }
 
 const boilerplateVersionPriority = [
   BoilerplateVersion.v4_mixinBased,
   BoilerplateVersion.v2_legacyBackwardsCompat,
   BoilerplateVersion.v3_legacyDart2Only,
-  BoilerplateVersion.noGenerate,
 ];
 
 enum BoilerplateVersion {
   v2_legacyBackwardsCompat,
   v3_legacyDart2Only,
   v4_mixinBased,
-  noGenerate,
+}
+
+class VersionWithConfidence {
+  final BoilerplateVersion version;
+  final num confidence;
+
+  VersionWithConfidence(this.version, this.confidence);
+
+  bool get shouldGenerate => confidence >= Confidence.medium;
 }
 
 extension BoilerplateVersionExtension on BoilerplateVersion {
@@ -32,31 +77,14 @@ extension BoilerplateVersionExtension on BoilerplateVersion {
       this == BoilerplateVersion.v3_legacyDart2Only;
 }
 
-BoilerplateVersion resolveVersion(Iterable<BoilerplateMember> members) {
-  return resolveVersions(members).first;
-}
-
-List<BoilerplateVersion> resolveVersions(Iterable<BoilerplateMember> members) {
-  final totals = <BoilerplateVersion, int>{};
+VersionWithConfidence resolveVersion(Iterable<BoilerplateMember> members) {
+  var totals = <BoilerplateVersion, int>{};
   for (var member in members) {
-    member.versionConfidence.forEach((key, value) {
-      totals[key] = (totals[key] ?? 0) + value;
-    });
+    totals += member.versionConfidence;
   }
 
-  final sortedVersionEntries = totals.entries.where((entry) => entry.value != 0).toList()
-    ..sort((a, b) {
-      // Sort highest to lowest for values
-      final compareResult = b.value.compareTo(a.value);
-      // For ties, chose the preferred boilerplate.
-      if (compareResult == 0) {
-        return boilerplateVersionPriority
-            .indexOf(a.key)
-            .compareTo(boilerplateVersionPriority.indexOf(b.key));
-      }
-      return compareResult;
-    });
-
-  final versions = sortedVersionEntries.map((entry) => entry.key).toList();
-  return versions.isNotEmpty ? versions : [BoilerplateVersion.noGenerate];
+  return totals.maxConfidence;
 }
+
+
+

--- a/lib/src/builder/generation/parsing/version.dart
+++ b/lib/src/builder/generation/parsing/version.dart
@@ -5,7 +5,7 @@ import 'members.dart';
 @sealed
 abstract class Confidence {
   static const none = 0;
-  static const veryLow = 1;
+  static const low = 1;
   static const medium = 10;
   static const high = 100;
   static const certain = 100000;
@@ -29,17 +29,17 @@ extension VersionExtension on Version {
       this == Version.v3_legacyDart2Only;
 }
 
-class VersionWithConfidence {
+class VersionConfidencePair {
   final Version version;
   final num confidence;
 
-  VersionWithConfidence(this.version, this.confidence);
+  VersionConfidencePair(this.version, this.confidence);
 
   bool get shouldGenerate => confidence >= Confidence.medium;
 }
 
 
-VersionWithConfidence resolveVersion(Iterable<BoilerplateMember> members) {
+VersionConfidencePair resolveVersion(Iterable<BoilerplateMember> members) {
   var totals = VersionConfidence.none();
   for (var member in members) {
     totals += member.versionConfidence;
@@ -68,10 +68,10 @@ class VersionConfidence {
   VersionConfidence.none() : this.all(Confidence.none);
 
 
-  List<VersionWithConfidence> toList() => [
-    VersionWithConfidence(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),
-    VersionWithConfidence(Version.v3_legacyDart2Only, v3_legacyDart2Only),
-    VersionWithConfidence(Version.v4_mixinBased, v4_mixinBased),
+  List<VersionConfidencePair> toList() => [
+    VersionConfidencePair(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),
+    VersionConfidencePair(Version.v3_legacyDart2Only, v3_legacyDart2Only),
+    VersionConfidencePair(Version.v4_mixinBased, v4_mixinBased),
   ];
 
   VersionConfidence operator +(VersionConfidence other) {
@@ -82,12 +82,12 @@ class VersionConfidence {
     );
   }
 
-  List<VersionWithConfidence> get _sortedVersions {
+  List<VersionConfidencePair> get _sortedVersions {
     final sortedVersionEntries = toList()
       ..sort((a, b) {
         // Sort highest to lowest for values
         final compareResult = b.confidence.compareTo(a.confidence);
-        // For ties, chose the preferred boilerplate.
+        // For ties, choose the preferred boilerplate.
         if (compareResult == 0) {
           return _versionsInPriorityOrder
               .indexOf(a.version)
@@ -99,7 +99,7 @@ class VersionConfidence {
     return sortedVersionEntries;
   }
 
-  VersionWithConfidence get maxConfidence => _sortedVersions.first;
+  VersionConfidencePair get maxConfidence => _sortedVersions.first;
 
   @override
   String toString() {

--- a/lib/src/builder/generation/parsing/version.dart
+++ b/lib/src/builder/generation/parsing/version.dart
@@ -25,8 +25,7 @@ const _versionsInPriorityOrder = [
 
 extension VersionExtension on Version {
   bool get isLegacy =>
-      this == Version.v2_legacyBackwardsCompat ||
-      this == Version.v3_legacyDart2Only;
+      this == Version.v2_legacyBackwardsCompat || this == Version.v3_legacyDart2Only;
 }
 
 class VersionConfidencePair {
@@ -62,19 +61,20 @@ class VersionConfidence {
     @required this.v4_mixinBased,
   });
 
-  VersionConfidence.all(int value) : this(
-    v2_legacyBackwardsCompat: value,
-    v3_legacyDart2Only: value,
-    v4_mixinBased: value,
-  );
+  VersionConfidence.all(int value)
+      : this(
+          v2_legacyBackwardsCompat: value,
+          v3_legacyDart2Only: value,
+          v4_mixinBased: value,
+        );
 
   VersionConfidence.none() : this.all(Confidence.none);
 
   List<VersionConfidencePair> toList() => [
-    VersionConfidencePair(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),
-    VersionConfidencePair(Version.v3_legacyDart2Only, v3_legacyDart2Only),
-    VersionConfidencePair(Version.v4_mixinBased, v4_mixinBased),
-  ];
+        VersionConfidencePair(Version.v2_legacyBackwardsCompat, v2_legacyBackwardsCompat),
+        VersionConfidencePair(Version.v3_legacyDart2Only, v3_legacyDart2Only),
+        VersionConfidencePair(Version.v4_mixinBased, v4_mixinBased),
+      ];
 
   VersionConfidence operator +(VersionConfidence other) {
     return VersionConfidence(
@@ -114,5 +114,3 @@ class VersionConfidence {
     return '${runtimeType.toString()}; confidence:$confidenceMap';
   }
 }
-
-

--- a/test/vm_tests/builder/declaration_parsing_test.dart
+++ b/test/vm_tests/builder/declaration_parsing_test.dart
@@ -143,8 +143,8 @@ main() {
             expect(decl.component?.name?.name, '${ors.baseName}Component');
 
             final boilerplateVersion = backwardsCompatible
-                ? BoilerplateVersion.v2_legacyBackwardsCompat
-                : BoilerplateVersion.v3_legacyDart2Only;
+                ? Version.v2_legacyBackwardsCompat
+                : Version.v3_legacyDart2Only;
             if (componentVersion == 1) {
               expect(decl.component.meta, isA<annotations.Component>());
               expect(decl.component.isComponent2(boilerplateVersion), isFalse);


### PR DESCRIPTION
### Major Changes:
- Be more strict 
- Move version confidence logic out of member classes and into member detection. This:
    - allows for computation before we create member instances, so we don't have to filter them out after the fact.
    - unifies the "is this a boilerplate member" logic with the "which version is it" logic, since the two have a lot of overlap and resulted in duplicate code
- Remove `BoilerplateVersion.noGenerate`; instead, use a confidence threshold to determine whether something should be generated. For declarations, this is the mean confidence of all members.
    - This allows us to easily determine whether leftover boilerplate members should result in warning/errors (above threshold) or be ignored (below threshold)
    - This removes the multiple ways to say something shouldn't be generated (low confidence in boilerplates vs high confidence in `noGenerate`)

- Create classes for version confidence instead of using a Map, which was more susceptible to missing keys

### Minor changes / fixes
- Find components' props by the UiProps parameter if the name doesn't match
- Rename `BoilerplateVersion` -> `Version` since it was too long lol
- Fix inverted `classish.abstractKeyword` null-check
- Clean up `BoilerplateMemberDetector` / decouple it from BoilerplateMembers