### PR TITLE
Account for super getter access in PseudoStaticLifecycleDiagnostic

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
@@ -27,7 +27,6 @@ class PseudoStaticLifecycleDiagnostic extends DiagnosticContributor {
     final visitor = LifecycleMethodVisitor();
     result.unit.accept(visitor);
 
-    // FIXME account for super calls
     for (final reference in visitor.nonStaticReferences) {
       if (reference is SimpleIdentifier && instanceMemberWhitelist.contains(reference.name)) {
         continue;
@@ -49,9 +48,14 @@ class PseudoStaticLifecycleDiagnostic extends DiagnosticContributor {
             end = parent.methodName.end;
           }
         } else if (parent is PropertyAccess) {
-          // Include the `super.`/`this.` in the error region
-          offset = parent.offset;
-          end = parent.end;
+          if (parent.propertyName.name == enclosingMethodName.name) {
+            // Ignore super-calls to same getter
+            continue;
+          } else {
+            // Include the `super.`/`this.` in the error region
+            offset = parent.offset;
+            end = parent.end;
+          }
         }
       }
 

--- a/tools/analyzer_plugin/playground/web/pseudo_static_lifecycle.dart
+++ b/tools/analyzer_plugin/playground/web/pseudo_static_lifecycle.dart
@@ -1,6 +1,6 @@
 import 'package:over_react/over_react.dart';
 
-part 'dom_prop_types.over_react.g.dart';
+part 'pseudo_static_lifecycle.over_react.g.dart';
 
 UiFactory<HammerTimeProps> HammerTime =
     // ignore: undefined_identifier
@@ -17,8 +17,9 @@ class HammerTimeComponent extends UiStatefulComponent2<HammerTimeProps, HammerTi
 
   @override
   get defaultProps {
-    return newProps()
-      ..somethingThatCanBeTouched = mcHammer;
+    return newProps() // This newProps() call should not lint
+      ..addProps(super.defaultProps) // This super.defaultProps access should not lint
+      ..somethingThatCanBeTouched = mcHammer; // This mcHammer access SHOULD lint
   }
 
   @override


### PR DESCRIPTION
Accessing `super.defaultProps` within the `defaultProps` getter of a component was triggering the `PseudoStaticLifecycleDiagnostic` to display an error, but it should not.

This PR fixes that, and updates the test case in the playground to account for this.