### PR TITLE
CPLAT-10514 Consume all prop mixins by default in mixin-based syntax

### DIFF
--- a/app/over_react_redux/todo_client/lib/src/components/app_bar/app_bar_local_storage_menu.dart
+++ b/app/over_react_redux/todo_client/lib/src/components/app_bar/app_bar_local_storage_menu.dart
@@ -35,6 +35,9 @@ class AppBarLocalStorageMenuComponent extends UiComponent2<AppBarLocalStorageMen
   bool get _currentStateKeyIsReadOnly => TodoAppLocalStorage.reservedStateKeys.contains(props.currentDataSetName);
 
   @override
+  get consumedProps => propsMeta.allExceptForMixins({MenuOverlayProps});
+
+  @override
   render() {
     return (MenuOverlay()
       ..modifyProps(addUnconsumedProps)

--- a/app/over_react_redux/todo_client/lib/src/components/shared/empty_view.dart
+++ b/app/over_react_redux/todo_client/lib/src/components/shared/empty_view.dart
@@ -39,11 +39,6 @@ class EmptyViewComponent extends UiComponent2<EmptyViewProps> {
   get defaultProps => (newProps()..type = EmptyViewType.DEFAULT);
 
   @override
-  get consumedProps => [
-        propsMeta.forMixin(EmptyViewProps),
-      ];
-
-  @override
   get propTypes => {
     keyForProp((p) => p.glyph): (props, info) {
       if (props.glyph != null && props.content != null) {

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -681,7 +681,7 @@ We couldn't "consume" props from other classes by default, since we didn't have 
 props classes and mixins inherited by a given props class's superclass (due to not having a resolved AST in our builder,
 for performance reasons).
 
-However, in the new mixin-based syntax, props classes must explicitly mix in all propss mixins they inherit from,
+However, in the new mixin-based syntax, props classes must explicitly mix in all props mixins they inherit from,
 so we're able to easily tell at build time what they all are, and thus don't have that same restriction. 
 
 

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -8,6 +8,7 @@
         * [Remove Annotations](#remove-annotations)
         * [Ignore Ungenerated Warnings Project-Wide](#ignore-ungenerated-warnings-project-wide)
         * [Use Mixin-Based Props Declaration that Disallows Subclassing](#use-mixin-based-props-declaration-that-disallows-subclassing)
+        * [Consume props from all props mixins props by default](#consume-props-from-all-props-mixins-props-by-default)
 * __[Function Component Boilerplate](#function-component-boilerplate)__
     * [Constraints](#function-component-constraints)
     * [Design](#design)
@@ -475,6 +476,214 @@ usage() {
 +   final mapView = FooMapView(someExistingMap);
 }
 ```
+
+### Consume props from all props mixins props by default
+
+#### Background: consumed props defaults for legacy syntax
+
+Each component has a `consumedProps` method, a list of props that are considered "consumed" by the component,
+and thus should not get forwarded on to other components via `addUnconsumedProps`/`copyUnconsumedProps`, and should
+be validated via `propTypes`.
+
+```dart
+@Props()
+class FooProps extends UiProps {
+  int foo;
+  int bar;
+}
+
+@Component()
+class FooComponent extends UiComponent<FooProps> {
+  render() {
+    // {
+    //   FooProps.foo: 1, 
+    //   FooProps.bar: 2, 
+    //   data-a-dom-prop: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    // }
+    print(props);
+    
+    // {
+    //   someArbitraryProp: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    // } 
+    print(copyUnconsumedProps());
+  }
+}
+```
+
+In the legacy boilerplate, this only included props declared within the props class:
+```dart
+@Props()
+class FooProps extends OtherPropsMixin {
+  int foo;
+  int bar;
+}
+
+@Component()
+class FooComponent extends UiComponent<FooProps> {
+  render() {
+    // {
+    //   FooProps.foo: 1, 
+    //   FooProps.bar: 2, 
+    //   data-a-dom-prop: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    //   OtherPropsMixin.other: 6, 
+    // }
+    print(props);
+    
+    // {
+    //   someArbitraryProp: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    //   OtherPropsMixin.other: 6,
+    // } 
+    print(copyUnconsumedProps());
+  }
+}
+```
+
+This was convenient most of the time, especially for simple components that didn't want to pass their props along.
+
+If needed, you could override `consumedProps`  to explicitly include other props:
+```dart
+@override
+get consumedProps => [
+      FooProps.meta,
+      OtherPropsMixin.meta,
+    ];
+```
+
+#### Updated default behavior in the mixin-based syntax
+
+With the new mixin-based syntax, props cannot be declared directly within props classes, so if we kept using the consumed
+props behavior from the legacy syntax, they wouldn't have any consumed props by default. (Unless we picked a mixin or something, 
+which could get confusing)
+
+This would mean that any props class that consumes the props of a single mixin would need to override consumedProps,
+whereas before they wouldn't have to.
+
+```dart
+// Before
+@Props()
+class FooProps extends UiProps with OtherPropsMixin {
+  int foo;
+  int bar;
+}
+
+@Component()
+class FooComponent ... {
+  // no consumedProps override necessary
+}
+```
+```dart
+// After
+mixin FooPropsMixin on UiProps {
+  int foo;
+  int bar;
+}
+
+class FooProps = UiProps with FooPropsMixin, OtherPropsMixin;
+
+class FooComponent ... {
+  // consumedProps override necessary
+  @override
+  get consumedProps => propsMeta.forMixins({FooPropsMixin});
+}
+```
+
+To help optimize this use-case, as well as to make whether props are consumed or not more consistent across different 
+forms of the new syntax, we decided to __consume all props by default__, if consumedProps is not overridden.
+
+So, taking the above example again, the new behavior would be:
+```dart
+mixin FooPropsMixin on UiProps {
+  int foo;
+  int bar;
+}
+
+class FooProps = UiProps with FooPropsMixin, OtherPropsMixin;
+
+class FooComponent extends UiComponent<FooProps> {
+  render() {
+    // {
+    //   FooProps.foo: 1, 
+    //   FooProps.bar: 2, 
+    //   data-a-dom-prop: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    //   OtherPropsMixin.other: 6, 
+    // }
+    print(props);
+    
+    // {
+    //   someArbitraryProp: 3,
+    //   onClick: 4,
+    //   someArbitraryProp: 5,
+    // } 
+    print(copyUnconsumedProps());
+  }
+}
+```
+
+The old behavior is still achievable through overriding `consumedProps`, and some cases will be easier than before thanks to propsMeta.
+
+For example:
+
+- Consuming all props except for a few mixins:
+
+    Before:     
+    ```dart
+    @Props()  
+    class FooProps extends UiProps with 
+        AProps, 
+        BProps, 
+        CProps, 
+        NoConsumeProps { ... } 
+    
+    @Component()  
+    class FooComponent extends UiComponent<FooProps> {
+      @override
+      consumedProps => [
+            FooProps.meta,
+            AProps.meta,
+            BProps.meta,
+            CProps.meta,
+          ];
+    
+      ...
+    }
+    ```
+    After:
+    ```dart
+    class FooProps = UiProps with
+        FooPropsMixin 
+        AProps, 
+        BProps, 
+        CProps, 
+        NoConsumeProps; 
+    
+    class FooComponent extends UiComponent<FooProps> {
+      @override
+      consumedProps => 
+          propsMeta.allExceptForMixins({NoConsumeProps}),
+    
+      ...
+    }
+    ```
+
+#### Why didn't we do this earlier?
+
+We couldn't "consume" props from other classes by default, since we didn't have full knowledge of all the 
+props classes and mixins inherited by a given props class's superclass (due to not having a resolved AST in our builder,
+for performance reasons).
+
+However, in the new mixin-based syntax, props classes must explicitly mix in all propss mixins they inherit from,
+so we're able to easily tell at build time what they all are, and thus don't have that same restriction. 
+
 
 ## Function Component Boilerplate
 

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -505,7 +505,7 @@ class FooComponent extends UiComponent<FooProps> {
     print(props);
     
     // {
-    //   someArbitraryProp: 3,
+    //   data-a-dom-prop: 3,
     //   onClick: 4,
     //   someArbitraryProp: 5,
     // } 
@@ -536,7 +536,7 @@ class FooComponent extends UiComponent<FooProps> {
     print(props);
     
     // {
-    //   someArbitraryProp: 3,
+    //   data-a-dom-prop: 3,
     //   onClick: 4,
     //   someArbitraryProp: 5,
     //   OtherPropsMixin.other: 6,
@@ -620,7 +620,7 @@ class FooComponent extends UiComponent<FooProps> {
     print(props);
     
     // {
-    //   someArbitraryProp: 3,
+    //   data-a-dom-prop: 3,
     //   onClick: 4,
     //   someArbitraryProp: 5,
     // } 

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -8,7 +8,7 @@
         * [Remove Annotations](#remove-annotations)
         * [Ignore Ungenerated Warnings Project-Wide](#ignore-ungenerated-warnings-project-wide)
         * [Use Mixin-Based Props Declaration that Disallows Subclassing](#use-mixin-based-props-declaration-that-disallows-subclassing)
-        * [Consume props from all props mixins props by default](#consume-props-from-all-props-mixins-props-by-default)
+        * [Consume props from all props mixins by default](#consume-props-from-all-props-mixins-by-default)
 * __[Function Component Boilerplate](#function-component-boilerplate)__
     * [Constraints](#function-component-constraints)
     * [Design](#design)
@@ -477,7 +477,7 @@ usage() {
 }
 ```
 
-### Consume props from all props mixins props by default
+### Consume props from all props mixins by default
 
 #### Background: consumed props defaults for legacy syntax
 
@@ -596,7 +596,7 @@ class FooComponent ... {
 ```
 
 To help optimize this use-case, as well as to make whether props are consumed or not more consistent across different 
-forms of the new syntax, we decided to __consume all props by default__, if consumedProps is not overridden.
+forms of the new syntax, we decided to __consume props from all props mixins by default__, if consumedProps is not overridden.
 
 So, taking the above example again, the new behavior would be:
 ```dart

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -222,7 +222,7 @@ class _$SubComponent extends SubComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by SubProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -221,8 +221,8 @@ class _$SubComponent extends SubComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from SubProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by SubProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -224,7 +224,7 @@ class _$SubComponent extends SubComponent {
   /// The default consumed props, taken from SubProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -135,8 +135,7 @@ class _$BasicComponent extends BasicComponent {
   /// The default consumed props, taken from BasicProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(BasicProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -133,7 +133,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -132,8 +132,8 @@ class _$BasicComponent extends BasicComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -225,7 +225,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -501,7 +501,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by SubPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -227,7 +227,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   /// The default consumed props, taken from BasicPartOfLibProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
@@ -503,7 +503,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   /// The default consumed props, taken from SubPartOfLibProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -224,8 +224,8 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicPartOfLibProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -500,8 +500,8 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from SubPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by SubPartOfLibProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -221,8 +221,8 @@ class _$BasicComponent extends BasicComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -222,7 +222,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -224,7 +224,7 @@ class _$BasicComponent extends BasicComponent {
   /// The default consumed props, taken from BasicProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -134,8 +134,8 @@ class _$BasicComponent extends BasicComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -135,7 +135,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -137,7 +137,7 @@ class _$BasicComponent extends BasicComponent {
   /// The default consumed props, taken from BasicProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -226,7 +226,7 @@ class _$GenericSubComponent extends GenericSubComponent {
   /// The default consumed props, taken from GenericSubProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -223,8 +223,8 @@ class _$GenericSubComponent extends GenericSubComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from GenericSubProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by GenericSubProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -224,7 +224,7 @@ class _$GenericSubComponent extends GenericSubComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by GenericSubProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -221,7 +221,7 @@ class _$GenericSuperComponent extends GenericSuperComponent {
   /// The default consumed props, taken from GenericSuperProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -219,7 +219,7 @@ class _$GenericSuperComponent extends GenericSuperComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by GenericSuperProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -218,8 +218,8 @@ class _$GenericSuperComponent extends GenericSuperComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from GenericSuperProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by GenericSuperProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -217,8 +217,8 @@ class _$PrivateComponent extends PrivateComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from _PrivateProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by _PrivateProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -220,8 +220,7 @@ class _$PrivateComponent extends PrivateComponent {
   /// The default consumed props, taken from _PrivateProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(_PrivateProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -218,7 +218,7 @@ class _$PrivateComponent extends PrivateComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by _PrivateProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -134,8 +134,8 @@ class _$FormActionInputComponent extends FormActionInputComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FormActionInputProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FormActionInputProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -137,8 +137,7 @@ class _$FormActionInputComponent extends FormActionInputComponent {
   /// The default consumed props, taken from FormActionInputProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FormActionInputProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -135,7 +135,7 @@ class _$FormActionInputComponent extends FormActionInputComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FormActionInputProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -136,7 +136,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -138,7 +138,7 @@ class _$BasicComponent extends BasicComponent {
   /// The default consumed props, taken from BasicProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -135,8 +135,8 @@ class _$BasicComponent extends BasicComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -145,7 +145,7 @@ class _$MyContextComponentComponent extends MyContextComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$MyContextComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForMyContextComponentProps

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -145,7 +145,7 @@ class _$MyContextComponentComponent extends MyContextComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$MyContextComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForMyContextComponentProps

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -260,7 +260,7 @@ class _$MyProviderComponentComponent extends MyProviderComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$MyProviderComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForMyProviderComponentProps

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -260,7 +260,7 @@ class _$MyProviderComponentComponent extends MyProviderComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$MyProviderComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForMyProviderComponentProps

--- a/lib/src/builder/codegen/component_generator.dart
+++ b/lib/src/builder/codegen/component_generator.dart
@@ -166,7 +166,7 @@ class _ComponentGenerator extends ComponentGenerator {
   @override
   String get defaultConsumedPropsImpl =>
       '  /// The default consumed props, comprising all props mixins used by ${propsNames.consumerName}.\n'
-      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.\n'
+      '  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.\n'
       '  @override\n'
       '  get \$defaultConsumedProps => propsMeta.all;';
 
@@ -220,7 +220,7 @@ class _LegacyComponentGenerator extends ComponentGenerator {
   @override
   String get defaultConsumedPropsImpl =>
       '  /// The default consumed props, taken from ${propsNames.consumerName}.\n'
-      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.\n'
+      '  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.\n'
       '  @override\n'
       '  final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}];';
 }

--- a/lib/src/builder/codegen/component_generator.dart
+++ b/lib/src/builder/codegen/component_generator.dart
@@ -165,9 +165,9 @@ class _ComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      '  /// The default consumed props, comprising all props mixins used by ${propsNames.consumerName}.'
-      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.'
-      '  @override'
+      '  /// The default consumed props, comprising all props mixins used by ${propsNames.consumerName}.\n'
+      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.\n'
+      '  @override\n'
       '  get \$defaultConsumedProps => propsMeta.all;';
 
   @override
@@ -219,8 +219,8 @@ class _LegacyComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      '  /// The default consumed props, taken from ${propsNames.consumerName}.'
-      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.'
-      '  @override'
+      '  /// The default consumed props, taken from ${propsNames.consumerName}.\n'
+      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.\n'
+      '  @override\n'
       '  final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}];';
 }

--- a/lib/src/builder/codegen/component_generator.dart
+++ b/lib/src/builder/codegen/component_generator.dart
@@ -121,9 +121,6 @@ abstract class ComponentGenerator extends BoilerplateDeclarationGenerator {
       ..writeln('  @override')
       ..writeln('  bool get \$isClassGenerated => true;')
       ..writeln()
-      ..writeln('  /// The default consumed props, taken from ${propsNames.consumerName}.')
-      ..writeln('  /// Used in `ConsumedProps` if [consumedProps] is not overridden.')
-      ..writeln('  @override')
       ..writeln('  $defaultConsumedPropsImpl');
 
     _generateAdditionalComponentBody();
@@ -168,7 +165,10 @@ class _ComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      r'get $defaultConsumedProps => propsMeta.all;';
+      '  /// The default consumed props, comprising all props mixins used by ${propsNames.consumerName}.'
+      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.'
+      '  @override'
+      '  get \$defaultConsumedProps => propsMeta.all;';
 
   @override
   void _generateAdditionalComponentBody() {
@@ -219,5 +219,8 @@ class _LegacyComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      'final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}];';
+      '  /// The default consumed props, taken from ${propsNames.consumerName}.'
+      '  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.'
+      '  @override'
+      '  final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}];';
 }

--- a/lib/src/builder/codegen/component_generator.dart
+++ b/lib/src/builder/codegen/component_generator.dart
@@ -124,7 +124,7 @@ abstract class ComponentGenerator extends BoilerplateDeclarationGenerator {
       ..writeln('  /// The default consumed props, taken from ${propsNames.consumerName}.')
       ..writeln('  /// Used in `ConsumedProps` if [consumedProps] is not overridden.')
       ..writeln('  @override')
-      ..writeln('  $defaultConsumedPropsImpl;');
+      ..writeln('  $defaultConsumedPropsImpl');
 
     _generateAdditionalComponentBody();
 
@@ -168,13 +168,7 @@ class _ComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      r'List<ConsumedProps> get $defaultConsumedProps => ' +
-      declaration.props.switchCase(
-        (a) => 'const []', // Concrete props classes do not have generated meta
-        // Use propsMeta.forMixin instead of directly accessing the props class so that
-        // we don't reference the generated mixin and have to emit another warning comment.
-        (b) => '[propsMeta.forMixin(${propsNames.consumerName})]',
-      );
+      r'get $defaultConsumedProps => propsMeta.all;';
 
   @override
   void _generateAdditionalComponentBody() {
@@ -225,5 +219,5 @@ class _LegacyComponentGenerator extends ComponentGenerator {
 
   @override
   String get defaultConsumedPropsImpl =>
-      'final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}]';
+      'final List<ConsumedProps> \$defaultConsumedProps = const [${propsNames.metaConstantName}];';
 }

--- a/lib/src/component/_deprecated/error_boundary.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary.over_react.g.dart
@@ -246,7 +246,7 @@ class _$ErrorBoundaryComponent extends ErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForErrorBoundaryProps

--- a/lib/src/component/_deprecated/error_boundary.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary.over_react.g.dart
@@ -246,7 +246,7 @@ class _$ErrorBoundaryComponent extends ErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForErrorBoundaryProps

--- a/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
@@ -256,7 +256,7 @@ class _$RecoverableErrorBoundaryComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$RecoverableErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForRecoverableErrorBoundaryProps

--- a/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
@@ -256,7 +256,7 @@ class _$RecoverableErrorBoundaryComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$RecoverableErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForRecoverableErrorBoundaryProps

--- a/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
+++ b/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
@@ -145,7 +145,7 @@ class _$ResizeSensorComponent extends ResizeSensorComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ResizeSensorProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForResizeSensorProps

--- a/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
+++ b/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
@@ -145,7 +145,7 @@ class _$ResizeSensorComponent extends ResizeSensorComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ResizeSensorProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForResizeSensorProps

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -95,11 +95,6 @@ abstract class AbstractTransitionComponent<T extends AbstractTransitionProps,
   static const String transitionPhaseTestAttr = 'data-transition-phase';
 
   @override
-  get consumedProps => [
-    propsMeta.forMixin(TransitionPropsMixin),
-  ];
-
-  @override
   get defaultProps => (newProps()
     ..addProps(TransitionPropsMixin.defaultProps)
   );

--- a/lib/src/component/dummy_component2.over_react.g.dart
+++ b/lib/src/component/dummy_component2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$_Dummy2Component extends _Dummy2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$_Dummy2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaFor_Dummy2Props

--- a/lib/src/component/dummy_component2.over_react.g.dart
+++ b/lib/src/component/dummy_component2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$_Dummy2Component extends _Dummy2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$_Dummy2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaFor_Dummy2Props

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -222,8 +222,7 @@ class _$ErrorBoundaryComponent extends ErrorBoundaryComponent {
   /// The default consumed props, taken from ErrorBoundaryProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ErrorBoundaryProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -219,8 +219,8 @@ class _$ErrorBoundaryComponent extends ErrorBoundaryComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ErrorBoundaryProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -220,7 +220,7 @@ class _$ErrorBoundaryComponent extends ErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -229,8 +229,8 @@ class _$RecoverableErrorBoundaryComponent
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from RecoverableErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by RecoverableErrorBoundaryProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -232,7 +232,7 @@ class _$RecoverableErrorBoundaryComponent
   /// The default consumed props, taken from RecoverableErrorBoundaryProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -230,7 +230,7 @@ class _$RecoverableErrorBoundaryComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by RecoverableErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -133,8 +133,8 @@ class _$ResizeSensorComponent extends ResizeSensorComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ResizeSensorProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ResizeSensorProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -136,8 +136,7 @@ class _$ResizeSensorComponent extends ResizeSensorComponent {
   /// The default consumed props, taken from ResizeSensorProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ResizeSensorProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -134,7 +134,7 @@ class _$ResizeSensorComponent extends ResizeSensorComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ResizeSensorProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -852,6 +852,8 @@ abstract class _AccessorMetaCollection<T extends _Descriptor, U extends Accessor
   U get _emptyMeta;
 
   /// Returns the metadata for only the prop fields declared in [mixinType].
+  ///
+  /// See `UiComponent2.consumedProps` for usage examples.
   U forMixin(Type mixinType) {
     final meta = _metaByMixin[mixinType];
     assert(meta != null,
@@ -862,15 +864,21 @@ abstract class _AccessorMetaCollection<T extends _Descriptor, U extends Accessor
 
   /// Returns a set of all the metadata in this collection
   /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class).
+  ///
+  /// See `UiComponent2.consumedProps` for usage examples.
   Iterable<U> get all => _metaByMixin.values;
 
   /// Returns a set of the metadata corresponding to [mixinTypes].
+  ///
+  /// See `UiComponent2.consumedProps` for usage examples.
   Iterable<U> forMixins(Set<Type> mixinTypes) =>
       mixinTypes.map(forMixin);
 
   /// Returns a set of all the metadata in this collection
   /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class),
   /// except for the metadata corresponding to [excludedMixinTypes].
+  ///
+  /// See `UiComponent2.consumedProps` for usage examples.
   Iterable<U> allExceptForMixins(Set<Type> excludedMixinTypes) {
     final filtered = Map.of(_metaByMixin);
     for (final mixinType in excludedMixinTypes) {

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -801,6 +801,9 @@ class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
 
   @override
   List<PropDescriptor> get props => fields;
+
+  @override
+  String toString() => 'PropsMeta:$keys';
 }
 
 /// Metadata for the state fields declared in a specific state class--

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -783,6 +783,22 @@ class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
 
   const PropsMeta({this.fields, this.keys});
 
+  /// A convenience constructor to make a metadata object for a single key.
+  ///
+  /// Useful within [UiComponent.consumedProps].
+  ///
+  /// Example:
+  ///
+  ///     @override
+  ///     get consumedProps => [
+  ///       propsMeta.forMixin(InputWrapperProps),
+  ///       PropsMeta.forSimpleKey('onChange'),
+  ///     ];
+  factory PropsMeta.forSimpleKey(String key) => PropsMeta(
+    fields: [PropDescriptor(key)],
+    keys: [key],
+  );
+
   @override
   List<PropDescriptor> get props => fields;
 }
@@ -839,6 +855,28 @@ abstract class _AccessorMetaCollection<T extends _Descriptor, U extends Accessor
         'No meta found for $mixinType;'
         'it likely isn\'t mixed in by the props/state class.');
     return meta ?? _emptyMeta;
+  }
+
+  /// Returns a set of all the metadata in this collection
+  /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class).
+  Iterable<U> get all => _metaByMixin.values;
+
+  /// Returns a set of the metadata corresponding to [mixinTypes].
+  Iterable<U> forMixins(Set<Type> mixinTypes) =>
+      mixinTypes.map(forMixin);
+
+  /// Returns a set of all the metadata in this collection
+  /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class),
+  /// except for the metadata corresponding to [excludedMixinTypes].
+  Iterable<U> allExceptForMixins(Set<Type> excludedMixinTypes) {
+    final filtered = Map.of(_metaByMixin);
+    for (final mixinType in excludedMixinTypes) {
+      assert(_metaByMixin.containsKey(mixinType),
+      'No meta found for $mixinType;'
+          'it likely isn\'t mixed in by the props/state class.');
+      filtered.remove(mixinType);
+    }
+    return filtered.values;
   }
 
   @override

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -863,7 +863,7 @@ abstract class _AccessorMetaCollection<T extends _Descriptor, U extends Accessor
   }
 
   /// Returns a set of all the metadata in this collection
-  /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class).
+  /// (for `propsMeta`, this corresponds to all props mixins mixed into the props class).
   ///
   /// See `UiComponent2.consumedProps` for usage examples.
   Iterable<U> get all => _metaByMixin.values;
@@ -875,7 +875,7 @@ abstract class _AccessorMetaCollection<T extends _Descriptor, U extends Accessor
       mixinTypes.map(forMixin);
 
   /// Returns a set of all the metadata in this collection
-  /// (for `propsMeta`, this corresponds to  all props mixins mixed into the props class),
+  /// (for `propsMeta`, this corresponds to all props mixins mixed into the props class),
   /// except for the metadata corresponding to [excludedMixinTypes].
   ///
   /// See `UiComponent2.consumedProps` for usage examples.

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -325,7 +325,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// - Consume an arbitrary key as well as some prop mixins. __Note:__ this is not recommended in
   ///   general. If you need to do this, it's often easier implement and follow by explicitly
-  ///   nulling out single props you don't which to forward.
+  ///   nulling out single props you don't want to forward.
   ///
   ///     static final _onChangePropKey = getKeyFor((p) => p.onChange, domProps);
   ///
@@ -352,7 +352,7 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   ///
   /// Note: for legacy syntax component declarations, this defaults to just the props declared within
   /// the `@Props` class for this component, and not any inherited props. Also, [propsMeta] is not
-  /// available
+  /// available.
   @override
   Iterable<ConsumedProps> get consumedProps => $defaultConsumedProps;
 

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -291,18 +291,76 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   Iterable<ConsumedProps> get $defaultConsumedProps => throw UngeneratedError(member: #$defaultConsumedProps);
 
   /// The sets of props that should be considered "consumed" by this component, and thus
-  /// omitted when forwarding props and validated in propTypes.
+  /// omitted when forwarding props and validated in [propTypes].
   ///
-  /// For legacy syntax component declarations, this defaults to just the props declared within
-  /// the `@Props` class for this component, and not any inherited props.
+  /// This defaults to all of the prop mixins mixed into the props class
+  /// (or just the single props mixin for the shorthand syntax), or [propsMeta]`.all`.
   ///
-  /// For the new mixin-based syntax component declarations, this defaults to all of the prop mixins
-  /// mixed into the props class (or just the single props mixin for the shorthand syntax).
+  /// ## Examples on how to override this to get certain behavior:
+  ///
+  /// - Consume all props - no override; this is the default behavior.
+  ///
+  /// - Consume no props - override with an empty list.
+  ///
+  ///     @override
+  ///     get consumedProps => const [];
+  ///
+  /// - Consume props from some of the props mixins - use `.forMixins`.
+  ///
+  ///     // Note: A set literal here is recommended to prevent accidental duplicates of mixins.
+  ///     @override
+  ///     get consumedProps => propsMeta.forMixins({
+  ///       FooPropsMixin,
+  ///       BarPropsMixin,
+  ///     });
+  ///
+  /// - Consume props from all props mixins except some of them
+  ///
+  ///     // Note: A set literal here is recommended to prevent accidental duplicates of mixins.
+  ///     @override
+  ///     get consumedProps => propsMeta.allExceptForMixins({
+  ///       NoConsume1PropsMixin,
+  ///       NoConsume2PropsMixin,
+  ///     });
+  ///
+  /// - Consume an arbitrary key as well as some prop mixins. __Note:__ this is not recommended in
+  ///   general. If you need to do this, it's often easier implement and follow by explicitly
+  ///   nulling out single props you don't which to forward.
+  ///
+  ///     static final _onChangePropKey = getKeyFor((p) => p.onChange, domProps);
+  ///
+  ///     @override
+  ///     get consumedProps => [
+  ///       ...propsMeta.forMixins({FooPropsMixin, BarPropsMixin}),
+  ///       PropsMeta.forSimpleKey(_onChangePropKey),
+  ///     ];
+  ///
+  ///     // Alternative:
+  ///
+  ///     @override
+  ///     get consumedProps => propsMeta.forMixins({FooPropsMixin, BarPropsMixin});
+  ///
+  ///     render() {
+  ///       return (ComponentPropsAreForwardedTo()
+  ///         ..modifyProps(addUnconsumedProps)
+  ///         // Don't forward onChange
+  ///         ..onChange = null
+  ///       )();
+  ///     }
+  ///
+  /// ----
+  ///
+  /// Note: for legacy syntax component declarations, this defaults to just the props declared within
+  /// the `@Props` class for this component, and not any inherited props. Also, [propsMeta] is not
+  /// available
   @override
   Iterable<ConsumedProps> get consumedProps => $defaultConsumedProps;
 
-  /// A collection of metadata for the prop fields in all prop mixins
-  /// used by the props class of this component.
+  /// A collection of metadata for the prop fields in all prop mixins used by this component's
+  /// generated props class.
+  ///
+  /// This can be used to override [consumedProps] to customize forwarding behavior. See the doc
+  /// comment for [consumedProps] for examples on customizing.
   @protected
   @toBeGenerated
   PropsMetaCollection get propsMeta => throw UngeneratedError(member: #propsMeta);

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -290,10 +290,14 @@ abstract class UiComponent2<TProps extends UiProps> extends react.Component2
   @toBeGenerated
   Iterable<ConsumedProps> get $defaultConsumedProps => throw UngeneratedError(member: #$defaultConsumedProps);
 
-  /// The non-forwarding props defined in this component.
+  /// The sets of props that should be considered "consumed" by this component, and thus
+  /// omitted when forwarding props and validated in propTypes.
   ///
-  /// For generated components, this defaults to the keys generated in the associated [UiProps] class
-  /// if this getter is not overridden.
+  /// For legacy syntax component declarations, this defaults to just the props declared within
+  /// the `@Props` class for this component, and not any inherited props.
+  ///
+  /// For the new mixin-based syntax component declarations, this defaults to all of the prop mixins
+  /// mixed into the props class (or just the single props mixin for the shorthand syntax).
   @override
   Iterable<ConsumedProps> get consumedProps => $defaultConsumedProps;
 

--- a/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
@@ -180,7 +180,7 @@ class _$ReduxMultiProviderComponent extends ReduxMultiProviderComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ReduxMultiProviderProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForReduxMultiProviderProps

--- a/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
@@ -180,7 +180,7 @@ class _$ReduxMultiProviderComponent extends ReduxMultiProviderComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ReduxMultiProviderProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForReduxMultiProviderProps

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -295,7 +295,7 @@ class _$SafeRenderManagerHelperComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SafeRenderManagerHelperProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSafeRenderManagerHelperProps

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -295,7 +295,7 @@ class _$SafeRenderManagerHelperComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SafeRenderManagerHelperProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSafeRenderManagerHelperProps

--- a/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
@@ -296,7 +296,7 @@ class _$TransitionerComponent extends TransitionerComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TransitionerProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTransitionerProps

--- a/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
@@ -296,7 +296,7 @@ class _$TransitionerComponent extends TransitionerComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TransitionerProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTransitionerProps

--- a/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
+++ b/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
@@ -244,7 +244,7 @@ class _$CustomErrorBoundaryComponent extends CustomErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CustomErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCustomErrorBoundaryProps

--- a/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
+++ b/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
@@ -244,7 +244,7 @@ class _$CustomErrorBoundaryComponent extends CustomErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CustomErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCustomErrorBoundaryProps

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -221,8 +221,8 @@ class _$TransitionerComponent extends TransitionerComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from TransitionerProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by TransitionerProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -222,7 +222,7 @@ class _$TransitionerComponent extends TransitionerComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by TransitionerProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -224,7 +224,7 @@ class _$TransitionerComponent extends TransitionerComponent {
   /// The default consumed props, taken from TransitionerProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
@@ -142,7 +142,7 @@ class _$BasicChildComponent extends BasicChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicChildProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicChildProps

--- a/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
@@ -142,7 +142,7 @@ class _$BasicChildComponent extends BasicChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicChildProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicChildProps

--- a/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
@@ -88,7 +88,7 @@ class _$BasicUiComponentComponent extends BasicUiComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicUiComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicUiComponentProps

--- a/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
@@ -88,7 +88,7 @@ class _$BasicUiComponentComponent extends BasicUiComponentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicUiComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicUiComponentProps

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -268,7 +268,7 @@ class _$ContextProviderWrapperComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ContextProviderWrapperProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForContextProviderWrapperProps

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -268,7 +268,7 @@ class _$ContextProviderWrapperComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ContextProviderWrapperProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForContextProviderWrapperProps

--- a/test/over_react/component/fixtures/context_type_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_type_component.over_react.g.dart
@@ -142,7 +142,7 @@ class _$ContextTypeComponent extends ContextTypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ContextTypeProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForContextTypeProps

--- a/test/over_react/component/fixtures/context_type_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_type_component.over_react.g.dart
@@ -142,7 +142,7 @@ class _$ContextTypeComponent extends ContextTypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ContextTypeProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForContextTypeProps

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -153,7 +153,7 @@ class _$DummyComponent extends DummyComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DummyProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForDummyProps];
 }

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -153,7 +153,7 @@ class _$DummyComponent extends DummyComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DummyProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForDummyProps];
 }

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -278,7 +278,7 @@ class _$FlawedComponent extends FlawedComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedProps

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -278,7 +278,7 @@ class _$FlawedComponent extends FlawedComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedProps

--- a/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FlawedOnMountComponent extends FlawedOnMountComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedOnMountProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedOnMountProps

--- a/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FlawedOnMountComponent extends FlawedOnMountComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedOnMountProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedOnMountProps

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
@@ -143,7 +143,7 @@ class _$FlawedWithStringChildComponent extends FlawedWithStringChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedWithStringChildProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedWithStringChildProps

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
@@ -143,7 +143,7 @@ class _$FlawedWithStringChildComponent extends FlawedWithStringChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedWithStringChildProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedWithStringChildProps

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FlawedWithNoChildComponent extends FlawedWithNoChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedWithNoChildProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedWithNoChildProps

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FlawedWithNoChildComponent extends FlawedWithNoChildComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FlawedWithNoChildProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFlawedWithNoChildProps

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
@@ -348,7 +348,7 @@ class _$TestConsumingAbstractCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConsumingAbstractCustomRendererComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConsumingAbstractCustomRendererComponentProps
@@ -547,7 +547,7 @@ class _$TestConsumingCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConsumingCustomRendererComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConsumingCustomRendererComponentProps
@@ -836,7 +836,7 @@ class _$TestCustomRendererFromAbstractComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCustomRendererFromAbstractComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCustomRendererFromAbstractComponentProps
@@ -1194,7 +1194,7 @@ class _$TestCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCustomRendererComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCustomRendererComponentProps

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
@@ -348,7 +348,7 @@ class _$TestConsumingAbstractCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConsumingAbstractCustomRendererComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConsumingAbstractCustomRendererComponentProps
@@ -547,7 +547,7 @@ class _$TestConsumingCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConsumingCustomRendererComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConsumingCustomRendererComponentProps
@@ -836,7 +836,7 @@ class _$TestCustomRendererFromAbstractComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCustomRendererFromAbstractComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCustomRendererFromAbstractComponentProps
@@ -1194,7 +1194,7 @@ class _$TestCustomRendererComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCustomRendererComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCustomRendererComponentProps

--- a/test/over_react/component/forward_ref_test.over_react.g.dart
+++ b/test/over_react/component/forward_ref_test.over_react.g.dart
@@ -151,7 +151,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test/over_react/component/forward_ref_test.over_react.g.dart
+++ b/test/over_react/component/forward_ref_test.over_react.g.dart
@@ -151,7 +151,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test/over_react/component/typed_factory_test.over_react.g.dart
+++ b/test/over_react/component/typed_factory_test.over_react.g.dart
@@ -277,7 +277,7 @@ class _$TypedFactoryTesterComponent extends TypedFactoryTesterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TypedFactoryTesterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTypedFactoryTesterProps

--- a/test/over_react/component/typed_factory_test.over_react.g.dart
+++ b/test/over_react/component/typed_factory_test.over_react.g.dart
@@ -277,7 +277,7 @@ class _$TypedFactoryTesterComponent extends TypedFactoryTesterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TypedFactoryTesterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTypedFactoryTesterProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.dart
@@ -106,8 +106,8 @@ main() {
       });
     });
 
-    test('omits props declared in the @Props() class when forwarding by default', () {
-      var shallowInstance = renderShallow((ComponentTest()
+    test('omits only props declared in the @Props() class when forwarding by default', () {
+      final builder = ComponentTest()
         ..addProp('extraneous', true)
         ..stringProp = 'test'
         ..dynamicProp = 'test'
@@ -115,23 +115,38 @@ main() {
         ..customKeyProp = 'test'
         ..customNamespaceProp = 'test'
         ..customKeyAndNamespaceProp = 'test'
-      )());
+        ..propsMixinProp = 'test';
 
+      final mixinPropKey = getPropKey<ComponentTestProps>((p) => p.propsMixinProp, ComponentTest);
+      expect(builder, containsPair(mixinPropKey, 'test'),
+          reason: 'test setup check: mixin prop accessors should write props as expected');
+
+      var shallowInstance = renderShallow(builder());
       var shallowProps = getProps(shallowInstance);
       Iterable<String> shallowPropKeys = shallowProps.keys.map((key) => key as String); // ignore: avoid_as
 
-      expect(shallowPropKeys.where((key) => !key.startsWith('data-prop-')), unorderedEquals(['id', 'extraneous', 'children']));
+      expect(
+          shallowPropKeys.where((key) => !key.startsWith('data-prop-')),
+          unorderedEquals({
+            'id',
+            'extraneous',
+            'children',
+            mixinPropKey,
+          }));
     });
   });
 }
 
+mixin TestPropsMixin on UiProps {
+  dynamic propsMixinProp;
+}
 
 @Factory()
 // ignore: undefined_identifier
 UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
 
 @Props()
-class _$ComponentTestProps extends UiProps {
+class _$ComponentTestProps extends UiProps with TestPropsMixin, $TestPropsMixin {
   String stringProp;
   dynamic dynamicProp;
   var untypedProp; // ignore: prefer_typing_uninitialized_variables

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -188,7 +188,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -194,3 +194,35 @@ class _$ComponentTestComponent extends ComponentTestComponent {
     _$metaForComponentTestProps
   ];
 }
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestPropsMixin on TestPropsMixin {
+  static const PropsMeta meta = _$metaForTestPropsMixin;
+  @override
+  dynamic get propsMixinProp =>
+      props[_$key__propsMixinProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set propsMixinProp(dynamic value) =>
+      props[_$key__propsMixinProp__TestPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__propsMixinProp__TestPropsMixin =
+      PropDescriptor(_$key__propsMixinProp__TestPropsMixin);
+  static const String _$key__propsMixinProp__TestPropsMixin =
+      'TestPropsMixin.propsMixinProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__propsMixinProp__TestPropsMixin
+  ];
+  static const List<String> $propKeys = [_$key__propsMixinProp__TestPropsMixin];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestPropsMixin = PropsMeta(
+  fields: $TestPropsMixin.$props,
+  keys: $TestPropsMixin.$propKeys,
+);

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.over_react.g.dart
@@ -188,7 +188,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -121,7 +121,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.over_react.g.dart
@@ -121,7 +121,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -242,7 +242,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -242,7 +242,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -353,7 +353,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.over_react.g.dart
@@ -353,7 +353,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -92,7 +92,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.over_react.g.dart
@@ -92,7 +92,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -239,7 +239,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.over_react.g.dart
@@ -239,7 +239,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -111,7 +111,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.over_react.g.dart
@@ -111,7 +111,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -92,7 +92,7 @@ class _$AnnotationErrorDefaultPropsComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorDefaultPropsProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorDefaultPropsProps
@@ -180,7 +180,7 @@ class _$AnnotationErrorComponent extends AnnotationErrorComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorProps
@@ -316,7 +316,7 @@ class _$AnnotationErrorStatefulComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorStatefulProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorStatefulProps
@@ -464,7 +464,7 @@ class _$AnnotationErrorStatefulDefaultPropsComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorStatefulDefaultPropsProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorStatefulDefaultPropsProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -92,7 +92,7 @@ class _$AnnotationErrorDefaultPropsComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorDefaultPropsProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorDefaultPropsProps
@@ -180,7 +180,7 @@ class _$AnnotationErrorComponent extends AnnotationErrorComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorProps
@@ -316,7 +316,7 @@ class _$AnnotationErrorStatefulComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorStatefulProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorStatefulProps
@@ -464,7 +464,7 @@ class _$AnnotationErrorStatefulDefaultPropsComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$AnnotationErrorStatefulDefaultPropsProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForAnnotationErrorStatefulDefaultPropsProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -282,7 +282,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps
@@ -427,7 +427,7 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$IsErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForIsErrorBoundaryProps
@@ -572,7 +572,7 @@ class _$IsNotErrorBoundaryComponent extends IsNotErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$IsNotErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForIsNotErrorBoundaryProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -282,7 +282,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps
@@ -427,7 +427,7 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$IsErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForIsErrorBoundaryProps
@@ -572,7 +572,7 @@ class _$IsNotErrorBoundaryComponent extends IsNotErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$IsNotErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForIsNotErrorBoundaryProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -202,7 +202,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -202,7 +202,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -366,7 +366,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -366,7 +366,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -477,7 +477,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -477,7 +477,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -152,7 +152,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -152,7 +152,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -223,7 +223,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -223,7 +223,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -385,7 +385,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -385,7 +385,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -171,7 +171,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -171,7 +171,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -193,7 +193,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -193,7 +193,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -126,7 +126,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -126,7 +126,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -252,7 +252,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -252,7 +252,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DoNotGenerateAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDoNotGenerateAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -363,7 +363,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -363,7 +363,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NamespacedAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNamespacedAccessorTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -135,8 +135,7 @@ class _$FooComponent extends FooComponent {
   /// The default consumed props, taken from FooProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FooProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -133,7 +133,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -132,8 +132,8 @@ class _$FooComponent extends FooComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FooProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
@@ -145,27 +145,26 @@ main() {
           expect(Dom.div().componentDefaultProps, equals({}));
         });
       });
+    });
 
-      test('omits props declared in the @Props() class when forwarding by default', () {
-        var shallowInstance = renderShallow((ComponentTest()
-          ..addProp('extraneous', true)
-          ..stringProp = 'test'
-          ..dynamicProp = 'test'
-          ..untypedProp = 'test'
-          ..customKeyProp = 'test'
-          ..customNamespaceProp = 'test'
-          ..customKeyAndNamespaceProp = 'test'
-        )());
+    test('omits props declared in the props class when forwarding by default', () {
+      var shallowInstance = renderShallow((ComponentTest()
+        ..addProp('extraneous', true)
+        ..stringProp = 'test'
+        ..dynamicProp = 'test'
+        ..untypedProp = 'test'
+        ..customKeyProp = 'test'
+        ..customNamespaceProp = 'test'
+        ..customKeyAndNamespaceProp = 'test'
+      )());
 
-        var shallowProps = getProps(shallowInstance);
-        Iterable<String> shallowPropKeys = shallowProps.keys.map((key) => key as String); // ignore: avoid_as
+      var shallowProps = getProps(shallowInstance);
+      Iterable<String> shallowPropKeys = shallowProps.keys.map((key) => key as String); // ignore: avoid_as
 
-        expect(shallowPropKeys.where((key) => !key.startsWith('data-prop-')), unorderedEquals(['id', 'extraneous', 'children']));
-      });
+      expect(shallowPropKeys.where((key) => !key.startsWith('data-prop-')), unorderedEquals(['id', 'extraneous', 'children']));
     });
   });
 }
-
 
 UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   /// The default consumed props, taken from ComponentTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ComponentTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
@@ -411,8 +410,7 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
   /// The default consumed props, taken from IsErrorBoundaryProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(IsErrorBoundaryProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
@@ -571,8 +569,7 @@ class _$IsNotErrorBoundaryComponent extends IsNotErrorBoundaryComponent {
   /// The default consumed props, taken from IsNotErrorBoundaryProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(IsNotErrorBoundaryProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ComponentTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -407,8 +407,8 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from IsErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by IsErrorBoundaryProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -566,8 +566,8 @@ class _$IsNotErrorBoundaryComponent extends IsNotErrorBoundaryComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from IsNotErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by IsNotErrorBoundaryProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -408,7 +408,7 @@ class _$IsErrorBoundaryComponent extends IsErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by IsErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -567,7 +567,7 @@ class _$IsNotErrorBoundaryComponent extends IsNotErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by IsNotErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
@@ -77,9 +77,40 @@ main() {
                 'not throw.');
       });
     });
+
+    test('omits all props mixed into the props class when forwarding by default', () {
+      final builder = ComponentTest()
+        ..addProp('extraneous', true)
+        ..stringProp = 'test'
+        ..dynamicProp = 'test'
+        ..untypedProp = 'test'
+        ..customKeyProp = 'test'
+        ..customNamespaceProp = 'test'
+        ..customKeyAndNamespaceProp = 'test'
+        ..propsMixinProp = 'test';
+
+      final mixinPropKey = getPropKey<ComponentTestProps>((p) => p.propsMixinProp, ComponentTest);
+      expect(builder, containsPair(mixinPropKey, 'test'),
+          reason: 'test setup check: mixin prop accessors should write props as expected');
+
+      var shallowInstance = renderShallow(builder());
+      var shallowProps = getProps(shallowInstance);
+      Iterable<String> shallowPropKeys = shallowProps.keys.map((key) => key as String); // ignore: avoid_as
+
+      expect(
+          shallowPropKeys.where((key) => !key.startsWith('data-prop-')),
+          unorderedEquals({
+            'id',
+            'extraneous',
+            'children',
+          }));
+    });
   });
 }
 
