### PR TITLE
Lint unitless string const values in style maps

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/style_missing_unit.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/style_missing_unit.dart
@@ -1,11 +1,8 @@
-// This is necessary for `ConstantEvaluator`. If that API is removed, it can just
-// be copied and pasted into this analyzer package (if still needed).
-// ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart' show ConstantEvaluator;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 
 class StyleMissingUnitDiagnostic extends ComponentUsageDiagnosticContributor {
   static final code = DiagnosticCode(
@@ -29,7 +26,7 @@ class StyleMissingUnitDiagnostic extends ComponentUsageDiagnosticContributor {
     }
 
     for (final entry in styleEntries) {
-      final propertyName = _stringValueIfApplicable(entry.key);
+      final propertyName = getConstOrLiteralStringValueFrom(entry.key);
       if (propertyName == null) continue;
 
       if (unitlessNumberStyles.contains(propertyName) || _isCustomProperty(propertyName)) {
@@ -37,7 +34,7 @@ class StyleMissingUnitDiagnostic extends ComponentUsageDiagnosticContributor {
       }
 
       // Only worry about strings, since numbers get values
-      final stringValue = _stringValueIfApplicable(entry.value);
+      final stringValue = getConstOrLiteralStringValueFrom(entry.value);
       if (stringValue == null) continue;
 
       if (num.tryParse(stringValue) != null) {
@@ -74,11 +71,6 @@ class _RecursiveMapLiteralEntryVisitor extends RecursiveAstVisitor<void> {
     onMapLiteralEntry(node);
     node.visitChildren(this);
   }
-}
-
-String _stringValueIfApplicable(Expression value) {
-  final constantValue = value.accept(ConstantEvaluator());
-  return constantValue is String ? constantValue : null;
 }
 
 bool _isCustomProperty(String propertyName) => propertyName.startsWith('--');

--- a/tools/analyzer_plugin/lib/src/util/ast_util.dart
+++ b/tools/analyzer_plugin/lib/src/util/ast_util.dart
@@ -8,10 +8,32 @@ import 'dart:collection';
 import 'package:analyzer/analyzer.dart' show ConstantEvaluator;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/source/line_info.dart';
 
 export 'package:over_react/src/builder/parsing/ast_util.dart';
 export 'package:over_react/src/builder/parsing/util.dart';
+
+/// Returns a String value when a literal or constant var/identifier is found within [expr].
+String getConstOrLiteralStringValueFrom(Expression expr) {
+  if (!expr.staticType.isDartCoreString) return null;
+
+  if (expr is StringInterpolation) {
+    final constantValue = expr.accept(ConstantEvaluator());
+    return constantValue is String ? constantValue : null;
+  } else if (expr is StringLiteral) {
+    return expr.stringValue;
+  } else if (expr is SimpleIdentifier) {
+    final element = expr.staticElement;
+    if (element is PropertyAccessorElement) {
+      return element.variable.computeConstantValue()?.toStringValue();
+    } else if (element is VariableElement) {
+      return element.computeConstantValue()?.toStringValue();
+    }
+  }
+
+  return null;
+}
 
 /// Returns a lazy iterable of all descendants of [node], in breadth-first order.
 Iterable<AstNode> allDescendants(AstNode node) sync* {

--- a/tools/analyzer_plugin/playground/web/link_target_without_rel.dart
+++ b/tools/analyzer_plugin/playground/web/link_target_without_rel.dart
@@ -33,6 +33,23 @@ final relWithNonConstValue = (Dom.a()
   ..rel = myRelTarget3
 )();
 
+ReactElement relWithLocalConstValue() {
+  const invalidLocalRel = 'nofollow';
+  const validLocalRel = myRelTarget2;
+
+  final invalid = (Dom.a()
+    ..href = 'https://www.workiva.com'
+    ..target = '_blank' // Should lint
+    ..rel = invalidLocalRel
+  )();
+
+  final valid = (Dom.a()
+    ..href = 'https://www.workiva.com'
+    ..target = '_blank' // Should not lint
+    ..rel = validLocalRel
+  )();
+}
+
 final relIsNull = (Dom.a()
   ..href = 'https://www.workiva.com'
   ..target = '_blank'

--- a/tools/analyzer_plugin/playground/web/style_missing_unit.dart
+++ b/tools/analyzer_plugin/playground/web/style_missing_unit.dart
@@ -1,5 +1,7 @@
 import 'package:over_react/over_react.dart';
 
+part 'style_missing_unit.over_react.g.dart';
+
 styleMissingUnit() {
   (Dom.div()..style = {
     'width': '1',
@@ -18,14 +20,36 @@ styleMissingUnit() {
     'width': '1',
   }))();
 
-//  const one = '1';
+  const ten = '10';
+  const two = '2px';
+  final three = '3';
 
   // Non-SimpleStringLiteral cases detected (but don't have assists)
   (Dom.div()..style = {
-    // constant value  // todo uncomment once ConstantEvaluator supports fields
-    //'width': one,
+    'width': ten, // Should lint
+    'minWidth': two, // Should not lint
+    'minHeight': three, // Cannot lint currently since its not const, but also should not cause analyzer errors
     'height': '1' '2',
     'top': '${1}',
     'left': 1,
   })();
+}
+
+UiFactory<SomeWidgetWithBadStylesProps> SomeWidgetWithBadStyles =
+    // ignore: undefined_identifier
+    _$SomeWidgetWithBadStyles;
+
+mixin SomeWidgetWithBadStylesProps on UiProps {}
+
+class SomeWidgetWithBadStylesComponent extends UiComponent2<SomeWidgetWithBadStylesProps> {
+  static const ten = '10';
+  static const two = '2px';
+
+  @override
+  render() {
+    return (Dom.div()..style = {
+      'width': ten, // Should lint
+      'minWidth': two, // Should not lint
+    })();
+  }
 }


### PR DESCRIPTION
## Motivation
1. The `StyleMissingUnitDiagnostic` currently does not lint when a unitless string value is stored within a `const` that is referenced in the style map, but it should.

## Changes
1. Update the diagnostic logic to detect constant values and lint _(without offering a quick fix)_ when appropriate using the logic from `LinkTargetUsageWithoutRelDiagnostic` as inspiration.
2. Split out the new and improved logic _(that now detects local constants in addition to instance fields)_ as a shared utility, and use it in both places.
3. Add / update playground test cases to exercise all new / improved logic.

Closes #562
