### PR TITLE
Do not lint comments on declarations in a file with a MapView

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/incorrect_doc_comment_location.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/incorrect_doc_comment_location.dart
@@ -25,6 +25,8 @@ class IncorrectDocCommentLocationDiagnostic extends DiagnosticContributor {
     final declarations = parseDeclarations(result.unit, errorCollector);
 
     for (final decl in declarations) {
+      if (decl is PropsMapViewOrFunctionComponentDeclaration) continue;
+
       final factories = decl.members.whereType<BoilerplateFactory>();
 
       if (factories.isNotEmpty) {

--- a/tools/analyzer_plugin/playground/web/doc_comment_location.dart
+++ b/tools/analyzer_plugin/playground/web/doc_comment_location.dart
@@ -1,6 +1,6 @@
 import 'package:over_react/over_react.dart';
 
-part 'incorrect_doc_comment_location.over_react.g.dart';
+part 'doc_comment_location.over_react.g.dart';
 
 @Factory()
 UiFactory<BarProps> Bar = _$Bar; // ignore: undefined_identifier
@@ -43,3 +43,11 @@ abstract class AbstractBarComponent<P extends UiProps, S extends UiState> extend
 
 /// This doc comment is okay.
 class RandomClass {}
+
+/// This doc comment is okay.
+mixin FooPropsMixin on UiProps {
+  bool isBar;
+}
+
+UiFactory<FooPropsMixin> FooPropsMixinMapView =
+    _$FooPropsMixinMapView; // ignore: undefined_identifier


### PR DESCRIPTION
Props mixin map views look a lot like a `BoilerplateFactory`, but they are different. Doc comments found on their analogous props mixin should not be linted as being in the wrong place.

This PR fixes that, and updates the test case in the playground to account for this.