### PR TITLE
Misc. iterable children improvements

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -7,8 +7,8 @@ class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
   static const code = DiagnosticCode(
     'over_react_variadic_children',
     'Variadic children should be used instead of lists where possible',
-    AnalysisErrorSeverity.WARNING,
-    AnalysisErrorType.STATIC_WARNING,
+    AnalysisErrorSeverity.INFO,
+    AnalysisErrorType.LINT,
   );
 
   static final fixKind = FixKind(code.name, 200, 'Unwrap children from list literal',

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -2,6 +2,8 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
+import 'package:over_react_analyzer_plugin/src/fluent_interface_util/cascade_read.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 
 class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
   static const code = DiagnosticCode(
@@ -11,8 +13,7 @@ class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
     AnalysisErrorType.LINT,
   );
 
-  static final fixKind = FixKind(code.name, 200, 'Unwrap children from list literal',
-      appliedTogetherMessage: 'Unwrap children from list literals');
+  static final fixKind = convertUsageListLiteralToVariadicChildrenFixKind(code);
 
   @override
   computeErrorsForUsage(result, collector, usage) async {
@@ -25,11 +26,46 @@ class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
         result.locationFor(list),
         fixKind: fixKind,
         computeFix: () => buildFileEdit(result, (builder) {
-          builder.addDeletion(range.token(list.leftBracket));
-          builder.addDeletion(range.token(list.rightBracket));
-          // todo remove any keys from children as well
+          convertUsageListLiteralToVariadicChildren(builder, list);
         }),
       );
+    }
+  }
+}
+
+FixKind convertUsageListLiteralToVariadicChildrenFixKind(
+  DiagnosticCode code, {
+  int priority = 200,
+  String message = 'Unwrap children from unnecessary list literal',
+}) =>
+    FixKind(code.name, priority, message);
+
+/// Removes the left/right bracket from the provided [listLiteral], and removes the value of `props.key` from
+/// any child elements that have one set if [removeKeyFromChildren] is true.
+///
+/// Should only be used if the [listLiteral] is an argument within a [FluentComponentUsage]'s node invocation.
+///
+/// Can be shared in [convertUsageListLiteralToVariadicChildrenFixKind] quick fixes for lints
+/// involving the keying of children / use of list literals as element children.
+void convertUsageListLiteralToVariadicChildren(
+  DartFileEditBuilder builder,
+  ListLiteral listLiteral, {
+  bool removeKeyFromChildren = true,
+}) {
+  builder.addDeletion(range.token(listLiteral.leftBracket));
+  builder.addDeletion(range.token(listLiteral.rightBracket));
+
+  if (!removeKeyFromChildren) return;
+
+  for (final node in allDescendants(listLiteral)) {
+    final usages = <FluentComponentUsage>[];
+    node.accept(ComponentUsageVisitor(usages.add));
+    for (final usage in usages) {
+      for (final prop in usage.cascadedProps) {
+        if (prop.name.name == 'key') {
+          builder.addDeletion(prop.rangeForRemoval);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Motivation
1. The variadic children diagnostic is misclassified as a warning
1. The quick fix for converting list literals into variadic children did not remove the `key` prop from component children, but it should
1. List literal / mapped iterable children without keys did not have quick fixes

## Changes
1. Downgrade the variadic children diagnostic to info
1. Remove prop keys when converting list literal children to variadic children
1. Added quick fixes for iterable children without keys:
    1. _Within list literals:_ Unwrap from list literal _(only if found within the invocation of a parent component usage)_
    1. _Within mapped iterable:_ Add a key prop

Closes #543