+mixin TestPropsMixin on UiProps {
+  dynamic propsMixinProp;
+}
 
 UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
 
@@ -100,7 +131,7 @@ mixin ComponentTestPropsMixin on UiProps {
   dynamic customKeyAndNamespaceProp;
 }
 
-class ComponentTestProps = UiProps with ComponentTestPropsMixin;
+class ComponentTestProps = UiProps with ComponentTestPropsMixin, TestPropsMixin;
 
 class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
   @override

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -138,7 +138,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -34,7 +34,9 @@ _$$ComponentTestProps _$ComponentTest([Map backingProps]) =>
 abstract class _$$ComponentTestProps extends UiProps
     with
         ComponentTestPropsMixin,
-        $ComponentTestPropsMixin // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of ComponentTestPropsMixin.
+        $ComponentTestPropsMixin, // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of ComponentTestPropsMixin.
+        TestPropsMixin,
+        $TestPropsMixin // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TestPropsMixin.
     implements
         ComponentTestProps {
   _$$ComponentTestProps._();
@@ -144,8 +146,42 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of ComponentTestPropsMixin.
         ComponentTestPropsMixin: $ComponentTestPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TestPropsMixin.
+        TestPropsMixin: $TestPropsMixin.meta,
       });
 }
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestPropsMixin on TestPropsMixin {
+  static const PropsMeta meta = _$metaForTestPropsMixin;
+  @override
+  dynamic get propsMixinProp =>
+      props[_$key__propsMixinProp__TestPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set propsMixinProp(dynamic value) =>
+      props[_$key__propsMixinProp__TestPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__propsMixinProp__TestPropsMixin =
+      PropDescriptor(_$key__propsMixinProp__TestPropsMixin);
+  static const String _$key__propsMixinProp__TestPropsMixin =
+      'TestPropsMixin.propsMixinProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__propsMixinProp__TestPropsMixin
+  ];
+  static const List<String> $propKeys = [_$key__propsMixinProp__TestPropsMixin];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestPropsMixin = PropsMeta(
+  fields: $TestPropsMixin.$props,
+  keys: $TestPropsMixin.$propKeys,
+);
 
 @Deprecated('This API is for use only within generated code.'
     ' Do not reference it in your code, as it may change at any time.'

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -138,7 +138,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   /// The default consumed props, taken from ComponentTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -135,8 +135,8 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ComponentTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   /// The default consumed props, taken from ComponentTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ComponentTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ComponentTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -229,8 +229,7 @@ class _$DoNotGenerateAccessorTestComponent
   /// The default consumed props, taken from DoNotGenerateAccessorTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(DoNotGenerateAccessorTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -227,7 +227,7 @@ class _$DoNotGenerateAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by DoNotGenerateAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -226,8 +226,8 @@ class _$DoNotGenerateAccessorTestComponent
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from DoNotGenerateAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by DoNotGenerateAccessorTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -225,8 +225,8 @@ class _$NamespacedAccessorTestComponent
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from NamespacedAccessorTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by NamespacedAccessorTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -228,8 +228,7 @@ class _$NamespacedAccessorTestComponent
   /// The default consumed props, taken from NamespacedAccessorTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(NamespacedAccessorTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -226,7 +226,7 @@ class _$NamespacedAccessorTestComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by NamespacedAccessorTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -135,8 +135,7 @@ class _$FooComponent extends FooComponent {
   /// The default consumed props, taken from FooProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FooProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -133,7 +133,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -132,8 +132,8 @@ class _$FooComponent extends FooComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FooProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -140,7 +140,7 @@ class _$TestComponent extends TestComponent {
   /// The default consumed props, taken from TestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -138,7 +138,7 @@ class _$TestComponent extends TestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by TestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -137,8 +137,8 @@ class _$TestComponent extends TestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from TestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by TestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   /// The default consumed props, taken from ComponentTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ComponentTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ComponentTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -227,8 +227,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   /// The default consumed props, taken from StatefulComponentTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(StatefulComponentTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -225,7 +225,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by StatefulComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -224,8 +224,8 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from StatefulComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by StatefulComponentTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -135,8 +135,7 @@ class _$FooComponent extends FooComponent {
   /// The default consumed props, taken from FooProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FooProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -133,7 +133,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -132,8 +132,8 @@ class _$FooComponent extends FooComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FooProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -96,7 +96,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -96,7 +96,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -140,7 +140,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -140,7 +140,7 @@ class _$ComponentTestComponent extends ComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -249,7 +249,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -249,7 +249,7 @@ class _$StatefulComponentTestComponent extends StatefulComponentTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StatefulComponentTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStatefulComponentTestProps

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -115,7 +115,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -115,7 +115,7 @@ class _$FooComponent extends FooComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FooProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForFooProps];
 }

--- a/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$TestA2Component extends TestA2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestA2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestA2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$TestA2Component extends TestA2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestA2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestA2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$TestB2Component extends TestB2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestB2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestB2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
@@ -141,7 +141,7 @@ class _$TestB2Component extends TestB2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestB2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestB2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
@@ -145,7 +145,7 @@ class _$TestExtendtype2Component extends TestExtendtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestExtendtype2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestExtendtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
@@ -145,7 +145,7 @@ class _$TestExtendtype2Component extends TestExtendtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestExtendtype2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestExtendtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
@@ -142,7 +142,7 @@ class _$TestParent2Component extends TestParent2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestParent2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestParent2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
@@ -142,7 +142,7 @@ class _$TestParent2Component extends TestParent2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestParent2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestParent2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
@@ -145,7 +145,7 @@ class _$TestSubsubtype2Component extends TestSubsubtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtype2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
@@ -145,7 +145,7 @@ class _$TestSubsubtype2Component extends TestSubsubtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtype2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
@@ -151,7 +151,7 @@ class _$TestSubsubtypeOfComponent1Component
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtypeOfComponent1Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtypeOfComponent1Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
@@ -151,7 +151,7 @@ class _$TestSubsubtypeOfComponent1Component
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtypeOfComponent1Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtypeOfComponent1Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$TestSubtype2Component extends TestSubtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtype2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$TestSubtype2Component extends TestSubtype2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtype2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtype2Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
@@ -150,7 +150,7 @@ class _$TestSubtypeOfComponent1Component
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtypeOfComponent1Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtypeOfComponent1Props

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
@@ -150,7 +150,7 @@ class _$TestSubtypeOfComponent1Component
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtypeOfComponent1Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtypeOfComponent1Props

--- a/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
@@ -84,7 +84,7 @@ class _$TestAComponent extends TestAComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestAProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestAProps];
 }

