### PR TITLE
Add integration tests for BadKeyDiagnosticContributor

### DIFF
--- a/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
+++ b/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
@@ -156,9 +156,12 @@ class _DiagnosticGenerator {
       // `<=` because we do want the end to be inclusive (you should get
       // the fix when your cursor is on the tail end of the error).
       if (request.offset >= errorStart && request.offset <= errorEnd) {
+        final fix = collector.fixes[i];
         fixes.add(AnalysisErrorFixes(
           error,
-          fixes: [collector.fixes[i]],
+          fixes: [
+            if (fix != null) fix,
+          ],
         ));
       }
     }

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
@@ -2,9 +2,10 @@
 import 'package:analyzer/analyzer.dart'
     show CompileTimeErrorCode, NodeLocator, StaticTypeWarningCode, StaticWarningCode;
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
-import 'package:over_react_analyzer_plugin/src/diagnostic/analyzer_debug_helper.dart';
+//import 'package:over_react_analyzer_plugin/src/diagnostic/analyzer_debug_helper.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/util/util.dart';
 
@@ -78,8 +79,8 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
       if (isBadFunction || isBadArity || isVoidUsage) {
         final node = NodeLocator(error.offset, error.offset + error.length).searchWithin(result.unit);
 
-        final debug = AnalyzerDebugHelper(result, collector);
-        debug.log('node.type: ${node.runtimeType}');
+//        final debug = AnalyzerDebugHelper(result, collector);
+//        debug.log('node.type: ${node.runtimeType}');
 
         InvocationExpression invocation;
         final parent = node.parent;
@@ -91,7 +92,7 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
         } else if (isVoidUsage && parent is InvocationExpression) {
           invocation = parent;
         }
-        debug.log('invocation : ${invocation?.toSource()}');
+//        debug.log('invocation : ${invocation?.toSource()}');
 
         if (invocation == null) return;
 
@@ -111,14 +112,14 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
           continue;
         }
 
