### PR TITLE
Fix boilerplate generated part directive lint false positives

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -64,6 +64,9 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
         collector.addError(debugCode, result.locationFor(member.name), errorMessageArgs: [member.debugString]);
       }
 
+      // Do not lint anything that is not a likely boilerplate member that will actually get generated.
+      if (member.versionConfidences.toList().every((vcp) => vcp.confidence <= Confidence.neutral)) continue;
+
       if (_overReactGeneratedPartDirective == null) {
         await _addPartDirectiveErrorForMember(
           result: result,

--- a/tools/analyzer_plugin/lib/src/diagnostic/bool_prop_name_readability.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/bool_prop_name_readability.dart
@@ -28,9 +28,12 @@ class BoolPropNameReadabilityDiagnostic extends DiagnosticContributor {
         if (field.type != typeProvider.boolType) continue;
         if (propName == null) continue; // just in case
 
+        final fieldDecl = propsClass.getField(propName);
+        if (fieldDecl == null) continue;
+
         final readability = checkBoolPropReadability(propName);
         if (!readability.isReadable) {
-          collector.addError(code, result.locationFor(propsClass.getField(field.name)),
+          collector.addError(code, result.locationFor(fieldDecl),
               errorMessageArgs: [propsClass.name, propName, allowedPrefixesForBoolProp.join(', ')]);
         }
       }

--- a/tools/analyzer_plugin/playground/web/boilerplate_validator_false_positives.dart
+++ b/tools/analyzer_plugin/playground/web/boilerplate_validator_false_positives.dart
@@ -1,0 +1,11 @@
+import 'package:over_react/over_react.dart';
+
+// This should not be linted as "an .over_react.g.dart" part is required.
+mixin SomeMixin on UiStatefulComponent2<UiProps, UiState> {}
+
+// This should not be linted as "an .over_react.g.dart" part is required.
+abstract class SomeAbstractComponent<T extends UiProps> extends UiComponent2<T> {}
+
+// This should not be linted as "an .over_react.g.dart" part is required.
+// ignore: deprecated_member_use_from_same_package
+abstract class LegacyAbstractComponent<T extends UiProps> extends UiComponent<T> {}


### PR DESCRIPTION
## Motivation
1. The lints that appear when a generated `.over_react.g.dart` `PartDirective` is missing - are appearing when they should not.  This is happening because `members` are really just things that *might* get generated.

## Changes
1. Bail out before producing the lints if the version confidence of the builder is not `likely` or `certain`.

Fixes #528 