--- a/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
@@ -84,7 +84,7 @@ class _$TestAComponent extends TestAComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestAProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestAProps];
 }

--- a/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
@@ -84,7 +84,7 @@ class _$TestBComponent extends TestBComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestBProps];
 }

--- a/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
@@ -84,7 +84,7 @@ class _$TestBComponent extends TestBComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestBProps];
 }

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
@@ -89,7 +89,7 @@ class _$TestExtendtypeComponent extends TestExtendtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestExtendtypeProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestExtendtypeProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
@@ -89,7 +89,7 @@ class _$TestExtendtypeComponent extends TestExtendtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestExtendtypeProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestExtendtypeProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestParentComponent extends TestParentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestParentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestParentProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestParentComponent extends TestParentComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestParentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestParentProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
@@ -89,7 +89,7 @@ class _$TestSubsubtypeComponent extends TestSubsubtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtypeProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtypeProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
@@ -89,7 +89,7 @@ class _$TestSubsubtypeComponent extends TestSubsubtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubsubtypeProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubsubtypeProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
@@ -88,7 +88,7 @@ class _$TestSubtypeComponent extends TestSubtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtypeProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtypeProps

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
@@ -88,7 +88,7 @@ class _$TestSubtypeComponent extends TestSubtypeComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestSubtypeProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestSubtypeProps

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -142,7 +142,7 @@ class _$TestBasicComponent extends TestBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestBasicProps
@@ -288,7 +288,7 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerLifecycleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerLifecycleProps
@@ -436,7 +436,7 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerPrecedenceProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerPrecedenceProps
@@ -601,7 +601,7 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPropValidationProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPropValidationProps
@@ -744,7 +744,7 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestRedrawOnProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestRedrawOnProps
@@ -888,7 +888,7 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStoreHandlersProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStoreHandlersProps
@@ -1129,7 +1129,7 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulBasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulBasicProps
@@ -1382,7 +1382,7 @@ class _$TestStatefulHandlerLifecycleComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerLifecycleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerLifecycleProps
@@ -1635,7 +1635,7 @@ class _$TestStatefulHandlerPrecedenceComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerPrecedenceProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerPrecedenceProps
@@ -1909,7 +1909,7 @@ class _$TestStatefulPropValidationComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulPropValidationProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulPropValidationProps
@@ -2154,7 +2154,7 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulRedrawOnProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulRedrawOnProps
@@ -2405,7 +2405,7 @@ class _$TestStatefulStoreHandlersComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulStoreHandlersProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulStoreHandlersProps

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -142,7 +142,7 @@ class _$TestBasicComponent extends TestBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestBasicProps
@@ -288,7 +288,7 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerLifecycleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerLifecycleProps
@@ -436,7 +436,7 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerPrecedenceProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerPrecedenceProps
@@ -601,7 +601,7 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPropValidationProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPropValidationProps
@@ -744,7 +744,7 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestRedrawOnProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestRedrawOnProps
@@ -888,7 +888,7 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStoreHandlersProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStoreHandlersProps
@@ -1129,7 +1129,7 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulBasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulBasicProps
@@ -1382,7 +1382,7 @@ class _$TestStatefulHandlerLifecycleComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerLifecycleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerLifecycleProps
@@ -1635,7 +1635,7 @@ class _$TestStatefulHandlerPrecedenceComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerPrecedenceProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerPrecedenceProps
@@ -1909,7 +1909,7 @@ class _$TestStatefulPropValidationComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulPropValidationProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulPropValidationProps
@@ -2154,7 +2154,7 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulRedrawOnProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulRedrawOnProps
@@ -2405,7 +2405,7 @@ class _$TestStatefulStoreHandlersComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulStoreHandlersProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulStoreHandlersProps

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestBasicComponent extends TestBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestBasicProps
@@ -175,7 +175,7 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerLifecycleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerLifecycleProps
@@ -263,7 +263,7 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerPrecedenceProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerPrecedenceProps
@@ -371,7 +371,7 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPropValidationProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPropValidationProps
@@ -459,7 +459,7 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestRedrawOnProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestRedrawOnProps
@@ -547,7 +547,7 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStoreHandlersProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStoreHandlersProps
@@ -682,7 +682,7 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulBasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulBasicProps
@@ -823,7 +823,7 @@ class _$TestStatefulHandlerLifecycleComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerLifecycleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerLifecycleProps
@@ -964,7 +964,7 @@ class _$TestStatefulHandlerPrecedenceComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerPrecedenceProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerPrecedenceProps
@@ -1126,7 +1126,7 @@ class _$TestStatefulPropValidationComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulPropValidationProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulPropValidationProps
@@ -1261,7 +1261,7 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulRedrawOnProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulRedrawOnProps
@@ -1398,7 +1398,7 @@ class _$TestStatefulStoreHandlersComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulStoreHandlersProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulStoreHandlersProps

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestBasicComponent extends TestBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestBasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestBasicProps
@@ -175,7 +175,7 @@ class _$TestHandlerLifecycleComponent extends TestHandlerLifecycleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerLifecycleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerLifecycleProps
@@ -263,7 +263,7 @@ class _$TestHandlerPrecedenceComponent extends TestHandlerPrecedenceComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestHandlerPrecedenceProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestHandlerPrecedenceProps
@@ -371,7 +371,7 @@ class _$TestPropValidationComponent extends TestPropValidationComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPropValidationProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPropValidationProps
@@ -459,7 +459,7 @@ class _$TestRedrawOnComponent extends TestRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestRedrawOnProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestRedrawOnProps
@@ -547,7 +547,7 @@ class _$TestStoreHandlersComponent extends TestStoreHandlersComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStoreHandlersProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStoreHandlersProps
@@ -682,7 +682,7 @@ class _$TestStatefulBasicComponent extends TestStatefulBasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulBasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulBasicProps
@@ -823,7 +823,7 @@ class _$TestStatefulHandlerLifecycleComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerLifecycleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerLifecycleProps
@@ -964,7 +964,7 @@ class _$TestStatefulHandlerPrecedenceComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulHandlerPrecedenceProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulHandlerPrecedenceProps
@@ -1126,7 +1126,7 @@ class _$TestStatefulPropValidationComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulPropValidationProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulPropValidationProps
@@ -1261,7 +1261,7 @@ class _$TestStatefulRedrawOnComponent extends TestStatefulRedrawOnComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulRedrawOnProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulRedrawOnProps
@@ -1398,7 +1398,7 @@ class _$TestStatefulStoreHandlersComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestStatefulStoreHandlersProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestStatefulStoreHandlersProps

