### PR TITLE
Add better handling for dom and aria prop "targets"

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types.dart
@@ -23,6 +23,8 @@ class InvalidDomAttributeDiagnostic extends ComponentUsageDiagnosticContributor 
 //    }
 
     for (final prop in usage.cascadedProps) {
+      // If the prop name is prefixed with anything other than `dom` (e.g. `aria`), ignore it.
+      if (prop.targetName != null && prop.targetName.name != 'dom') continue;
       final allowedElements = getAttributeMeta(prop.name.name);
       if (allowedElements == null) continue;
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
@@ -14,7 +14,13 @@ class DuplicatePropCascadeDiagnostic extends ComponentUsageDiagnosticContributor
 
   @override
   computeErrorsForUsage(result, collector, usage) async {
-    final propUsagesByName = groupBy<PropAssignment, String>(usage.cascadedProps, (prop) => prop.name.name);
+    final propUsagesByName = groupBy<PropAssignment, String>(usage.cascadedProps, (prop) {
+      if (prop.targetName != null && prop.targetName.name != 'dom') {
+        return '${prop.targetName.name}.${prop.name.name}';
+      }
+
+      return prop.name.name;
+    });
     final propUsagesWithDuplicates = propUsagesByName.values.where((usages) => usages.length > 1);
     for (final propUsages in propUsagesWithDuplicates) {
       // We iterate and apply the warning over all but the final instance of a duplicated prop, so that the last

--- a/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
+++ b/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/source_range.dart';
 import 'package:analyzer_plugin/utilities/range_factory.dart';
 import 'package:over_react_analyzer_plugin/src/component_usage.dart';
+import 'package:over_react_analyzer_plugin/src/util/util.dart';
 
 extension UsageCascades on FluentComponentUsage {
   Iterable<Expression> get _cascadeSections => cascadeExpression?.cascadeSections ?? const [];
@@ -34,6 +35,15 @@ class PropAssignment {
 
   /// The name of the prop being assigned.
   Identifier get name => leftHandSide.propertyName;
+
+  /// The "target" of the [name].
+  ///
+  /// For example, the value of `targetName.name` in the expression below is "aria":
+  ///
+  /// ```dart
+  /// ..aria.label = 'foo'
+  /// ```
+  Identifier get targetName => leftHandSide.target?.tryCast<PropertyAccess>()?.propertyName;
 
   /// A range that can be used in a `builder.addDeletion` call to remove this prop.
   ///

--- a/tools/analyzer_plugin/playground/web/dom_prop_types.dart
+++ b/tools/analyzer_plugin/playground/web/dom_prop_types.dart
@@ -1,18 +1,18 @@
 import 'package:over_react/over_react.dart';
 
-part 'dom_prop_types.over_react.g.dart';
-
 main() {
   final content = Fragment()(
     (Dom.a()
-      // This should have a lint.
+      // These should have a lint.
       ..size = 1
+      ..dom.label = 'foo'
       // These should have no lint
       ..href = null
       ..hrefLang = null
       ..download = null
       ..rel = null
       ..target = null
+      ..aria.label = 'foo'
     )(),
     (Dom.abbr()
       // This should have a lint.

--- a/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
@@ -3,9 +3,16 @@ import 'package:over_react/over_react.dart';
 duplicatePropCascade() {
   (Dom.div()
     ..id = '1'
+    ..dom.id = 'foo' // Should lint as dupe of `id`
     ..id = '2'
+    ..hidden = false
+    ..aria.hidden = false // Should not lint as dupe of `hidden`
     ..onClick = (_) {
       final bar = 'baz';
+      return false;
+    }
+    ..dom.onClick = (_) {
+      final biz = 'foo';
       return false;
     }
     ..onClick = (_) {


### PR DESCRIPTION
## Motivation
In the dom prop validator lint, and the dupe prop detection logic - the use of things like

```
..aria.<<some AriaProps field name>>
..dom.<<some DomProps field name>>
``` 

make them not work as expected.

## Changes
1. Add a new `targetName` getter to `PropAssignment` that returns the `propertyName` of `leftHandSide.target` - which in the cases shown above, will have a `name` of `'aria'` and `'dom'`, respectively.
1. Update the logic in the two aforementioned lints to ensure that the name of the target is factored in.
1. Add test cases for both in the playground.

Fixes #540
