### PR TITLE
[Analyzer Plugin] Add toggle stateful tests

### DIFF
--- a/tools/analyzer_plugin/lib/src/assist/toggle_stateful.dart
+++ b/tools/analyzer_plugin/lib/src/assist/toggle_stateful.dart
@@ -31,8 +31,7 @@ used to convert it to a `UiComponent2`, removing the analogous `UiState` mixin /
 // </editor-fold>
 
 class ToggleComponentStatefulness extends AssistContributorBase with ComponentDeclarationAssistApi {
-  static int statefulAssistPriority = 30;
-
+  static const int statefulAssistPriority = 30;
   @DocsMeta(_makeStatefulDesc, details: _makeStatefulDetails)
   static const makeStateful = AssistKind('makeStateful', statefulAssistPriority, _makeStatefulDesc);
   @DocsMeta(_makeStatelessDesc, details: _makeStatelessDetails)

--- a/tools/analyzer_plugin/lib/src/assist/toggle_stateful.dart
+++ b/tools/analyzer_plugin/lib/src/assist/toggle_stateful.dart
@@ -31,10 +31,12 @@ used to convert it to a `UiComponent2`, removing the analogous `UiState` mixin /
 // </editor-fold>
 
 class ToggleComponentStatefulness extends AssistContributorBase with ComponentDeclarationAssistApi {
+  static int statefulAssistPriority = 30;
+
   @DocsMeta(_makeStatefulDesc, details: _makeStatefulDetails)
-  static const makeStateful = AssistKind('makeStateful', 30, _makeStatefulDesc);
+  static const makeStateful = AssistKind('makeStateful', statefulAssistPriority, _makeStatefulDesc);
   @DocsMeta(_makeStatelessDesc, details: _makeStatelessDetails)
-  static const makeStateless = AssistKind('makeStateless', 30, _makeStatelessDesc);
+  static const makeStateless = AssistKind('makeStateless', statefulAssistPriority, _makeStatelessDesc);
 
   /// The counterpart base component class that will replace the current one.
   ///

--- a/tools/analyzer_plugin/playground/web/foo.dart
+++ b/tools/analyzer_plugin/playground/web/foo.dart
@@ -6,9 +6,14 @@ UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
 
 mixin FooProps on UiProps {}
 
-class FooComponent extends UiComponent2<FooProps> {
+mixin FooState on UiState {}
+
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
   @override
   get defaultProps => (newProps());
+
+  @override
+  get initialState => (newState());
 
   @override
   render() {}

--- a/tools/analyzer_plugin/playground/web/foo.dart
+++ b/tools/analyzer_plugin/playground/web/foo.dart
@@ -6,14 +6,9 @@ UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
 
 mixin FooProps on UiProps {}
 
-mixin FooState on UiState {}
-
-class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+class FooComponent extends UiComponent2<FooProps> {
   @override
   get defaultProps => (newProps());
-
-  @override
-  get initialState => (newState());
 
   @override
   render() {}

--- a/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
+++ b/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
@@ -1,5 +1,5 @@
 mixin BoilerplateAssistTestStrings {
-  static const fileName = 'test.dart';
+  String fileName = 'test.dart';
 
   static const prefix = 'Foo';
 
@@ -9,12 +9,16 @@ mixin ${prefix}State on UiState {}
 ''';
 
   static const getInitialState = '''
-
   @override
   get initialState => (newState());
 ''';
 
-  String componentName({bool withSelection = false}) => withSelection ? '#${prefix}Component#' : '${prefix}Component';
+  static const getDefaultProps = '''
+  @override
+  get defaultProps => (newProps());
+''';
+
+  String componentNameSelector = 'class #${prefix}Component# extends';
 
   String simpleComponentSuperclass({bool withState = false}) =>
       withState ? 'UiStatefulComponent2<${prefix}Props, ${prefix}State>' : 'UiComponent2<${prefix}Props>';
@@ -22,7 +26,8 @@ mixin ${prefix}State on UiState {}
   String fluxComponentSuperclass({bool withState = false}) =>
       withState ? 'FluxUiStatefulComponent2<${prefix}Props, ${prefix}State>' : 'FluxUiComponent2<${prefix}Props>';
 
-  String simpleUiComponentSource({bool isStateful = false, bool shouldIncludeSelection = false}) {
+  String simpleUiComponentSource(
+      {bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
     return '''
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
@@ -31,17 +36,17 @@ UiFactory<${prefix}Props> $prefix = _\$$prefix; // ignore: undefined_identifier
 
 mixin ${prefix}Props on UiProps {}
 ${isStateful ? stateMixin : ''}
-class ${componentName(withSelection: shouldIncludeSelection)} extends ${simpleComponentSuperclass(withState: isStateful)} {
-  @override
-  get defaultProps => (newProps());
-${isStateful ? getInitialState : ''}
+class ${prefix}Component extends ${simpleComponentSuperclass(withState: isStateful)} {
+${includeDefaultProps ? getDefaultProps : ''}${includeDefaultProps && isStateful ? '\n' : ''}${isStateful ? getInitialState : ''}
+
   @override
   render() {}
 }
 ''';
   }
 
-  String fluxUiComponentSource({bool isStateful = false, bool shouldIncludeSelection = false}) {
+  String fluxUiComponentSource(
+      {bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
     return '''
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
@@ -52,10 +57,9 @@ mixin ${prefix}Props on UiProps {}
 
 class ${prefix}Props = UiProps with FluxUiPropsMixin, ${prefix}PropsMixin;
 ${isStateful ? stateMixin : ''}
-class ${componentName(withSelection: shouldIncludeSelection)} extends ${fluxComponentSuperclass(withState: isStateful)} {
-  @override
-  get defaultProps => (newProps());
-${isStateful ? getInitialState : ''}
+class ${prefix}Component extends ${fluxComponentSuperclass(withState: isStateful)} {
+${includeDefaultProps ? getDefaultProps : ''}${includeDefaultProps && isStateful ? '\n' : ''}${isStateful ? getInitialState : ''}
+
   @override
   render() {}
 }

--- a/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
+++ b/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
@@ -1,0 +1,64 @@
+mixin BoilerplateAssistTestStrings {
+  static const fileName = 'test.dart';
+
+  static const prefix = 'Foo';
+
+  static const stateMixin = '''
+
+mixin ${prefix}State on UiState {}
+''';
+
+  static const getInitialState = '''
+
+  @override
+  get initialState => (newState());
+''';
+
+  String componentName({bool withSelection = false}) => withSelection ? '#${prefix}Component#' : '${prefix}Component';
+
+  String simpleComponentSuperclass({bool withState = false}) =>
+      withState ? 'UiStatefulComponent2<${prefix}Props, ${prefix}State>' : 'UiComponent2<${prefix}Props>';
+
+  String fluxComponentSuperclass({bool withState = false}) =>
+      withState ? 'FluxUiStatefulComponent2<${prefix}Props, ${prefix}State>' : 'FluxUiComponent2<${prefix}Props>';
+
+  String simpleUiComponentSource({bool isStateful = false, bool shouldIncludeSelection = false}) {
+    return '''
+import 'package:over_react/over_react.dart';
+part 'test.over_react.g.dart';
+
+UiFactory<${prefix}Props> $prefix = _\$$prefix; // ignore: undefined_identifier
+
+mixin ${prefix}Props on UiProps {}
+${isStateful ? stateMixin : ''}
+class ${componentName(withSelection: shouldIncludeSelection)} extends ${simpleComponentSuperclass(withState: isStateful)} {
+  @override
+  get defaultProps => (newProps());
+${isStateful ? getInitialState : ''}
+  @override
+  render() {}
+}
+''';
+  }
+
+  String fluxUiComponentSource({bool isStateful = false, bool shouldIncludeSelection = false}) {
+    return '''
+import 'package:over_react/over_react.dart';
+part 'test.over_react.g.dart';
+
+UiFactory<${prefix}Props> $prefix = _\$$prefix; // ignore: undefined_identifier
+
+mixin ${prefix}Props on UiProps {}
+
+class ${prefix}Props = UiProps with FluxUiPropsMixin, ${prefix}PropsMixin;
+${isStateful ? stateMixin : ''}
+class ${componentName(withSelection: shouldIncludeSelection)} extends ${fluxComponentSuperclass(withState: isStateful)} {
+  @override
+  get defaultProps => (newProps());
+${isStateful ? getInitialState : ''}
+  @override
+  render() {}
+}
+''';
+  }
+}

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -68,24 +68,21 @@ class TestComponent extends UiComponent<TestProps> {
   }
 
   Future<void> test_noAssistOnUnknownBase() async {
-    const oldBoilerplate = '''
+    const unknownBase = '''
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
 
-@Factory()
 UiFactory<TestProps> Test = _\$Test;
 
-@Props()
-class _\$TestProps extends UiProps {}
+mixin TestProps on UiProps {}
 
-@Component()
 class TestComponent extends AbstractBazComponent<TestProps> {
   @override
   render() {}
 }
 ''';
 
-    var source = newSource(fileName, oldBoilerplate);
+    var source = newSource(fileName, unknownBase);
     var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
   }

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -72,7 +72,7 @@ class TestComponent extends UiComponent<TestProps> {
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
 
-UiFactory<TestProps> Test = _\$Test;
+UiFactory<TestProps> Test = _\$Test; // ignore: undefined_identifier
 
 mixin TestProps on UiProps {}
 

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -67,6 +67,29 @@ class TestComponent extends UiComponent<TestProps> {
     await expectNoAssist(selection);
   }
 
+  Future<void> test_noAssistOnUnknownBase() async {
+    const oldBoilerplate = '''
+import 'package:over_react/over_react.dart';
+part 'test.over_react.g.dart';
+
+@Factory()
+UiFactory<TestProps> Test = _\$Test;
+
+@Props()
+class _\$TestProps extends UiProps {}
+
+@Component()
+class TestComponent extends AbstractBazComponent<TestProps> {
+  @override
+  render() {}
+}
+''';
+
+    var source = newSource(fileName, oldBoilerplate);
+    var selection = createSelection(source, 'class #TestComponent# extends');
+    await expectNoAssist(selection);
+  }
+
   Future<void> test_addsStatefulness() async {
     var retrievedSource = newSource(fileName, simpleUiComponentSource());
     var selection = createSelection(retrievedSource, componentNameSelector);

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -22,26 +22,30 @@ class AddStatefulnessAssist extends AssistTestBase with BoilerplateAssistTestStr
   @override
   AssistKind get assistKindUnderTest => ToggleComponentStatefulness.makeStateful;
 
+  Future<void> test_noAssist() async {
+    final source = newSource('test.dart', 'var foo = true;');
+    final selection = createSelection(source, '#var foo = true;#');
+    await expectNoAssist(selection);
+  }
+
   Future<void> test_noAssistOnFactory() async {
     final generatedSource = simpleUiComponentSource();
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, generatedSource);
-    var selection = createSelection(source,
-        generatedSource.replaceFirst(r'UiFactory<FooProps> Foo = _$Foo;', r'UiFactory<FooProps> #Foo# = _$Foo;'));
+    var source = newSource(fileName, generatedSource);
+    var selection = createSelection(source, r'UiFactory<FooProps> #Foo# = _$Foo;');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnProps() async {
     final generatedSource = simpleUiComponentSource();
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, generatedSource);
-    var selection = createSelection(
-        source, generatedSource.replaceFirst('mixin FooProps on UiProps {}', 'mixin #FooProps# on UiProps {}'));
+    var source = newSource(fileName, generatedSource);
+    var selection = createSelection(source, 'mixin #FooProps# on UiProps {}');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnOldBoilerplate() async {
-    String oldBoilerplate({bool withSelection = false}) => '''
+    const oldBoilerplate = '''
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
 
@@ -52,31 +56,47 @@ UiFactory<TestProps> Test = _\$Test;
 class _\$TestProps extends UiProps {}
 
 @Component()
-class ${withSelection ? '#TestComponent#' : 'TestComponent'} extends UiComponent<TestProps> {
+class TestComponent extends UiComponent<TestProps> {
   @override
   render() {}
 }
 ''';
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, oldBoilerplate());
-    var selection = createSelection(source, oldBoilerplate(withSelection: true));
+    var source = newSource(fileName, oldBoilerplate);
+    var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
   }
 
   Future<void> test_addsStatefulness() async {
-    var retrievedSource = newSource(BoilerplateAssistTestStrings.fileName, simpleUiComponentSource());
-    var selection = createSelection(retrievedSource, simpleUiComponentSource(shouldIncludeSelection: true));
+    var retrievedSource = newSource(fileName, simpleUiComponentSource());
+    var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
     expect(retrievedSource.contents.data, simpleUiComponentSource(isStateful: true));
   }
 
+  Future<void> test_addsStatefulnessWithoutDefaultProps() async {
+    var retrievedSource = newSource(fileName, simpleUiComponentSource(includeDefaultProps: false));
+    var selection = createSelection(retrievedSource, componentNameSelector);
+    final change = await expectAndGetSingleAssist(selection);
+    retrievedSource = applySourceChange(change, retrievedSource);
+    expect(retrievedSource.contents.data, simpleUiComponentSource(isStateful: true, includeDefaultProps: false));
+  }
+
   Future<void> test_addsStatefulnessToFlux() async {
-    var retrievedSource = newSource(BoilerplateAssistTestStrings.fileName, fluxUiComponentSource());
-    var selection = createSelection(retrievedSource, fluxUiComponentSource(shouldIncludeSelection: true));
+    var retrievedSource = newSource(fileName, fluxUiComponentSource());
+    var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
     expect(retrievedSource.contents.data, fluxUiComponentSource(isStateful: true));
+  }
+
+  Future<void> test_addsStatefulnessToFluxWithoutDefaultProps() async {
+    var retrievedSource = newSource(fileName, fluxUiComponentSource(includeDefaultProps: false));
+    var selection = createSelection(retrievedSource, componentNameSelector);
+    final change = await expectAndGetSingleAssist(selection);
+    retrievedSource = applySourceChange(change, retrievedSource);
+    expect(retrievedSource.contents.data, fluxUiComponentSource(isStateful: true, includeDefaultProps: false));
   }
 }
 
@@ -87,26 +107,30 @@ class RemoveStatefulnessAssist extends AssistTestBase with BoilerplateAssistTest
   @override
   AssistKind get assistKindUnderTest => ToggleComponentStatefulness.makeStateless;
 
+  Future<void> test_noAssist() async {
+    final source = newSource('test.dart', 'var foo = true;');
+    final selection = createSelection(source, '#var foo = true;#');
+    await expectNoAssist(selection);
+  }
+
   Future<void> test_noAssistOnFactory() async {
     final generatedSource = simpleUiComponentSource(isStateful: true);
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, generatedSource);
-    var selection = createSelection(source,
-        generatedSource.replaceFirst(r'UiFactory<FooProps> Foo = _$Foo;', r'UiFactory<FooProps> #Foo# = _$Foo;'));
+    var source = newSource(fileName, generatedSource);
+    var selection = createSelection(source, r'UiFactory<FooProps> #Foo# = _$Foo;');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnProps() async {
     final generatedSource = simpleUiComponentSource(isStateful: true);
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, generatedSource);
-    var selection = createSelection(
-        source, generatedSource.replaceFirst('mixin FooProps on UiProps {}', 'mixin #FooProps# on UiProps {}'));
+    var source = newSource(fileName, generatedSource);
+    var selection = createSelection(source, 'mixin #FooProps# on UiProps {}');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnOldBoilerplate() async {
-    String oldBoilerplate({bool withSelection = false}) => '''
+    const oldBoilerplate = '''
 import 'package:over_react/over_react.dart';
 part 'test.over_react.g.dart';
 
@@ -120,123 +144,58 @@ class _\$TestProps extends UiProps {}
 class _\$TestState extends UiState {}
 
 @Component()
-class ${withSelection ? '#TestComponent#' : 'TestComponent'} extends UiStatefulComponent<TestProps, TestState> {
+class TestComponent extends UiStatefulComponent<TestProps, TestState> {
   @override
   render() {}
 }
 ''';
 
-    var source = newSource(BoilerplateAssistTestStrings.fileName, oldBoilerplate());
-    var selection = createSelection(source, oldBoilerplate(withSelection: true));
+    var source = newSource(fileName, oldBoilerplate);
+    var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
   }
 
   Future<void> test_removesStatefulness() async {
-    var retrievedSource = newSource(BoilerplateAssistTestStrings.fileName, simpleUiComponentSource(isStateful: true));
-    var selection =
-        createSelection(retrievedSource, simpleUiComponentSource(shouldIncludeSelection: true, isStateful: true));
+    var retrievedSource = newSource(fileName, simpleUiComponentSource(isStateful: true));
+    var selection = createSelection(retrievedSource, componentNameSelector);
+    final change = await expectAndGetSingleAssist(selection);
+    retrievedSource = applySourceChange(change, retrievedSource);
+    expect(retrievedSource.contents.data, simpleUiComponentSource());
+  }
+
+  Future<void> test_removesStatefulnessWithNoInitalState() async {
+    const statefulComponentWithNoInitialState = r'''
+import 'package:over_react/over_react.dart';
+part 'test.over_react.g.dart';
+
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+
+mixin FooProps on UiProps {}
+
+mixin FooState on UiState {}
+
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+  @override
+  get defaultProps => (newProps());
+
+
+  @override
+  render() {}
+}
+''';
+
+    var retrievedSource = newSource(fileName, statefulComponentWithNoInitialState);
+    var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
     expect(retrievedSource.contents.data, simpleUiComponentSource());
   }
 
   Future<void> test_removesStatefulnessToFlux() async {
-    var retrievedSource = newSource(BoilerplateAssistTestStrings.fileName, fluxUiComponentSource(isStateful: true));
-    var selection =
-        createSelection(retrievedSource, fluxUiComponentSource(shouldIncludeSelection: true, isStateful: true));
+    var retrievedSource = newSource(fileName, fluxUiComponentSource(isStateful: true));
+    var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
     expect(retrievedSource.contents.data, fluxUiComponentSource());
-  }
-}
-
-@reflectiveTest
-class RemoveStatefulnessAssist extends AssistTestBase {
-  static int expectedPriority = AddPropsAssistContributor.addPropsKind.priority;
-
-  static String simpleSource = '''
-import 'package:over_react/over_react.dart';
-var foo = Dom.div()('hello');
-''';
-
-  @override
-  AsyncAssistContributor getContributorUnderTest() => AddPropsAssistContributor();
-
-  Future<void> test_noAssist() async {
-    var source = newSource('test.dart', 'var foo = true;');
-    var selection = createSelection(source, '#var foo#');
-    expect(await getAssists(selection), isEmpty);
-  }
-
-  Future<void> test_noAssistForSelection() async {
-    var source = newSource('test.dart', simpleSource);
-    var selection = createSelection(source, '#var foo#');
-    expect(await getAssists(selection), isEmpty);
-  }
-
-  Future<void> test_producesAssistForAllSelectionTypes() async {
-    final selectionTargets = [
-      '##Dom.div', // empty selection at beginning
-      'Dom.div##', // empty selection at end
-      'Dom.##div', // empty selection within
-      '#Dom.div#', // range starting at beginning
-      '#Dom.div()#', // range extending beyond end
-      'Do#m.d#iv', // range within
-    ];
-    for (final target in selectionTargets) {
-      await _verifySelectionProducesAssist(target);
-    }
-  }
-
-  Future<void> _verifySelectionProducesAssist(String selectionTarget) async {
-    var source = newSource('test.dart', simpleSource);
-    var selection = createSelection(source, selectionTarget);
-    final assists = await getAssists(selection);
-    expect(assists, hasLength(1), reason: 'Expected selection to produce an assist, but it did not: $selectionTarget');
-  }
-
-  Future<void> test_assistMeta() async {
-    var source = newSource('test.dart', simpleSource);
-    var selection = createSelection(source, '#Dom.div#');
-    final assists = await getAssists(selection);
-    expect(assists, hasLength(1));
-
-    final assist = assists.first;
-    expect(assist.priority, expectedPriority);
-  }
-
-  Future<void> test_addsParensAndPropsCascade() async {
-    var source = newSource('test.dart', simpleSource);
-    var selection = createSelection(source, '#Dom.div#');
-    final assists = await getAssists(selection);
-    expect(assists, hasLength(1));
-
-    source = applySourceChange(assists.first.change, source);
-    expect(source.contents.data, r'''
-import 'package:over_react/over_react.dart';
-var foo = (Dom.div()..)('hello');
-''');
-    selection = createSelection(source, '(Dom.div()..##)');
-    // TODO: this fails, but the test is correct. Seems like an issue with DartEditBuilder.selectHere()?
-    // expect(assist.change.selection.offset, selection.offset);
-  }
-
-  Future<void> test_alreadyHasParens() async {
-    var source = newSource('test.dart', '''
-import 'package:over_react/over_react.dart';
-var foo = (Dom.div())('hello');
-''');
-    var selection = createSelection(source, '#Dom.div#');
-    final assists = await getAssists(selection);
-    expect(assists, hasLength(1));
-
-    source = applySourceChange(assists.first.change, source);
-    expect(source.contents.data, r'''
-import 'package:over_react/over_react.dart';
-var foo = (Dom.div()..)('hello');
-''');
-    selection = createSelection(source, '(Dom.div()..##)');
-    // TODO: this fails, but the test is correct. Seems like an issue with DartEditBuilder.selectHere()?
-    // expect(assist.change.selection.offset, selection.offset);
   }
 }

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:over_react_analyzer_plugin/src/assist/add_props.dart';
+import 'package:over_react_analyzer_plugin/src/assist/toggle_stateful.dart';
+import 'package:over_react_analyzer_plugin/src/async_plugin_apis/assist.dart';
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../test_bases/assist_test_base.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AddStatefulnessAssist);
+//    defineReflectiveTests(RemoveStatefulnessAssist);
+  });
+}
+
+@reflectiveTest
+class AddStatefulnessAssist extends AssistTestBase {
+  static int expectedPriority = ToggleComponentStatefulness.statefulAssistPriority;
+
+  static String simpleUiComponentSource = r'''
+import 'package:over_react/over_react.dart';
+part 'foo.over_react.g.dart';
+
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+
+mixin FooProps on UiProps {}
+
+class FooComponent extends UiComponent2<FooProps> {
+  @override
+  get defaultProps => (newProps());
+
+  @override
+  render() {}
+}
+''';
+
+  static String fluxUiComponentSource = r'''
+import 'package:over_react/over_react.dart';
+part 'foo.over_react.g.dart';
+
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+
+mixin FooPropsMixin on UiProps {}
+
+class FooProps = UiProps with FluxUiPropsMixin, FooPropsMixin;
+
+class FooComponent extends FluxUiComponent2<FooProps> {
+  @override
+  render() {}
+}
+''';
+
+  static String simpleUiStatefulComponentSource = r'''
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+mixin FooProps on UiProps {}
+
+mixin FooState on UiState {}
+
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+  @override
+  get defaultProps => (newProps());
+
+  @override
+  get initialState => (newState());
+
+  @override
+  render() {}
+}
+''';
+
+  static String fluxUiStatefulComponentSource = r'''
+UiFactory<BarProps> Bar = _$Bar; // ignore: undefined_identifier
+mixin BarPropsMixin on UiProps {}
+
+class BarProps = UiProps with FluxUiPropsMixin, BarPropsMixin;
+
+mixin BarState on UiState {}
+
+class BarComponent extends FluxUiStatefulComponent2<BarProps, BarState> {
+  @override
+  get initialState => (newState());
+
+  @override
+  render() {}
+}
+''';
+
+  static List<String> statelessSources = [simpleUiComponentSource, fluxUiComponentSource];
+  static List<String> statefulSources = [simpleUiStatefulComponentSource, fluxUiStatefulComponentSource];
+  static Map<String, String> boilerplateAssociation = {
+    simpleUiComponentSource: simpleUiStatefulComponentSource,
+    fluxUiComponentSource: fluxUiStatefulComponentSource,
+  };
+
+  @override
+  AsyncAssistContributor getContributorUnderTest() => ToggleComponentStatefulness();
+
+
+  void testBothSources(void Function(String) callbackWithTests) => statelessSources.forEach(callbackWithTests);
+
+  Future<void> test_noAssistOnFactory() async {
+    var source = newSource('test.dart', simpleUiComponentSource);
+    var selection = createSelection(source, r'UiFactory<FooProps> #Foo# = _$Foo;');
+    expect(await getAssists(selection), isEmpty);
+  }
+
+  Future<void> test_noAssistOnProps() async {
+    var source = newSource('test.dart', simpleUiComponentSource);
+    var selection = createSelection(source, 'mixin #FooProps#');
+    expect(await getAssists(selection), isEmpty);
+  }
+
+  Future<void> test_producesAssistForBothBoilerplate() async {
+    testBothSources((source) async {
+      var retrievedSource = newSource('test.dart', source);
+      var selection = createSelection(retrievedSource, '#FooComponent#');
+      final assists = await getAssists(selection);
+      expect(assists, hasLength(1), reason: 'Expected selection to produce an assist, but it did not: $source');
+    });
+  }
+  Future<void> test_assistMeta() async {
+    testBothSources((source) async {
+      var retrievedSource = newSource('test.dart', source);
+      var selection = createSelection(retrievedSource, '#FooComponent#');
+      final assists = await getAssists(selection);
+      expect(assists, hasLength(1));
+
+      final assist = assists.first;
+      expect(assist.priority, expectedPriority);
+    });
+  }
+
+  Future<void> test_addsStatefulness() async {
+    testBothSources((source) async {
+      var retrievedSource = newSource('test.dart', source);
+      var selection = createSelection(retrievedSource, '#Dom.div#');
+      final assists = await getAssists(selection);
+      expect(assists, hasLength(1));
+
+      retrievedSource = applySourceChange(assists.first.change, retrievedSource);
+      expect(retrievedSource.contents.data, boilerplateAssociation[source]);
+    });
+  }
+}
+
+@reflectiveTest
+class RemoveStatefulnessAssist extends AssistTestBase {
+  static int expectedPriority = AddPropsAssistContributor.addPropsKind.priority;
+
+  static String simpleSource = '''
+import 'package:over_react/over_react.dart';
+var foo = Dom.div()('hello');
+''';
+
+  @override
+  AsyncAssistContributor getContributorUnderTest() => AddPropsAssistContributor();
+
+  Future<void> test_noAssist() async {
+    var source = newSource('test.dart', 'var foo = true;');
+    var selection = createSelection(source, '#var foo#');
+    expect(await getAssists(selection), isEmpty);
+  }
+
+  Future<void> test_noAssistForSelection() async {
+    var source = newSource('test.dart', simpleSource);
+    var selection = createSelection(source, '#var foo#');
+    expect(await getAssists(selection), isEmpty);
+  }
+
+  Future<void> test_producesAssistForAllSelectionTypes() async {
+    final selectionTargets = [
+      '##Dom.div', // empty selection at beginning
+      'Dom.div##', // empty selection at end
+      'Dom.##div', // empty selection within
+      '#Dom.div#', // range starting at beginning
+      '#Dom.div()#', // range extending beyond end
+      'Do#m.d#iv', // range within
+    ];
+    for (final target in selectionTargets) {
+      await _verifySelectionProducesAssist(target);
+    }
+  }
+
+  Future<void> _verifySelectionProducesAssist(String selectionTarget) async {
+    var source = newSource('test.dart', simpleSource);
+    var selection = createSelection(source, selectionTarget);
+    final assists = await getAssists(selection);
+    expect(assists, hasLength(1), reason: 'Expected selection to produce an assist, but it did not: $selectionTarget');
+  }
+
+  Future<void> test_assistMeta() async {
+    var source = newSource('test.dart', simpleSource);
+    var selection = createSelection(source, '#Dom.div#');
+    final assists = await getAssists(selection);
+    expect(assists, hasLength(1));
+
+    final assist = assists.first;
+    expect(assist.priority, expectedPriority);
+  }
+
+  Future<void> test_addsParensAndPropsCascade() async {
+    var source = newSource('test.dart', simpleSource);
+    var selection = createSelection(source, '#Dom.div#');
+    final assists = await getAssists(selection);
+    expect(assists, hasLength(1));
+
+    source = applySourceChange(assists.first.change, source);
+    expect(source.contents.data, r'''
+import 'package:over_react/over_react.dart';
+var foo = (Dom.div()..)('hello');
+''');
+    selection = createSelection(source, '(Dom.div()..##)');
+    // TODO: this fails, but the test is correct. Seems like an issue with DartEditBuilder.selectHere()?
+    // expect(assist.change.selection.offset, selection.offset);
+  }
+
+  Future<void> test_alreadyHasParens() async {
+    var source = newSource('test.dart', '''
+import 'package:over_react/over_react.dart';
+var foo = (Dom.div())('hello');
+''');
+    var selection = createSelection(source, '#Dom.div#');
+    final assists = await getAssists(selection);
+    expect(assists, hasLength(1));
+
+    source = applySourceChange(assists.first.change, source);
+    expect(source.contents.data, r'''
+import 'package:over_react/over_react.dart';
+var foo = (Dom.div()..)('hello');
+''');
+    selection = createSelection(source, '(Dom.div()..##)');
+    // TODO: this fails, but the test is correct. Seems like an issue with DartEditBuilder.selectHere()?
+    // expect(assist.change.selection.offset, selection.offset);
+  }
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Added tests for the toggle stateful analyzer plugin assist. This is a new PR for the changes first introduced in #580. 
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add tests for assist
- Add some utils in a mixin for testing component boilerplate assist
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