--- a/test/over_react/component_declaration/redux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/redux_component_test.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestDefaultComponent extends TestDefaultComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestDefaultProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestDefaultProps
@@ -174,7 +174,7 @@ class _$TestConnectComponent extends TestConnectComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConnectProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConnectProps
@@ -260,7 +260,7 @@ class _$TestPureComponent extends TestPureComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPureProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPureProps

--- a/test/over_react/component_declaration/redux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/redux_component_test.over_react.g.dart
@@ -87,7 +87,7 @@ class _$TestDefaultComponent extends TestDefaultComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestDefaultProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestDefaultProps
@@ -174,7 +174,7 @@ class _$TestConnectComponent extends TestConnectComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestConnectProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestConnectProps
@@ -260,7 +260,7 @@ class _$TestPureComponent extends TestPureComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestPureProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestPureProps

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -147,7 +147,7 @@ class _$TestCompositeComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCompositeComponentProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCompositeComponentProps

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -147,7 +147,7 @@ class _$TestCompositeComponentComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestCompositeComponentProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTestCompositeComponentProps

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -141,7 +141,7 @@ class _$DomTestComponent extends DomTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DomTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDomTestProps

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -141,7 +141,7 @@ class _$DomTestComponent extends DomTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$DomTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForDomTestProps

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -169,7 +169,7 @@ class _$TestComponent extends TestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestProps];
 }

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -169,7 +169,7 @@ class _$TestComponent extends TestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestProps];
 }

