### PR TITLE
Update dupe prop fix to remove all dupes except the last one

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
@@ -9,25 +9,27 @@ class DuplicatePropCascadeDiagnostic extends ComponentUsageDiagnosticContributor
       AnalysisErrorSeverity.WARNING,
       AnalysisErrorType.STATIC_TYPE_WARNING);
 
-  static final fixKind = FixKind(code.name, 200, 'Remove duplicate prop key / value',
-      appliedTogetherMessage: 'Remove duplicate prop keys / values');
+  static final fixKind = FixKind(code.name, 200, 'Remove duplicate prop keys / values');
 
   @override
   computeErrorsForUsage(result, collector, usage) async {
     final propUsagesByName = groupBy<PropAssignment, String>(usage.cascadedProps, (prop) => prop.name.name);
     final propUsagesWithDuplicates = propUsagesByName.values.where((usages) => usages.length > 1);
     for (final propUsages in propUsagesWithDuplicates) {
-      // We iterate and apply the warning over all but the final instance of a duplicated prop, so that the last
-      // instance (the one that is actually used at run time) is retained.
-      for (var i = 0; i < propUsages.length - 1; i++) {
-        final prop = propUsages[i];
+      for (var i = 0; i < propUsages.length; i++) {
+        final propWithWarning = propUsages[i];
         await collector.addErrorWithFix(
           code,
-          result.locationFor(prop.leftHandSide),
-          errorMessageArgs: [prop.name.name, i + 1, propUsages.length],
+          result.locationFor(propWithWarning.leftHandSide),
+          errorMessageArgs: [propWithWarning.name.name, i + 1, propUsages.length],
           fixKind: fixKind,
           computeFix: () => buildFileEdit(result, (builder) {
-            builder.addDeletion(prop.rangeForRemoval);
+            for (var i = 0; i < propUsages.length - 1; i++) {
+              final propToRemove = propUsages[i];
+              // We iterate and remove all but the final instance of a duplicated prop, so that the last
+              // instance (the one that is actually used at run time) is retained.
+              builder.addDeletion(propToRemove.rangeForRemoval);
+            }
           }),
         );
       }

--- a/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
@@ -14,3 +14,17 @@ duplicatePropCascade() {
     }
   )('foo');
 }
+
+duplicatePropCascadeWithMoreThanOneDupe() {
+  (Dom.div()
+    ..id = '1'
+    ..id = '2'
+    ..id = '3'
+    ..id = '4'
+    ..title = 'biz'
+    ..title = 'baz'
+    ..id = 'winner'
+    ..title = 'winner'
+    ..aria.label = 'chicken dinner'
+  )('foo');
+}


### PR DESCRIPTION
## Motivation
1. #537 made it so that the last of 1 or more duplicate props didn't show as a lint.
2. Fixing duplicates had to be done on individual props, and with the changes from #537 reverted, the last of the dupes could be removed - which would change the runtime behavior of the component.

## Changes
1. Revert #537 so that all dupes are linted.
1. Update the fix so that all dupes except the last one is removed - preserving the runtime behavior of the component.

Fixes #547