-        debug.log('${invocation.function.staticType?.getDisplayString()}');
+//        debug.log('${invocation.function.staticType?.getDisplayString()}');
 
         if (isBadFunction && (invocation.function.staticType?.isReactElement ?? false)) {
           final expr = invocation.function?.tryCast<InvocationExpression>() ??
               invocation.function?.tryCast<ParenthesizedExpression>()?.unParenthesized?.tryCast();
 
-          debug.log('expr: ${expr?.runtimeType} ${expr?.toSource()}');
-          debug.log('expr.parent: ${expr?.parent?.runtimeType} ${expr?.parent?.toSource()}');
+//          debug.log('expr: ${expr?.runtimeType} ${expr?.toSource()}');
+//          debug.log('expr.parent: ${expr?.parent?.runtimeType} ${expr?.parent?.toSource()}');
 
           if (expr.argumentList.arguments.firstOrNull?.staticType?.isPropsClass ?? false) {
             await collector.addErrorWithFix(

--- a/tools/analyzer_plugin/lib/src/util/ast_util.dart
+++ b/tools/analyzer_plugin/lib/src/util/ast_util.dart
@@ -166,3 +166,22 @@ extension on DartObject {
 extension on Symbol {
   String get name => MirrorSystem.getName(this);
 }
+
+extension EmptyIdentifier on Expression {
+  /// Whether this is an identifier with no name, usually stubbed in by the
+  /// parser in response to invalid syntax.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// // '..foo = '
+  /// print(assignmentExpressionWithNoRhs.toSource());
+  ///
+  /// // 'true'
+  /// print(assignmentExpressionWithNoRhs.rightHandSide.isEmdtyIdentifier);
+  /// ```
+  bool get isEmptyIdentifier {
+    final self = this;
+    return self is SimpleIdentifier && self.name == '';
+  }
+}

--- a/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
@@ -1,11 +1,9 @@
 import 'dart:async';
 
 import 'package:over_react_analyzer_plugin/src/diagnostic/arrow_function_prop.dart';
-import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
-import '../matchers.dart';
 import '../test_bases/diagnostic_test_base.dart';
 
 void main() {
@@ -17,10 +15,10 @@ void main() {
 @reflectiveTest
 class ArrowFunctionPropCascadeDiagnosticTest extends DiagnosticTestBase {
   @override
-  DiagnosticCode get errorUnderTest => ArrowFunctionPropCascadeDiagnostic.code;
+  get errorsUnderTest => {ArrowFunctionPropCascadeDiagnostic.code};
 
   @override
-  FixKind get fixKindUnderTest => ArrowFunctionPropCascadeDiagnostic.fixKind;
+  get fixKindsUnderTest => {ArrowFunctionPropCascadeDiagnostic.fixKind};
 
   static String simpleSource = /*language=dart*/ '''
 import 'package:over_react/over_react.dart';
@@ -101,7 +99,7 @@ var bar = (Dom.div()..onSubmit = (_) => null..key = 'bar')('');
       createSelection(source, 'onSubmit = #(_) => null#'),
     ];
     for (final selection in errorSelections) {
-      expect(allErrors, contains(isDiagnostic(errorUnderTest, locatedAt: selection, hasFix: true)));
+      expect(allErrors, contains(isAnErrorUnderTest(locatedAt: selection, hasFix: true)));
     }
   }
 }

--- a/tools/analyzer_plugin/test/integration/diagnostics/bad_key_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/bad_key_test.dart
@@ -1,0 +1,191 @@
+// ignore_for_file: camel_case_types
+import 'dart:async';
+
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:over_react_analyzer_plugin/src/diagnostic/bad_key.dart';
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../test_bases/diagnostic_test_base.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(BadKeyDiagnosticTest_NoErrors);
+    defineReflectiveTests(BadKeyDiagnosticTest_LowQualityCode);
+    defineReflectiveTests(BadKeyDiagnosticTest_ToString);
+    defineReflectiveTests(BadKeyDiagnosticTest_UnknownKeyType);
+  });
+}
+
+abstract class BadKeyDiagnosticTest extends DiagnosticTestBase {
+  Source source;
+
+  @override
+  get fixKindsUnderTest => {};
+
+  @override
+  tearDown() async {
+    await super.tearDown();
+    source = null;
+  }
+
+  void initSource(String sourceFragment) {
+    source = newSource('test.dart', sourcePrefix + sourceFragment);
+  }
+
+  Future<AnalysisError> expectError(String selection) =>
+      expectAndGetSingleErrorAtSelection(createSelection(source, selection));
+
+  static const sourcePrefix = /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
+MyModel modelVar;
+MyModelWithCustomToString modelVarWithCustomToString;
+
+Object objectVar;
+dynamic dynamicVar;
+
+// ignore: missing_return
+String deriveKeyFrom(Object object) {}
+
+class MyModel {
+  int id;
+}
+
+class MyModelWithCustomToString {
+  int id;
+
+  @override
+  toString() => '$id';
+}
+''';
+}
+
+@reflectiveTest
+class BadKeyDiagnosticTest_NoErrors extends BadKeyDiagnosticTest {
+  @override
+  get errorsUnderTest => {};
+
+  Future<void> test_noErrors() async {
+    initSource(/*language=dart*/ r'''
+      test() => [
+        (Dom.div()..key = 'a string')(),
+        (Dom.div()..key = 122)(),
+        (Dom.div()..key = modelVar.id)(),
+        (Dom.div()..key = modelVarWithCustomToString)(),
+        (Dom.div()..key = deriveKeyFrom(modelVar))(),
+      ];
+    ''');
+
+    expect(await getAllErrors(source, includeOtherCodes: true), isEmpty);
+  }
+
+  Future<void> test_noErrorsEvenWithEdgeCases() async {
+    initSource(/*language=dart*/ r'''
+      void voidVar;        
+      test() => [
+        // Not an assignment
+        (Dom.div()..key)(),
+        (Dom.div()..key = 'greg')(),
+        // Missing RHS
+        (Dom.div()..key = )(),
+        // Missing interpolated expression
+        (Dom.div()..key = '${}')(),
+        // Weird type 
+        (Dom.div()..key = voidVar)(),
+      ];
+    ''');
+
+    expect(await getAllErrors(source, includeOtherCodes: true), isEmpty);
+  }
+}
+
+@reflectiveTest
+class BadKeyDiagnosticTest_LowQualityCode extends BadKeyDiagnosticTest {
+  @override
+  get errorsUnderTest => {BadKeyDiagnostic.lowQualityCode};
+
+  Future<void> test_bool() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = false)();''');
+    final error = await expectAndGetSingleErrorAtSelection(createSelection(source, '= #false#'));
+    expect(error.message, contains("'bool.toString()'"));
+  }
+
+  Future<void> test_Null() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = null)();''');
+    final error = await expectAndGetSingleErrorAtSelection(createSelection(source, '= #null#'));
+    expect(error.message, contains("'Null.toString()'"));
+  }
+}
+
+@reflectiveTest
+class BadKeyDiagnosticTest_ToString extends BadKeyDiagnosticTest {
+  @override
+  get errorsUnderTest => {BadKeyDiagnostic.toStringCode};
+
+  Future<void> test_rawObjecct() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = modelVar)();''');
+    final error = await expectError('= #modelVar#)');
+    expect(error.message, contains("'MyModel.toString()'"));
+  }
+
+  Future<void> test_explicitToString() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = modelVar.toString())();''');
+    final error = await expectError('= #modelVar#.toString())');
+    expect(error.message, contains("'MyModel.toString()'"));
+  }
+
+  Future<void> test_explicitToStringNested() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = deriveKeyFrom(modelVar.toString()))();''');
+    final error = await expectError('= deriveKeyFrom(#modelVar#.toString())');
+    expect(error.message, contains("'MyModel.toString()'"));
+  }
+
+  Future<void> test_interpolated() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = 'interpolated $modelVar')();''');
+    final error = await expectError(r"= 'interpolated $#modelVar#')");
+    expect(error.message, contains("'MyModel.toString()'"));
+  }
+
+  Future<void> test_inMap() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = {'foo': modelVar})();''');
+    final error = await expectError(r"= #{'foo': modelVar}#");
+    expect(error.message, contains("'MyModel.toString()' (from Map<String, MyModel>)"));
+  }
+
+  Future<void> test_inList() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = [modelVar])();''');
+    final error = await expectError(r"= #[modelVar]#");
+    expect(error.message, contains("'MyModel.toString()' (from List<MyModel>)"));
+  }
+}
+
+@reflectiveTest
+class BadKeyDiagnosticTest_UnknownKeyType extends BadKeyDiagnosticTest {
+  @override
+  get errorsUnderTest => {BadKeyDiagnostic.dynamicOrObjectCode};
+
+  Future<void> test_object() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = objectVar)();''');
+    final error = await expectAndGetSingleErrorAtSelection(createSelection(source, '= #objectVar#'));
+    expect(error.message, contains("'Object.toString()'"));
+  }
+
+  Future<void> test_dynamic() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = dynamicVar)();''');
+    final error = await expectAndGetSingleErrorAtSelection(createSelection(source, r"= #dynamicVar#"));
+    expect(error.message, contains("'dynamic.toString()'"));
+  }
+
+  Future<void> test_inMap() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = {'foo': modelVar, 'bar': 1})();''');
+    final error = await expectAndGetSingleErrorAtSelection(createSelection(source, r"= #{'foo': modelVar, 'bar': 1}#"));
+    expect(error.message, contains("'Object.toString()' (from Map<String, Object>)"));
+  }
+
+  Future<void> test_inList() async {
+    initSource(/*language=dart*/ r'''test() => (Dom.div()..key = [dynamicVar])();''');
+    final error = await expectError(r"= #[dynamicVar]#");
+    expect(error.message, contains("'dynamic.toString()' (from List<dynamic>)"));
+  }
+}

--- a/tools/analyzer_plugin/test/integration/test_bases/diagnostic_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/diagnostic_test_base.dart
@@ -7,10 +7,12 @@ import 'package:test/test.dart';
 import '../matchers.dart';
 import 'server_plugin_contributor_test_base.dart';
 
+export 'package:analyzer/src/generated/source.dart' show Source;
+
 /// Test base for integration tests that exercise a single diagnostic
 /// contributor.
 ///
-/// Tests should extend this class and override [errorUnderTest] to
+/// Tests should extend this class and override [errorsUnderTest] to
 /// return the contributor that is being tested.
 ///
 /// Most tests should use [newSource] to create a test source file,
@@ -27,14 +29,29 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
   ///
   /// This will be used to filter the analysis errors produced by the test
   /// plugin to only those originating from this diagnostic contributor.
-  DiagnosticCode get errorUnderTest;
+  Set<DiagnosticCode> get errorsUnderTest;
 
   /// Tests should override this to return the [FixKind] for the diagnostic
   /// contributor that is being tested.
   ///
   /// This will be used to filter the error fixes produced by the test plugin to
   /// only those originating from this diagnostic contributor.
-  FixKind get fixKindUnderTest;
+  Set<FixKind> get fixKindsUnderTest;
+
+  /// Returns a matcher that matches any [fixKindsUnderTest].
+  ///
+  /// See [isDiagnostic] for more details.
+  Matcher isAnErrorUnderTest({bool hasFix, SourceSelection locatedAt}) {
+    hasFix ??= fixKindsUnderTest.isNotEmpty;
+    return anyOf(errorsUnderTest.map((e) => isDiagnostic(e, hasFix: hasFix, locatedAt: locatedAt)).toList());
+  }
+
+  /// Returns a matcher that matches any [fixKindsUnderTest].
+  ///
+  /// See [isFix] for more details.
+  Matcher isAFixUnderTest() {
+    return anyOf(fixKindsUnderTest.map(isFix).toList());
+  }
 
   /// Applies the source change from [errorFix] to [source] and returns the
   /// updated source.
@@ -42,7 +59,7 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
     final fixes = errorFix.fixes;
     expect(fixes, hasLength(1), reason: 'Expected error fix to have exactly one change.');
     final fix = fixes.single;
-    expect(fix, isFix(fixKindUnderTest), reason: 'Expected fix to match the fix kind under test.');
+    expect(fix, isAFixUnderTest(), reason: 'Expected fix to match the fix kind under test.');
     return applySourceChange(fix.change, source);
   }
 
@@ -56,6 +73,19 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
     }
   }
 
+  Future<AnalysisError> expectAndGetSingleErrorAtSelection(SourceSelection selection,
+      {bool exactSelectionMatch = true}) async {
+    final errorsAtSelection = await _getAllErrorsAtSelection(selection);
+    expect(errorsAtSelection, [isAnErrorUnderTest()],
+        reason: 'Expected a single error that matches `errorUnderTest` (selection: ${selection.target}.');
+    final error = errorsAtSelection[0];
+
+    if (exactSelectionMatch) {
+      expect(error.location, matchesSelectionLocation(selection), reason: 'error location should match selection');
+    }
+    return error;
+  }
+
   /// Returns the error fix for the single error produced at [selection] and
   /// fails the test if anything other than a single error fix is produced.
   Future<AnalysisErrorFixes> expectAndGetSingleErrorFix(SourceSelection selection) async {
@@ -63,11 +93,11 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
     expect(allErrorFixes, hasLength(1),
         reason: 'Expected only a single error at selection (selection: ${selection.target})');
     final errorFix = allErrorFixes.single;
-    expect(errorFix.error, isDiagnostic(errorUnderTest, hasFix: fixKindUnderTest != null),
+    expect(errorFix.error, isAnErrorUnderTest(),
         reason: 'Expected error to match the `errorUnderTest` (selection: ${selection.target})');
     expect(errorFix.fixes, hasLength(1),
         reason: 'Expected only a single error fix at selection. (selection: ${selection.target})');
-    expect(errorFix.fixes, everyElement(isFix(fixKindUnderTest)),
+    expect(errorFix.fixes, everyElement(isAFixUnderTest()),
         reason: 'Expected error fix to match the `fixKindUnderTest` (selection: ${selection.target})');
     return errorFix;
   }
@@ -79,13 +109,37 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
   }
 
   /// Returns all errors produced over the entire [source] and fails the test if
-  /// any of them do not match [errorUnderTest] or [fixKindUnderTest].
-  Future<List<AnalysisError>> getAllErrors(Source source) async {
-    final analysisResult = await testPlugin.getResolvedUnitResult(sourcePath(source));
-    final errors = await testPlugin.getAllErrors(analysisResult);
-    expect(errors, everyElement(isDiagnostic(errorUnderTest, hasFix: fixKindUnderTest != null)),
-        reason: 'Expected all errors to match the error & fix kinds under test.');
+  /// any of them do not match [isAnErrorUnderTest] or [isAFixUnderTest].
+  Future<List<AnalysisError>> getAllErrors(Source source, {bool includeOtherCodes = false}) async {
+    final errors = await _getAllErrors(source);
+    if (!includeOtherCodes) {
+      expect(errors, everyElement(isAnErrorUnderTest()),
+          reason: 'Expected all errors to match the error & fix kinds under test.');
+    }
     return errors;
+  }
+
+  Future<List<AnalysisError>> getAllErrorsAtSelection(SourceSelection selection,
+      {bool includeOtherCodes = false}) async {
+    final errors = await _getAllErrorsAtSelection(selection);
+    if (!includeOtherCodes) {
+      expect(errors, everyElement(isAnErrorUnderTest()),
+          reason: 'Expected all errors to match the error & fix kinds under test.');
+    }
+    return errors;
+  }
+
+  /// Returns all error fixes produced at [selection].
+  Future<List<AnalysisError>> _getAllErrorsAtSelection(SourceSelection selection) async {
+    final allErrors = await _getAllErrors(selection.source);
+    final errorsOverlappingSelection =
+        allErrors.where((e) => e.location.toRange().intersects(selection.toRange())).toList();
+    return errorsOverlappingSelection;
+  }
+
+  Future<List<AnalysisError>> _getAllErrors(Source source) async {
+    final analysisResult = await testPlugin.getResolvedUnitResult(sourcePath(source));
+    return testPlugin.getAllErrors(analysisResult);
   }
 
   /// Returns all error fixes prroduced at [selection].

--- a/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
@@ -9,6 +9,8 @@ import '../mocks.dart';
 import 'analysis_driver_test_base.dart';
 import 'assist_test_base.dart';
 
+export 'package:analyzer/src/generated/source.dart' show Source;
+
 /// Representation of a selected range on a [Source] file.
 ///
 /// Useful when testing assist and diagnostic contributors that use the
@@ -24,6 +26,30 @@ class SourceSelection {
   final String target;
 
   SourceSelection(this.source, this.offset, this.length, {this.target});
+}
+
+extension AsRange$SourceRange on SourceSelection {
+  /// Returns SourceRange using [offset] and [length].
+  ///
+  /// Useful when you're dealing with ranges represented by incompatible types,
+  /// and need to compare them (using [SourceRange.intersects], etc.).
+  SourceRange toRange() => SourceRange(offset, length);
+}
+
+extension AsRange$Location on Location {
+  /// Returns SourceRange using [offset] and [length].
+  ///
+  /// Useful when you're dealing with ranges represented by incompatible types,
+  /// and need to compare them (using [SourceRange.intersects], etc.).
+  SourceRange toRange() => SourceRange(offset, length);
+}
+
+extension AsRange$Position on Position {
+  /// Returns SourceRange using [offset]].
+  ///
+  /// Useful when you're dealing with ranges represented by incompatible types,
+  /// and need to compare them (using [SourceRange.intersects], etc.).
+  SourceRange toRange() => SourceRange(offset, 0);
 }
 
 /// Test base that handles constructing an analysis server plugin designed for


### PR DESCRIPTION
- Add integration tests for BadKeyDiagnosticContributor
- Add some utils to functional test base classes around getting errors
- Make errorUnderTest/fixKindUnderTest accept multiple values
- Add `isEmptyIdentifier` utility