--- a/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
+++ b/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
@@ -180,7 +180,7 @@ class _$TestComponent extends TestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestProps];
 }

--- a/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
+++ b/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
@@ -180,7 +180,7 @@ class _$TestComponent extends TestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTestProps];
 }

--- a/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
@@ -243,7 +243,7 @@ class _$ConnectFluxCounterComponent extends ConnectFluxCounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ConnectFluxCounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForConnectFluxCounterProps

--- a/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
@@ -243,7 +243,7 @@ class _$ConnectFluxCounterComponent extends ConnectFluxCounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ConnectFluxCounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForConnectFluxCounterProps

--- a/test/over_react_redux/fixtures/counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter.over_react.g.dart
@@ -206,7 +206,7 @@ class _$CounterComponent extends CounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCounterProps

--- a/test/over_react_redux/fixtures/counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter.over_react.g.dart
@@ -206,7 +206,7 @@ class _$CounterComponent extends CounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCounterProps

--- a/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
@@ -142,7 +142,7 @@ class _$FluxCounterComponent extends FluxCounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FluxCounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFluxCounterProps

--- a/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
@@ -142,7 +142,7 @@ class _$FluxCounterComponent extends FluxCounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FluxCounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFluxCounterProps

--- a/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
@@ -89,7 +89,7 @@ class _$NonComponentTwoCounterComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NonComponentTwoCounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNonComponentTwoCounterProps

