### PR TITLE
Use propsOrStateMapsEqual in connect so that tearoffs don't cause unnecessary rerenders

### DIFF
--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -355,9 +355,9 @@ mixin InfluxStoreMixin<S> on flux.Store {
 /// If you do not provide [mergeProps], the wrapped component receives {...ownProps, ...stateProps, ...dispatchProps}
 /// by default.
 ///
-/// - [areOwnPropsEqual] does an equality check using JS `===` (equivalent to [identical]) by default.
-/// - [areStatePropsEqual] does a shallow Map equality check using JS `===` (equivalent to [identical]) by default.
-/// - [areMergedPropsEqual] does a shallow Map equality check using JS `===` (equivalent to [identical]) by default.
+/// - [areOwnPropsEqual] does an equality check using [propsOrStateMapsEqual] by default.
+/// - [areStatePropsEqual] does a shallow Map equality check using [propsOrStateMapsEqual] by default.
+/// - [areMergedPropsEqual] does a shallow Map equality check using [propsOrStateMapsEqual] by default.
 ///
 /// - [context] can be utilized to provide a custom context object created with `createContext`.
 /// [context] is how you can utilize multiple stores. While supported, this is not recommended.
@@ -417,9 +417,11 @@ UiFactory<TProps> Function(UiFactory<TProps>)
   Map Function(TActions actions, TProps ownProps) mapActionsToPropsWithOwnProps,
   Map Function(TProps stateProps, TProps dispatchProps, TProps ownProps)
       mergeProps,
-  bool Function(TProps nextProps, TProps prevProps) areOwnPropsEqual,
-  bool Function(TProps nextProps, TProps prevProps) areStatePropsEqual,
-  bool Function(TProps nextProps, TProps prevProps) areMergedPropsEqual,
+  // Use default parameter values instead of ??= in the function body to allow consumers
+  // to specify `null` and fall back to the JS default.
+  bool Function(TProps nextProps, TProps prevProps) areOwnPropsEqual = propsOrStateMapsEqual,
+  bool Function(TProps nextProps, TProps prevProps) areStatePropsEqual = propsOrStateMapsEqual,
+  bool Function(TProps nextProps, TProps prevProps) areMergedPropsEqual = propsOrStateMapsEqual,
   Context context,
   bool pure = true,
   bool forwardRef = false,
@@ -570,7 +572,7 @@ UiFactory<TProps> Function(UiFactory<TProps>)
   // In dev mode, if areStatePropsEqual is not specified, pass in a version
   // that warns for common pitfall cases.
   assert(() {
-    if (areStatePropsEqual == null) {
+    if (areStatePropsEqual == propsOrStateMapsEqual) {
       bool areStatePropsEqualWrapper(TProps nextProps, TProps prevProps) {
         const propHasher = CollectionLengthHasher();
 

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -90,9 +90,9 @@ typedef dynamic Dispatcher(dynamic action);
 /// by default.
 ///
 /// - [areStatesEqual] does an equality check using JS `===` (equivalent to [identical]) by default.
-/// - [areOwnPropsEqual] does a shallow Map equality check using JS `===` (equivalent to [identical]) by default.
-/// - [areStatePropsEqual] does a shallow Map equality check using JS `===` (equivalent to [identical]) by default.
-/// - [areMergedPropsEqual] does a shallow Map equality check using JS `===` (equivalent to [identical]) by default.
+/// - [areOwnPropsEqual] does a shallow Map equality check using [propsOrStateMapsEqual] by default.
+/// - [areStatePropsEqual] does a shallow Map equality check using [propsOrStateMapsEqual] by default.
+/// - [areMergedPropsEqual] does a shallow Map equality check using [propsOrStateMapsEqual] by default.
 ///
 /// - [context] can be utilized to provide a custom context object created with `createContext`.
 /// [context] is how you can utilize multiple stores. While supported, this is not recommended. :P
@@ -149,9 +149,11 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
   Map Function(dynamic Function(dynamic) dispatch, TProps ownProps) mapDispatchToPropsWithOwnProps,
   Map Function(TProps stateProps, TProps dispatchProps, TProps ownProps) mergeProps,
   bool Function(TReduxState nextState, TReduxState prevState) areStatesEqual,
-  bool Function(TProps nextProps, TProps prevProps) areOwnPropsEqual,
-  bool Function(TProps nextProps, TProps prevProps) areStatePropsEqual,
-  bool Function(TProps nextProps, TProps prevProps) areMergedPropsEqual,
+  // Use default parameter values instead of ??= in the function body to allow consumers
+  // to specify `null` and fall back to the JS default.
+  bool Function(TProps nextProps, TProps prevProps) areOwnPropsEqual = propsOrStateMapsEqual,
+  bool Function(TProps nextProps, TProps prevProps) areStatePropsEqual = propsOrStateMapsEqual,
+  bool Function(TProps nextProps, TProps prevProps) areMergedPropsEqual = propsOrStateMapsEqual,
   Context context,
   bool pure = true,
   bool forwardRef = false,

--- a/lib/src/util/equality.dart
+++ b/lib/src/util/equality.dart
@@ -1,6 +1,8 @@
 /// Returns whether maps [a] and [b] have [identical] sets of values for the same keys.
 ///
 /// Identity is not used for `Function`s found within the maps since tear-offs are not canonicalized.
+///
+/// Behavior is similar to JS shallow equality.
 //
 // Ported from https://github.com/reduxjs/react-redux/blob/573db0bfc8d1d50fdb6e2a98bd8a7d4675fecf11/src/utils/shallowEqual.js
 //


### PR DESCRIPTION
> Discovered while testing #499

## Motivation
[Tearoffs aren't guaranteed to be identical](https://github.com/dart-lang/sdk/issues/31665#issuecomment-352678783), and we don't want the use of them to trigger unnecessary rerenders in connect-ed components

## Changes
Use `propsOrStateMapsEqual` instead of default JS equality

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [x] Tests were updated and provide good coverage of the changeset and other affected code
- [x] Manual testing was performed if needed
    - [x] Steps from PR author: 
       - [x] Verify in redux example app that there are no unnecessary rerenders introduced by these changes
       - [x] Passing consumer tests
    - [x] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [x] A Client Platform member has reviewed these changes
- [x] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
