### PR TITLE
Revert use of runZoneGuarded for now

### DIFF
--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -95,9 +95,11 @@ class OverReactAnalyzerPlugin extends ServerPlugin
       ..performanceLog = performanceLog
       ..fileContentOverlay = fileContentOverlay;
     final result = contextBuilder.buildDriver(root);
-    runZonedGuarded(() {
+    runZoned(() {
       result.results.listen(processDiagnosticsForResult);
-    }, (e, stackTrace) {
+      // ignore: avoid_types_on_closure_parameters
+      // TODO: Once we are ready to bump the SDK lower bound to 2.8.x, we should swap this out for `runZoneGuarded`.
+    }, onError: (Object e, StackTrace stackTrace) {
       channel.sendNotification(plugin.PluginErrorParams(false, e.toString(), stackTrace.toString()).toNotification());
     });
     return result;

--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -97,8 +97,8 @@ class OverReactAnalyzerPlugin extends ServerPlugin
     final result = contextBuilder.buildDriver(root);
     runZoned(() {
       result.results.listen(processDiagnosticsForResult);
-      // ignore: avoid_types_on_closure_parameters
       // TODO: Once we are ready to bump the SDK lower bound to 2.8.x, we should swap this out for `runZoneGuarded`.
+      // ignore: avoid_types_on_closure_parameters
     }, onError: (Object e, StackTrace stackTrace) {
       channel.sendNotification(plugin.PluginErrorParams(false, e.toString(), stackTrace.toString()).toNotification());
     });


### PR DESCRIPTION
+ In order to use this, we would have to bump the lower bound of the Dart SDK to 2.8.x - which we aren’t ready to do just yet as a result of https://github.com/dart-lang/build/issues/2688

Partially reverts #534