--- a/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
@@ -89,7 +89,7 @@ class _$NonComponentTwoCounterComponent
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NonComponentTwoCounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNonComponentTwoCounterProps

--- a/test/test_util/component2/one_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/one_level_wrapper2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$OneLevelWrapper2Component extends OneLevelWrapper2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$OneLevelWrapper2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForOneLevelWrapper2Props

--- a/test/test_util/component2/one_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/one_level_wrapper2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$OneLevelWrapper2Component extends OneLevelWrapper2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$OneLevelWrapper2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForOneLevelWrapper2Props

--- a/test/test_util/component2/two_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/two_level_wrapper2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$TwoLevelWrapper2Component extends TwoLevelWrapper2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TwoLevelWrapper2Props.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTwoLevelWrapper2Props

--- a/test/test_util/component2/two_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/two_level_wrapper2.over_react.g.dart
@@ -144,7 +144,7 @@ class _$TwoLevelWrapper2Component extends TwoLevelWrapper2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TwoLevelWrapper2Props.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTwoLevelWrapper2Props

--- a/test/test_util/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/one_level_wrapper.over_react.g.dart
@@ -88,7 +88,7 @@ class _$OneLevelWrapperComponent extends OneLevelWrapperComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$OneLevelWrapperProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForOneLevelWrapperProps

