### PR TITLE
CPLAT-11143 Emit a build error for mismatched components in the new boilerplate

### DIFF
--- a/lib/src/builder/parsing/declarations_from_members.dart
+++ b/lib/src/builder/parsing/declarations_from_members.dart
@@ -362,7 +362,7 @@ Iterable<BoilerplateDeclaration> getBoilerplateDeclarations(
 
 const errorStateOnly =
     'Could not find matching factory, props class, and component class in this file;'
-    ' these are required to use UiState';
+    ' these are required to use UiState.';
 
 const errorFactoryOnly = 'Could not find matching props class in this file;'
     ' this is required to declare a props map view or function component,'
@@ -376,10 +376,10 @@ const errorComponentClassOnly = 'Could not find matching factory and props class
     ' these are required to declare a class-based component.';
 
 const errorNoFactory = 'Could not find a matching factory in this file;'
-    ' this is required to declare a component or props map view';
+    ' this is required to declare a component or props map view.';
 
 const errorNoProps = 'Could not find a matching props class in this file;'
-    ' this is required to declare a component or props map view';
+    ' this is required to declare a component or props map view.';
 
 const errorNoComponent = 'Could not find a matching component class in this file;'
-    ' this is required to declare a class-based component';
+    ' this is required to declare a class-based component.';

--- a/lib/src/builder/parsing/members_from_ast.dart
+++ b/lib/src/builder/parsing/members_from_ast.dart
@@ -427,7 +427,7 @@ class _BoilerplateMemberDetector {
   }
 
   /// UiComponent, UiComponent2, UiStatefulComponent, FluxUiComponent, CustomUiComponent, ...
-  static final _componentBaseClassPattern = RegExp('Ui\w+Component');
+  static final _componentBaseClassPattern = RegExp(r'Ui\w*Component');
 
   bool _detectPotentialComponent(ClassishDeclaration classish) {
     // Don't detect react-dart components as boilerplate components, since they cause issues with grouping

--- a/lib/src/builder/parsing/members_from_ast.dart
+++ b/lib/src/builder/parsing/members_from_ast.dart
@@ -448,10 +448,12 @@ class _BoilerplateMemberDetector {
           'FluxUiStatefulComponent2'
         };
         final confidences = VersionConfidences(
-          // If the class extends from a base class known to be supported by the new boilerplate,
+          // If the component extends from a base class known to be supported by the new boilerplate,
           // has no annotation, is not abstract, and does not have $isClassGenerated, then it's
-          // most likely a valid component. Make this `likely` so that components that don't
-          // get associated with factory/props due to naming issues aren't silently ignored.
+          // most likely intended to be part of a new boilerplate class component declaration.
+          //
+          // Make this `likely` so that components that don't get associated with factory/props
+          // due to naming issues aren't silently ignored.
           v4_mixinBased: !classish.hasAbstractKeyword &&
                   !_overridesIsClassGenerated(classish) &&
                   mixinBoilerplateBaseClasses.contains(classish.superclass?.nameWithoutPrefix)

--- a/lib/src/builder/parsing/members_from_ast.dart
+++ b/lib/src/builder/parsing/members_from_ast.dart
@@ -382,12 +382,9 @@ class _BoilerplateMemberDetector {
     // Thus, it's non-legacy boilerplate.
 
     VersionConfidences getConfidence() {
-      final overridesIsClassGenerated = classish.members
-          .whereType<MethodDeclaration>()
-          .any((member) => member.isGetter && member.name.name == r'$isClassGenerated');
       // Handle classes that look like props but are really just used as interfaces, and aren't extended from or directly used as a component's props.
       // Watch out for empty mixins, though; those are valid props/state mixins.
-      if (overridesIsClassGenerated ||
+      if (_overridesIsClassGenerated(classish) ||
           (node is! MixinDeclaration && onlyImplementsThings(classish))) {
         return VersionConfidences.none();
       } else if (classish.members.whereType<ConstructorDeclaration>().isNotEmpty) {
@@ -429,6 +426,9 @@ class _BoilerplateMemberDetector {
     return false;
   }
 
+  /// UiComponent, UiComponent2, UiStatefulComponent, FluxUiComponent, CustomUiComponent, ...
+  static final _componentBaseClassPattern = RegExp('Ui\w+Component');
+
   bool _detectPotentialComponent(ClassishDeclaration classish) {
     // Don't detect react-dart components as boilerplate components, since they cause issues with grouping
     // if they're in the same file as an OverReact component with non-matching names.
@@ -436,12 +436,31 @@ class _BoilerplateMemberDetector {
       if (classish.name.name.endsWith('Component') ||
           classish.allSuperTypes
               .map((t) => t.typeNameWithoutPrefix)
-              .any(const {'UiComponent', 'UiComponent2'}.contains) ||
+              .any(_componentBaseClassPattern.hasMatch) ||
           (classish.superclass?.typeArguments?.arguments
                   ?.map((t) => t.typeNameWithoutPrefix)
                   ?.any(propsOrMixinNamePattern.hasMatch) ??
               false)) {
-        onComponent(BoilerplateComponent(classish, VersionConfidences.all(Confidence.neutral)));
+        const mixinBoilerplateBaseClasses = {
+          'UiComponent2',
+          'UiStatefulComponent2',
+          'FluxUiComponent2',
+          'FluxUiStatefulComponent2'
+        };
+        final confidences = VersionConfidences(
+          // If the class extends from a base class known to be supported by the new boilerplate,
+          // has no annotation, is not abstract, and does not have $isClassGenerated, then it's
+          // most likely a valid component. Make this `likely` so that components that don't
+          // get associated with factory/props due to naming issues aren't silently ignored.
+          v4_mixinBased: !classish.hasAbstractKeyword &&
+                  !_overridesIsClassGenerated(classish) &&
+                  mixinBoilerplateBaseClasses.contains(classish.superclass?.nameWithoutPrefix)
+              ? Confidence.likely
+              : Confidence.neutral,
+          v2_legacyBackwardsCompat: Confidence.neutral,
+          v3_legacyDart2Only: Confidence.neutral,
+        );
+        onComponent(BoilerplateComponent(classish, confidences));
 
         return true;
       }
@@ -449,6 +468,10 @@ class _BoilerplateMemberDetector {
 
     return false;
   }
+
+  static bool _overridesIsClassGenerated(ClassishDeclaration classish) => classish.members
+      .whereType<MethodDeclaration>()
+      .any((member) => member.isGetter && member.name.name == r'$isClassGenerated');
 }
 
 class _BoilerplateMemberDetectorVisitor extends SimpleAstVisitor<void> {

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -514,6 +514,7 @@ abstract class UiProps extends MapBase
         '1. Something went wrong when initializing the `\$${runtimeType}Factory` variable in the generated code.\n'
         '   It\'s possible React swallowed errors thrown during that initialization, so try pausing on caught exceptions to see it.\n'
         '2. This is a props map view factory (declared as just a factory and props), and should not be invoked.\n'
+        '   This can also happen if your component didn\'t get grouped with your factory/props (e.g., if its name doesn\'t match).'
         '3. This is a function component factory that was set up improperly, not wrapping the generated function in `uiFunction`.\n'
         '4. componentFactory was erroneously assigned to null on this UiProps instance, potentially in an HOC function.');
   }


### PR DESCRIPTION
## Motivation
If a component isn't named correctly in the new boilerplate, it won't get associated with the factory and props class the author intended it to be.

Currently, this mismatched component is ignored and the component gets interpreted as a props mapview, and when the consumer invokes the builder, they get a runtime error.

It would be better if it failed the build.

## Changes
- When possible, increase `v4_mixinBased` confidence of components to above `neutral`, resulting in mismatched components emitting errors instead of getting silently ignored.
   - Add tests
- Update runtime error to mention the mismatched component case, for better debugging of edge case mismatched components (with neutral confidences) that don't trigger a build error
- (Boyscouting) update punctuation in error messages

#### Release Notes
Emit a build error for mismatched components in the new boilerplate

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Verify in consumer repos that this does not cause any new failures
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
