### PR TITLE
Do not lint whitelisted instance members within propTypes

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
@@ -4,7 +4,7 @@ import 'package:over_react_analyzer_plugin/src/diagnostic/pseudo_static_lifecycl
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/non_static_reference_visitor.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/proptypes_visitors.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
-import 'package:over_react_analyzer_plugin/src/utils/util.dart';
+import 'package:over_react_analyzer_plugin/src/util/util.dart';
 
 /// An error that appears when accessing instance members of a class in propTypes values
 ///
@@ -33,7 +33,7 @@ class PropTypesInstanceMembersDiagnostic extends DiagnosticContributor {
 
         if (reference is SuperExpression) {
           // Do not lint calls to super.propTypes
-          if (reference.parent.tryCast<PropertyAccess>()?.propertyName.name == 'propTypes') continue;
+          if (reference.parent.tryCast<PropertyAccess>()?.propertyName?.name == 'propTypes') continue;
         }
 
         collector.addError(

--- a/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
@@ -4,6 +4,7 @@ import 'package:over_react_analyzer_plugin/src/diagnostic/pseudo_static_lifecycl
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/non_static_reference_visitor.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/proptypes_visitors.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
+import 'package:over_react_analyzer_plugin/src/utils/util.dart';
 
 /// An error that appears when accessing instance members of a class in propTypes values
 ///
@@ -28,6 +29,11 @@ class PropTypesInstanceMembersDiagnostic extends DiagnosticContributor {
       for (final reference in blockVisitor.nonStaticReferences) {
         if (reference is SimpleIdentifier && instanceMemberWhitelist.contains(reference.name)) {
           continue;
+        }
+
+        if (reference is SuperExpression) {
+          // Do not lint calls to super.propTypes
+          if (reference.parent.tryCast<PropertyAccess>()?.propertyName.name == 'propTypes') continue;
         }
 
         collector.addError(

--- a/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/proptypes_instance_members.dart
@@ -1,4 +1,6 @@
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:over_react_analyzer_plugin/src/diagnostic/pseudo_static_lifecycle.dart' show instanceMemberWhitelist;
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/non_static_reference_visitor.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/visitors/proptypes_visitors.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
@@ -24,6 +26,10 @@ class PropTypesInstanceMembersDiagnostic extends DiagnosticContributor {
 
       value.accept(blockVisitor);
       for (final reference in blockVisitor.nonStaticReferences) {
+        if (reference is SimpleIdentifier && instanceMemberWhitelist.contains(reference.name)) {
+          continue;
+        }
+
         collector.addError(
           code,
           result.locationFor(reference),

--- a/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
@@ -11,6 +11,7 @@ const instanceMemberWhitelist = [
   'typedPropsFactoryJs',
   'typedStateFactory',
   'typedStateFactoryJs',
+  'keyForProp',
 ];
 
 class PseudoStaticLifecycleDiagnostic extends DiagnosticContributor {

--- a/tools/analyzer_plugin/playground/web/proptypes.dart
+++ b/tools/analyzer_plugin/playground/web/proptypes.dart
@@ -29,6 +29,8 @@ class FooComponent extends UiComponent2<FooProps> {
         throw PropError.required(info.propName);
       } else if (props.prop1 > 0) {
         throw PropError.value(props.prop1, info.propName);
+      } else if (props.prop1 > 100) {
+        return super.propTypes[keyForProp((p) => p.prop1)](props, info); // Should not lint
       }
       return null;
     },

--- a/tools/analyzer_plugin/playground/web/proptypes.dart
+++ b/tools/analyzer_plugin/playground/web/proptypes.dart
@@ -33,6 +33,7 @@ class FooComponent extends UiComponent2<FooProps> {
       return null;
     },
     keyForProp((p) => p.prop2): (props, info) {
+      final tProps = typedPropsFactory(props); // Should not lint
       _someField = 'foo';
       if (someGetter == 'foo') {
         print('woo');


### PR DESCRIPTION
## Motivation
#535 added a lint for when users reference instance members within `propTypes`, but it doesn't prevent lints on the "whitelisted" instance members that the similar `PseudoStaticLifecycleDiagnostic` uses - and it should.

## Changes
1. Update logic to not lint on "whitelisted" instance members within `propTypes`, and not to lint on calls to `super.propTypes`.
1. Update test case in the playground