--- a/test/test_util/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/one_level_wrapper.over_react.g.dart
@@ -88,7 +88,7 @@ class _$OneLevelWrapperComponent extends OneLevelWrapperComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$OneLevelWrapperProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForOneLevelWrapperProps

--- a/test/test_util/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/two_level_wrapper.over_react.g.dart
@@ -88,7 +88,7 @@ class _$TwoLevelWrapperComponent extends TwoLevelWrapperComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TwoLevelWrapperProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTwoLevelWrapperProps

--- a/test/test_util/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/two_level_wrapper.over_react.g.dart
@@ -88,7 +88,7 @@ class _$TwoLevelWrapperComponent extends TwoLevelWrapperComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TwoLevelWrapperProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForTwoLevelWrapperProps

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -173,7 +173,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -173,7 +173,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -243,7 +243,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -341,7 +341,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -243,7 +243,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -341,7 +341,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -179,7 +179,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic.over_react.g.dart.goldFile
@@ -179,7 +179,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -253,7 +253,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -356,7 +356,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/basic_library.over_react.g.dart.goldFile
@@ -253,7 +253,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -356,7 +356,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
@@ -235,7 +235,7 @@ class _$Basic2Component extends Basic2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic.over_react.g.dart.goldFile
@@ -235,7 +235,7 @@ class _$Basic2Component extends Basic2Component {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
 }

--- a/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
@@ -359,7 +359,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -517,7 +517,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/component2/basic_library.over_react.g.dart.goldFile
@@ -359,7 +359,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$BasicPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForBasicPartOfLibProps
@@ -517,7 +517,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$SubPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForSubPartOfLibProps

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -132,11 +132,10 @@ class _$BasicComponent extends BasicComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(BasicProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -133,7 +133,7 @@ class _$BasicComponent extends BasicComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -225,7 +225,7 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BasicPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 
@@ -501,7 +501,7 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by SubPartOfLibProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -224,10 +224,10 @@ class _$BasicPartOfLibComponent extends BasicPartOfLibComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BasicPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BasicPartOfLibProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
@@ -500,10 +500,10 @@ class _$SubPartOfLibComponent extends SubPartOfLibComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from SubPartOfLibProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by SubPartOfLibProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -349,7 +349,7 @@ class _$ButtonComponent extends ButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ButtonProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForButtonProps

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -349,7 +349,7 @@ class _$ButtonComponent extends ButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ButtonProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForButtonProps

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -207,7 +207,7 @@ class _$ButtonGroupComponent extends ButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ButtonGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForButtonGroupProps

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -207,7 +207,7 @@ class _$ButtonGroupComponent extends ButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ButtonGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForButtonGroupProps

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -112,7 +112,7 @@ class _$ListGroupComponent extends ListGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListGroupProps

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -112,7 +112,7 @@ class _$ListGroupComponent extends ListGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListGroupProps

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -365,7 +365,7 @@ class _$ListGroupItemComponent extends ListGroupItemComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListGroupItemProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListGroupItemProps

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -365,7 +365,7 @@ class _$ListGroupItemComponent extends ListGroupItemComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListGroupItemProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListGroupItemProps

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -416,7 +416,7 @@ class _$ProgressComponent extends ProgressComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ProgressProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForProgressProps

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -416,7 +416,7 @@ class _$ProgressComponent extends ProgressComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ProgressProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForProgressProps

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -139,7 +139,7 @@ class _$TagComponent extends TagComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TagProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTagProps];
 }

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -139,7 +139,7 @@ class _$TagComponent extends TagComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$TagProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [_$metaForTagProps];
 }

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -301,7 +301,7 @@ class _$ToggleButtonComponent extends ToggleButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ToggleButtonProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForToggleButtonProps

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -301,7 +301,7 @@ class _$ToggleButtonComponent extends ToggleButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ToggleButtonProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForToggleButtonProps

--- a/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
@@ -136,7 +136,7 @@ class _$ToggleButtonGroupComponent extends ToggleButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ToggleButtonGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForToggleButtonGroupProps

--- a/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
@@ -136,7 +136,7 @@ class _$ToggleButtonGroupComponent extends ToggleButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ToggleButtonGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForToggleButtonGroupProps

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -220,8 +220,7 @@ class _$ButtonComponent extends ButtonComponent {
   /// The default consumed props, taken from ButtonProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ButtonProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -218,7 +218,7 @@ class _$ButtonComponent extends ButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ButtonProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -217,8 +217,8 @@ class _$ButtonComponent extends ButtonComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ButtonProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ButtonProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -218,7 +218,7 @@ class _$ButtonGroupComponent extends ButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ButtonGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -217,8 +217,8 @@ class _$ButtonGroupComponent extends ButtonGroupComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ButtonGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ButtonGroupProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -220,8 +220,7 @@ class _$ButtonGroupComponent extends ButtonGroupComponent {
   /// The default consumed props, taken from ButtonGroupProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ButtonGroupProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -136,8 +136,7 @@ class _$ListGroupComponent extends ListGroupComponent {
   /// The default consumed props, taken from ListGroupProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ListGroupProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -134,7 +134,7 @@ class _$ListGroupComponent extends ListGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ListGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -133,8 +133,8 @@ class _$ListGroupComponent extends ListGroupComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ListGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ListGroupProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ListGroupItemComponent extends ListGroupItemComponent {
   /// The default consumed props, taken from ListGroupItemProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ListGroupItemProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ListGroupItemComponent extends ListGroupItemComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ListGroupItemProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ListGroupItemProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ListGroupItemComponent extends ListGroupItemComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ListGroupItemProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -220,8 +220,7 @@ class _$ProgressComponent extends ProgressComponent {
   /// The default consumed props, taken from ProgressProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ProgressProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -217,8 +217,8 @@ class _$ProgressComponent extends ProgressComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ProgressProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ProgressProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -218,7 +218,7 @@ class _$ProgressComponent extends ProgressComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ProgressProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -134,8 +134,8 @@ class _$PropTypesTestComponent extends PropTypesTestComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from PropTypesTestProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by PropTypesTestProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -137,8 +137,7 @@ class _$PropTypesTestComponent extends PropTypesTestComponent {
   /// The default consumed props, taken from PropTypesTestProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(PropTypesTestProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -135,7 +135,7 @@ class _$PropTypesTestComponent extends PropTypesTestComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by PropTypesTestProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -218,8 +218,8 @@ class _$PropTypesWrapComponent extends PropTypesWrapComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from PropTypesWrapProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by PropTypesWrapProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -221,8 +221,7 @@ class _$PropTypesWrapComponent extends PropTypesWrapComponent {
   /// The default consumed props, taken from PropTypesWrapProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(PropTypesWrapProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -219,7 +219,7 @@ class _$PropTypesWrapComponent extends PropTypesWrapComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by PropTypesWrapProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -135,8 +135,7 @@ class _$TagComponent extends TagComponent {
   /// The default consumed props, taken from TagProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(TagProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -133,7 +133,7 @@ class _$TagComponent extends TagComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by TagProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -132,8 +132,8 @@ class _$TagComponent extends TagComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from TagProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by TagProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/toggle_button.dart
+++ b/web/component2/src/demo_components/toggle_button.dart
@@ -89,13 +89,6 @@ class ToggleButtonComponent extends ButtonComponent<ToggleButtonProps, ToggleBut
   );
 
   @override
