### PR TITLE
Fix unintended removal of keys in granchildren, add removeProp util

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
@@ -44,10 +44,9 @@ class DuplicatePropCascadeDiagnostic extends ComponentUsageDiagnosticContributor
           fixKind: fixKind,
           computeFix: () => buildFileEdit(result, (builder) {
             for (var i = 0; i < propUsages.length - 1; i++) {
-              final propToRemove = propUsages[i];
               // We iterate and remove all but the final instance of a duplicated prop, so that the last
               // instance (the one that is actually used at run time) is retained.
-              builder.addDeletion(propToRemove.rangeForRemoval);
+              removeProp(usage, builder, propUsages[i]);
             }
           }),
         );

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -87,14 +87,11 @@ void convertUsageListLiteralToVariadicChildren(
 
   if (!removeKeyFromChildren) return;
 
-  for (final node in allDescendants(listLiteral)) {
-    final usages = <FluentComponentUsage>[];
-    node.accept(ComponentUsageVisitor(usages.add));
-    for (final usage in usages) {
-      for (final prop in usage.cascadedProps) {
-        if (prop.name.name == 'key') {
-          builder.addDeletion(prop.rangeForRemoval);
-        }
+  final usagesInList = listLiteral.elements.whereType<InvocationExpression>().map(getComponentUsage).whereNotNull();
+  for (final usage in usagesInList) {
+    for (final prop in usage.cascadedProps) {
+      if (prop.name.name == 'key') {
+        builder.addDeletion(prop.rangeForRemoval);
       }
     }
   }

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util/cascade_read.dart';
+import 'package:over_react_analyzer_plugin/src/fluent_interface_util/cascade_edits.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 
 const _desc = r'Avoid using iterable children when variadic children can be used.';
@@ -91,7 +92,7 @@ void convertUsageListLiteralToVariadicChildren(
   for (final usage in usagesInList) {
     for (final prop in usage.cascadedProps) {
       if (prop.name.name == 'key') {
-        builder.addDeletion(prop.rangeForRemoval);
+        removeProp(usage, builder, prop);
       }
     }
   }

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children_with_keys.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children_with_keys.dart
@@ -92,7 +92,7 @@ class VariadicChildrenWithKeys extends ComponentUsageDiagnosticContributor {
             result.locationFor(prop.assignment),
             fixKind: fixKind,
             computeFix: () => buildFileEdit(result, (builder) {
-              builder.addDeletion(prop.rangeForRemoval);
+              removeProp(usage, builder, prop);
             }),
           );
         }

--- a/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
+++ b/tools/analyzer_plugin/lib/src/fluent_interface_util/cascade_read.dart
@@ -3,8 +3,11 @@ import 'dart:async';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/source_range.dart';
 import 'package:analyzer_plugin/utilities/range_factory.dart';
+import 'package:meta/meta.dart';
 import 'package:over_react_analyzer_plugin/src/component_usage.dart';
 import 'package:over_react_analyzer_plugin/src/util/util.dart';
+
+import 'cascade_edits.dart';
 
 extension UsageCascades on FluentComponentUsage {
   Iterable<Expression> get _cascadeSections => cascadeExpression?.cascadeSections ?? const [];
@@ -49,6 +52,9 @@ class PropAssignment {
   ///
   /// Includes the space between the previous token and the start of this assignment, so that
   /// the entire prop line is removed.
+  ///
+  /// __Note: prefer using [removeProp] instead of using this directly to perform removals__
+  @protected
   SourceRange get rangeForRemoval => range.endEnd(assignment.beginToken.previous, assignment);
 }
 


### PR DESCRIPTION
## Motivation
- `convertUsageListLiteralToVariadicChildren` was iterating through children recursively, and removing keys on non-children descendants
- I noticed when testing it out that it was pretty annoying that the  parentheses were left in place after the fixes were applied, so I spiked out a solution to #545 and ended up tacking it on since it was so straightforward. 
    We previously considered this post-MVP, but I think it does a lot to improve the UX of our plugin, so it seemed important enough to include.

## Changes
- Only remove keys from children
- Add removeProp utility that removes parens when the last cascade is removed (fixes #545)
    - Update all other prop removals to use this