### PR TITLE
Allow static members in concrete props/state classes

### DIFF
--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -456,7 +456,7 @@ String _copyClassMembers(ClassOrMixinDeclaration node) {
     // generated for them, so don't copy those over either. We also don't want
     // to copy anything that would conflict with what the builder already may
     // generate, namely `props`, `state`, and `meta`
-    final isValid = !_isStaticFieldOrMethod(member) &&
+    final isValid = !isStaticMember(member) &&
         !(member is FieldDeclaration && !member.isSynthetic) &&
         !_memberHasName(member, 'props') &&
         !_memberHasName(member, 'state') &&
@@ -482,18 +482,13 @@ String _copyClassMembers(ClassOrMixinDeclaration node) {
 
 String _copyStaticMembers(ClassOrMixinDeclaration node) {
   final buffer = StringBuffer();
-  node.members.where(_isStaticFieldOrMethod).forEach((member) {
+  node.members.where(isStaticMember).forEach((member) {
     // Don't copy over anything named `meta`, since the static meta field is already going to be generated.
     if (!_memberHasName(member, 'meta')) {
       buffer.writeln(member.toSource());
     }
   });
   return buffer.toString();
-}
-
-bool _isStaticFieldOrMethod(ClassMember member) {
-  return (member is MethodDeclaration && member.isStatic) ||
-      (member is FieldDeclaration && member.isStatic);
 }
 
 bool _memberHasName(ClassMember member, String name) {

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -151,6 +151,11 @@ extension SourceFileSpanHelper on SourceFile {
   FileSpan _getSpanForEntity(SyntacticEntity node) => span(node.offset, node.end);
 }
 
+/// Returns whether [member] is static.
+bool isStaticMember(ClassMember member) =>
+    (member is MethodDeclaration && member.isStatic) ||
+    (member is FieldDeclaration && member.isStatic);
+
 /// Returns whether [classish] has one or more types it implements and does not
 /// extend or mix in anything.
 ///
@@ -159,7 +164,7 @@ bool onlyImplementsThings(ClassishDeclaration classish) =>
     classish.interfaces.isNotEmpty &&
     classish.superclass == null &&
     classish.mixins.isEmpty &&
-    classish.members.isEmpty;
+    classish.members.whereNot(isStaticMember).isEmpty;
 
 /// Returns whether any [Identifier] within [expression] matches the predicate [test].
 bool anyDescendantIdentifiers(Expression expression, bool Function(Identifier) test) {

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -164,7 +164,7 @@ bool onlyImplementsThings(ClassishDeclaration classish) =>
     classish.interfaces.isNotEmpty &&
     classish.superclass == null &&
     classish.mixins.isEmpty &&
-    classish.members.whereNot(isStaticMember).isEmpty;
+    !classish.members.every(isStaticMember);
 
 /// Returns whether any [Identifier] within [expression] matches the predicate [test].
 bool anyDescendantIdentifiers(Expression expression, bool Function(Identifier) test) {

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -164,7 +164,7 @@ bool onlyImplementsThings(ClassishDeclaration classish) =>
     classish.interfaces.isNotEmpty &&
     classish.superclass == null &&
     classish.mixins.isEmpty &&
-    !classish.members.every(isStaticMember);
+    classish.members.every(isStaticMember);
 
 /// Returns whether any [Identifier] within [expression] matches the predicate [test].
 bool anyDescendantIdentifiers(Expression expression, bool Function(Identifier) test) {

--- a/lib/src/builder/parsing/members.dart
+++ b/lib/src/builder/parsing/members.dart
@@ -24,6 +24,7 @@ import 'declarations.dart';
 import 'members_from_ast.dart';
 import 'meta.dart';
 import 'error_collection.dart';
+import 'util.dart';
 import 'version.dart';
 
 part 'members/component.dart';

--- a/lib/src/builder/parsing/members.dart
+++ b/lib/src/builder/parsing/members.dart
@@ -24,7 +24,6 @@ import 'declarations.dart';
 import 'members_from_ast.dart';
 import 'meta.dart';
 import 'error_collection.dart';
-import 'util.dart';
 import 'version.dart';
 
 part 'members/component.dart';

--- a/lib/src/builder/parsing/members/props_and_state.dart
+++ b/lib/src/builder/parsing/members/props_and_state.dart
@@ -77,7 +77,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateTypedMapMember
                 errorCollector.spanFor(nodeHelper.superclass ?? node));
           }
 
-          if (node is ClassDeclaration && node.members.whereNot(isStaticMember).isNotEmpty) {
+          if (node is ClassDeclaration && !node.members.every(isStaticMember)) {
             errorCollector.addError(
                 '$propsOrStateClassString implementations must not declare any $propsOrStateFieldsName or other non-static members.',
                 errorCollector.span(node.leftBracket.offset, node.rightBracket.end));
@@ -93,7 +93,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateTypedMapMember
       case Version.v2_legacyBackwardsCompat:
         // It's possible to declare an abstract class without any props/state fields that need to be generated,
         //  so long as it doesn't have the annotation.
-        if (nodeHelper.members.whereNot(isStaticMember).isNotEmpty ||
+        if (!nodeHelper.members.every(isStaticMember) ||
             node.hasAnnotationWithNames(
                 {propsOrStateAnnotationName, propsOrStateAbstractAnnotationName})) {
           _sharedLegacyValidation(errorCollector);

--- a/lib/src/builder/parsing/members/props_and_state.dart
+++ b/lib/src/builder/parsing/members/props_and_state.dart
@@ -77,9 +77,9 @@ abstract class BoilerplatePropsOrState extends BoilerplateTypedMapMember
                 errorCollector.spanFor(nodeHelper.superclass ?? node));
           }
 
-          if (node is ClassDeclaration && node.members.isNotEmpty) {
+          if (node is ClassDeclaration && node.members.whereNot(isStaticMember).isNotEmpty) {
             errorCollector.addError(
-                '$propsOrStateClassString implementations must not declare any $propsOrStateFieldsName or other members.',
+                '$propsOrStateClassString implementations must not declare any $propsOrStateFieldsName or other non-static members.',
                 errorCollector.span(node.leftBracket.offset, node.rightBracket.end));
           }
 
@@ -93,7 +93,7 @@ abstract class BoilerplatePropsOrState extends BoilerplateTypedMapMember
       case Version.v2_legacyBackwardsCompat:
         // It's possible to declare an abstract class without any props/state fields that need to be generated,
         //  so long as it doesn't have the annotation.
-        if (nodeHelper.members.isNotEmpty ||
+        if (nodeHelper.members.whereNot(isStaticMember).isNotEmpty ||
             node.hasAnnotationWithNames(
                 {propsOrStateAnnotationName, propsOrStateAbstractAnnotationName})) {
           _sharedLegacyValidation(errorCollector);

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -99,7 +99,7 @@ void main() {
             ..required = true
             ..requiredAndLengthLimited = [1,2]
           )());
-        }, logsPropError('ComponentTestProps.nullable'));
+        }, logsPropRequiredError('ComponentTestProps.nullable'));
       });
 
       test('on re-render', () {
@@ -120,7 +120,7 @@ void main() {
             ..required = true
             ..requiredAndLengthLimited = [1,2]
           )());
-        }, logsPropError('ComponentTestProps.nullable'));
+        }, logsPropRequiredError('ComponentTestProps.nullable'));
       });
     });
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
@@ -99,7 +99,7 @@ void main() {
             ..required = true
             ..requiredAndLengthLimited = [1,2]
           )());