-  get consumedProps => [
-        propsMeta.forMixin(ToggleButtonPropsMixin),
-        propsMeta.forMixin(ButtonProps),
-        propsMeta.forMixin(AbstractInputPropsMixin),
-      ];
-
-  @override
   void componentDidMount() {
     _validateProps(props);
   }

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -229,7 +229,7 @@ class _$ToggleButtonComponent extends ToggleButtonComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ToggleButtonProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -228,8 +228,8 @@ class _$ToggleButtonComponent extends ToggleButtonComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ToggleButtonProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ToggleButtonProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -231,7 +231,7 @@ class _$ToggleButtonComponent extends ToggleButtonComponent {
   /// The default consumed props, taken from ToggleButtonProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/toggle_button_group.dart
+++ b/web/component2/src/demo_components/toggle_button_group.dart
@@ -53,6 +53,9 @@ class ToggleButtonGroupComponent
     ..name = 'toggle_button_group_' + generateGuid()
   );
 
+  @override
+  get consumedProps => propsMeta.forMixins({AbstractInputPropsMixin});
+
   /// The props that should be added when we clone the given [child] using
   /// [cloneElement] via [renderButton].
   @override

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -225,8 +225,8 @@ class _$ToggleButtonGroupComponent extends ToggleButtonGroupComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ToggleButtonGroupProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ToggleButtonGroupProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -228,7 +228,7 @@ class _$ToggleButtonGroupComponent extends ToggleButtonGroupComponent {
   /// The default consumed props, taken from ToggleButtonGroupProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -226,7 +226,7 @@ class _$ToggleButtonGroupComponent extends ToggleButtonGroupComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ToggleButtonGroupProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/component2/src/demos/custom_error_boundary.over_react.g.dart
+++ b/web/component2/src/demos/custom_error_boundary.over_react.g.dart
@@ -244,7 +244,7 @@ class _$CustomErrorBoundaryComponent extends CustomErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CustomErrorBoundaryProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCustomErrorBoundaryProps

--- a/web/component2/src/demos/custom_error_boundary.over_react.g.dart
+++ b/web/component2/src/demos/custom_error_boundary.over_react.g.dart
@@ -244,7 +244,7 @@ class _$CustomErrorBoundaryComponent extends CustomErrorBoundaryComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$CustomErrorBoundaryProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForCustomErrorBoundaryProps

--- a/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FragmentExampleComponent extends FragmentExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FragmentExampleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFragmentExampleProps

--- a/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/fragment_example_component.over_react.g.dart
@@ -139,7 +139,7 @@ class _$FragmentExampleComponent extends FragmentExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$FragmentExampleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForFragmentExampleProps

--- a/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
@@ -137,7 +137,7 @@ class _$ListExampleComponent extends ListExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListExampleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListExampleProps

--- a/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/list_example_component.over_react.g.dart
@@ -137,7 +137,7 @@ class _$ListExampleComponent extends ListExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$ListExampleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForListExampleProps

--- a/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
@@ -137,7 +137,7 @@ class _$NumExampleComponent extends NumExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NumExampleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNumExampleProps

--- a/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/num_example_component.over_react.g.dart
@@ -137,7 +137,7 @@ class _$NumExampleComponent extends NumExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$NumExampleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForNumExampleProps

--- a/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
@@ -139,7 +139,7 @@ class _$StringExampleComponent extends StringExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StringExampleProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStringExampleProps

--- a/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
+++ b/web/component2/src/demos/return-types/string_example_component.over_react.g.dart
@@ -139,7 +139,7 @@ class _$StringExampleComponent extends StringExampleComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, taken from _$StringExampleProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   final List<ConsumedProps> $defaultConsumedProps = const [
     _$metaForStringExampleProps

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -133,8 +133,8 @@ class _$LittleBlockComponent extends LittleBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from LittleBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by LittleBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -134,7 +134,7 @@ class _$LittleBlockComponent extends LittleBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by LittleBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -136,8 +136,7 @@ class _$LittleBlockComponent extends LittleBlockComponent {
   /// The default consumed props, taken from LittleBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(LittleBlockProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -140,7 +140,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   /// The default consumed props, taken from BigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -137,8 +137,8 @@ class _$BigBlockComponent extends BigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -140,7 +140,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   /// The default consumed props, taken from BigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -137,8 +137,8 @@ class _$BigBlockComponent extends BigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -139,7 +139,7 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ConnectFluxBigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -141,7 +141,7 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   /// The default consumed props, taken from ConnectFluxBigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -138,8 +138,8 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ConnectFluxBigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ConnectFluxBigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -137,8 +137,8 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ReduxBigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ReduxBigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ReduxBigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -140,7 +140,7 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   /// The default consumed props, taken from ReduxBigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ShouldNotUpdateProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   /// The default consumed props, taken from ShouldNotUpdateProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ShouldNotUpdateProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -138,7 +138,7 @@ class _$RandomColorReduxComponent extends RandomColorReduxComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by RandomColorReduxProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -137,8 +137,8 @@ class _$RandomColorReduxComponent extends RandomColorReduxComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from RandomColorReduxProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by RandomColorReduxProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -140,7 +140,7 @@ class _$RandomColorReduxComponent extends RandomColorReduxComponent {
   /// The default consumed props, taken from RandomColorReduxProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ShouldNotUpdateProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   /// The default consumed props, taken from ShouldNotUpdateProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ShouldNotUpdateProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   /// The default consumed props, taken from BigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -136,7 +136,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -135,8 +135,8 @@ class _$BigBlockComponent extends BigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   /// The default consumed props, taken from BigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -136,7 +136,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -135,8 +135,8 @@ class _$BigBlockComponent extends BigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -139,7 +139,7 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ConnectFluxBigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -141,7 +141,7 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   /// The default consumed props, taken from ConnectFluxBigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -138,8 +138,8 @@ class _$ConnectFluxBigBlockComponent extends ConnectFluxBigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ConnectFluxBigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ConnectFluxBigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -137,8 +137,8 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ReduxBigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ReduxBigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -138,7 +138,7 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ReduxBigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -140,7 +140,7 @@ class _$ReduxBigBlockComponent extends ReduxBigBlockComponent {
   /// The default consumed props, taken from ReduxBigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ShouldNotUpdateProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   /// The default consumed props, taken from ShouldNotUpdateProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ShouldNotUpdateProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -136,8 +136,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   /// The default consumed props, taken from BigBlockProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(BigBlockProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -134,7 +134,7 @@ class _$BigBlockComponent extends BigBlockComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by BigBlockProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -133,8 +133,8 @@ class _$BigBlockComponent extends BigBlockComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from BigBlockProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by BigBlockProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -135,7 +135,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -134,8 +134,8 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from ShouldNotUpdateProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by ShouldNotUpdateProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -137,8 +137,7 @@ class _$ShouldNotUpdateComponent extends ShouldNotUpdateComponent {
   /// The default consumed props, taken from ShouldNotUpdateProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(ShouldNotUpdateProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -136,8 +136,8 @@ class _$CounterComponent extends CounterComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from CounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by CounterProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -137,7 +137,7 @@ class _$CounterComponent extends CounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by CounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -139,7 +139,7 @@ class _$CounterComponent extends CounterComponent {
   /// The default consumed props, taken from CounterProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -136,8 +136,8 @@ class _$CounterComponent extends CounterComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from CounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by CounterProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -137,7 +137,7 @@ class _$CounterComponent extends CounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by CounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -139,7 +139,7 @@ class _$CounterComponent extends CounterComponent {
   /// The default consumed props, taken from CounterProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -136,8 +136,8 @@ class _$CounterComponent extends CounterComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from CounterProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by CounterProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -137,7 +137,7 @@ class _$CounterComponent extends CounterComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by CounterProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -139,7 +139,7 @@ class _$CounterComponent extends CounterComponent {
   /// The default consumed props, taken from CounterProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps => const [];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -217,8 +217,8 @@ class _$FaultyComponent extends FaultyComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FaultyProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FaultyProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -220,8 +220,7 @@ class _$FaultyComponent extends FaultyComponent {
   /// The default consumed props, taken from FaultyProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FaultyProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -218,7 +218,7 @@ class _$FaultyComponent extends FaultyComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FaultyProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -135,7 +135,7 @@ class _$FaultyOnMountComponent extends FaultyOnMountComponent {
   bool get $isClassGenerated => true;
 
   /// The default consumed props, comprising all props mixins used by FaultyOnMountProps.
-  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -134,8 +134,8 @@ class _$FaultyOnMountComponent extends FaultyOnMountComponent {
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from FaultyOnMountProps.
-  /// Used in `ConsumedProps` if [consumedProps] is not overridden.
+  /// The default consumed props, comprising all props mixins used by FaultyOnMountProps.
+  /// Used in -`ConsumedProps` methods if [consumedProps] is not overridden.
   @override
   get $defaultConsumedProps => propsMeta.all;
 

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -137,8 +137,7 @@ class _$FaultyOnMountComponent extends FaultyOnMountComponent {
   /// The default consumed props, taken from FaultyOnMountProps.
   /// Used in `ConsumedProps` if [consumedProps] is not overridden.
   @override
-  List<ConsumedProps> get $defaultConsumedProps =>
-      [propsMeta.forMixin(FaultyOnMountProps)];
+  get $defaultConsumedProps => propsMeta.all;
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({


### PR DESCRIPTION
## Motivation
We want changing the default behavior of `consumedProps` to make overriding it not necessary as often, and to make prop forwarding behavior more consistent (not forwarding props from just one class by default).

## Changes
- Update builder implementation to default to `propsMeta.all` for new boilerplate
    - Update generated doc comments for old and new boilerplate
- Add tests verifying default consumed props behavior for both legacy and new boilerplate
- Add new `propsMeta` helper methods and tests
- Add section to boilerplate migration README
- Update `consumedProps` doc comment
- Update components in lib, web, and app with correct prop forwarding behavior

#### Release Notes
Consume all props mixins by default in mixin-based syntax

## Review

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Test with [this over_react_test branch](https://github.com/Workiva/over_react_test/pull/95) and ensure commonComponentTests (specifically the prop forwarding ones) pass for all component they're run on in this repo
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
