### PR TITLE
CPLAT-10402 Fix new connect syntax, update docs to use it

### DIFF
--- a/doc/built_redux_to_redux.md
+++ b/doc/built_redux_to_redux.md
@@ -70,7 +70,7 @@ This model fits perfectly with Redux because the premise is that a component sho
 ```dart
 // Starting Props Class
 // It's normal that the props class has few, if any, props because they values are coming from the substate
-class _$ExampleComponentProps extends BuiltReduxUiProps<AppState, AppStateBuilder, AppActions> {}
+class _$ExampleProps extends BuiltReduxUiProps<AppState, AppStateBuilder, AppActions> {}
 
 // The starting substate
 abstract class ExampleComponentState implements Built<AppSubstate, AppSubstateBuilder> {
@@ -83,13 +83,13 @@ abstract class ExampleComponentState implements Built<AppSubstate, AppSubstateBu
 
 // After refactor
 // connect call
-UiFactory<ExampleComponentProps> ConnectedExampleComponent = connect<AppState, ExampleComponentProps>(
+UiFactory<ExampleProps> Example = connect<AppState, ExampleProps>(
     // The `text` prop points to the `text` state field
-    mapStateToProps: (state) => (ExampleComponent()..text = state.text),
-)(ExampleComponent);
+    mapStateToProps: (state) => (Example()..text = state.text),
+)(_$Example);
 
 // Redux Props Class (e.g. a normal props class)
-mixin ExampleComponentProps on UiProps {
+mixin ExampleProps on UiProps {
   String text;
 }
 ```
@@ -311,12 +311,12 @@ Once all of the state pieces have been updated, the UiComponents are ready to be
     import 'package:over_react/over_react_redux.dart';
 
     import './store.dart';
-    import './components/component.dart';
+    import './components/example.dart';
 
     main() {
         react_dom.render(
-            (ReduxProvider()..store = randomColorStore)(
-                ConnectedComponent()(),
+            (ReduxProvider()..store = counterStore)(
+              Example()(),
             ),
             querySelector('#content'));
     }
@@ -429,12 +429,10 @@ Once all of the state pieces have been updated, the UiComponents are ready to be
         }
 
         // The same component converted to a connected Redux component
