### PR TITLE
Disable implicit casts and implicit dynamic, fix lints

### DIFF
--- a/tools/analyzer_plugin/analysis_options.yaml
+++ b/tools/analyzer_plugin/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
+  strong-mode:
+    implicit-casts: false
   errors:
     # Treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/tools/analyzer_plugin/analysis_options.yaml
+++ b/tools/analyzer_plugin/analysis_options.yaml
@@ -3,6 +3,7 @@ include: package:workiva_analysis_options/v1.recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
+    implicit-dynamic: false
   errors:
     # Treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
+++ b/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
@@ -88,7 +88,7 @@ mixin DiagnosticMixin on ServerPlugin {
   }
 
   // from DartFixesMixin
-  Future<FixesRequest> _getFixesRequest(EditGetFixesParams parameters) async {
+  Future<DartFixesRequest> _getFixesRequest(EditGetFixesParams parameters) async {
     final path = parameters.file;
     final offset = parameters.offset;
     final result = await getResolvedUnitResult(path);

--- a/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
@@ -19,10 +19,11 @@ class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContrib
     for (final prop in usage.cascadedProps) {
       final rhs = prop.rightHandSide;
       if (rhs is FunctionExpression && rhs.body is ExpressionFunctionBody) {
+        final body = rhs.body as ExpressionFunctionBody;
+
         var wrapOffset = rhs.offset;
         var wrapEnd = rhs.end;
 
-        final ExpressionFunctionBody body = rhs.body;
         final expression = body.expression;
         if (expression is CascadeExpression) {
           // todo do this intelligently based on indent

--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -105,6 +105,7 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
         errorCode,
         result.locationFor(_overReactGeneratedPartDirective),
         errorMessageArgs: [
+          // ignore: no_adjacent_strings_in_list
           'This part will not be generated because there are no valid OverReact component boilerplate '
               'declarations in this file. If you expect this file to contain OverReact component boilerplate declarations, '
               'double check that they have no syntax errors / lints. Otherwise, the part can safely be removed.'

--- a/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types_gen.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types_gen.dart
@@ -1,5 +1,5 @@
 /// Generates allowedHtmlElementsForAttribute for use in dom_prop_types.dart
-main() {
+void main() {
   final supportedElements = <String, List<String>>{};
   final globalAttributes = <String>[];
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
@@ -4,7 +4,6 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/dart/element/type_provider.dart';
 import 'package:analyzer/dart/element/type_system.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
-import 'package:meta/meta.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';

--- a/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
@@ -1,6 +1,5 @@
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/syntactic_entity.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';

--- a/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
@@ -79,15 +79,9 @@ class IteratorKey extends ComponentUsageDiagnosticContributor {
 
   List<MethodInvocation> _buildInvocationList(MethodInvocation method) {
     // A list of all the methods that could possibly be chained to the input method
-    final methodsInvoked = <MethodInvocation>[method];
-    dynamic target = method.target;
-    while (target != null) {
-      if (target is MethodInvocation) {
-        methodsInvoked.add(target as MethodInvocation);
-        target = target.target;
-      } else {
-        return methodsInvoked;
-      }
+    final methodsInvoked = <MethodInvocation>[];
+    for (var current = method; current != null; current = current.target.tryCast<MethodInvocation>()) {
+      methodsInvoked.add(current);
     }
     return methodsInvoked;
   }

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
@@ -44,13 +44,14 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
         debug.log('node.type: ${node.runtimeType}');
 
         InvocationExpression invocation;
-        if (isBadArity && node is ArgumentList && node.parent is InvocationExpression) {
-          invocation = node.parent;
-        } else if (isBadFunction && node.parent is InvocationExpression) {
+        final parent = node.parent;
+        if (isBadArity && node is ArgumentList && parent is InvocationExpression) {
+          invocation = parent;
+        } else if (isBadFunction && parent is InvocationExpression) {
           // FIXME we explain why we use the parent instead of node
-          invocation = node.parent;
-        } else if (isVoidUsage && node.parent is InvocationExpression) {
-          invocation = node.parent;
+          invocation = parent;
+        } else if (isVoidUsage && parent is InvocationExpression) {
+          invocation = parent;
         }
         debug.log('invocation : ${invocation?.toSource()}');
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/proptypes_return_value.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/proptypes_return_value.dart
@@ -71,7 +71,10 @@ class PropTypesMapVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitMapLiteralEntry(MapLiteralEntry node) {
-    values.add(node.value);
+    final value = node.value;
+    if (value is FunctionExpression) {
+      values.add(value);
+    }
   }
 }
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/render_return_value.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/render_return_value.dart
@@ -24,8 +24,6 @@ class RenderReturnValueDiagnostic extends DiagnosticContributor {
 
   @override
   computeErrors(result, collector) async {
-    final typeSystem = result.libraryElement.typeSystem;
-
     // This is the return type even if it's not explicitly declared.
     final visitor = RenderVisitor();
     result.unit.accept(visitor);
@@ -35,7 +33,8 @@ class RenderReturnValueDiagnostic extends DiagnosticContributor {
         continue;
       }
 
-      await validateReactChildType(returnType, typeSystem, onInvalidType: (invalidType) async {
+      await validateReactChildType(returnType, result.typeSystem, result.typeProvider,
+          onInvalidType: (invalidType) async {
         final code = invalidTypeErrorCode;
         final location = result.locationFor(returnExpression);
         if (couldBeMissingBuilderInvocation(returnExpression)) {
@@ -89,4 +88,3 @@ class RenderVisitor extends SimpleAstVisitor<void> {
     }
   }
 }
-

--- a/tools/analyzer_plugin/lib/src/diagnostic/single_child_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/single_child_key.dart
@@ -20,21 +20,20 @@ class SingleChildWithKey extends ComponentUsageDiagnosticContributor {
 
     final parentMethodName = usage.node.thisOrAncestorOfType<MethodDeclaration>()?.name?.name;
 
-    if (usage.node.parent is ListLiteral && (usage.node.parent?.parent is! ReturnStatement)) {
-      ListLiteral parent = usage.node.parent;
+    final parent = usage.node.parent;
+    if (parent is ListLiteral && (parent?.parent is! ReturnStatement)) {
       isInAList = true;
 
       if (parent.elements.length == 1) {
         isSingleChild = true;
       }
-    } else if (usage.node.parent is ArgumentList) {
-      ArgumentList parent = usage.node.parent;
+    } else if (parent is ArgumentList) {
       final enclosingUsage = identifyUsage(parent?.parent);
 
       if (enclosingUsage?.node?.argumentList == parent ?? false) {
         isVariadic = true;
       }
-    } else if (usage.node.parent is ReturnStatement && (parentMethodName == 'render' ?? false)) {
+    } else if (parent is ReturnStatement && (parentMethodName == 'render' ?? false)) {
       isVariadic = true;
     }
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/style_missing_unit.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/style_missing_unit.dart
@@ -1,3 +1,6 @@
+// This is necessary for `ConstantEvaluator`. If that API is removed, it can just
+// be copied and pasted into this analyzer package (if still needed).
+// ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart' show ConstantEvaluator;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -18,7 +18,7 @@ class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
   computeErrorsForUsage(result, collector, usage) async {
     final arguments = usage.node.argumentList.arguments;
     if (arguments.length == 1 && arguments.single is ListLiteral) {
-      ListLiteral list = arguments.single;
+      final list = arguments.single as ListLiteral;
 
       await collector.addErrorWithFix(
         code,

--- a/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
@@ -82,7 +82,9 @@ abstract class ComponentUsageDiagnosticContributor extends DiagnosticContributor
   Future<void> computeErrors(ResolvedUnitResult result, DiagnosticCollector collector) async {
     final usages = <FluentComponentUsage>[];
     result.unit.accept(ComponentUsageVisitor(usages.add));
-    await Future.forEach(usages, (usage) => computeErrorsForUsage(result, collector, usage));
+    for (final usage in usages) {
+      await computeErrorsForUsage(result, collector, usage);
+    }
   }
 }
 

--- a/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
@@ -122,6 +122,7 @@ abstract class DiagnosticCollector {
       List<Object> fixMessageArgs});
 }
 
+// ignore: subtype_of_sealed_class
 @protected
 class DiagnosticCollectorImpl implements DiagnosticCollector {
   DiagnosticCollectorImpl({@required this.shouldComputeFixes});

--- a/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
+++ b/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
@@ -27,7 +27,7 @@ class PropAssignment {
   PropAssignment(this.assignment) : assert(assignment.leftHandSide is PropertyAccess);
 
   /// The property access representing the left hand side of this assignment.
-  PropertyAccess get leftHandSide => assignment.leftHandSide;
+  PropertyAccess get leftHandSide => assignment.leftHandSide as PropertyAccess;
 
   /// The expression for the right hand side of this assignment.
   Expression get rightHandSide => assignment.rightHandSide;

--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -94,9 +94,9 @@ class OverReactAnalyzerPlugin extends ServerPlugin
       ..performanceLog = performanceLog
       ..fileContentOverlay = fileContentOverlay;
     final result = contextBuilder.buildDriver(root);
-    runZoned(() {
+    runZonedGuarded(() {
       result.results.listen(processDiagnosticsForResult);
-    }, onError: (e, stackTrace) {
+    }, (e, stackTrace) {
       channel.sendNotification(plugin.PluginErrorParams(false, e.toString(), stackTrace.toString()).toNotification());
     });
     return result;

--- a/tools/analyzer_plugin/lib/src/util/ast_util.dart
+++ b/tools/analyzer_plugin/lib/src/util/ast_util.dart
@@ -81,7 +81,7 @@ extension BlockFunctionBodyUtils on BlockFunctionBody {
   }
 }
 
-class _ReturnStatementsForBodyVisitor extends RecursiveAstVisitor {
+class _ReturnStatementsForBodyVisitor extends RecursiveAstVisitor<void> {
   final returnStatementsForBody = <ReturnStatement>[];
 
   @override

--- a/tools/analyzer_plugin/lib/src/util/ast_util.dart
+++ b/tools/analyzer_plugin/lib/src/util/ast_util.dart
@@ -2,9 +2,9 @@
 library over_react_analyzer_plugin.src.ast_util;
 
 import 'dart:collection';
-// ignore: deprecated_member_use
 // This is necessary for `ConstantEvaluator`. If that API is removed, it can just
 // be copied and pasted into this analyzer package (if still needed).
+// ignore: deprecated_member_use
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';

--- a/tools/analyzer_plugin/lib/src/util/react_types.dart
+++ b/tools/analyzer_plugin/lib/src/util/react_types.dart
@@ -23,7 +23,7 @@ extension on Element /*?*/ {
   }
 
   bool isTypeFromPackage(String typeName, String packageName) =>
-      this?.name == typeName && isDeclaredInPackage(packageName);
+      this != null && name == typeName && isDeclaredInPackage(packageName);
 }
 
 extension on Element {

--- a/tools/analyzer_plugin/playground/web/children.dart
+++ b/tools/analyzer_plugin/playground/web/children.dart
@@ -16,7 +16,7 @@ validChildren() {
     functionThatReturnsDynamic(),
     [1, 2, 3],
     ['foo', 2, true],
-    [new MyObject(), new MyObject()].map((obj) => obj.id),
+    [MyObject(), MyObject()].map((obj) => obj.id),
   );
 }
 
@@ -34,18 +34,18 @@ invalidChildren() {
     functionThatReturnsDynamic(),
     [1, 2, 3],
     ['foo', 2, true],
-    [new MyObject(), new MyObject()].map((obj) => obj.id),
+    [MyObject(), MyObject()].map((obj) => obj.id),
 
     //
     // Unsupported types
     //
     {'just': 'a map'},
-    new MyObject(),
-    new Future(() {}),
+    MyObject(),
+    Future(() {}),
     // Iterable type parameters are checked
-    [new MyObject()],
-    [1, 2, 3].map((_) => new MyObject()),
-    [1, 2, 3].map((number) async => Dom.div()(number)),
+    [MyObject()],
+    [1, 2, 3].map((_) => MyObject()),
+    [1, 2, 3].map((number) async => (Dom.div()..key = number)(number)),
 
 
     // Unsupported types, uninvoked builders: has quick fix

--- a/tools/analyzer_plugin/test/unit/fluent_interface_util/cascade_read_test.dart
+++ b/tools/analyzer_plugin/test/unit/fluent_interface_util/cascade_read_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 import '../../test_util.dart';
 
-main() {
+void main() {
   group('cascade_read', () {
     group('FluentComponentUsage.cascadedProps', () {
       test('returns cascaded props', () {

--- a/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 import '../../test_util.dart';
 
-main() {
+void main() {
   group('ast_util', () {
     test('allDescendants returns all descendants in breadth-first order', () {
       final unit = parseAndGetUnit(/*language=dart*/ r'''

--- a/tools/analyzer_plugin/tool/init_local_dev.dart
+++ b/tools/analyzer_plugin/tool/init_local_dev.dart
@@ -100,7 +100,7 @@ void validatePackageRoot(String pluginPath) {
   try {
     final pubspecContents = pluginPubspec.readAsStringSync();
     final pubspecYaml = loadYaml(pubspecContents);
-    name = pubspecYaml['name'];
+    name = pubspecYaml['name'] as String;
   } on FileSystemException catch (_) {
     logger.severe('Error reading plugin pubspec.');
     rethrow;

--- a/tools/analyzer_plugin/tool/init_local_dev.dart
+++ b/tools/analyzer_plugin/tool/init_local_dev.dart
@@ -99,7 +99,7 @@ void validatePackageRoot(String pluginPath) {
   String name;
   try {
     final pubspecContents = pluginPubspec.readAsStringSync();
-    final pubspecYaml = loadYaml(pubspecContents);
+    final pubspecYaml = loadYaml(pubspecContents) as Map;
     name = pubspecYaml['name'] as String;
   } on FileSystemException catch (_) {
     logger.severe('Error reading plugin pubspec.');


### PR DESCRIPTION
## Motivation

Implicit casts and implicit dynamic can obscure programming issues that can result in runtime errors.

In enabling these, several bad casts that previously went undetected were surfaced and able to be fixed.

Enabling these wasn't too bad in this repo, either, since there's so much good typing, generics, and type-checking in place already.

## Solution
- Disable implicit-casts and fix issues
- Disable implicit-dynamic and fix issues
- Fix miscellaneous warnings/hints

## Testing
- Verify in playground/web/iterator_key.dart that missing keys are correctly linted for `.map` calls as well as `.map()` calls with `.toList()` chained on the end
- Verify in playground/web/invalid_child.dart that lists of unsupported types are linted while lists of supported types are not