### PR TITLE
Increase severity of / narrow scope of arrow function in cascade lint

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
@@ -6,13 +6,14 @@ import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
 
 class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContributor {
   static final code = DiagnosticCode(
-      'over_react_cascaded_arrow_functions',
-      'Unparenthesized arrow function values prevent subsequent cascades',
-      AnalysisErrorSeverity.WARNING,
-      AnalysisErrorType.STATIC_WARNING);
+    'over_react_cascaded_arrow_functions',
+    'Never place un-parenthesized arrow functions in the middle of prop setter cascades.',
+    AnalysisErrorSeverity.ERROR,
+    AnalysisErrorType.SYNTACTIC_ERROR,
+    correction: 'Wrap arrow functions in parentheses when placed in the middle of prop setter cascades.',
+  );
 
-  static final fixKind = FixKind(code.name, 200, 'Wrap arrow function in parentheses',
-      appliedTogetherMessage: 'Wrap arrow functions in parentheses');
+  static final fixKind = FixKind(code.name, 200, 'Wrap arrow function in parentheses');
 
   @override
   computeErrorsForUsage(result, collector, usage) async {

--- a/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
@@ -3,6 +3,7 @@ import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 
 class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContributor {
   static final code = DiagnosticCode(
@@ -21,6 +22,10 @@ class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContrib
       final rhs = prop.rightHandSide;
       if (rhs is FunctionExpression && rhs.body is ExpressionFunctionBody) {
         final body = rhs.body as ExpressionFunctionBody;
+
+        // If a cascade expression is not found in the body, it is not an un-parenthesized
+        // function expression in the middle of another cascade... do not lint.
+        if (allDescendantsOfType<CascadeExpression>(body).isEmpty) continue;
 
         var wrapOffset = rhs.offset;
         var wrapEnd = rhs.end;

--- a/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
@@ -18,6 +18,9 @@ class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContrib
 
   @override
   computeErrorsForUsage(result, collector, usage) async {
+    // If there is only one cascaded prop, do not lint
+    if (usage.cascadedProps.length == 1) return;
+
     for (final prop in usage.cascadedProps) {
       final rhs = prop.rightHandSide;
       if (rhs is FunctionExpression && rhs.body is ExpressionFunctionBody) {

--- a/tools/analyzer_plugin/playground/web/misc_fixes.dart
+++ b/tools/analyzer_plugin/playground/web/misc_fixes.dart
@@ -12,6 +12,10 @@ fixes() {
   ]);
 }
 
+shouldNotLint() {
+  return (Dom.div()..onClick = (_) => Dom.div()..id = 'foo')();
+}
+
 class MyObject {
   String id;
 }

--- a/tools/analyzer_plugin/playground/web/misc_fixes.dart
+++ b/tools/analyzer_plugin/playground/web/misc_fixes.dart
@@ -3,8 +3,9 @@ import 'package:over_react/over_react.dart';
 fixes() {
   (Dom.div()
     ..key = new Object().hashCode
+    ..onMouseEnter = (_) => 'arrow function' // should lint
     ..id = '1'
-    ..onClick = (_) => 'arrow function'
+    ..onClick = (_) => 'arrow function' // should not lint once onMouseEnter arrow function is wrapped
   )([
     'could be',
     'variadic children',


### PR DESCRIPTION
## Motivation
1. The arrow functions in prop cascades lint is very noisy - especially since most consumers just move them to be the last setter in the cascade to avoid the other core dart errors caused by placing it in the middle of the cascade.

## Changes
1. Upgrade the lint to an error
1. Only lint when the unwrapped function expression is in the middle of a cascade with more than one setter.

Closes #541