-        UiFactory<SimpleProps> ConnectedSimple = connect<ReduxState, SimpleProps>(
+        UiFactory<SimpleProps> Simple = connect<ReduxState, SimpleProps>(
             mapStateToProps: (state) => (Simple()..text = state.text),
             mapDispatchToProps: (dispatch) => (Simple()..updateText = (Sring text) { dispatch(UpdateText()); }),
-        )(Simple);
-
-        UiFactory<SimpleProps> Simple = _$Simple;
+        )(_$Simple);
 
         mixin SimpleProps on UiProps {
           String text;

--- a/doc/flux_to_redux.md
+++ b/doc/flux_to_redux.md
@@ -233,12 +233,12 @@ redux.Store randomColorStore = redux.Store<RandomColorState>(reducer, initialSta
     import 'package:over_react/over_react_redux.dart';
 
     import './store.dart';
-    import './components/component.dart';
+    import './components/example.dart';
 
     main() {
       react_dom.render(
           (ReduxProvider()..store = randomColorStore)(
-            ConnectedComponent()(),
+            Example()(),
           ),
           querySelector('#content'));
     }

--- a/doc/over_react_redux_documentation.md
+++ b/doc/over_react_redux_documentation.md
@@ -107,8 +107,6 @@ ways to do this.
         ...
     )(_$Foo);
 
-    UiFactory<FooProps> Foo = ;
-
     // Use the ConnectPropsMixin to gain access to React Redux's dispatch function, which can be accessed via
     // props.dispatch.
     mixin FooPropsMixin on UiProps {

--- a/doc/over_react_redux_documentation.md
+++ b/doc/over_react_redux_documentation.md
@@ -103,9 +103,11 @@ ways to do this.
         using `ConnectPropsToMixin`.
     ```dart
     // AppState is a class that represents the application's state and can be defined in the same file as the store.
-    UiFactory<FooProps> ConnectedFoo = connect<AppState, FooProps>()(Foo);
+    UiFactory<FooProps> Foo = connect<AppState, FooProps>(
+        ...
+    )(_$Foo);
 
-    UiFactory<FooProps> Foo = _$Foo;
+    UiFactory<FooProps> Foo = ;
 
     // Use the ConnectPropsMixin to gain access to React Redux's dispatch function, which can be accessed via
     // props.dispatch.
@@ -145,14 +147,14 @@ A wrapper around the JS react-redux `connect` function that supports OverReact c
 
 __Example:__
 ```dart
-UiFactory<CounterProps> ConnectedCounter = connect<CounterState, CounterProps>(
-  mapStateToProps: (state) => (
-    Counter()..count = state.count
+UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
+  mapStateToProps: (state) => (Counter()
+    ..count = state.count
   ),
-  mapDispatchToProps: (dispatch) => (
-    Counter()..increment = (() => dispatch(IncrementAction()))
+  mapDispatchToProps: (dispatch) => (Counter()
+    ..increment = (() => dispatch(IncrementAction()))
   ),
-)(Counter);
+)(_$Counter);
 ```
 
 ### `connect` Parameters
@@ -229,14 +231,14 @@ __Multiple Stores Example:__
 Store store1 = new Store<CounterState>(counterStateReducer, initialState: new CounterState(count: 0));
 Store store2 = new Store<BigCounterState>(bigCounterStateReducer, initialState: new BigCounterState(bigCount: 100));
 
-UiFactory<CounterProps> ConnectedCounter = connect<CounterState, CounterProps>(
+UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
   mapStateToProps: (state) => (Counter()..count = state.count)
-)(Counter);
+)(_$Counter);
 
-UiFactory<CounterProps> ConnectedBigCounter = connect<BigCounterState, CounterProps>(
-  mapStateToProps: (state) => (Counter()..count = state.bigCount),
+UiFactory<CounterProps> BigCounter = connect<BigCounterState, CounterProps>(
+  mapStateToProps: (state) => (BigCounter()..count = state.bigCount),
   context: bigCounterContext,
-)(Counter);
+)(_$Counter);
 
 react_dom.render(
   Dom.div()(
@@ -246,10 +248,10 @@ react_dom.render(
         ..context = bigCounterContext
       )(
         Dom.div()(
-          Dom.h3()('ConnectedBigCounter Store2'),
-          ConnectedBigCounter()(
-            Dom.h4()('ConnectedCounter Store1'),
-            ConnectedCounter()(),
+          Dom.h3()('BigCounter Store2'),
+          BigCounter()(
+            Dom.h4()('Counter Store1'),
+            Counter()(),
           ),
         ),
       ),
@@ -265,10 +267,10 @@ In the case that you need to have multiple stores, here are the steps to do so:
     ```
 1. In the `connect` function wrapping the component, pass in the context instance.
     ```dart
-    UiFactory<BarProps> ConnectedBar = connect<BarState, BarProps>(
+    UiFactory<BarProps> Bar = connect<BarState, BarProps>(
       // ... mapStateToProps
       context: fooContext,
-    )(Bar);
+    )(_$Bar);
     ```
 1. Add an additional `ReduxProvider`, with its `context` prop set to the next Context instance and the `store` prop
 set to your additional store.

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'abstract_inheritance.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $SubComponentFactory = registerComponent2(
   () => _$SubComponent(),
-  builderFactory: Sub,
+  builderFactory: _$Sub,
   componentClass: SubComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'basic.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'basic_library.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicPartOfLibComponentFactory = registerComponent2(
   () => _$BasicPartOfLibComponent(),
-  builderFactory: BasicPartOfLib,
+  builderFactory: _$BasicPartOfLib,
   componentClass: BasicPartOfLibComponent,
   isWrapper: false,
   parentType: null,
@@ -378,7 +378,7 @@ const StateMeta _$metaForBasicPartOfLibStateMixin = StateMeta(
     ' Do not reference it in your code, as it may change at any time.')
 final $SubPartOfLibComponentFactory = registerComponent2(
   () => _$SubPartOfLibComponent(),
-  builderFactory: SubPartOfLib,
+  builderFactory: _$SubPartOfLib,
   componentClass: SubPartOfLibComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'basic_with_state.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'basic_with_type_params.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'generic_inheritance_sub.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $GenericSubComponentFactory = registerComponent2(
   () => _$GenericSubComponent(),
-  builderFactory: GenericSub,
+  builderFactory: _$GenericSub,
   componentClass: GenericSubComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'generic_inheritance_super.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $GenericSuperComponentFactory = registerComponent2(
   () => _$GenericSuperComponent(),
-  builderFactory: GenericSuper,
+  builderFactory: _$GenericSuper,
   componentClass: GenericSuperComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'private_component.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $PrivateComponentFactory = registerComponent2(
   () => _$PrivateComponent(),
-  builderFactory: _Private,
+  builderFactory: _$_Private,
   componentClass: PrivateComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'private_factory_public_component.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $FormActionInputComponentFactory = registerComponent2(
   () => _$FormActionInputComponent(),
-  builderFactory: _FormActionInput,
+  builderFactory: _$_FormActionInput,
   componentClass: FormActionInputComponent,
   isWrapper: false,
   parentType: null,

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'with_legacy_props_mixin.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'my_context_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $MyContextComponentComponentFactory = registerComponent2(
   () => _$MyContextComponentComponent(),
-  builderFactory: MyContextComponent,
+  builderFactory: _$MyContextComponent,
   componentClass: MyContextComponentComponent,
   isWrapper: false,
   parentType: null,

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'my_provider_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $MyProviderComponentComponentFactory = registerComponent2(
   () => _$MyProviderComponentComponent(),
-  builderFactory: MyProviderComponent,
+  builderFactory: _$MyProviderComponent,
   componentClass: MyProviderComponentComponent,
   isWrapper: false,
   parentType: null,

--- a/lib/src/builder/codegen/component_factory_generator.dart
+++ b/lib/src/builder/codegen/component_factory_generator.dart
@@ -73,53 +73,34 @@ class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
           span: getSpan(sourceFile, parentType)));
     }
 
-    if (isComponent2) {
-      outputContentsBuffer
-        ..writeln('// React component factory implementation.')
-        ..writeln('//')
-        ..writeln('// Registers component implementation and links type meta to builder factory.')
-        ..write(internalGeneratedMemberDeprecationLine())
-        ..writeln('final ${componentNames.componentFactoryName}'
-            ' = registerComponent2(() => ${componentNames.implName}(),')
-        // Use the generated factory instead of the user-authored one so we don't trigger
-        // a cyclic initialization error when referencing the component factory during the
-        // user's factory initialization (e.g., when passing the generated factory directly into
-        // HOCs like connect).
-        ..writeln('    builderFactory: ${factoryNames.implName},')
-        ..writeln('    componentClass: ${componentNames.consumerName},')
-        ..writeln('    isWrapper: ${component.meta.isWrapper},')
-        ..writeln('    parentType: $parentTypeParam,$parentTypeParamComment')
-        ..writeln('    displayName: ${stringLiteral(factoryNames.consumerName)},');
+    final registerComponent = isComponent2 ? 'registerComponent2' : 'registerComponent';
 
-      // If isComponent2 is true, we can safely assume the component class has a
-      // `@Component2()` (or no annotation), since other cases would fail validation.
-      if ((component.meta as annotations.Component2).isErrorBoundary) {
-        // Override `skipMethods` as an empty list so that
-        // the `componentDidCatch` and `getDerivedStateFromError`
-        // lifecycle methods are included in the component's JS bindings.
-        outputContentsBuffer.writeln('    skipMethods: const [],');
-      }
+    outputContentsBuffer
+      ..writeln('// React component factory implementation.')
+      ..writeln('//')
+      ..writeln('// Registers component implementation and links type meta to builder factory.')
+      ..write(internalGeneratedMemberDeprecationLine())
+      ..writeln('final ${componentNames.componentFactoryName} = $registerComponent(')
+      ..writeln('  () => ${componentNames.implName}(),')
+      // Use the generated factory instead of the user-authored one so we don't trigger
+      // a cyclic initialization error when referencing the component factory during the
+      // user's factory initialization (e.g., when passing the generated factory directly into
+      // HOCs like connect).
+      ..writeln('  builderFactory: ${factoryNames.implName},')
+      ..writeln('  componentClass: ${componentNames.consumerName},')
+      ..writeln('  isWrapper: ${component.meta.isWrapper},')
+      ..writeln('  parentType: $parentTypeParam,$parentTypeParamComment')
+      ..writeln('  displayName: ${stringLiteral(factoryNames.consumerName)},');
 
-      outputContentsBuffer..writeln(');')..writeln();
-    } else {
-      outputContentsBuffer
-        ..writeln('// React component factory implementation.')
-        ..writeln('//')
-        ..writeln('// Registers component implementation and links type meta to builder factory.')
-        ..write(internalGeneratedMemberDeprecationLine())
-        ..writeln(
-            'final ${componentNames.componentFactoryName} = registerComponent(() => ${componentNames.implName}(),')
-        // Use the generated factory instead of the user-authored one so we don't trigger
-        // a cyclic initialization error when referencing the component factory during the
-        // user's factory initialization (e.g., when passing the generated factory directly into
-        // HOCs like connect).
-        ..writeln('    builderFactory: ${factoryNames.implName},')
-        ..writeln('    componentClass: ${componentNames.consumerName},')
-        ..writeln('    isWrapper: ${component.meta.isWrapper},')
-        ..writeln('    parentType: $parentTypeParam,$parentTypeParamComment')
-        ..writeln('    displayName: ${stringLiteral(factoryNames.consumerName)}')
-        ..writeln(');')
-        ..writeln();
+    // If isComponent2 is true, we can safely assume the component class has a
+    // `@Component2()` (or no annotation), since other cases would fail validation.
+    if (isComponent2 && (component.meta as annotations.Component2).isErrorBoundary) {
+      // Override `skipMethods` as an empty list so that
+      // the `componentDidCatch` and `getDerivedStateFromError`
+      // lifecycle methods are included in the component's JS bindings.
+      outputContentsBuffer.writeln('    skipMethods: const [],');
     }
+
+    outputContentsBuffer..writeln(');')..writeln();
   }
 }

--- a/lib/src/builder/codegen/component_factory_generator.dart
+++ b/lib/src/builder/codegen/component_factory_generator.dart
@@ -25,7 +25,7 @@ import 'util.dart';
 /// for all boilerplate versions.
 class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
   final ComponentNames componentNames;
-  final String factoryName;
+  final FactoryNames factoryNames;
 
   final BoilerplateComponent component;
   final bool isComponent2;
@@ -34,14 +34,14 @@ class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
   final Version version;
 
   ComponentFactoryProxyGenerator.legacy(LegacyClassComponentDeclaration declaration)
-      : factoryName = declaration.factory.name.name,
+      : factoryNames = FactoryNames(declaration.factory.name.name),
         componentNames = ComponentNames(declaration.component.name.name),
         component = declaration.component,
         isComponent2 = declaration.isComponent2,
         version = declaration.version;
 
   ComponentFactoryProxyGenerator(ClassComponentDeclaration declaration)
-      : factoryName = declaration.factory.name.name,
+      : factoryNames = FactoryNames(declaration.factory.name.name),
         componentNames = ComponentNames(declaration.component.name.name),
         component = declaration.component,
         isComponent2 = true,
@@ -81,11 +81,15 @@ class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
         ..write(internalGeneratedMemberDeprecationLine())
         ..writeln('final ${componentNames.componentFactoryName}'
             ' = registerComponent2(() => ${componentNames.implName}(),')
-        ..writeln('    builderFactory: $factoryName,')
+        // Use the generated factory instead of the user-authored one so we don't trigger
+        // a cyclic initialization error when referencing the component factory during the
+        // user's factory initialization (e.g., when passing the generated factory directly into
+        // HOCs like connect).
+        ..writeln('    builderFactory: ${factoryNames.implName},')
         ..writeln('    componentClass: ${componentNames.consumerName},')
         ..writeln('    isWrapper: ${component.meta.isWrapper},')
         ..writeln('    parentType: $parentTypeParam,$parentTypeParamComment')
-        ..writeln('    displayName: ${stringLiteral(factoryName)},');
+        ..writeln('    displayName: ${stringLiteral(factoryNames.consumerName)},');
 
       // If isComponent2 is true, we can safely assume the component class has a
       // `@Component2()` (or no annotation), since other cases would fail validation.
@@ -105,11 +109,15 @@ class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
         ..write(internalGeneratedMemberDeprecationLine())
         ..writeln(
             'final ${componentNames.componentFactoryName} = registerComponent(() => ${componentNames.implName}(),')
-        ..writeln('    builderFactory: $factoryName,')
+        // Use the generated factory instead of the user-authored one so we don't trigger
+        // a cyclic initialization error when referencing the component factory during the
+        // user's factory initialization (e.g., when passing the generated factory directly into
+        // HOCs like connect).
+        ..writeln('    builderFactory: ${factoryNames.implName},')
         ..writeln('    componentClass: ${componentNames.consumerName},')
         ..writeln('    isWrapper: ${component.meta.isWrapper},')
         ..writeln('    parentType: $parentTypeParam,$parentTypeParamComment')
-        ..writeln('    displayName: ${stringLiteral(factoryName)}')
+        ..writeln('    displayName: ${stringLiteral(factoryNames.consumerName)}')
         ..writeln(');')
         ..writeln();
     }

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -46,8 +46,7 @@ class FactoryNames {
   ///
   /// NOTE: The factory name must be public, since sub components will reference
   /// factories from super components.
-  String get implName =>
-      '$_prefix$privateSourcePrefix${unprefixedConsumerName}';
+  String get implName => '$_prefix$privateSourcePrefix${unprefixedConsumerName}';
 }
 
 /// A set of names of the different generated members for a given component class.

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -43,9 +43,6 @@ class FactoryNames {
   ///
   /// - Input: `Foo`
   /// - Output: `_$Foo`
-  ///
-  /// NOTE: The factory name must be public, since sub components will reference
-  /// factories from super components.
   String get implName => '$_prefix$privateSourcePrefix${unprefixedConsumerName}';
 }
 

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -14,6 +14,42 @@
 
 import '../util.dart';
 
+/// A set of names of the different generated members for a given factory variable.
+///
+/// Supports prefixed identifiers (e.g., `foo_library.Foo`).
+class FactoryNames {
+  final String _prefix;
+  final String unprefixedConsumerName;
+
+  factory FactoryNames(String consumerFactory) {
+    final parts = consumerFactory.split('.');
+    if (parts.length == 1) {
+      return FactoryNames._('', consumerFactory);
+    }
+
+    return FactoryNames._('${parts[0]}.', parts.skip(1).join('.'));
+  }
+
+  FactoryNames._(this._prefix, this.unprefixedConsumerName);
+
+  /// The name of the consumer-authored factory variable.
+  ///
+  /// Example: `Foo`
+  String get consumerName => '$_prefix$unprefixedConsumerName';
+
+  /// The name of the generated factory function implementation.
+  ///
+  /// Example:
+  ///
+  /// - Input: `Foo`
+  /// - Output: `_$Foo`
+  ///
+  /// NOTE: The factory name must be public, since sub components will reference
+  /// factories from super components.
+  String get implName =>
+      '$_prefix$privateSourcePrefix${unprefixedConsumerName}';
+}
+
 /// A set of names of the different generated members for a given component class.
 ///
 /// Supports prefixed identifiers (e.g., `foo_library.FooComponent`).

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -46,7 +46,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
 
   TypedMapNames get names;
   bool get isComponent2;
-  String get factoryName;
+  FactoryNames get factoryNames;
   bool get isProps;
 
   BoilerplateTypedMapMember get member;
@@ -70,10 +70,10 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
   void _generateStateImpl();
 
   void _generateFactory() {
-    if (factoryName == null) throw StateError('factoryName must not be null');
+    if (factoryNames == null) throw StateError('factoryNames must not be null');
 
     outputContentsBuffer
-        .write('${names.implName} $privateSourcePrefix$factoryName([Map backingProps]) => ');
+        .write('${names.implName} ${factoryNames.implName}([Map backingProps]) => ');
 
     if (!isComponent2) {
       /// _$$FooProps _$Foo([Map backingProps]) => _$$FooProps(backingProps);
@@ -266,6 +266,9 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
   final TypedMapNames names;
 
   @override
+  final FactoryNames factoryNames;
+
+  @override
   final bool isProps;
 
   final LegacyClassComponentDeclaration declaration;
@@ -275,11 +278,13 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
 
   _LegacyTypedMapImplGenerator.props(this.declaration)
       : names = TypedMapNames(declaration.props.name.name),
+        factoryNames = FactoryNames(declaration.factory.name.name),
         member = declaration.props,
         isProps = true;
 
   _LegacyTypedMapImplGenerator.state(this.declaration)
       : names = TypedMapNames(declaration.state.name.name),
+        factoryNames = FactoryNames(declaration.factory.name.name),
         member = declaration.state,
         isProps = false;
 
@@ -288,9 +293,6 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
 
   @override
   bool get isComponent2 => declaration.isComponent2;
-
-  @override
-  String get factoryName => declaration.factory.name.name;
 
   @override
   void _generatePropsImpl() {
@@ -327,13 +329,13 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
   final TypedMapNames names;
 
   @override
+  final FactoryNames factoryNames;
+
+  @override
   final bool isProps;
 
   @override
   final BoilerplateTypedMapMember member;
-
-  @override
-  final String factoryName;
 
   final String componentFactoryName;
 
@@ -342,26 +344,26 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
 
   _TypedMapImplGenerator.props(ClassComponentDeclaration declaration)
       : names = TypedMapNames(declaration.props.either.name.name),
+        factoryNames = FactoryNames(declaration.factory.name.name),
         member = declaration.props.either,
         isProps = true,
-        factoryName = declaration.factory.name.name,
         componentFactoryName = ComponentNames(declaration.component.name.name).componentFactoryName,
         version = declaration.version;
 
   _TypedMapImplGenerator.state(ClassComponentDeclaration declaration)
       : names = TypedMapNames(declaration.state.either.name.name),
+        factoryNames = FactoryNames(declaration.factory.name.name),
         member = declaration.state.either,
         isProps = false,
-        factoryName = declaration.factory.name.name,
         componentFactoryName = ComponentNames(declaration.component.name.name).componentFactoryName,
         version = declaration.version;
 
   _TypedMapImplGenerator.propsMapViewOrFunctionComponent(
       PropsMapViewOrFunctionComponentDeclaration declaration)
       : names = TypedMapNames(declaration.props.either.name.name),
+        factoryNames = FactoryNames(declaration.factory.name.name),
         member = declaration.props.either,
         isProps = true,
-        factoryName = declaration.factory.name.name,
         componentFactoryName = 'null',
         version = declaration.version;
 

--- a/lib/src/component/dummy_component2.over_react.g.dart
+++ b/lib/src/component/dummy_component2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'dummy_component2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $_Dummy2ComponentFactory = registerComponent2(
   () => _$_Dummy2Component(),
-  builderFactory: _Dummy2,
+  builderFactory: _$_Dummy2,
   componentClass: _Dummy2Component,
   isWrapper: false,
   parentType: null,

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'error_boundary.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ErrorBoundaryComponentFactory = registerComponent2(
   () => _$ErrorBoundaryComponent(),
-  builderFactory: ErrorBoundary,
+  builderFactory: _$ErrorBoundary,
   componentClass: ErrorBoundaryComponent,
   isWrapper: true,
   parentType: null,

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'error_boundary_recoverable.dart';
 // Registers component implementation and links type meta to builder factory.
 final $RecoverableErrorBoundaryComponentFactory = registerComponent2(
   () => _$RecoverableErrorBoundaryComponent(),
-  builderFactory: RecoverableErrorBoundary,
+  builderFactory: _$RecoverableErrorBoundary,
   componentClass: RecoverableErrorBoundaryComponent,
   isWrapper: true,
   parentType: null,

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'resize_sensor.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ResizeSensorComponentFactory = registerComponent2(
   () => _$ResizeSensorComponent(),
-  builderFactory: ResizeSensor,
+  builderFactory: _$ResizeSensor,
   componentClass: ResizeSensorComponent,
   isWrapper: false,
   parentType: null,

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -309,16 +309,16 @@ bool _shallowMapEquality(Map a, Map b) => const MapEquality().equals(a, b);
 ///
 /// __Example:__
 /// ```dart
-/// UiFactory<CounterProps> ConnectedCounter = connectFlux<FluxStore, FluxActions, CounterProps>(
+/// UiFactory<CounterProps> Counter = connectFlux<FluxStore, FluxActions, CounterProps>(
 ///     mapStateToProps: (state) => (
 ///       Counter()..count = state.count
 ///     ),
 ///     mapActionsToProps: (actions) => (
 ///       Counter()..increment = actions.incrementAction
 ///     ),
-/// )(Counter);
+/// )(_$Counter);
 ///
-/// // A standard `Counter` component implementation would also be in this file.
+/// // The `Counter` component implementation would also be in this file.
 /// ```
 ///
 /// - [mapStateToProps] is used for selecting the part of the data from the store that the connected
@@ -359,14 +359,16 @@ bool _shallowMapEquality(Map a, Map b) => const MapEquality().equals(a, b);
 /// Store store1 = Store<CounterState>(counterStateReducer, initialState: CounterState(count: 0));
 /// Store store2 = Store<BigCounterState>(bigCounterStateReducer, initialState: BigCounterState(bigCount: 100));
 ///
-/// UiFactory<CounterProps> ConnectedCounter = connectFlux<SmallCounterFluxStore, FluxActions, CounterProps>(
+/// UiFactory<CounterProps> Counter = connectFlux<SmallCounterFluxStore, FluxActions, CounterProps>(
 ///   mapStateToProps: (state) => (Counter()..count = state.count)
-/// )(Counter);
+/// )(_$Counter);
 ///
-/// UiFactory<CounterProps> ConnectedBigCounter = connect<BigCounterFluxStore, FluxActions, CounterProps>(
+/// UiFactory<CounterProps> BigCounter = connect<BigCounterFluxStore, FluxActions, CounterProps>(
 ///   mapStateToProps: (state) => (Counter()..count = state.bigCount),
 ///   context: bigCounterContext,
-/// )(Counter);
+/// )(_$Counter);
+///
+///
 ///
 /// react_dom.render(
 ///   Dom.div()(
@@ -376,10 +378,10 @@ bool _shallowMapEquality(Map a, Map b) => const MapEquality().equals(a, b);
 ///         ..context = bigCounterContext
 ///       )(
 ///         Dom.div()(
-///           Dom.h3()('ConnectedBigCounter Store2'),
-///           ConnectedBigCounter()(
-///             Dom.h4()('ConnectedCounter Store1'),
-///             ConnectedCounter()(),
+///           Dom.h3()('BigCounter Store2'),
+///           BigCounter()(
+///             Dom.h4()('Counter Store1'),
+///             Counter()(),
 ///           ),
 ///         ),
 ///       ),

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -368,8 +368,6 @@ bool _shallowMapEquality(Map a, Map b) => const MapEquality().equals(a, b);
 ///   context: bigCounterContext,
 /// )(_$Counter);
 ///
-///
-///
 /// react_dom.render(
 ///   Dom.div()(
 ///     (ReduxProvider()..store = store1)(

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -60,14 +60,14 @@ typedef dynamic Dispatcher(dynamic action);
 ///
 /// __Example:__
 /// ```dart
-///     UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
-///       mapStateToProps: (state) => (Counter()
-///         ..count = state.count
-///       ),
-///       mapDispatchToProps: (dispatch) => (Counter()
-///         ..increment = (() => dispatch(INCREMENT_ACTION()))
-///       ),
-///     )(_$Counter);
+/// UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
+///   mapStateToProps: (state) => (Counter()
+///     ..count = state.count
+///   ),
+///   mapDispatchToProps: (dispatch) => (Counter()
+///     ..increment = (() => dispatch(INCREMENT_ACTION()))
+///   ),
+/// )(_$Counter);
 /// ```
 ///
 /// - [mapStateToProps] is used for selecting the part of the data from the store that the connected
@@ -101,8 +101,8 @@ typedef dynamic Dispatcher(dynamic action);
 ///
 /// __Example:__
 /// ```dart
-///     Store store1 = new Store<CounterState>(counterStateReducer, initialState: new CounterState(count: 0));
-///     Store store2 = new Store<BigCounterState>(bigCounterStateReducer, initialState: new BigCounterState(bigCount: 100));
+///     Store store1 = Store<CounterState>(counterStateReducer, initialState: new CounterState(count: 0));
+///     Store store2 = Store<BigCounterState>(bigCounterStateReducer, initialState: new BigCounterState(bigCount: 100));
 ///
 ///     UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
 ///       mapStateToProps: (state) => (Counter()..count = state.count)

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -60,14 +60,14 @@ typedef dynamic Dispatcher(dynamic action);
 ///
 /// __Example:__
 /// ```dart
-///     UiFactory<CounterProps> ConnectedCounter = connect<CounterState, CounterProps>(
-///         mapStateToProps: (state) => (
-///           Counter()..count = state.count
-///         ),
-///         mapDispatchToProps: (dispatch) => (
-///           Counter()..increment = () => dispatch(INCREMENT_ACTION())
-///         ),
-///     )(Counter);
+///     UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
+///       mapStateToProps: (state) => (Counter()
+///         ..count = state.count
+///       ),
+///       mapDispatchToProps: (dispatch) => (Counter()
+///         ..increment = (() => dispatch(INCREMENT_ACTION()))
+///       ),
+///     )(_$Counter);
 /// ```
 ///
 /// - [mapStateToProps] is used for selecting the part of the data from the store that the connected
@@ -104,14 +104,14 @@ typedef dynamic Dispatcher(dynamic action);
 ///     Store store1 = new Store<CounterState>(counterStateReducer, initialState: new CounterState(count: 0));
 ///     Store store2 = new Store<BigCounterState>(bigCounterStateReducer, initialState: new BigCounterState(bigCount: 100));
 ///
-///     UiFactory<CounterProps> ConnectedCounter = connect<CounterState, CounterProps>(
+///     UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
 ///       mapStateToProps: (state) => (Counter()..count = state.count)
-///     )(Counter);
+///     )(_$Counter);
 ///
-///     UiFactory<CounterProps> ConnectedBigCounter = connect<BigCounterState, CounterProps>(
-///       mapStateToProps: (state) => (Counter()..count = state.bigCount),
+///     UiFactory<CounterProps> BigCounter = connect<BigCounterState, CounterProps>(
+///       mapStateToProps: (state) => (BigCounter()..count = state.bigCount),
 ///       context: bigCounterContext,
-///     )(Counter);
+///     )(_$Counter);
 ///
 ///     react_dom.render(
 ///       Dom.div()(
@@ -121,10 +121,10 @@ typedef dynamic Dispatcher(dynamic action);
 ///             ..context = bigCounterContext
 ///           )(
 ///             Dom.div()(
-///               Dom.h3()('ConnectedBigCounter Store2'),
-///               ConnectedBigCounter()(
-///                 Dom.h4()('ConnectedCounter Store1'),
-///                 ConnectedCounter()(),
+///               Dom.h3()('BigCounter Store2'),
+///               BigCounter()(
+///                 Dom.h4()('Counter Store1'),
+///                 Counter()(),
 ///               ),
 ///             ),
 ///           ),

--- a/lib/src/over_react_redux/redux_multi_provider.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.dart
@@ -24,9 +24,9 @@ part 'redux_multi_provider.over_react.g.dart';
 ///     )(
 ///       // Note that when being wrapped with `connect`, these components can
 ///       // each reference a context included in `storesByContext`.
-///       ConnectedConnectFluxBigBlock()(),
-///       ConnectedReduxBigBlock()(),
-///       ConnectedShouldNotUpdate()(),
+///       ConnectFluxBigBlock()(),
+///       ReduxBigBlock()(),
+///       ShouldNotUpdate()(),
 ///     ),
 ///     querySelector('#content'));
 /// ```

--- a/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'redux_multi_provider.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ReduxMultiProviderComponentFactory = registerComponent2(
   () => _$ReduxMultiProviderComponent(),
-  builderFactory: ReduxMultiProvider,
+  builderFactory: _$ReduxMultiProvider,
   componentClass: ReduxMultiProviderComponent,
   isWrapper: false,
   parentType: null,

--- a/lib/src/util/hoc.dart
+++ b/lib/src/util/hoc.dart
@@ -10,26 +10,26 @@
 /// __EXAMPLE:__
 /// ```dart
 /// // Without composeHocs:
-/// UiFactory<ComponentProps> ConnectedReduxBigBlock = connect<RandomColorStore, ReduxBigBlockProps>(
+/// UiFactory<BigBlockProps> BigBlock = connect<RandomColorStore, BigBlockProps>(
 ///   // `connect` implementation
-/// )(connect<LowLevelStore, ReduxBigBlockProps>(
+/// )(connect<LowLevelStore, BigBlockProps>(
 ///   // `connect` implementation
-/// )(connect<AnotherColorStore, ReduxBigBlockProps>(
+/// )(connect<AnotherColorStore, BigBlockProps>(
 ///   // `connect` implementation
-/// )(Component)));
+/// )(_$BigBlock)));
 ///
 /// // With composeHocs:
-/// UiFactory<ComponentProps> ConnectedReduxBigBlock = composeHocs([
-///   connect<RandomColorStore, ReduxBigBlockProps>(
+/// UiFactory<BigBlockProps> BigBlock = composeHocs([
+///   connect<RandomColorStore, BigBlockProps>(
 ///     // `connect` implementation
 ///   ),
-///   connect<LowLevelStore, ReduxBigBlockProps>(
+///   connect<LowLevelStore, BigBlockProps>(
 ///     // `connect` implementation
 ///   ),
-///   connect<AnotherColorStore, ReduxBigBlockProps>(
+///   connect<AnotherColorStore, BigBlockProps>(
 ///     // `connect` implementation
 ///   ),
-/// ])(Component);
+/// ])(_$BigBlock);
 /// ```
 R Function(A) composeHocs<R, A extends R>(Iterable<R Function(A)> functions) {
   return functions.reduce((a, b) => (result) => a(b(result)));

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'safe_render_manager_helper.dart';
 // Registers component implementation and links type meta to builder factory.
 final $SafeRenderManagerHelperComponentFactory = registerComponent2(
   () => _$SafeRenderManagerHelperComponent(),
-  builderFactory: SafeRenderManagerHelper,
+  builderFactory: _$SafeRenderManagerHelper,
   componentClass: SafeRenderManagerHelperComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/abstract_transition2_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition2_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'abstract_transition2_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TransitionerComponentFactory = registerComponent2(
   () => _$TransitionerComponent(),
-  builderFactory: Transitioner,
+  builderFactory: _$Transitioner,
   componentClass: TransitionerComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'abstract_transition_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TransitionerComponentFactory = registerComponent(
-    () => _$TransitionerComponent(),
-    builderFactory: Transitioner,
-    componentClass: TransitionerComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Transitioner');
+  () => _$TransitionerComponent(),
+  builderFactory: _$Transitioner,
+  componentClass: TransitionerComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Transitioner',
+);
 
 abstract class _$TransitionerPropsAccessorsMixin
     implements _$TransitionerProps {

--- a/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'basic_child_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BasicChildComponentFactory = registerComponent2(
   () => _$BasicChildComponent(),
-  builderFactory: BasicChild,
+  builderFactory: _$BasicChild,
   componentClass: BasicChildComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'basic_ui_component.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $BasicUiComponentComponentFactory = registerComponent(
-    () => _$BasicUiComponentComponent(),
-    builderFactory: BasicUiComponent,
-    componentClass: BasicUiComponentComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'BasicUiComponent');
+  () => _$BasicUiComponentComponent(),
+  builderFactory: _$BasicUiComponent,
+  componentClass: BasicUiComponentComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'BasicUiComponent',
+);
 
 abstract class _$BasicUiComponentPropsAccessorsMixin
     implements _$BasicUiComponentProps {

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'context_provider_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ContextProviderWrapperComponentFactory = registerComponent2(
   () => _$ContextProviderWrapperComponent(),
-  builderFactory: ContextProviderWrapper,
+  builderFactory: _$ContextProviderWrapper,
   componentClass: ContextProviderWrapperComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/context_type_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_type_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'context_type_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ContextTypeComponentFactory = registerComponent2(
   () => _$ContextTypeComponent(),
-  builderFactory: ContextType,
+  builderFactory: _$ContextType,
   componentClass: ContextTypeComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/custom_error_boundary_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/custom_error_boundary_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'custom_error_boundary_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CustomErrorBoundaryComponentFactory = registerComponent2(
   () => _$CustomErrorBoundaryComponent(),
-  builderFactory: CustomErrorBoundary,
+  builderFactory: _$CustomErrorBoundary,
   componentClass: CustomErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'dummy_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $DummyComponentFactory = registerComponent2(
   () => _$DummyComponent(),
-  builderFactory: Dummy,
+  builderFactory: _$Dummy,
   componentClass: DummyComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flawed_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FlawedComponentFactory = registerComponent2(
   () => _$FlawedComponent(),
-  builderFactory: Flawed,
+  builderFactory: _$Flawed,
   componentClass: FlawedComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flawed_component_on_mount.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FlawedOnMountComponentFactory = registerComponent2(
   () => _$FlawedOnMountComponent(),
-  builderFactory: FlawedOnMount,
+  builderFactory: _$FlawedOnMount,
   componentClass: FlawedOnMountComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flawed_component_that_renders_a_string.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FlawedWithStringChildComponentFactory = registerComponent2(
   () => _$FlawedWithStringChildComponent(),
-  builderFactory: FlawedWithStringChild,
+  builderFactory: _$FlawedWithStringChild,
   componentClass: FlawedWithStringChildComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flawed_component_that_renders_nothing.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FlawedWithNoChildComponentFactory = registerComponent2(
   () => _$FlawedWithNoChildComponent(),
-  builderFactory: FlawedWithNoChild,
+  builderFactory: _$FlawedWithNoChild,
   componentClass: FlawedWithNoChildComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
@@ -152,7 +152,7 @@ abstract class TestAbstractCustomRendererComponentState
 final $TestConsumingAbstractCustomRendererComponentComponentFactory =
     registerComponent2(
   () => _$TestConsumingAbstractCustomRendererComponentComponent(),
-  builderFactory: TestConsumingAbstractCustomRendererComponent,
+  builderFactory: _$TestConsumingAbstractCustomRendererComponent,
   componentClass: TestConsumingAbstractCustomRendererComponentComponent,
   isWrapper: false,
   parentType: null,
@@ -361,7 +361,7 @@ class _$TestConsumingAbstractCustomRendererComponentComponent
 final $TestConsumingCustomRendererComponentComponentFactory =
     registerComponent2(
   () => _$TestConsumingCustomRendererComponentComponent(),
-  builderFactory: TestConsumingCustomRendererComponent,
+  builderFactory: _$TestConsumingCustomRendererComponent,
   componentClass: TestConsumingCustomRendererComponentComponent,
   isWrapper: false,
   parentType: null,
@@ -560,7 +560,7 @@ class _$TestConsumingCustomRendererComponentComponent
 final $TestCustomRendererFromAbstractComponentComponentFactory =
     registerComponent2(
   () => _$TestCustomRendererFromAbstractComponentComponent(),
-  builderFactory: TestCustomRendererFromAbstractComponent,
+  builderFactory: _$TestCustomRendererFromAbstractComponent,
   componentClass: TestCustomRendererFromAbstractComponentComponent,
   isWrapper: false,
   parentType: null,
@@ -848,7 +848,7 @@ class _$TestCustomRendererFromAbstractComponentComponent
 // Registers component implementation and links type meta to builder factory.
 final $TestCustomRendererComponentComponentFactory = registerComponent2(
   () => _$TestCustomRendererComponentComponent(),
-  builderFactory: TestCustomRendererComponent,
+  builderFactory: _$TestCustomRendererComponent,
   componentClass: TestCustomRendererComponentComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/forward_ref_test.over_react.g.dart
+++ b/test/over_react/component/forward_ref_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'forward_ref_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component/typed_factory_test.over_react.g.dart
+++ b/test/over_react/component/typed_factory_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'typed_factory_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TypedFactoryTesterComponentFactory = registerComponent2(
   () => _$TypedFactoryTesterComponent(),
-  builderFactory: TypedFactoryTester,
+  builderFactory: _$TypedFactoryTester,
   componentClass: TypedFactoryTesterComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'component_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'constant_required_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'do_not_generate_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $DoNotGenerateAccessorTestComponentFactory = registerComponent(
-    () => _$DoNotGenerateAccessorTestComponent(),
-    builderFactory: DoNotGenerateAccessorTest,
-    componentClass: DoNotGenerateAccessorTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'DoNotGenerateAccessorTest');
+  () => _$DoNotGenerateAccessorTestComponent(),
+  builderFactory: _$DoNotGenerateAccessorTest,
+  componentClass: DoNotGenerateAccessorTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'DoNotGenerateAccessorTest',
+);
 
 abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
     implements _$DoNotGenerateAccessorTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'namespaced_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $NamespacedAccessorTestComponentFactory = registerComponent(
-    () => _$NamespacedAccessorTestComponent(),
-    builderFactory: NamespacedAccessorTest,
-    componentClass: NamespacedAccessorTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'NamespacedAccessorTest');
+  () => _$NamespacedAccessorTestComponent(),
+  builderFactory: _$NamespacedAccessorTest,
+  componentClass: NamespacedAccessorTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'NamespacedAccessorTest',
+);
 
 abstract class _$NamespacedAccessorTestPropsAccessorsMixin
     implements _$NamespacedAccessorTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'private_props_ddc_bug.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $FooComponentFactory = registerComponent(() => _$FooComponent(),
-    builderFactory: Foo,
-    componentClass: FooComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Foo');
+final $FooComponentFactory = registerComponent(
+  () => _$FooComponent(),
+  builderFactory: _$Foo,
+  componentClass: FooComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Foo',
+);
 
 abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'required_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'stateful_component_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $StatefulComponentTestComponentFactory = registerComponent(
-    () => _$StatefulComponentTestComponent(),
-    builderFactory: StatefulComponentTest,
-    componentClass: StatefulComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'StatefulComponentTest');
+  () => _$StatefulComponentTestComponent(),
+  builderFactory: _$StatefulComponentTest,
+  componentClass: StatefulComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'StatefulComponentTest',
+);
 
 abstract class _$StatefulComponentTestPropsAccessorsMixin
     implements _$StatefulComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'unassigned_prop_integration_test.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $FooComponentFactory = registerComponent(() => _$FooComponent(),
-    builderFactory: Foo,
-    componentClass: FooComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Foo');
+final $FooComponentFactory = registerComponent(
+  () => _$FooComponent(),
+  builderFactory: _$Foo,
+  componentClass: FooComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Foo',
+);
 
 abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'annotation_error_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $AnnotationErrorDefaultPropsComponentFactory = registerComponent(
-    () => _$AnnotationErrorDefaultPropsComponent(),
-    builderFactory: AnnotationErrorDefaultProps,
-    componentClass: AnnotationErrorDefaultPropsComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'AnnotationErrorDefaultProps');
+  () => _$AnnotationErrorDefaultPropsComponent(),
+  builderFactory: _$AnnotationErrorDefaultProps,
+  componentClass: AnnotationErrorDefaultPropsComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'AnnotationErrorDefaultProps',
+);
 
 abstract class _$AnnotationErrorDefaultPropsPropsAccessorsMixin
     implements _$AnnotationErrorDefaultPropsProps {
@@ -102,12 +103,13 @@ class _$AnnotationErrorDefaultPropsComponent
 //
 // Registers component implementation and links type meta to builder factory.
 final $AnnotationErrorComponentFactory = registerComponent(
-    () => _$AnnotationErrorComponent(),
-    builderFactory: AnnotationError,
-    componentClass: AnnotationErrorComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'AnnotationError');
+  () => _$AnnotationErrorComponent(),
+  builderFactory: _$AnnotationError,
+  componentClass: AnnotationErrorComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'AnnotationError',
+);
 
 abstract class _$AnnotationErrorPropsAccessorsMixin
     implements _$AnnotationErrorProps {
@@ -189,12 +191,13 @@ class _$AnnotationErrorComponent extends AnnotationErrorComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $AnnotationErrorStatefulComponentFactory = registerComponent(
-    () => _$AnnotationErrorStatefulComponent(),
-    builderFactory: AnnotationErrorStateful,
-    componentClass: AnnotationErrorStatefulComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'AnnotationErrorStateful');
+  () => _$AnnotationErrorStatefulComponent(),
+  builderFactory: _$AnnotationErrorStateful,
+  componentClass: AnnotationErrorStatefulComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'AnnotationErrorStateful',
+);
 
 abstract class _$AnnotationErrorStatefulPropsAccessorsMixin
     implements _$AnnotationErrorStatefulProps {
@@ -324,12 +327,13 @@ class _$AnnotationErrorStatefulComponent
 //
 // Registers component implementation and links type meta to builder factory.
 final $AnnotationErrorStatefulDefaultPropsComponentFactory = registerComponent(
-    () => _$AnnotationErrorStatefulDefaultPropsComponent(),
-    builderFactory: AnnotationErrorStatefulDefaultProps,
-    componentClass: AnnotationErrorStatefulDefaultPropsComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'AnnotationErrorStatefulDefaultProps');
+  () => _$AnnotationErrorStatefulDefaultPropsComponent(),
+  builderFactory: _$AnnotationErrorStatefulDefaultProps,
+  componentClass: AnnotationErrorStatefulDefaultPropsComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'AnnotationErrorStatefulDefaultProps',
+);
 
 abstract class _$AnnotationErrorStatefulDefaultPropsPropsAccessorsMixin
     implements _$AnnotationErrorStatefulDefaultPropsProps {

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'component_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,
@@ -294,7 +294,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
 // Registers component implementation and links type meta to builder factory.
 final $IsErrorBoundaryComponentFactory = registerComponent2(
   () => _$IsErrorBoundaryComponent(),
-  builderFactory: IsErrorBoundary,
+  builderFactory: _$IsErrorBoundary,
   componentClass: IsErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,
@@ -439,7 +439,7 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
 // Registers component implementation and links type meta to builder factory.
 final $IsNotErrorBoundaryComponentFactory = registerComponent2(
   () => _$IsNotErrorBoundaryComponent(),
-  builderFactory: IsNotErrorBoundary,
+  builderFactory: _$IsNotErrorBoundary,
   componentClass: IsNotErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'constant_required_accessor_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'do_not_generate_accessor_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $DoNotGenerateAccessorTestComponentFactory = registerComponent2(
   () => _$DoNotGenerateAccessorTestComponent(),
-  builderFactory: DoNotGenerateAccessorTest,
+  builderFactory: _$DoNotGenerateAccessorTest,
   componentClass: DoNotGenerateAccessorTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'namespaced_accessor_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $NamespacedAccessorTestComponentFactory = registerComponent2(
   () => _$NamespacedAccessorTestComponent(),
-  builderFactory: NamespacedAccessorTest,
+  builderFactory: _$NamespacedAccessorTest,
   componentClass: NamespacedAccessorTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'private_props_ddc_bug.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FooComponentFactory = registerComponent2(
   () => _$FooComponent(),
-  builderFactory: Foo,
+  builderFactory: _$Foo,
   componentClass: FooComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'required_accessor_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'stateful_component_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $StatefulComponentTestComponentFactory = registerComponent2(
   () => _$StatefulComponentTestComponent(),
-  builderFactory: StatefulComponentTest,
+  builderFactory: _$StatefulComponentTest,
   componentClass: StatefulComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'unassigned_prop_integration_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FooComponentFactory = registerComponent2(
   () => _$FooComponent(),
-  builderFactory: Foo,
+  builderFactory: _$Foo,
   componentClass: FooComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'component_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'constant_required_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'do_not_generate_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $DoNotGenerateAccessorTestComponentFactory = registerComponent(
-    () => _$DoNotGenerateAccessorTestComponent(),
-    builderFactory: DoNotGenerateAccessorTest,
-    componentClass: DoNotGenerateAccessorTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'DoNotGenerateAccessorTest');
+  () => _$DoNotGenerateAccessorTestComponent(),
+  builderFactory: _$DoNotGenerateAccessorTest,
+  componentClass: DoNotGenerateAccessorTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'DoNotGenerateAccessorTest',
+);
 
 abstract class _$DoNotGenerateAccessorTestPropsAccessorsMixin
     implements _$DoNotGenerateAccessorTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'namespaced_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $NamespacedAccessorTestComponentFactory = registerComponent(
-    () => _$NamespacedAccessorTestComponent(),
-    builderFactory: NamespacedAccessorTest,
-    componentClass: NamespacedAccessorTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'NamespacedAccessorTest');
+  () => _$NamespacedAccessorTestComponent(),
+  builderFactory: _$NamespacedAccessorTest,
+  componentClass: NamespacedAccessorTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'NamespacedAccessorTest',
+);
 
 abstract class _$NamespacedAccessorTestPropsAccessorsMixin
     implements _$NamespacedAccessorTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'package:over_react/over_react.dart';
+import 'package:over_react/over_react_redux.dart';
+import 'package:over_react_test/over_react_test.dart';
+import 'package:redux/redux.dart';
+import 'package:test/test.dart';
+
+part 'compact_hoc_syntax_integration_test.over_react.g.dart';
+
+main() {
+  group('Compact HOC syntax, with generated factory used in factory initializer:', () {
+    test('variable initializes correctly', () {
+      expect(() => Foo, returnsNormally);
+      expect(Foo, isNotNull);
+    });
+
+    test('component renders normally, and reading/writing props works', () {
+      TestJacket<FooComponent> jacket;
+      expect(() {
+        jacket = mount(
+          (ReduxProvider()..store = Store((_, __) => null))(
+            (Foo()..foo = 'bar')(),
+          ),
+        );
+      }, returnsNormally);
+      expect(jacket.mountNode.text, contains('bar'));
+    });
+  });
+}
+
+UiFactory<FooProps> Foo = connect<Null, FooProps>(
+  mapStateToPropsWithOwnProps: (state, props) => Foo(),
+  mapDispatchToPropsWithOwnProps: (state, props) => Foo(),
+)(_$Foo); // ignore: undefined_identifier
+
+mixin FooProps on UiProps {
+  String foo;
+}
+
+class FooComponent extends UiComponent2<FooProps> {
+  @override
+  render() => props.foo;
+}

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'compact_hoc_syntax_integration_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $FooComponentFactory = registerComponent2(
+  () => _$FooComponent(),
+  builderFactory: _$Foo,
+  componentClass: FooComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Foo',
+);
+
+_$$FooProps _$Foo([Map backingProps]) => backingProps == null
+    ? _$$FooProps$JsMap(JsBackedMap())
+    : _$$FooProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$FooProps extends UiProps
+    with
+        FooProps,
+        $FooProps // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of FooProps.
+{
+  _$$FooProps._();
+
+  factory _$$FooProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$FooProps$JsMap(backingMap);
+    } else {
+      return _$$FooProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $FooComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$FooProps$PlainMap extends _$$FooProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FooProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$FooProps$JsMap extends _$$FooProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FooProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$FooComponent extends FooComponent {
+  _$$FooProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$FooProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$FooProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$FooProps$JsMap(backingMap);
+
+  @override
+  _$$FooProps typedPropsFactory(Map backingMap) => _$$FooProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from FooProps.
+  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  @override
+  List<ConsumedProps> get $defaultConsumedProps =>
+      [propsMeta.forMixin(FooProps)];
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of FooProps.
+        FooProps: $FooProps.meta,
+      });
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $FooProps on FooProps {
+  static const PropsMeta meta = _$metaForFooProps;
+  @override
+  String get foo =>
+      props[_$key__foo__FooProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set foo(String value) => props[_$key__foo__FooProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__foo__FooProps =
+      PropDescriptor(_$key__foo__FooProps);
+  static const String _$key__foo__FooProps = 'FooProps.foo';
+
+  static const List<PropDescriptor> $props = [_$prop__foo__FooProps];
+  static const List<String> $propKeys = [_$key__foo__FooProps];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForFooProps = PropsMeta(
+  fields: $FooProps.$props,
+  keys: $FooProps.$propKeys,
+);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'component_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,
@@ -287,7 +287,7 @@ const PropsMeta _$metaForComponentTestProps = PropsMeta(
     ' Do not reference it in your code, as it may change at any time.')
 final $IsErrorBoundaryComponentFactory = registerComponent2(
   () => _$IsErrorBoundaryComponent(),
-  builderFactory: IsErrorBoundary,
+  builderFactory: _$IsErrorBoundary,
   componentClass: IsErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,
@@ -447,7 +447,7 @@ const PropsMeta _$metaForIsErrorBoundaryProps = PropsMeta(
     ' Do not reference it in your code, as it may change at any time.')
 final $IsNotErrorBoundaryComponentFactory = registerComponent2(
   () => _$IsNotErrorBoundaryComponent(),
-  builderFactory: IsNotErrorBoundary,
+  builderFactory: _$IsNotErrorBoundary,
   componentClass: IsNotErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'component_integration_verbose_syntax_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'constant_required_accessor_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'do_not_generate_accessor_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $DoNotGenerateAccessorTestComponentFactory = registerComponent2(
   () => _$DoNotGenerateAccessorTestComponent(),
-  builderFactory: DoNotGenerateAccessorTest,
+  builderFactory: _$DoNotGenerateAccessorTest,
   componentClass: DoNotGenerateAccessorTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'namespaced_accessor_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $NamespacedAccessorTestComponentFactory = registerComponent2(
   () => _$NamespacedAccessorTestComponent(),
-  builderFactory: NamespacedAccessorTest,
+  builderFactory: _$NamespacedAccessorTest,
   componentClass: NamespacedAccessorTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'private_props_ddc_bug.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $FooComponentFactory = registerComponent2(
   () => _$FooComponent(),
-  builderFactory: Foo,
+  builderFactory: _$Foo,
   componentClass: FooComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'props_meta_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $TestComponentFactory = registerComponent2(
   () => _$TestComponent(),
-  builderFactory: Test,
+  builderFactory: _$Test,
   componentClass: TestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'required_accessor_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $ComponentTestComponentFactory = registerComponent2(
   () => _$ComponentTestComponent(),
-  builderFactory: ComponentTest,
+  builderFactory: _$ComponentTest,
   componentClass: ComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'stateful_component_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $StatefulComponentTestComponentFactory = registerComponent2(
   () => _$StatefulComponentTestComponent(),
-  builderFactory: StatefulComponentTest,
+  builderFactory: _$StatefulComponentTest,
   componentClass: StatefulComponentTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -14,7 +14,7 @@ part of 'unassigned_prop_integration_test.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $FooComponentFactory = registerComponent2(
   () => _$FooComponent(),
-  builderFactory: Foo,
+  builderFactory: _$Foo,
   componentClass: FooComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'private_props_ddc_bug.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $FooComponentFactory = registerComponent(() => _$FooComponent(),
-    builderFactory: Foo,
-    componentClass: FooComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Foo');
+final $FooComponentFactory = registerComponent(
+  () => _$FooComponent(),
+  builderFactory: _$Foo,
+  componentClass: FooComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Foo',
+);
 
 abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'required_accessor_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ComponentTestComponentFactory = registerComponent(
-    () => _$ComponentTestComponent(),
-    builderFactory: ComponentTest,
-    componentClass: ComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ComponentTest');
+  () => _$ComponentTestComponent(),
+  builderFactory: _$ComponentTest,
+  componentClass: ComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ComponentTest',
+);
 
 abstract class _$ComponentTestPropsAccessorsMixin
     implements _$ComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'stateful_component_integration_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $StatefulComponentTestComponentFactory = registerComponent(
-    () => _$StatefulComponentTestComponent(),
-    builderFactory: StatefulComponentTest,
-    componentClass: StatefulComponentTestComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'StatefulComponentTest');
+  () => _$StatefulComponentTestComponent(),
+  builderFactory: _$StatefulComponentTest,
+  componentClass: StatefulComponentTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'StatefulComponentTest',
+);
 
 abstract class _$StatefulComponentTestPropsAccessorsMixin
     implements _$StatefulComponentTestProps {

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'unassigned_prop_integration_test.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $FooComponentFactory = registerComponent(() => _$FooComponent(),
-    builderFactory: Foo,
-    componentClass: FooComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Foo');
+final $FooComponentFactory = registerComponent(
+  () => _$FooComponent(),
+  builderFactory: _$Foo,
+  componentClass: FooComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Foo',
+);
 
 abstract class _$FooPropsAccessorsMixin implements _$FooProps {
   @override

--- a/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'test_a2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestA2ComponentFactory = registerComponent2(
   () => _$TestA2Component(),
-  builderFactory: TestA2,
+  builderFactory: _$TestA2,
   componentClass: TestA2Component,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'test_b2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestB2ComponentFactory = registerComponent2(
   () => _$TestB2Component(),
-  builderFactory: TestB2,
+  builderFactory: _$TestB2,
   componentClass: TestB2Component,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'extendedtype2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestExtendtype2ComponentFactory = registerComponent2(
   () => _$TestExtendtype2Component(),
-  builderFactory: TestExtendtype2,
+  builderFactory: _$TestExtendtype2,
   componentClass: TestExtendtype2Component,
   isWrapper: false,
   parentType: $TestAbstract2ComponentFactory,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'parent2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestParent2ComponentFactory = registerComponent2(
   () => _$TestParent2Component(),
-  builderFactory: TestParent2,
+  builderFactory: _$TestParent2,
   componentClass: TestParent2Component,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'subsubtype2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestSubsubtype2ComponentFactory = registerComponent2(
   () => _$TestSubsubtype2Component(),
-  builderFactory: TestSubsubtype2,
+  builderFactory: _$TestSubsubtype2,
   componentClass: TestSubsubtype2Component,
   isWrapper: false,
   parentType: $TestSubtype2ComponentFactory,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'subsubtype_of_component1.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestSubsubtypeOfComponent1ComponentFactory = registerComponent2(
   () => _$TestSubsubtypeOfComponent1Component(),
-  builderFactory: TestSubsubtypeOfComponent1,
+  builderFactory: _$TestSubsubtypeOfComponent1,
   componentClass: TestSubsubtypeOfComponent1Component,
   isWrapper: false,
   parentType: $TestSubtypeOfComponent1ComponentFactory,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'subtype2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestSubtype2ComponentFactory = registerComponent2(
   () => _$TestSubtype2Component(),
-  builderFactory: TestSubtype2,
+  builderFactory: _$TestSubtype2,
   componentClass: TestSubtype2Component,
   isWrapper: false,
   parentType: $TestParent2ComponentFactory,

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'subtype_of_component1.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestSubtypeOfComponent1ComponentFactory = registerComponent2(
   () => _$TestSubtypeOfComponent1Component(),
-  builderFactory: TestSubtypeOfComponent1,
+  builderFactory: _$TestSubtypeOfComponent1,
   componentClass: TestSubtypeOfComponent1Component,
   isWrapper: false,
   parentType: $TestParentComponentFactory,

--- a/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'test_a.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestAComponentFactory = registerComponent(() => _$TestAComponent(),
-    builderFactory: TestA,
-    componentClass: TestAComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestA');
+final $TestAComponentFactory = registerComponent(
+  () => _$TestAComponent(),
+  builderFactory: _$TestA,
+  componentClass: TestAComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestA',
+);
 
 abstract class _$TestAPropsAccessorsMixin implements _$TestAProps {
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'test_b.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestBComponentFactory = registerComponent(() => _$TestBComponent(),
-    builderFactory: TestB,
-    componentClass: TestBComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestB');
+final $TestBComponentFactory = registerComponent(
+  () => _$TestBComponent(),
+  builderFactory: _$TestB,
+  componentClass: TestBComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestB',
+);
 
 abstract class _$TestBPropsAccessorsMixin implements _$TestBProps {
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
@@ -10,14 +10,15 @@ part of 'extendedtype.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestExtendtypeComponentFactory =
-    registerComponent(() => _$TestExtendtypeComponent(),
-        builderFactory: TestExtendtype,
-        componentClass: TestExtendtypeComponent,
-        isWrapper: false,
-        parentType: $TestAbstractComponentFactory,
-        /* from `subtypeOf: TestAbstractComponent` */
-        displayName: 'TestExtendtype');
+final $TestExtendtypeComponentFactory = registerComponent(
+  () => _$TestExtendtypeComponent(),
+  builderFactory: _$TestExtendtype,
+  componentClass: TestExtendtypeComponent,
+  isWrapper: false,
+  parentType: $TestAbstractComponentFactory,
+  /* from `subtypeOf: TestAbstractComponent` */
+  displayName: 'TestExtendtype',
+);
 
 abstract class _$TestExtendtypePropsAccessorsMixin
     implements _$TestExtendtypeProps {

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'parent.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestParentComponentFactory = registerComponent(
-    () => _$TestParentComponent(),
-    builderFactory: TestParent,
-    componentClass: TestParentComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestParent');
+  () => _$TestParentComponent(),
+  builderFactory: _$TestParent,
+  componentClass: TestParentComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestParent',
+);
 
 abstract class _$TestParentPropsAccessorsMixin implements _$TestParentProps {
   @override

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
@@ -10,14 +10,15 @@ part of 'subsubtype.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestSubsubtypeComponentFactory =
-    registerComponent(() => _$TestSubsubtypeComponent(),
-        builderFactory: TestSubsubtype,
-        componentClass: TestSubsubtypeComponent,
-        isWrapper: false,
-        parentType: $TestSubtypeComponentFactory,
-        /* from `subtypeOf: TestSubtypeComponent` */
-        displayName: 'TestSubsubtype');
+final $TestSubsubtypeComponentFactory = registerComponent(
+  () => _$TestSubsubtypeComponent(),
+  builderFactory: _$TestSubsubtype,
+  componentClass: TestSubsubtypeComponent,
+  isWrapper: false,
+  parentType: $TestSubtypeComponentFactory,
+  /* from `subtypeOf: TestSubtypeComponent` */
+  displayName: 'TestSubsubtype',
+);
 
 abstract class _$TestSubsubtypePropsAccessorsMixin
     implements _$TestSubsubtypeProps {

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
@@ -10,14 +10,15 @@ part of 'subtype.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestSubtypeComponentFactory =
-    registerComponent(() => _$TestSubtypeComponent(),
-        builderFactory: TestSubtype,
-        componentClass: TestSubtypeComponent,
-        isWrapper: false,
-        parentType: $TestParentComponentFactory,
-        /* from `subtypeOf: TestParentComponent` */
-        displayName: 'TestSubtype');
+final $TestSubtypeComponentFactory = registerComponent(
+  () => _$TestSubtypeComponent(),
+  builderFactory: _$TestSubtype,
+  componentClass: TestSubtypeComponent,
+  isWrapper: false,
+  parentType: $TestParentComponentFactory,
+  /* from `subtypeOf: TestParentComponent` */
+  displayName: 'TestSubtype',
+);
 
 abstract class _$TestSubtypePropsAccessorsMixin implements _$TestSubtypeProps {
   @override

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flux_component_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestBasicComponentFactory = registerComponent2(
   () => _$TestBasicComponent(),
-  builderFactory: TestBasic,
+  builderFactory: _$TestBasic,
   componentClass: TestBasicComponent,
   isWrapper: false,
   parentType: null,
@@ -154,7 +154,7 @@ class _$TestBasicComponent extends TestBasicComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestHandlerLifecycleComponentFactory = registerComponent2(
   () => _$TestHandlerLifecycleComponent(),
-  builderFactory: TestHandlerLifecycle,
+  builderFactory: _$TestHandlerLifecycle,
   componentClass: TestHandlerLifecycleComponent,
   isWrapper: false,
   parentType: null,
@@ -300,7 +300,7 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestHandlerPrecedenceComponentFactory = registerComponent2(
   () => _$TestHandlerPrecedenceComponent(),
-  builderFactory: TestHandlerPrecedence,
+  builderFactory: _$TestHandlerPrecedence,
   componentClass: TestHandlerPrecedenceComponent,
   isWrapper: false,
   parentType: null,
@@ -448,7 +448,7 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestPropValidationComponentFactory = registerComponent2(
   () => _$TestPropValidationComponent(),
-  builderFactory: TestPropValidation,
+  builderFactory: _$TestPropValidation,
   componentClass: TestPropValidationComponent,
   isWrapper: false,
   parentType: null,
@@ -613,7 +613,7 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestRedrawOnComponentFactory = registerComponent2(
   () => _$TestRedrawOnComponent(),
-  builderFactory: TestRedrawOn,
+  builderFactory: _$TestRedrawOn,
   componentClass: TestRedrawOnComponent,
   isWrapper: false,
   parentType: null,
@@ -756,7 +756,7 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestStoreHandlersComponentFactory = registerComponent2(
   () => _$TestStoreHandlersComponent(),
-  builderFactory: TestStoreHandlers,
+  builderFactory: _$TestStoreHandlers,
   componentClass: TestStoreHandlersComponent,
   isWrapper: false,
   parentType: null,
@@ -900,7 +900,7 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulBasicComponentFactory = registerComponent2(
   () => _$TestStatefulBasicComponent(),
-  builderFactory: TestStatefulBasic,
+  builderFactory: _$TestStatefulBasic,
   componentClass: TestStatefulBasicComponent,
   isWrapper: false,
   parentType: null,
@@ -1141,7 +1141,7 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulHandlerLifecycleComponentFactory = registerComponent2(
   () => _$TestStatefulHandlerLifecycleComponent(),
-  builderFactory: TestStatefulHandlerLifecycle,
+  builderFactory: _$TestStatefulHandlerLifecycle,
   componentClass: TestStatefulHandlerLifecycleComponent,
   isWrapper: false,
   parentType: null,
@@ -1394,7 +1394,7 @@ class _$TestStatefulHandlerLifecycleComponent
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulHandlerPrecedenceComponentFactory = registerComponent2(
   () => _$TestStatefulHandlerPrecedenceComponent(),
-  builderFactory: TestStatefulHandlerPrecedence,
+  builderFactory: _$TestStatefulHandlerPrecedence,
   componentClass: TestStatefulHandlerPrecedenceComponent,
   isWrapper: false,
   parentType: null,
@@ -1647,7 +1647,7 @@ class _$TestStatefulHandlerPrecedenceComponent
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulPropValidationComponentFactory = registerComponent2(
   () => _$TestStatefulPropValidationComponent(),
-  builderFactory: TestStatefulPropValidation,
+  builderFactory: _$TestStatefulPropValidation,
   componentClass: TestStatefulPropValidationComponent,
   isWrapper: false,
   parentType: null,
@@ -1921,7 +1921,7 @@ class _$TestStatefulPropValidationComponent
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulRedrawOnComponentFactory = registerComponent2(
   () => _$TestStatefulRedrawOnComponent(),
-  builderFactory: TestStatefulRedrawOn,
+  builderFactory: _$TestStatefulRedrawOn,
   componentClass: TestStatefulRedrawOnComponent,
   isWrapper: false,
   parentType: null,
@@ -2166,7 +2166,7 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulStoreHandlersComponentFactory = registerComponent2(
   () => _$TestStatefulStoreHandlersComponent(),
-  builderFactory: TestStatefulStoreHandlers,
+  builderFactory: _$TestStatefulStoreHandlers,
   componentClass: TestStatefulStoreHandlersComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'flux_component_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestBasicComponentFactory = registerComponent(
-    () => _$TestBasicComponent(),
-    builderFactory: TestBasic,
-    componentClass: TestBasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestBasic');
+  () => _$TestBasicComponent(),
+  builderFactory: _$TestBasic,
+  componentClass: TestBasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestBasic',
+);
 
 abstract class _$TestBasicPropsAccessorsMixin implements _$TestBasicProps {
   @override
@@ -97,12 +98,13 @@ class _$TestBasicComponent extends TestBasicComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestHandlerLifecycleComponentFactory = registerComponent(
-    () => _$TestHandlerLifecycleComponent(),
-    builderFactory: TestHandlerLifecycle,
-    componentClass: TestHandlerLifecycleComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestHandlerLifecycle');
+  () => _$TestHandlerLifecycleComponent(),
+  builderFactory: _$TestHandlerLifecycle,
+  componentClass: TestHandlerLifecycleComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestHandlerLifecycle',
+);
 
 abstract class _$TestHandlerLifecyclePropsAccessorsMixin
     implements _$TestHandlerLifecycleProps {
@@ -184,12 +186,13 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestHandlerPrecedenceComponentFactory = registerComponent(
-    () => _$TestHandlerPrecedenceComponent(),
-    builderFactory: TestHandlerPrecedence,
-    componentClass: TestHandlerPrecedenceComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestHandlerPrecedence');
+  () => _$TestHandlerPrecedenceComponent(),
+  builderFactory: _$TestHandlerPrecedence,
+  componentClass: TestHandlerPrecedenceComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestHandlerPrecedence',
+);
 
 abstract class _$TestHandlerPrecedencePropsAccessorsMixin
     implements _$TestHandlerPrecedenceProps {
@@ -271,12 +274,13 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestPropValidationComponentFactory = registerComponent(
-    () => _$TestPropValidationComponent(),
-    builderFactory: TestPropValidation,
-    componentClass: TestPropValidationComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestPropValidation');
+  () => _$TestPropValidationComponent(),
+  builderFactory: _$TestPropValidation,
+  componentClass: TestPropValidationComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestPropValidation',
+);
 
 abstract class _$TestPropValidationPropsAccessorsMixin
     implements _$TestPropValidationProps {
@@ -378,12 +382,13 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestRedrawOnComponentFactory = registerComponent(
-    () => _$TestRedrawOnComponent(),
-    builderFactory: TestRedrawOn,
-    componentClass: TestRedrawOnComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestRedrawOn');
+  () => _$TestRedrawOnComponent(),
+  builderFactory: _$TestRedrawOn,
+  componentClass: TestRedrawOnComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestRedrawOn',
+);
 
 abstract class _$TestRedrawOnPropsAccessorsMixin
     implements _$TestRedrawOnProps {
@@ -465,12 +470,13 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStoreHandlersComponentFactory = registerComponent(
-    () => _$TestStoreHandlersComponent(),
-    builderFactory: TestStoreHandlers,
-    componentClass: TestStoreHandlersComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStoreHandlers');
+  () => _$TestStoreHandlersComponent(),
+  builderFactory: _$TestStoreHandlers,
+  componentClass: TestStoreHandlersComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStoreHandlers',
+);
 
 abstract class _$TestStoreHandlersPropsAccessorsMixin
     implements _$TestStoreHandlersProps {
@@ -552,12 +558,13 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulBasicComponentFactory = registerComponent(
-    () => _$TestStatefulBasicComponent(),
-    builderFactory: TestStatefulBasic,
-    componentClass: TestStatefulBasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulBasic');
+  () => _$TestStatefulBasicComponent(),
+  builderFactory: _$TestStatefulBasic,
+  componentClass: TestStatefulBasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulBasic',
+);
 
 abstract class _$TestStatefulBasicPropsAccessorsMixin
     implements _$TestStatefulBasicProps {
@@ -686,12 +693,13 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulHandlerLifecycleComponentFactory = registerComponent(
-    () => _$TestStatefulHandlerLifecycleComponent(),
-    builderFactory: TestStatefulHandlerLifecycle,
-    componentClass: TestStatefulHandlerLifecycleComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulHandlerLifecycle');
+  () => _$TestStatefulHandlerLifecycleComponent(),
+  builderFactory: _$TestStatefulHandlerLifecycle,
+  componentClass: TestStatefulHandlerLifecycleComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulHandlerLifecycle',
+);
 
 abstract class _$TestStatefulHandlerLifecyclePropsAccessorsMixin
     implements _$TestStatefulHandlerLifecycleProps {
@@ -826,12 +834,13 @@ class _$TestStatefulHandlerLifecycleComponent
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulHandlerPrecedenceComponentFactory = registerComponent(
-    () => _$TestStatefulHandlerPrecedenceComponent(),
-    builderFactory: TestStatefulHandlerPrecedence,
-    componentClass: TestStatefulHandlerPrecedenceComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulHandlerPrecedence');
+  () => _$TestStatefulHandlerPrecedenceComponent(),
+  builderFactory: _$TestStatefulHandlerPrecedence,
+  componentClass: TestStatefulHandlerPrecedenceComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulHandlerPrecedence',
+);
 
 abstract class _$TestStatefulHandlerPrecedencePropsAccessorsMixin
     implements _$TestStatefulHandlerPrecedenceProps {
@@ -966,12 +975,13 @@ class _$TestStatefulHandlerPrecedenceComponent
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulPropValidationComponentFactory = registerComponent(
-    () => _$TestStatefulPropValidationComponent(),
-    builderFactory: TestStatefulPropValidation,
-    componentClass: TestStatefulPropValidationComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulPropValidation');
+  () => _$TestStatefulPropValidationComponent(),
+  builderFactory: _$TestStatefulPropValidation,
+  componentClass: TestStatefulPropValidationComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulPropValidation',
+);
 
 abstract class _$TestStatefulPropValidationPropsAccessorsMixin
     implements _$TestStatefulPropValidationProps {
@@ -1127,12 +1137,13 @@ class _$TestStatefulPropValidationComponent
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulRedrawOnComponentFactory = registerComponent(
-    () => _$TestStatefulRedrawOnComponent(),
-    builderFactory: TestStatefulRedrawOn,
-    componentClass: TestStatefulRedrawOnComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulRedrawOn');
+  () => _$TestStatefulRedrawOnComponent(),
+  builderFactory: _$TestStatefulRedrawOn,
+  componentClass: TestStatefulRedrawOnComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulRedrawOn',
+);
 
 abstract class _$TestStatefulRedrawOnPropsAccessorsMixin
     implements _$TestStatefulRedrawOnProps {
@@ -1261,12 +1272,13 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestStatefulStoreHandlersComponentFactory = registerComponent(
-    () => _$TestStatefulStoreHandlersComponent(),
-    builderFactory: TestStatefulStoreHandlers,
-    componentClass: TestStatefulStoreHandlersComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestStatefulStoreHandlers');
+  () => _$TestStatefulStoreHandlersComponent(),
+  builderFactory: _$TestStatefulStoreHandlers,
+  componentClass: TestStatefulStoreHandlersComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestStatefulStoreHandlers',
+);
 
 abstract class _$TestStatefulStoreHandlersPropsAccessorsMixin
     implements _$TestStatefulStoreHandlersProps {

--- a/test/over_react/component_declaration/redux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/redux_component_test.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'redux_component_test.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestDefaultComponentFactory = registerComponent(
-    () => _$TestDefaultComponent(),
-    builderFactory: TestDefault,
-    componentClass: TestDefaultComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestDefault');
+  () => _$TestDefaultComponent(),
+  builderFactory: _$TestDefault,
+  componentClass: TestDefaultComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestDefault',
+);
 
 abstract class _$TestDefaultPropsAccessorsMixin implements _$TestDefaultProps {
   @override
@@ -97,12 +98,13 @@ class _$TestDefaultComponent extends TestDefaultComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestConnectComponentFactory = registerComponent(
-    () => _$TestConnectComponent(),
-    builderFactory: TestConnect,
-    componentClass: TestConnectComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestConnect');
+  () => _$TestConnectComponent(),
+  builderFactory: _$TestConnect,
+  componentClass: TestConnectComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestConnect',
+);
 
 abstract class _$TestConnectPropsAccessorsMixin implements _$TestConnectProps {
   @override
@@ -182,12 +184,14 @@ class _$TestConnectComponent extends TestConnectComponent {
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestPureComponentFactory = registerComponent(() => _$TestPureComponent(),
-    builderFactory: TestPure,
-    componentClass: TestPureComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestPure');
+final $TestPureComponentFactory = registerComponent(
+  () => _$TestPureComponent(),
+  builderFactory: _$TestPure,
+  componentClass: TestPureComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestPure',
+);
 
 abstract class _$TestPurePropsAccessorsMixin implements _$TestPureProps {
   @override

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'dummy_composite_component.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TestCompositeComponentComponentFactory = registerComponent(
-    () => _$TestCompositeComponentComponent(),
-    builderFactory: TestCompositeComponent,
-    componentClass: TestCompositeComponentComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'TestCompositeComponent');
+  () => _$TestCompositeComponentComponent(),
+  builderFactory: _$TestCompositeComponent,
+  componentClass: TestCompositeComponentComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestCompositeComponent',
+);
 
 abstract class _$TestCompositeComponentPropsAccessorsMixin
     implements _$TestCompositeComponentProps {

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'dom_util_test.dart';
 // Registers component implementation and links type meta to builder factory.
 final $DomTestComponentFactory = registerComponent2(
   () => _$DomTestComponent(),
-  builderFactory: DomTest,
+  builderFactory: _$DomTest,
   componentClass: DomTestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'prop_key_util_test_dart2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TestComponentFactory = registerComponent2(
   () => _$TestComponent(),
-  builderFactory: Test,
+  builderFactory: _$Test,
   componentClass: TestComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
+++ b/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'test_component.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TestComponentFactory = registerComponent(() => _$TestComponent(),
-    builderFactory: Test,
-    componentClass: TestComponent,
-    isWrapper: true,
-    parentType: null,
-    displayName: 'Test');
+final $TestComponentFactory = registerComponent(
+  () => _$TestComponent(),
+  builderFactory: _$Test,
+  componentClass: TestComponent,
+  isWrapper: true,
+  parentType: null,
+  displayName: 'Test',
+);
 
 abstract class _$TestPropsAccessorsMixin implements _$TestProps {
   @override

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -63,6 +63,7 @@ import 'over_react/component_declaration/builder_integration_tests/component2/re
 import 'over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.dart' as component2_stateful_component_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.dart' as component2_unassigned_prop_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.dart' as new_boilerplate_accessor_mixin_integration_test;
+import 'over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart' as new_boilerplate_compact_hoc_syntax_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart' as new_boilerplate_component_integration_test;
 import 'over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart' as new_boilerplate_component_integration_verbose_syntax_test;
 import 'over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart' as new_boilerplate_constant_required_accessor_integration_test;
@@ -125,6 +126,7 @@ main() {
   component2_unassigned_prop_integration_test.main();
 
   new_boilerplate_accessor_mixin_integration_test.main();
+  new_boilerplate_compact_hoc_syntax_integration_test.main();
   new_boilerplate_component_integration_test.main();
   new_boilerplate_component_integration_verbose_syntax_test.main();
   new_boilerplate_constant_required_accessor_integration_test.main();

--- a/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'connect_flux_counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ConnectFluxCounterComponentFactory = registerComponent2(
   () => _$ConnectFluxCounterComponent(),
-  builderFactory: ConnectFluxCounter,
+  builderFactory: _$ConnectFluxCounter,
   componentClass: ConnectFluxCounterComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react_redux/fixtures/counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CounterComponentFactory = registerComponent2(
   () => _$CounterComponent(),
-  builderFactory: Counter,
+  builderFactory: _$Counter,
   componentClass: CounterComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'flux_counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FluxCounterComponentFactory = registerComponent2(
   () => _$FluxCounterComponent(),
-  builderFactory: FluxCounter,
+  builderFactory: _$FluxCounter,
   componentClass: FluxCounterComponent,
   isWrapper: false,
   parentType: null,

--- a/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'non_component_two_counter.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $NonComponentTwoCounterComponentFactory = registerComponent(
-    () => _$NonComponentTwoCounterComponent(),
-    builderFactory: NonComponentTwoCounter,
-    componentClass: NonComponentTwoCounterComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'NonComponentTwoCounter');
+  () => _$NonComponentTwoCounterComponent(),
+  builderFactory: _$NonComponentTwoCounter,
+  componentClass: NonComponentTwoCounterComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'NonComponentTwoCounter',
+);
 
 abstract class _$NonComponentTwoCounterPropsAccessorsMixin
     implements _$NonComponentTwoCounterProps {

--- a/test/test_util/component2/one_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/one_level_wrapper2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'one_level_wrapper2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $OneLevelWrapper2ComponentFactory = registerComponent2(
   () => _$OneLevelWrapper2Component(),
-  builderFactory: OneLevelWrapper2,
+  builderFactory: _$OneLevelWrapper2,
   componentClass: OneLevelWrapper2Component,
   isWrapper: true,
   parentType: null,

--- a/test/test_util/component2/two_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/two_level_wrapper2.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'two_level_wrapper2.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TwoLevelWrapper2ComponentFactory = registerComponent2(
   () => _$TwoLevelWrapper2Component(),
-  builderFactory: TwoLevelWrapper2,
+  builderFactory: _$TwoLevelWrapper2,
   componentClass: TwoLevelWrapper2Component,
   isWrapper: true,
   parentType: null,

--- a/test/test_util/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/one_level_wrapper.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'one_level_wrapper.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $OneLevelWrapperComponentFactory = registerComponent(
-    () => _$OneLevelWrapperComponent(),
-    builderFactory: OneLevelWrapper,
-    componentClass: OneLevelWrapperComponent,
-    isWrapper: true,
-    parentType: null,
-    displayName: 'OneLevelWrapper');
+  () => _$OneLevelWrapperComponent(),
+  builderFactory: _$OneLevelWrapper,
+  componentClass: OneLevelWrapperComponent,
+  isWrapper: true,
+  parentType: null,
+  displayName: 'OneLevelWrapper',
+);
 
 abstract class _$OneLevelWrapperPropsAccessorsMixin
     implements _$OneLevelWrapperProps {

--- a/test/test_util/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/two_level_wrapper.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'two_level_wrapper.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $TwoLevelWrapperComponentFactory = registerComponent(
-    () => _$TwoLevelWrapperComponent(),
-    builderFactory: TwoLevelWrapper,
-    componentClass: TwoLevelWrapperComponent,
-    isWrapper: true,
-    parentType: null,
-    displayName: 'TwoLevelWrapper');
+  () => _$TwoLevelWrapperComponent(),
+  builderFactory: _$TwoLevelWrapper,
+  componentClass: TwoLevelWrapperComponent,
+  isWrapper: true,
+  parentType: null,
+  displayName: 'TwoLevelWrapper',
+);
 
 abstract class _$TwoLevelWrapperPropsAccessorsMixin
     implements _$TwoLevelWrapperProps {

--- a/test/vm_tests/builder/codegen/names_test.dart
+++ b/test/vm_tests/builder/codegen/names_test.dart
@@ -4,6 +4,28 @@ import 'package:test/test.dart';
 
 main() {
   group('boilerplate name utilities -', () {
+    group('FactoryNames -', () {
+      FactoryNames names;
+
+      group('unprefixed -', () {
+        setUp(() {
+          names = FactoryNames('Foo');
+        });
+
+        test('consumerName', () => expect(names.consumerName, r'Foo'));
+        test('implName', () => expect(names.implName, r'_$Foo'));
+      });
+
+      group('prefixed -', () {
+        setUp(() {
+          names = FactoryNames('foo.Foo');
+        });
+
+        test('consumerName', () => expect(names.consumerName, r'foo.Foo'));
+        test('implName', () => expect(names.implName, r'foo._$Foo'));
+      });
+    });
+
     group('ComponentNames -', () {
       ComponentNames names;
 

--- a/test/vm_tests/builder/codegen_test.dart
+++ b/test/vm_tests/builder/codegen_test.dart
@@ -307,12 +307,13 @@ main() {
                 setUpAndGenerate(ors.source);
                 final baseName = ors.prefixedBaseName;
                 expect(implGenerator.outputContentsBuffer.toString(), contains(
-                    'final \$${baseName}ComponentFactory = registerComponent(() => _\$${baseName}Component(),\n'
-                    '    builderFactory: $baseName,\n'
-                    '    componentClass: ${baseName}Component,\n'
-                    '    isWrapper: false,\n'
-                    '    parentType: null,\n'
-                    '    displayName: \'$baseName\'\n'
+                    'final \$${baseName}ComponentFactory = registerComponent(\n'
+                    '  () => _\$${baseName}Component(),\n'
+                    '  builderFactory: _\$$baseName,\n'
+                    '  componentClass: ${baseName}Component,\n'
+                    '  isWrapper: false,\n'
+                    '  parentType: null,\n'
+                    '  displayName: \'$baseName\',\n'
                   ');\n'));
               });
             }

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -10,12 +10,14 @@ part of 'basic.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent(() => _$BasicComponent(),
-    builderFactory: Basic,
-    componentClass: BasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Basic');
+final $BasicComponentFactory = registerComponent(
+  () => _$BasicComponent(),
+  builderFactory: _$Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
 
 abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -11,12 +11,13 @@ part of 'basic_library.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $BasicPartOfLibComponentFactory = registerComponent(
-    () => _$BasicPartOfLibComponent(),
-    builderFactory: BasicPartOfLib,
-    componentClass: BasicPartOfLibComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'BasicPartOfLib');
+  () => _$BasicPartOfLibComponent(),
+  builderFactory: _$BasicPartOfLib,
+  componentClass: BasicPartOfLibComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'BasicPartOfLib',
+);
 
 abstract class _$BasicPartOfLibPropsAccessorsMixin
     implements _$BasicPartOfLibProps {
@@ -253,12 +254,13 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $SubPartOfLibComponentFactory = registerComponent(
-    () => _$SubPartOfLibComponent(),
-    builderFactory: SubPartOfLib,
-    componentClass: SubPartOfLibComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'SubPartOfLib');
+  () => _$SubPartOfLibComponent(),
+  builderFactory: _$SubPartOfLib,
+  componentClass: SubPartOfLibComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'SubPartOfLib',
+);
 
 abstract class _$SubPartOfLibPropsAccessorsMixin
     implements _$SubPartOfLibProps {

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -10,12 +10,14 @@ part of 'basic.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent(() => _$BasicComponent(),
-    builderFactory: Basic,
-    componentClass: BasicComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Basic');
+final $BasicComponentFactory = registerComponent(
+  () => _$BasicComponent(),
+  builderFactory: _$Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
 
 abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
   @override

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -11,12 +11,13 @@ part of 'basic_library.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $BasicPartOfLibComponentFactory = registerComponent(
-    () => _$BasicPartOfLibComponent(),
-    builderFactory: BasicPartOfLib,
-    componentClass: BasicPartOfLibComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'BasicPartOfLib');
+  () => _$BasicPartOfLibComponent(),
+  builderFactory: _$BasicPartOfLib,
+  componentClass: BasicPartOfLibComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'BasicPartOfLib',
+);
 
 abstract class _$BasicPartOfLibPropsAccessorsMixin
     implements _$BasicPartOfLibProps {
@@ -263,12 +264,13 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
 //
 // Registers component implementation and links type meta to builder factory.
 final $SubPartOfLibComponentFactory = registerComponent(
-    () => _$SubPartOfLibComponent(),
-    builderFactory: SubPartOfLib,
-    componentClass: SubPartOfLibComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'SubPartOfLib');
+  () => _$SubPartOfLibComponent(),
+  builderFactory: _$SubPartOfLib,
+  componentClass: SubPartOfLibComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'SubPartOfLib',
+);
 
 abstract class _$SubPartOfLibPropsAccessorsMixin
     implements _$SubPartOfLibProps {

--- a/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
@@ -12,7 +12,7 @@ part of 'basic.dart';
 // Registers component implementation and links type meta to builder factory.
 final $Basic2ComponentFactory = registerComponent2(
   () => _$Basic2Component(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: Basic2Component,
   isWrapper: false,
   parentType: null,

--- a/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
@@ -12,7 +12,7 @@ part of 'basic_library.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BasicPartOfLibComponentFactory = registerComponent2(
   () => _$BasicPartOfLibComponent(),
-  builderFactory: BasicPartOfLib,
+  builderFactory: _$BasicPartOfLib,
   componentClass: BasicPartOfLibComponent,
   isWrapper: false,
   parentType: null,
@@ -371,7 +371,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
 // Registers component implementation and links type meta to builder factory.
 final $SubPartOfLibComponentFactory = registerComponent2(
   () => _$SubPartOfLibComponent(),
-  builderFactory: SubPartOfLib,
+  builderFactory: _$SubPartOfLib,
   componentClass: SubPartOfLibComponent,
   isWrapper: false,
   parentType: null,

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -14,7 +14,7 @@ part of 'basic.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicComponentFactory = registerComponent2(
   () => _$BasicComponent(),
-  builderFactory: Basic,
+  builderFactory: _$Basic,
   componentClass: BasicComponent,
   isWrapper: false,
   parentType: null,

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -14,7 +14,7 @@ part of 'basic_library.dart';
     ' Do not reference it in your code, as it may change at any time.')
 final $BasicPartOfLibComponentFactory = registerComponent2(
   () => _$BasicPartOfLibComponent(),
-  builderFactory: BasicPartOfLib,
+  builderFactory: _$BasicPartOfLib,
   componentClass: BasicPartOfLibComponent,
   isWrapper: false,
   parentType: null,
@@ -378,7 +378,7 @@ const StateMeta _$metaForBasicPartOfLibStateMixin = StateMeta(
     ' Do not reference it in your code, as it may change at any time.')
 final $SubPartOfLibComponentFactory = registerComponent2(
   () => _$SubPartOfLibComponent(),
-  builderFactory: SubPartOfLib,
+  builderFactory: _$SubPartOfLib,
   componentClass: SubPartOfLibComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'button.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $ButtonComponentFactory = registerComponent(() => _$ButtonComponent(),
-    builderFactory: Button,
-    componentClass: ButtonComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Button');
+final $ButtonComponentFactory = registerComponent(
+  () => _$ButtonComponent(),
+  builderFactory: _$Button,
+  componentClass: ButtonComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Button',
+);
 
 abstract class _$ButtonPropsAccessorsMixin implements _$ButtonProps {
   @override

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'button_group.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ButtonGroupComponentFactory = registerComponent(
-    () => _$ButtonGroupComponent(),
-    builderFactory: ButtonGroup,
-    componentClass: ButtonGroupComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ButtonGroup');
+  () => _$ButtonGroupComponent(),
+  builderFactory: _$ButtonGroup,
+  componentClass: ButtonGroupComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ButtonGroup',
+);
 
 abstract class _$ButtonGroupPropsAccessorsMixin implements _$ButtonGroupProps {
   @override

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'list_group.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ListGroupComponentFactory = registerComponent(
-    () => _$ListGroupComponent(),
-    builderFactory: ListGroup,
-    componentClass: ListGroupComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ListGroup');
+  () => _$ListGroupComponent(),
+  builderFactory: _$ListGroup,
+  componentClass: ListGroupComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ListGroup',
+);
 
 abstract class _$ListGroupPropsAccessorsMixin implements _$ListGroupProps {
   @override

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -11,12 +11,13 @@ part of 'list_group_item.dart';
 //
 // Registers component implementation and links type meta to builder factory.
 final $ListGroupItemComponentFactory = registerComponent(
-    () => _$ListGroupItemComponent(),
-    builderFactory: ListGroupItem,
-    componentClass: ListGroupItemComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'ListGroupItem');
+  () => _$ListGroupItemComponent(),
+  builderFactory: _$ListGroupItem,
+  componentClass: ListGroupItemComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'ListGroupItem',
+);
 
 abstract class _$ListGroupItemPropsAccessorsMixin
     implements _$ListGroupItemProps {

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'progress.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $ProgressComponentFactory = registerComponent(() => _$ProgressComponent(),
-    builderFactory: Progress,
-    componentClass: ProgressComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Progress');
+final $ProgressComponentFactory = registerComponent(
+  () => _$ProgressComponent(),
+  builderFactory: _$Progress,
+  componentClass: ProgressComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Progress',
+);
 
 abstract class _$ProgressPropsAccessorsMixin implements _$ProgressProps {
   @override

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -10,12 +10,14 @@ part of 'tag.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $TagComponentFactory = registerComponent(() => _$TagComponent(),
-    builderFactory: Tag,
-    componentClass: TagComponent,
-    isWrapper: false,
-    parentType: null,
-    displayName: 'Tag');
+final $TagComponentFactory = registerComponent(
+  () => _$TagComponent(),
+  builderFactory: _$Tag,
+  componentClass: TagComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Tag',
+);
 
 abstract class _$TagPropsAccessorsMixin implements _$TagProps {
   @override

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -10,14 +10,15 @@ part of 'toggle_button.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $ToggleButtonComponentFactory =
-    registerComponent(() => _$ToggleButtonComponent(),
-        builderFactory: ToggleButton,
-        componentClass: ToggleButtonComponent,
-        isWrapper: false,
-        parentType: $ButtonComponentFactory,
-        /* from `subtypeOf: ButtonComponent` */
-        displayName: 'ToggleButton');
+final $ToggleButtonComponentFactory = registerComponent(
+  () => _$ToggleButtonComponent(),
+  builderFactory: _$ToggleButton,
+  componentClass: ToggleButtonComponent,
+  isWrapper: false,
+  parentType: $ButtonComponentFactory,
+  /* from `subtypeOf: ButtonComponent` */
+  displayName: 'ToggleButton',
+);
 
 abstract class _$ToggleButtonPropsAccessorsMixin
     implements _$ToggleButtonProps {

--- a/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
@@ -10,14 +10,15 @@ part of 'toggle_button_group.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $ToggleButtonGroupComponentFactory =
-    registerComponent(() => _$ToggleButtonGroupComponent(),
-        builderFactory: ToggleButtonGroup,
-        componentClass: ToggleButtonGroupComponent,
-        isWrapper: false,
-        parentType: $ButtonGroupComponentFactory,
-        /* from `subtypeOf: ButtonGroupComponent` */
-        displayName: 'ToggleButtonGroup');
+final $ToggleButtonGroupComponentFactory = registerComponent(
+  () => _$ToggleButtonGroupComponent(),
+  builderFactory: _$ToggleButtonGroup,
+  componentClass: ToggleButtonGroupComponent,
+  isWrapper: false,
+  parentType: $ButtonGroupComponentFactory,
+  /* from `subtypeOf: ButtonGroupComponent` */
+  displayName: 'ToggleButtonGroup',
+);
 
 abstract class _$ToggleButtonGroupPropsAccessorsMixin
     implements _$ToggleButtonGroupProps {

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'button.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ButtonComponentFactory = registerComponent2(
   () => _$ButtonComponent(),
-  builderFactory: Button,
+  builderFactory: _$Button,
   componentClass: ButtonComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'button_group.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ButtonGroupComponentFactory = registerComponent2(
   () => _$ButtonGroupComponent(),
-  builderFactory: ButtonGroup,
+  builderFactory: _$ButtonGroup,
   componentClass: ButtonGroupComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'list_group.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ListGroupComponentFactory = registerComponent2(
   () => _$ListGroupComponent(),
-  builderFactory: ListGroup,
+  builderFactory: _$ListGroup,
   componentClass: ListGroupComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'list_group_item.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ListGroupItemComponentFactory = registerComponent2(
   () => _$ListGroupItemComponent(),
-  builderFactory: ListGroupItem,
+  builderFactory: _$ListGroupItem,
   componentClass: ListGroupItemComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'progress.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ProgressComponentFactory = registerComponent2(
   () => _$ProgressComponent(),
-  builderFactory: Progress,
+  builderFactory: _$Progress,
   componentClass: ProgressComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'prop_validation.dart';
 // Registers component implementation and links type meta to builder factory.
 final $PropTypesTestComponentFactory = registerComponent2(
   () => _$PropTypesTestComponent(),
-  builderFactory: PropTypesTest,
+  builderFactory: _$PropTypesTest,
   componentClass: PropTypesTestComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'prop_validation_wrap.dart';
 // Registers component implementation and links type meta to builder factory.
 final $PropTypesWrapComponentFactory = registerComponent2(
   () => _$PropTypesWrapComponent(),
-  builderFactory: PropTypesWrap,
+  builderFactory: _$PropTypesWrap,
   componentClass: PropTypesWrapComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'tag.dart';
 // Registers component implementation and links type meta to builder factory.
 final $TagComponentFactory = registerComponent2(
   () => _$TagComponent(),
-  builderFactory: Tag,
+  builderFactory: _$Tag,
   componentClass: TagComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'toggle_button.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ToggleButtonComponentFactory = registerComponent2(
   () => _$ToggleButtonComponent(),
-  builderFactory: ToggleButton,
+  builderFactory: _$ToggleButton,
   componentClass: ToggleButtonComponent,
   isWrapper: false,
   parentType: $ButtonComponentFactory,

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'toggle_button_group.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ToggleButtonGroupComponentFactory = registerComponent2(
   () => _$ToggleButtonGroupComponent(),
-  builderFactory: ToggleButtonGroup,
+  builderFactory: _$ToggleButtonGroup,
   componentClass: ToggleButtonGroupComponent,
   isWrapper: false,
   parentType: $ButtonGroupComponentFactory,

--- a/web/component2/src/demos/custom_error_boundary.over_react.g.dart
+++ b/web/component2/src/demos/custom_error_boundary.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'custom_error_boundary.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CustomErrorBoundaryComponentFactory = registerComponent2(
   () => _$CustomErrorBoundaryComponent(),
-  builderFactory: CustomErrorBoundary,
+  builderFactory: _$CustomErrorBoundary,
   componentClass: CustomErrorBoundaryComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'fragment_example_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FragmentExampleComponentFactory = registerComponent2(
   () => _$FragmentExampleComponent(),
-  builderFactory: FragmentExample,
+  builderFactory: _$FragmentExample,
   componentClass: FragmentExampleComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'list_example_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ListExampleComponentFactory = registerComponent2(
   () => _$ListExampleComponent(),
-  builderFactory: ListExample,
+  builderFactory: _$ListExample,
   componentClass: ListExampleComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'num_example_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $NumExampleComponentFactory = registerComponent2(
   () => _$NumExampleComponent(),
-  builderFactory: NumExample,
+  builderFactory: _$NumExample,
   componentClass: NumExampleComponent,
   isWrapper: false,
   parentType: null,

--- a/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'string_example_component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $StringExampleComponentFactory = registerComponent2(
   () => _$StringExampleComponent(),
-  builderFactory: StringExample,
+  builderFactory: _$StringExample,
   componentClass: StringExampleComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'little_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $LittleBlockComponentFactory = registerComponent2(
   () => _$LittleBlockComponent(),
-  builderFactory: LittleBlock,
+  builderFactory: _$LittleBlock,
   componentClass: LittleBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BigBlockComponentFactory = registerComponent2(
   () => _$BigBlockComponent(),
-  builderFactory: BigBlock,
+  builderFactory: _$BigBlock,
   componentClass: BigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BigBlockComponentFactory = registerComponent2(
   () => _$BigBlockComponent(),
-  builderFactory: BigBlock,
+  builderFactory: _$BigBlock,
   componentClass: BigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'connect_flux_big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ConnectFluxBigBlockComponentFactory = registerComponent2(
   () => _$ConnectFluxBigBlockComponent(),
-  builderFactory: ConnectFluxBigBlock,
+  builderFactory: _$ConnectFluxBigBlock,
   componentClass: ConnectFluxBigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'redux_big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ReduxBigBlockComponentFactory = registerComponent2(
   () => _$ReduxBigBlockComponent(),
-  builderFactory: ReduxBigBlock,
+  builderFactory: _$ReduxBigBlock,
   componentClass: ReduxBigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'should_not_update.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ShouldNotUpdateComponentFactory = registerComponent2(
   () => _$ShouldNotUpdateComponent(),
-  builderFactory: ShouldNotUpdate,
+  builderFactory: _$ShouldNotUpdate,
   componentClass: ShouldNotUpdateComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'random_color_redux.dart';
 // Registers component implementation and links type meta to builder factory.
 final $RandomColorReduxComponentFactory = registerComponent2(
   () => _$RandomColorReduxComponent(),
-  builderFactory: RandomColorRedux,
+  builderFactory: _$RandomColorRedux,
   componentClass: RandomColorReduxComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'should_not_update.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ShouldNotUpdateComponentFactory = registerComponent2(
   () => _$ShouldNotUpdateComponent(),
-  builderFactory: ShouldNotUpdate,
+  builderFactory: _$ShouldNotUpdate,
   componentClass: ShouldNotUpdateComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BigBlockComponentFactory = registerComponent2(
   () => _$BigBlockComponent(),
-  builderFactory: BigBlock,
+  builderFactory: _$BigBlock,
   componentClass: BigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BigBlockComponentFactory = registerComponent2(
   () => _$BigBlockComponent(),
-  builderFactory: BigBlock,
+  builderFactory: _$BigBlock,
   componentClass: BigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'connect_flux_big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ConnectFluxBigBlockComponentFactory = registerComponent2(
   () => _$ConnectFluxBigBlockComponent(),
-  builderFactory: ConnectFluxBigBlock,
+  builderFactory: _$ConnectFluxBigBlock,
   componentClass: ConnectFluxBigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'redux_big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ReduxBigBlockComponentFactory = registerComponent2(
   () => _$ReduxBigBlockComponent(),
-  builderFactory: ReduxBigBlock,
+  builderFactory: _$ReduxBigBlock,
   componentClass: ReduxBigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'should_not_update.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ShouldNotUpdateComponentFactory = registerComponent2(
   () => _$ShouldNotUpdateComponent(),
-  builderFactory: ShouldNotUpdate,
+  builderFactory: _$ShouldNotUpdate,
   componentClass: ShouldNotUpdateComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'big_block.dart';
 // Registers component implementation and links type meta to builder factory.
 final $BigBlockComponentFactory = registerComponent2(
   () => _$BigBlockComponent(),
-  builderFactory: BigBlock,
+  builderFactory: _$BigBlock,
   componentClass: BigBlockComponent,
   isWrapper: false,
   parentType: null,

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'should_not_update.dart';
 // Registers component implementation and links type meta to builder factory.
 final $ShouldNotUpdateComponentFactory = registerComponent2(
   () => _$ShouldNotUpdateComponent(),
-  builderFactory: ShouldNotUpdate,
+  builderFactory: _$ShouldNotUpdate,
   componentClass: ShouldNotUpdateComponent,
   isWrapper: false,
   parentType: null,

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CounterComponentFactory = registerComponent2(
   () => _$CounterComponent(),
-  builderFactory: Counter,
+  builderFactory: _$Counter,
   componentClass: CounterComponent,
   isWrapper: false,
   parentType: null,

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CounterComponentFactory = registerComponent2(
   () => _$CounterComponent(),
-  builderFactory: Counter,
+  builderFactory: _$Counter,
   componentClass: CounterComponent,
   isWrapper: false,
   parentType: null,

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'counter.dart';
 // Registers component implementation and links type meta to builder factory.
 final $CounterComponentFactory = registerComponent2(
   () => _$CounterComponent(),
-  builderFactory: Counter,
+  builderFactory: _$Counter,
   componentClass: CounterComponent,
   isWrapper: false,
   parentType: null,

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'faulty-component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FaultyComponentFactory = registerComponent2(
   () => _$FaultyComponent(),
-  builderFactory: Faulty,
+  builderFactory: _$Faulty,
   componentClass: FaultyComponent,
   isWrapper: false,
   parentType: null,

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -12,7 +12,7 @@ part of 'faulty-on-mount-component.dart';
 // Registers component implementation and links type meta to builder factory.
 final $FaultyOnMountComponentFactory = registerComponent2(
   () => _$FaultyOnMountComponent(),
-  builderFactory: FaultyOnMount,
+  builderFactory: _$FaultyOnMount,
   componentClass: FaultyOnMountComponent,
   isWrapper: false,
   parentType: null,


### PR DESCRIPTION
## Motivation
The new boilerplate allowed for an improved connect syntax:

Before:
```dart
UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
UiFactory<FooProps> ConnectedFoo = connect(
  ...
)(Foo);
```
After:
```dart
UiFactory<FooProps> Foo = connect(
  ...
)(_$Foo); // ignore: undefined_identifier
```
However, there was a bug when actually using this syntax caused by an initialization loop, so that needed to be fixed.

Aaaand I had already updated all of the examples to use that new syntax (in my other PR).

So, as opposed to trying to revert all those, it's easier to fix the issue.

## Changes
- In generated code, use the generated factory instead of the user-authored one so we don't trigger a cyclic initialization error when referencing the component factory during the user's factory initialization (e.g., when passing the generated factory directly into HOCs like connect).
    ```diff
     ReactDartComponentFactoryProxy $FooComponentFactory = registerComponent(
       ... 
    -  builderFactory: Foo,
    +  builderFactory: _$Foo,
    ```
    - This change should have no other side-effects, since `_$Foo` and `Foo` are identical. If it did break something, component type checking tests would catch it.
    - Add integration test for this syntax
- Update markdown docs and doc comments to use the new connect syntax

I broke out these fixes/changes from the updates to the examples so they'd be easier to review

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @aaronlademann-wf @joebingham-wk @sydneyjodon-wk 
FYI: @kealjones-wk @davidmarne-wf @matthewnitschke-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
