### PR TITLE
Validate part directive for libs with parts

### DIFF
--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -121,10 +121,7 @@ class OverReactBuilder extends Builder {
     }
 
     // Collect all of the part files for this library.
-    final parts = libraryUnit.directives
-      .whereType<PartDirective>()
-      // Ignore all generated `.g.dart` parts.
-      .where((part) => !part.uri.stringValue.endsWith('.g.dart'));
+    final parts = getNonGeneratedParts(libraryUnit);
 
     // Generate over_react code for the input library.
     generateForFile(source, buildStep.inputId, libraryUnit);

--- a/lib/src/builder/util.dart
+++ b/lib/src/builder/util.dart
@@ -42,6 +42,12 @@ Uri idToPackageUri(AssetId id) {
       path: p.url.join(id.package, id.path.replaceFirst('lib/', '')));
 }
 
+Iterable<PartDirective> getNonGeneratedParts(CompilationUnit libraryUnit) {
+  return libraryUnit.directives
+      .whereType<PartDirective>()
+      // Ignore all generated `.g.dart` parts.
+      .where((part) => !part.uri.stringValue.endsWith('.g.dart'));
+}
 /// Returns true if the given compilation unit is a part file.
 bool isPart(CompilationUnit unit) =>
     unit.directives.any((directive) => directive is PartOfDirective);

--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -37,17 +37,19 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
   ///
   /// Does not report any errors for the part file, as those are handled when the part file is analyzed
   bool _partHasDeclarations(CompilationUnit unit, ResolvedUnitResult parentResult) {
-     return getBoilerplateDeclarations(detectBoilerplateMembers(unit), ErrorCollector.callback(
-      SourceFile.fromString(parentResult.content, url: parentResult.path),
-      onError: (message, [span]) {
-        // no-op. It is assumed this method will run for parent files, and the part file will get analyzed in it's own
-        // context
-      },
-      onWarning: (message, [span]) {
-        // no-op. It is assumed this method will run for parent files, and the part file will get analyzed in it's own
-        // context
-      },
-    )).isNotEmpty;
+    return getBoilerplateDeclarations(
+        detectBoilerplateMembers(unit),
+        ErrorCollector.callback(
+          SourceFile.fromString(parentResult.content, url: parentResult.path),
+          onError: (message, [span]) {
+            // no-op. It is assumed this method will run for parent files, and the part file will get analyzed in it's own
+            // context
+          },
+          onWarning: (message, [span]) {
+            // no-op. It is assumed this method will run for parent files, and the part file will get analyzed in it's own
+            // context
+          },
+        )).isNotEmpty;
   }
 
   /// Computes errors for over_react boilerplate
@@ -102,7 +104,6 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
           errorType: PartDirectiveErrorType.invalid,
         );
       }
-
     }
 
     final declarations = getBoilerplateDeclarations(members, errorCollector).toList();
@@ -124,7 +125,8 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
     return declarations.isNotEmpty;
   }
 
-  Future<void> _computePartDirectiveErrors(ResolvedUnitResult result, DiagnosticCollector collector, bool hasDeclarations) async {
+  Future<void> _computePartDirectiveErrors(
+      ResolvedUnitResult result, DiagnosticCollector collector, bool hasDeclarations) async {
     if (!hasDeclarations && _overReactGeneratedPartDirective != null) {
       await collector.addErrorWithFix(
         errorCode,
@@ -146,7 +148,9 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
       await collector.addErrorWithFix(
         errorCode,
         result.locationFor(_overReactGeneratedPartDirective),
-        errorMessageArgs: ['The generated part name must match the name of the file that contains it, but with `over_react.g.dart` for the file extension.'],
+        errorMessageArgs: [
+          'The generated part name must match the name of the file that contains it, but with `over_react.g.dart` for the file extension.'
+        ],
         fixKind: invalidGeneratedPartFixKind,
         computeFix: () => buildFileEdit(result, (builder) {
           fixOverReactGeneratedPartDirective(builder, result.unit, result.uri);
@@ -158,7 +162,7 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
   @override
   Future<void> computeErrors(result, collector) async {
     _overReactGeneratedPartDirective = getOverReactGeneratedPartDirective(result.unit);
-    _overReactGeneratedPartDirectiveIsValid =_overReactGeneratedPartDirective != null &&
+    _overReactGeneratedPartDirectiveIsValid = _overReactGeneratedPartDirective != null &&
         overReactGeneratedPartDirectiveIsValid(_overReactGeneratedPartDirective, result.uri);
 
     final hasDeclarations = await _computeBoilerplateErrors(result, collector);
@@ -181,8 +185,7 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
       }
     }
 
-    await _computePartDirectiveErrors(
-        result, collector, hasDeclarations || anyPartHasDeclarations);
+    await _computePartDirectiveErrors(result, collector, hasDeclarations || anyPartHasDeclarations);
   }
 
   Future<void> _addPartDirectiveErrorForMember({
@@ -234,6 +237,6 @@ extension<E> on Iterable<E> {
 Iterable<PartDirective> getNonGeneratedParts(CompilationUnit libraryUnit) {
   return libraryUnit.directives
       .whereType<PartDirective>()
-  // Ignore all generated `.g.dart` parts.
+      // Ignore all generated `.g.dart` parts.
       .where((part) => !part.uri.stringValue.endsWith('.g.dart'));
 }

--- a/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_parent.dart
+++ b/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_parent.dart
@@ -1,0 +1,6 @@
+library invalid_generated_part_filename;
+
+import 'package:over_react/over_react.dart';
+part 'invalid_gnerated_part_filename_parent.over_react.g.dart';
+
+part 'invalid_generated_part_filename_part.dart';

--- a/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_part.dart
+++ b/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_part.dart
@@ -1,6 +1,5 @@
-import 'package:over_react/over_react.dart';
-
-part 'invalid_generated_part_filename.over_react.g.dart';
+//part 'invaid_generated_part_filename_part.over_react.g.dart';
+part of invalid_generated_part_filename;
 
 UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
 

--- a/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_standalone.dart
+++ b/tools/analyzer_plugin/playground/web/invalid_generated_part_filename_standalone.dart
@@ -1,0 +1,12 @@
+import 'package:over_react/over_react.dart';
+
+part 'invalid_generated_pat_filename_standalone.over_react.g.dart';
+
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+
+mixin FooProps on UiProps {}
+
+class FooComponent extends UiComponent2<FooProps> {
+  @override
+  render() {}
+}


### PR DESCRIPTION
Fixes #522 
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The boiler plate validation logic doesn't currently account or the case where the component declarations are in a `part of` file.
## Changes
  <!-- What this PR changes to fix the problem. -->
* When analyzing a file which is a self-contained lib, run boilerplate validation and part directive validation.
* When the file is a `part of`, just run the boilerplate validation, but not any part directive validation.
* When we are in a parent lib file, examine the contents of all files in a lib and validate the part directive if any files in the lib contain over_react declarations.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
