### PR TITLE
Fix num type check that only works when implicit casts are enabled

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
@@ -50,8 +50,8 @@ Future<void> validateReactChildType(DartType type, TypeSystem typeSystem, TypePr
   if (type.isDynamic || type.isDartCoreObject) return;
   if (type.isReactElement) return;
   if (type.isDartCoreString) return;
-  // isAssignableTo to handle num, int, and double
-  if (typeSystem.isAssignableTo(typeProvider.numType, type)) return;
+  // isSubtypeOf to handle num, int, and double
+  if (typeSystem.isSubtypeOf(type, typeProvider.numType)) return;
   if (type.isDartCoreNull) return;
   if (type.isDartCoreBool) return;
   // If the children are in an iterable, validate its type argument.


### PR DESCRIPTION
Fixes #539

## Motivation
The existing type-check for whether a child was num was backwards, and thus only worked with implicit casts are enabled.

The code, 
```dart
typeSystem.isAssignableTo(typeProvider.numType, type)
```
translates to: "could a value of type `num` be assigned to `type`"?

For the case of `int`, "could a value of type `num` be assigned to `int`", the answer is:
- with implicit casts enabled: true
- with implicit casts disabled: false (because you can't assign `num` to `int` without casting it)

## Changes
Fix ordering of arguments an use more explicit `isSubTypeOf` check