-        }, logsPropError('ComponentTestProps.nullable'));
+        }, logsPropRequiredError('ComponentTestProps.nullable'));
       });
 
       test('on re-render', () {
@@ -120,7 +120,7 @@ void main() {
             ..required = true
             ..requiredAndLengthLimited = [1,2]
           )());
-        }, logsPropError('ComponentTestProps.nullable'));
+        }, logsPropRequiredError('ComponentTestProps.nullable'));
       });
     });
 

--- a/test/vm_tests/builder/declaration_parsing_test.dart
+++ b/test/vm_tests/builder/declaration_parsing_test.dart
@@ -1175,6 +1175,44 @@ main() {
               expect(decl.component.meta, isA<annotations.Component>());
             });
 
+            test('whose props class has a body with static members', () {
+              setUpAndParse(r'''
+                  UiFactory<FooProps> Foo = _$Foo;
+                  
+                  mixin FooPropsMixin on UiProps {
+                    String foo;
+                  }
+                  
+                  class FooProps extends UiProps with FooPropsMixin {
+                    static PropsMeta meta;
+                    static someMethod() {} 
+                  }
+                  
+                  class FooComponent extends UiComponent2<FooProps> {
+                    render() {}
+                  }
+              ''');
+
+              expect(declarations, unorderedEquals([
+                isA<PropsMixinDeclaration>(),
+                isA<ClassComponentDeclaration>(),
+              ]));
+
+              final propsMixinDecl = declarations.firstWhereType<PropsMixinDeclaration>();
+              expect(propsMixinDecl.mixin?.name?.name, 'FooPropsMixin');
+
+              final decl = declarations.firstWhereType<ClassComponentDeclaration>();
+
+              expect(decl.factory?.name?.name, 'Foo');
+              expect(decl.props?.a?.name?.name, 'FooProps');
+              expect(decl.component?.name?.name, 'FooComponent');
+              expect(decl.state?.either, isNull);
+
+              expect(decl.factory.meta, isA<annotations.Factory>());
+              expect(decl.props.a.meta, isA<annotations.Props>());
+              expect(decl.component.meta, isA<annotations.Component>());
+            });
+
             test('that is stateful', () {
               setUpAndParse(r'''
                   UiFactory<FooProps> Foo = _$Foo;

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -286,6 +286,11 @@ main() {
       expect(_onlyImplementsThings('class Foo implements Baz {}'), isTrue);
       expect(_onlyImplementsThings('class Foo implements Bar, Baz {}'), isTrue);
 
+      expect(_onlyImplementsThings('class Foo implements Bar { static var field; }'), isTrue);
+      expect(_onlyImplementsThings('class Foo implements Bar { static method() {} }'), isTrue);
+      expect(_onlyImplementsThings('class Foo implements Bar { var field; }'), isFalse);
+      expect(_onlyImplementsThings('class Foo implements Bar { method() {} }'), isFalse);
+
       expect(_onlyImplementsThings('mixin Foo implements Baz {}'), isTrue);
       expect(_onlyImplementsThings('mixin Foo implements Bar, Baz {}'), isTrue);
       expect(_onlyImplementsThings('mixin Foo on Bar {}'), isTrue);

--- a/test/vm_tests/builder/parsing/members_test.dart
+++ b/test/vm_tests/builder/parsing/members_test.dart
@@ -486,14 +486,14 @@ main() {
               props.validate(Version.v4_mixinBased, collector);
               expect(validateResults, [
                 contains(
-                    '${props.propsOrStateClassString} implementations must not declare any ${props.propsOrStateFieldsName} or other members.'),
+                    '${props.propsOrStateClassString} implementations must not declare any ${props.propsOrStateFieldsName} or other non-static members.'),
               ]);
 
               validateResults = <String>[];
               state.validate(Version.v4_mixinBased, collector);
               expect(validateResults, [
                 contains(
-                    '${state.propsOrStateClassString} implementations must not declare any ${state.propsOrStateFieldsName} or other members.'),
+                    '${state.propsOrStateClassString} implementations must not declare any ${state.propsOrStateFieldsName} or other non-static members.'),
               ]);
             });
 


### PR DESCRIPTION
## Motivation
It's currently an error to declare members within the body of a props/state class, since the generated class only implements it, not extends it.

However, that error should only apply to instance members, and it currently errors for static members.

## Changes
- Allow static members in concrete props/state classes
- Add regression test

#### Release Notes
- Allow static members in concrete props/state classes in new, mixin-based boilerplate

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
