### PR TITLE
Fix createRef quick fix for arrow functions

### DIFF
--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -149,7 +149,7 @@ void addCreateRef(
 }
 
 PropertyInducingElement _getRefCallbackAssignedField(Expression refPropRhs) {
-  final function = refPropRhs?.tryCast<FunctionExpression>();
+  final function = refPropRhs?.unParenthesized?.tryCast<FunctionExpression>();
   if (function == null) return null;
 
   final refCallbackArg = function.parameters.parameters.firstOrNull;

--- a/tools/analyzer_plugin/playground/web/refs.dart
+++ b/tools/analyzer_plugin/playground/web/refs.dart
@@ -34,18 +34,30 @@ mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
   ChildComponent _someCustomRefName;
+  ChildComponent _anotherCustomRefName;
 
   @override
   render() {
-    return (Child()
-      ..ref = (ref) { _someCustomRefName = ref; }
-    )(props.children);
+    return Fragment()(
+      (Child()
+        ..ref = (ref) {
+          _someCustomRefName = ref;
+        })(props.children),
+      (Child()
+        ..id = 'bar'
+        ..ref = ((ref) => _anotherCustomRefName = ref)
+      )('hi'),
+    );
   }
 
   void foo() {
     _someCustomRefName.someMethodName();
     _someCustomRefName?.anotherMethodName();
     final bar = _someCustomRefName.someGetter;
+
+    _anotherCustomRefName.someMethodName();
+    _anotherCustomRefName?.anotherMethodName();
+    final baz = _anotherCustomRefName.someGetter;
   }
 }
 


### PR DESCRIPTION
Declaring a callback ref with parenthesized arrow function messed up the quick fix in a way that the plugin stopped suggesting the quick fix - even on non-arrow function callback refs.

This PR fixes that, and updates the test case in the playground to account for this.