### PR TITLE
CPLAT-9347 Add memo for function components

### DIFF
--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -15,24 +15,26 @@
 /// Base classes for UI components and related utilities.
 library over_react;
 
-export 'package:react/react.dart' show
-    SyntheticEvent,
-    SyntheticAnimationEvent,
-    SyntheticClipboardEvent,
-    SyntheticKeyboardEvent,
-    SyntheticFocusEvent,
-    SyntheticFormEvent,
-    SyntheticDataTransfer,
-    SyntheticMouseEvent,
-    SyntheticTouchEvent,
-    SyntheticTransitionEvent,
-    SyntheticUIEvent,
-    SyntheticWheelEvent,
-    TypedSnapshot;
+export 'package:react/react.dart'
+    show
+        SyntheticEvent,
+        SyntheticAnimationEvent,
+        SyntheticClipboardEvent,
+        SyntheticKeyboardEvent,
+        SyntheticFocusEvent,
+        SyntheticFormEvent,
+        SyntheticDataTransfer,
+        SyntheticMouseEvent,
+        SyntheticTouchEvent,
+        SyntheticTransitionEvent,
+        SyntheticUIEvent,
+        SyntheticWheelEvent,
+        TypedSnapshot;
 
 export 'package:react/react_client/js_backed_map.dart' show JsBackedMap;
 
-export 'package:react/react_client.dart' show setClientConfiguration, ReactElement, ReactComponentFactoryProxy;
+export 'package:react/react_client.dart'
+    show setClientConfiguration, ReactElement, ReactComponentFactoryProxy;
 export 'package:react/react_client/react_interop.dart' show ReactErrorInfo, Ref;
 
 export 'src/component/_deprecated/abstract_transition.dart';
@@ -40,9 +42,11 @@ export 'src/component/_deprecated/abstract_transition_props.dart';
 export 'src/component/aria_mixin.dart';
 export 'src/component/callback_typedefs.dart';
 export 'src/component/_deprecated/error_boundary.dart';
-export 'src/component/_deprecated/error_boundary_mixins.dart' hide LegacyErrorBoundaryApi;
+export 'src/component/_deprecated/error_boundary_mixins.dart'
+    hide LegacyErrorBoundaryApi;
 export 'src/component/dom_components.dart';
-export 'src/component/error_boundary_api.dart' show defaultErrorBoundaryLoggerName;
+export 'src/component/error_boundary_api.dart'
+    show defaultErrorBoundaryLoggerName;
 export 'src/component/ref_util.dart';
 export 'src/component/fragment_component.dart';
 export 'src/component/strictmode_component.dart';
@@ -52,13 +56,15 @@ export 'src/component/prop_typedefs.dart';
 export 'src/component/pure_component_mixin.dart';
 export 'src/component/_deprecated/resize_sensor.dart';
 export 'src/component_declaration/annotations.dart';
-export 'src/component_declaration/builder_helpers.dart' hide GeneratedErrorMessages;
-export 'src/component_declaration/component_base_2.dart' show
-    registerComponent2,
-    registerAbstractComponent2,
-    UiComponent2,
-    UiStatefulComponent2,
-    UiStatefulMixin2;
+export 'src/component_declaration/builder_helpers.dart'
+    hide GeneratedErrorMessages;
+export 'src/component_declaration/component_base_2.dart'
+    show
+        registerComponent2,
+        registerAbstractComponent2,
+        UiComponent2,
+        UiStatefulComponent2,
+        UiStatefulMixin2;
 export 'src/component_declaration/built_redux_component.dart';
 export 'src/component_declaration/flux_component.dart';
 export 'src/component_declaration/function_component.dart';
@@ -74,6 +80,7 @@ export 'src/util/hoc.dart';
 export 'src/util/handler_chain_util.dart';
 export 'src/util/key_constants.dart';
 export 'src/util/map_util.dart';
+export 'src/util/memo.dart';
 export 'src/util/pretty_print.dart';
 export 'src/util/prop_errors.dart';
 export 'src/util/prop_key_util.dart';

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -18,8 +18,10 @@ library over_react.component_declaration.component_type_checking;
 import 'dart:js_util';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/src/component_declaration/component_base.dart' show UiFactory;
-import 'package:over_react/src/component_declaration/annotations.dart' as annotations show Component2;
+import 'package:over_react/src/component_declaration/component_base.dart'
+    show UiFactory;
+import 'package:over_react/src/component_declaration/annotations.dart'
+    as annotations show Component2;
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:over_react/src/util/string_util.dart';
 import 'package:react/react_client.dart';
@@ -29,14 +31,15 @@ import 'package:react/react_client/react_interop.dart';
 //   Component type registration and internal type metadata management
 // ----------------------------------------------------------------------
 
-
 // ignore: deprecated_member_use
-Expando<ReactDartComponentFactoryProxy> _typeAliasToFactory = Expando<ReactDartComponentFactoryProxy>();
+Expando<ReactComponentFactoryProxy> _typeAliasToFactory =
+    Expando<ReactComponentFactoryProxy>();
 
 /// Registers a type alias for the specified factory, so that [getComponentTypeFromAlias] can be
 /// called with [typeAlias] to retrieve [factory]'s [ReactClass] type.
 // ignore: deprecated_member_use
-void registerComponentTypeAlias(ReactDartComponentFactoryProxy factory, dynamic typeAlias) {
+void registerComponentTypeAlias(
+    ReactComponentFactoryProxy factory, dynamic typeAlias) {
   if (typeAlias != null) {
     _typeAliasToFactory[typeAlias] = factory;
   }
@@ -50,27 +53,33 @@ const String _componentTypeMetaKey = '_componentTypeMeta';
 /// the component type of the specified [factory].
 ///
 /// This meta is retrievable via [getComponentTypeMeta].
-void setComponentTypeMeta(ReactComponentFactoryProxy factory, {
+void setComponentTypeMeta(
+  ReactComponentFactoryProxy factory, {
   @required ReactComponentFactoryProxy parentType,
   bool isWrapper = false,
   bool isHoc = false,
 }) {
   // ignore: argument_type_not_assignable
-  setProperty(factory.type, _componentTypeMetaKey, ComponentTypeMeta(
-    parentType: parentType,
-    isWrapper: isWrapper,
-    isHoc: isHoc,
-  ));
+  setProperty(
+      factory.type,
+      _componentTypeMetaKey,
+      ComponentTypeMeta(
+        parentType: parentType,
+        isWrapper: isWrapper,
+        isHoc: isHoc,
+      ));
 }
 
 /// Returns the [ComponentTypeMeta] associated with the component type [type] in [setComponentTypeMeta],
 /// or `const ComponentTypeMeta.none()` if there is no associated meta.
 ComponentTypeMeta getComponentTypeMeta(dynamic type) {
   assert(isPotentiallyValidComponentType(type) &&
-      '`type` should be a valid component type (and not null or a type alias).' is String);
+      '`type` should be a valid component type (and not null or a type alias).'
+          is String);
 
   if (type is! String) {
-    return getProperty(type, _componentTypeMetaKey) ?? const ComponentTypeMeta.none();
+    return getProperty(type, _componentTypeMetaKey) ??
+        const ComponentTypeMeta.none();
   }
 
   return const ComponentTypeMeta.none();
@@ -122,11 +131,8 @@ class ComponentTypeMeta {
   // ignore: deprecated_member_use
   final ReactComponentFactoryProxy parentType;
 
-  ComponentTypeMeta({
-    @required this.parentType,
-    this.isWrapper = false,
-    this.isHoc = false
-  });
+  ComponentTypeMeta(
+      {@required this.parentType, this.isWrapper = false, this.isHoc = false});
 
   const ComponentTypeMeta.none()
       : this.isWrapper = false,
@@ -202,7 +208,8 @@ bool isPotentiallyValidComponentType(dynamic type) {
 ///     getParentTypes(getComponentTypeFromAlias(C)); // [B, A].map(getTypeFromAlias)
 Iterable<dynamic> getParentTypes(dynamic type) sync* {
   assert(isPotentiallyValidComponentType(type) &&
-      '`type` should be a valid component type (and not null or a type alias).' is String);
+      '`type` should be a valid component type (and not null or a type alias).'
+          is String);
 
   var currentType = type;
   dynamic parentType;
@@ -226,10 +233,8 @@ Iterable<dynamic> getParentTypes(dynamic type) sync* {
 /// * [String] tag name (DOM components only)
 ///
 /// > Related: [isValidElementOfType]
-bool isComponentOfType(ReactElement instance, dynamic typeAlias, {
-    bool traverseWrappers = true,
-    bool matchParentTypes = true
-}) {
+bool isComponentOfType(ReactElement instance, dynamic typeAlias,
+    {bool traverseWrappers = true, bool matchParentTypes = true}) {
   if (instance == null) {
     return false;
   }
@@ -292,4 +297,13 @@ void enforceMinimumComponentVersionFor(ReactComponentFactoryProxy component) {
         Instead, use a different factory (such as UiComponent2 or Component2).
         '''));
   }
+}
+
+/// Validates that a [ReactComponentFactoryProxy]'s component is a function component.
+void enforceFunctionComponent(ReactComponentFactoryProxy component) {
+  if (component is ReactDartFunctionComponentFactoryProxy) return;
+
+  throw ArgumentError(unindent('''
+        The UiFactory provided should be for a function component.
+        '''));
 }

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -20,6 +20,8 @@ import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:react/react.dart' as react;
 
+import 'component_type_checking.dart';
+
 export 'component_type_checking.dart'
     show isComponentOfType, isValidElementOfType;
 
@@ -131,6 +133,8 @@ UiFactory<TProps> uiFunction<TProps extends UiProps>(
 
     return builder..componentFactory = factory;
   }
+
+  registerComponentTypeAlias(factory, _uiFactory);
 
   return _uiFactory;
 }

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -41,7 +41,7 @@ import 'package:over_react/component_base.dart';
 /// ```
 ///
 /// `memo` only affects props changes. If your function component wrapped in `memo` has a
-/// [useState] or [useContext] Hook in its implementation, it will still rerender when `state` or `context` change.
+/// `useState` or `useContext` Hook in its implementation, it will still rerender when `state` or `context` change.
 ///
 /// By default it will only shallowly compare complex objects in the props map.
 /// If you want control over the comparison, you can also provide a custom comparison

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -1,0 +1,93 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library over_react.memo;
+
+import 'package:over_react/src/component_declaration/component_type_checking.dart';
+import 'package:react/react_client/react_interop.dart' as react_interop;
+import 'package:react/react_client.dart';
+import 'package:over_react/component_base.dart';
+
+/// A [higher order component](https://reactjs.org/docs/higher-order-components.html) for function components
+/// that behaves similar to the way [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent)
+/// does for class-based components.
+///
+/// If your function component renders the same result given the same props, you can wrap it in a call to
+/// `memo` for a performance boost in some cases by memoizing the result. This means that React will skip
+/// rendering the component, and reuse the last rendered result.
+///
+/// > __NOTE:__ This should only be used to wrap function components. It is redundant for connected function components.
+///
+/// ```dart
+/// import 'package:react/react.dart' as react;
+///
+/// final MyComponent = react.memo((props) {
+///   /* render using props */
+/// });
+/// ```
+///
+/// `memo` only affects props changes. If your function component wrapped in `memo` has a
+/// [useState] or [useContext] Hook in its implementation, it will still rerender when `state` or `context` change.
+///
+/// By default it will only shallowly compare complex objects in the props map.
+/// If you want control over the comparison, you can also provide a custom comparison
+/// function to the [areEqual] argument as shown in the example below.
+///
+/// ```dart
+/// import 'package:react/react.dart' as react;
+///
+/// final MyComponent = react.memo((props) {
+///   // render using props
+/// }, areEqual: (prevProps, nextProps) {
+///   // Do some custom comparison logic to return a bool based on prevProps / nextProps
+/// });
+/// ```
+///
+/// > __This method only exists as a performance optimization.__
+/// >
+/// > Do not rely on it to “prevent” a render, as this can lead to bugs.
+///
+/// See: <https://reactjs.org/docs/react-api.html#reactmemo>.
+
+UiFactory<TProps> Function(UiFactory<TProps>) memo<TProps extends UiProps>(
+    dynamic Function(TProps props) wrapperFunction,
+    {bool Function(TProps prevProps, TProps nextProps) areEqual,
+    String displayName}) {
+  UiFactory<TProps> wrapWithMemo(UiFactory<TProps> factory) {
+    enforceMinimumComponentVersionFor(factory().componentFactory);
+
+    Object wrapProps(Map props) {
+      return wrapperFunction(factory(props));
+    }
+
+    ReactComponentFactoryProxy hoc;
+    if (displayName != null) {
+      hoc = react_interop.memo(wrapProps,
+          areEqual: areEqual, displayName: displayName);
+    } else {
+      hoc = react_interop.memo(wrapProps, areEqual: areEqual);
+    }
+
+    setComponentTypeMeta(hoc,
+        isHoc: true, parentType: factory().componentFactory);
+
+    TProps forwardedFactory([Map props]) {
+      return factory(props)..componentFactory = hoc;
+    }
+
+    return forwardedFactory;
+  }
+
+  return wrapWithMemo;
+}

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,8 +24,10 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
-import 'package:react/react_client/react_interop.dart' hide createRef, forwardRef;
+import 'package:react/react_client/js_interop_helpers.dart'
+    show jsifyAndAllowInterop;
+import 'package:react/react_client/react_interop.dart'
+    hide createRef, forwardRef;
 import 'package:react/react_dom.dart' as react_dom;
 
 // Notes
@@ -46,7 +48,8 @@ import 'package:react/react_dom.dart' as react_dom;
 /// Returns internal data structure used by react-dart to maintain the native Dart component
 /// for a given react-dart [ReactElement] or [ReactComponent] [instance].
 // ignore: deprecated_member_use
-ReactDartComponentInternal _getInternal(/* ReactElement|ReactComponent */ instance) =>
+ReactDartComponentInternal _getInternal(
+        /* ReactElement|ReactComponent */ instance) =>
     // ignore: deprecated_member_use
     (instance.props as InteropProps).internal;
 
@@ -72,7 +75,8 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
 /// (react-dart [ReactElement] or [ReactComponent]), and null for other types of components.
 ///
 /// [instance] may not be null.
-String _getDartComponentVersionFromInstance(/* ReactElement|ReactComponent|Element */ instance) {
+String _getDartComponentVersionFromInstance(
+    /* ReactElement|ReactComponent|Element */ instance) {
   if (instance == null) {
     throw ArgumentError.notNull('instance');
   }
@@ -83,7 +87,8 @@ String _getDartComponentVersionFromInstance(/* ReactElement|ReactComponent|Eleme
   }
 
   // We need `type` if it's a ReactElement, or `constructor` if it's a `ReactComponent`.
-  final type = getProperty(instance, 'type') ?? getProperty(instance, 'constructor');
+  final type =
+      getProperty(instance, 'type') ?? getProperty(instance, 'constructor');
   // ignore: invalid_use_of_protected_member
   return ReactDartComponentVersion.fromType(type);
 }
@@ -111,9 +116,8 @@ final bool _canUseExpandoOnReactElement = (() {
 ///
 /// If caching isn't possible due to [_canUseExpandoOnReactElement] being false,
 /// then this will be initialized to `null`, and caching will be disabled.
-final Expando<Map> _elementPropsCache = _canUseExpandoOnReactElement
-    ? Expando<Map>('_elementPropsCache')
-    : null;
+final Expando<Map> _elementPropsCache =
+    _canUseExpandoOnReactElement ? Expando<Map>('_elementPropsCache') : null;
 
 /// Returns an unmodifiable Map view of props for a [ReactElement] or composite [ReactComponent] [instance].
 ///
@@ -124,7 +128,8 @@ final Expando<Map> _elementPropsCache = _canUseExpandoOnReactElement
 /// instance.
 ///
 /// Throws if [instance] is not a valid [ReactElement] or composite [ReactComponent] .
-Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers = false}) {
+Map getProps(/* ReactElement|ReactComponent */ instance,
+    {bool traverseWrappers = false}) {
   var isCompositeComponent = _isCompositeComponent(instance);
 
   if (isValidElement(instance) || isCompositeComponent) {
@@ -132,7 +137,8 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers 
       ComponentTypeMeta instanceTypeMeta;
 
       if (isCompositeComponent && isDartComponent(instance)) {
-        ReactClass type = getProperty(getDartComponent(instance).jsThis, 'constructor');
+        ReactClass type =
+            getProperty(getDartComponent(instance).jsThis, 'constructor');
         instanceTypeMeta = getComponentTypeMeta(type);
       } else if (isValidElement(instance)) {
         instanceTypeMeta = getComponentTypeMeta(instance.type);
@@ -142,11 +148,14 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers 
       }
 
       if (instanceTypeMeta.isWrapper) {
-        assert(isDartComponent(instance) && 'Non-dart components should not be wrappers' is String);
+        assert(isDartComponent(instance) &&
+            'Non-dart components should not be wrappers' is String);
 
         List children = getProps(instance)['children'];
 
-        if (children != null && children.isNotEmpty && isValidElement(children.first)) {
+        if (children != null &&
+            children.isNotEmpty &&
+            isValidElement(children.first)) {
           return getProps(children.first, traverseWrappers: true);
         }
       }
@@ -160,9 +169,11 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers 
     Map rawPropsOrCopy;
 
     final dartComponentVersion = _getDartComponentVersionFromInstance(instance);
-    if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
+    if (dartComponentVersion == ReactDartComponentVersion.component) {
+      // ignore: invalid_use_of_protected_member
       rawPropsOrCopy = _getExtendedProps(instance);
-    } else if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
+    } else if (dartComponentVersion == ReactDartComponentVersion.component2) {
+      // ignore: invalid_use_of_protected_member
       // TODO Since JS props are frozen don't wrap in UnmodifiableMapView once https://github.com/dart-lang/sdk/issues/15432 is fixed
       rawPropsOrCopy = JsBackedMap.backedBy(instance.props);
     } else {
@@ -177,7 +188,8 @@ Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers 
     return unmodifiableProps;
   }
 
-  throw ArgumentError.value(instance, 'instance', 'must be a valid ReactElement or composite ReactComponent');
+  throw ArgumentError.value(instance, 'instance',
+      'must be a valid ReactElement or composite ReactComponent');
 }
 
 /// Returns the DOM node associated with a mounted React component [instance],
@@ -194,7 +206,8 @@ Element findDomNode(dynamic instance) => react_dom.findDOMNode(instance);
 /// [children] can be any renderable React child, such as a [ReactElement], [String], or fragment.
 ///
 /// See: <https://reactjs.org/docs/portals.html>
-ReactPortal createPortal(dynamic children, Element container) => ReactDom.createPortal(children, container);
+ReactPortal createPortal(dynamic children, Element container) =>
+    ReactDom.createPortal(children, container);
 
 /// Dart wrapper for React.isValidElement.
 ///
@@ -230,12 +243,15 @@ bool _isCompositeComponent(dynamic instance) {
 /// * Children are likewise copied and potentially overwritten with [newChildren] as expected.
 /// * For JS components, a JS copy of [newProps] is returned, since React will merge the props without any special handling.
 ///   If these values might contain event handlers
-dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newChildren]) {
+dynamic preparePropsChangeset(ReactElement element, Map newProps,
+    [Iterable newChildren]) {
   final type = element.type;
-  final dartComponentVersion = ReactDartComponentVersion.fromType(type); // ignore: invalid_use_of_protected_member
+  final dartComponentVersion = ReactDartComponentVersion.fromType(
+      type); // ignore: invalid_use_of_protected_member
 
   // react.Component
-  if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
+  if (dartComponentVersion == ReactDartComponentVersion.component) {
+    // ignore: invalid_use_of_protected_member
     Map oldExtendedProps = _getInternal(element).props;
 
     Map extendedProps = Map.from(oldExtendedProps);
@@ -244,7 +260,8 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newC
     }
 
     // ignore: deprecated_member_use
-    return ReactDartComponentFactoryProxy.generateExtendedJsProps(extendedProps, newChildren ?? extendedProps['children']);
+    return ReactDartComponentFactoryProxy.generateExtendedJsProps(
+        extendedProps, newChildren ?? extendedProps['children']);
   }
 
   if (newProps == null) {
@@ -255,7 +272,8 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newC
   }
 
   // react.Component2
-  if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
+  if (dartComponentVersion == ReactDartComponentVersion.component2) {
+    // ignore: invalid_use_of_protected_member
     return ReactDartComponentFactoryProxy2.generateExtendedJsProps(newProps);
   }
 
@@ -284,7 +302,8 @@ external ReactElement _cloneElement(element, [props, children]);
 /// > Unlike React.addons.cloneWithProps, key and ref from the original element will be preserved.
 /// > There is no special behavior for merging any props (unlike cloneWithProps).
 /// > See the [v0.13 RC2 blog post](https://facebook.github.io/react/blog/2015/03/03/react-v0.13-rc2.html) for additional details.
-ReactElement cloneElement(ReactElement element, [Map props, Iterable children]) {
+ReactElement cloneElement(ReactElement element,
+    [Map props, Iterable children]) {
   if (element == null) throw ArgumentError.notNull('element');
 
   var propsChangeset = preparePropsChangeset(element, props, children);
@@ -300,7 +319,8 @@ ReactElement cloneElement(ReactElement element, [Map props, Iterable children]) 
 ///
 /// Returns `null` if the [instance] is not Dart-based _(an [Element] or a JS composite component)_.
 // ignore: deprecated_member_use
-T getDartComponent<T extends react.Component>(/* ReactElement|ReactComponent|Element */ instance) {
+T getDartComponent<T extends react.Component>(
+    /* ReactElement|ReactComponent|Element */ instance) {
   if (instance is Element) {
     return null;
   }
@@ -309,8 +329,7 @@ T getDartComponent<T extends react.Component>(/* ReactElement|ReactComponent|Ele
     if (isValidElement(instance)) {
       // `print` instead of `ValidationUtil.warn` so that this message shows up
       // in the test output when running `ddev test`.
-      print(unindent(
-          '''
+      print(unindent('''
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
           * WARNING: `getDartComponent`
           *
@@ -333,8 +352,7 @@ T getDartComponent<T extends react.Component>(/* ReactElement|ReactComponent|Ele
           *     var dartInstance = getDartComponent(jsInstance);
           *
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-          '''
-      ));
+          '''));
     }
     return true;
   }
@@ -392,18 +410,22 @@ CallbackRef chainRef(ReactElement element, CallbackRef newCallbackRef) {
         'The existing ref is a String ref and cannot be chained');
   }
 
-  if (existingRef is Function) { // Callback refs
+  if (existingRef is Function) {
+    // Callback refs
     void chainedRef(ref) {
       // For Dart components, the existing ref is a function passed to the JS that wraps the Dart
       // callback ref and converts the JS instance to the Dart component.
       // So, we need to undo the wrapping around this chained ref and pass in the JS instance.
-      existingRef(ref is react.Component ? ref.jsThis : ref); // ignore: deprecated_member_use
+      existingRef(ref is react.Component
+          ? ref.jsThis
+          : ref); // ignore: deprecated_member_use
 
       if (newCallbackRef != null) newCallbackRef(ref);
     }
 
     return chainedRef;
-  } else { // Assume it's a ref object created by createRef
+  } else {
+    // Assume it's a ref object created by createRef
     assert(existingRef is! Ref,
         'should be a JsRef; the factory that created `element` should never let a Dart ref get here');
     void chainedRef(ref) {
@@ -414,7 +436,12 @@ CallbackRef chainRef(ReactElement element, CallbackRef newCallbackRef) {
       // Update `.current` manually on the ref object.
       // As per https://github.com/facebook/react/issues/13029 it should be fine to set current this way.
       // Use setProperty so we don't have to expose a `JsRef.current` setter, which could be misused.
-      setProperty(existingRef, 'current', ref is react.Component ? ref.jsThis : ref); // ignore: deprecated_member_use
+      setProperty(
+          existingRef,
+          'current',
+          ref is react.Component
+              ? ref.jsThis
+              : ref); // ignore: deprecated_member_use
 
       if (newCallbackRef != null) newCallbackRef(ref);
     }

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -24,10 +24,8 @@ import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
-import 'package:react/react_client/js_interop_helpers.dart'
-    show jsifyAndAllowInterop;
-import 'package:react/react_client/react_interop.dart'
-    hide createRef, forwardRef;
+import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
+import 'package:react/react_client/react_interop.dart' hide createRef, forwardRef;
 import 'package:react/react_dom.dart' as react_dom;
 
 // Notes
@@ -48,8 +46,7 @@ import 'package:react/react_dom.dart' as react_dom;
 /// Returns internal data structure used by react-dart to maintain the native Dart component
 /// for a given react-dart [ReactElement] or [ReactComponent] [instance].
 // ignore: deprecated_member_use
-ReactDartComponentInternal _getInternal(
-        /* ReactElement|ReactComponent */ instance) =>
+ReactDartComponentInternal _getInternal(/* ReactElement|ReactComponent */ instance) =>
     // ignore: deprecated_member_use
     (instance.props as InteropProps).internal;
 
@@ -75,8 +72,7 @@ bool isDartComponent(/* ReactElement|ReactComponent|Element */ instance) {
 /// (react-dart [ReactElement] or [ReactComponent]), and null for other types of components.
 ///
 /// [instance] may not be null.
-String _getDartComponentVersionFromInstance(
-    /* ReactElement|ReactComponent|Element */ instance) {
+String _getDartComponentVersionFromInstance(/* ReactElement|ReactComponent|Element */ instance) {
   if (instance == null) {
     throw ArgumentError.notNull('instance');
   }
@@ -87,8 +83,7 @@ String _getDartComponentVersionFromInstance(
   }
 
   // We need `type` if it's a ReactElement, or `constructor` if it's a `ReactComponent`.
-  final type =
-      getProperty(instance, 'type') ?? getProperty(instance, 'constructor');
+  final type = getProperty(instance, 'type') ?? getProperty(instance, 'constructor');
   // ignore: invalid_use_of_protected_member
   return ReactDartComponentVersion.fromType(type);
 }
@@ -116,8 +111,9 @@ final bool _canUseExpandoOnReactElement = (() {
 ///
 /// If caching isn't possible due to [_canUseExpandoOnReactElement] being false,
 /// then this will be initialized to `null`, and caching will be disabled.
-final Expando<Map> _elementPropsCache =
-    _canUseExpandoOnReactElement ? Expando<Map>('_elementPropsCache') : null;
+final Expando<Map> _elementPropsCache = _canUseExpandoOnReactElement
+    ? Expando<Map>('_elementPropsCache')
+    : null;
 
 /// Returns an unmodifiable Map view of props for a [ReactElement] or composite [ReactComponent] [instance].
 ///
@@ -128,8 +124,7 @@ final Expando<Map> _elementPropsCache =
 /// instance.
 ///
 /// Throws if [instance] is not a valid [ReactElement] or composite [ReactComponent] .
-Map getProps(/* ReactElement|ReactComponent */ instance,
-    {bool traverseWrappers = false}) {
+Map getProps(/* ReactElement|ReactComponent */ instance, {bool traverseWrappers = false}) {
   var isCompositeComponent = _isCompositeComponent(instance);
 
   if (isValidElement(instance) || isCompositeComponent) {
@@ -137,8 +132,7 @@ Map getProps(/* ReactElement|ReactComponent */ instance,
       ComponentTypeMeta instanceTypeMeta;
 
       if (isCompositeComponent && isDartComponent(instance)) {
-        ReactClass type =
-            getProperty(getDartComponent(instance).jsThis, 'constructor');
+        ReactClass type = getProperty(getDartComponent(instance).jsThis, 'constructor');
         instanceTypeMeta = getComponentTypeMeta(type);
       } else if (isValidElement(instance)) {
         instanceTypeMeta = getComponentTypeMeta(instance.type);
@@ -148,14 +142,11 @@ Map getProps(/* ReactElement|ReactComponent */ instance,
       }
 
       if (instanceTypeMeta.isWrapper) {
-        assert(isDartComponent(instance) &&
-            'Non-dart components should not be wrappers' is String);
+        assert(isDartComponent(instance) && 'Non-dart components should not be wrappers' is String);
 
         List children = getProps(instance)['children'];
 
-        if (children != null &&
-            children.isNotEmpty &&
-            isValidElement(children.first)) {
+        if (children != null && children.isNotEmpty && isValidElement(children.first)) {
           return getProps(children.first, traverseWrappers: true);
         }
       }
@@ -169,11 +160,9 @@ Map getProps(/* ReactElement|ReactComponent */ instance,
     Map rawPropsOrCopy;
 
     final dartComponentVersion = _getDartComponentVersionFromInstance(instance);
-    if (dartComponentVersion == ReactDartComponentVersion.component) {
-      // ignore: invalid_use_of_protected_member
+    if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
       rawPropsOrCopy = _getExtendedProps(instance);
-    } else if (dartComponentVersion == ReactDartComponentVersion.component2) {
-      // ignore: invalid_use_of_protected_member
+    } else if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
       // TODO Since JS props are frozen don't wrap in UnmodifiableMapView once https://github.com/dart-lang/sdk/issues/15432 is fixed
       rawPropsOrCopy = JsBackedMap.backedBy(instance.props);
     } else {
@@ -188,8 +177,7 @@ Map getProps(/* ReactElement|ReactComponent */ instance,
     return unmodifiableProps;
   }
 
-  throw ArgumentError.value(instance, 'instance',
-      'must be a valid ReactElement or composite ReactComponent');
+  throw ArgumentError.value(instance, 'instance', 'must be a valid ReactElement or composite ReactComponent');
 }
 
 /// Returns the DOM node associated with a mounted React component [instance],
@@ -206,8 +194,7 @@ Element findDomNode(dynamic instance) => react_dom.findDOMNode(instance);
 /// [children] can be any renderable React child, such as a [ReactElement], [String], or fragment.
 ///
 /// See: <https://reactjs.org/docs/portals.html>
-ReactPortal createPortal(dynamic children, Element container) =>
-    ReactDom.createPortal(children, container);
+ReactPortal createPortal(dynamic children, Element container) => ReactDom.createPortal(children, container);
 
 /// Dart wrapper for React.isValidElement.
 ///
@@ -243,15 +230,12 @@ bool _isCompositeComponent(dynamic instance) {
 /// * Children are likewise copied and potentially overwritten with [newChildren] as expected.
 /// * For JS components, a JS copy of [newProps] is returned, since React will merge the props without any special handling.
 ///   If these values might contain event handlers
-dynamic preparePropsChangeset(ReactElement element, Map newProps,
-    [Iterable newChildren]) {
+dynamic preparePropsChangeset(ReactElement element, Map newProps, [Iterable newChildren]) {
   final type = element.type;
-  final dartComponentVersion = ReactDartComponentVersion.fromType(
-      type); // ignore: invalid_use_of_protected_member
+  final dartComponentVersion = ReactDartComponentVersion.fromType(type); // ignore: invalid_use_of_protected_member
 
   // react.Component
-  if (dartComponentVersion == ReactDartComponentVersion.component) {
-    // ignore: invalid_use_of_protected_member
+  if (dartComponentVersion == ReactDartComponentVersion.component) { // ignore: invalid_use_of_protected_member
     Map oldExtendedProps = _getInternal(element).props;
 
     Map extendedProps = Map.from(oldExtendedProps);
@@ -260,8 +244,7 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps,
     }
 
     // ignore: deprecated_member_use
-    return ReactDartComponentFactoryProxy.generateExtendedJsProps(
-        extendedProps, newChildren ?? extendedProps['children']);
+    return ReactDartComponentFactoryProxy.generateExtendedJsProps(extendedProps, newChildren ?? extendedProps['children']);
   }
 
   if (newProps == null) {
@@ -272,8 +255,7 @@ dynamic preparePropsChangeset(ReactElement element, Map newProps,
   }
 
   // react.Component2
-  if (dartComponentVersion == ReactDartComponentVersion.component2) {
-    // ignore: invalid_use_of_protected_member
+  if (dartComponentVersion == ReactDartComponentVersion.component2) { // ignore: invalid_use_of_protected_member
     return ReactDartComponentFactoryProxy2.generateExtendedJsProps(newProps);
   }
 
@@ -302,8 +284,7 @@ external ReactElement _cloneElement(element, [props, children]);
 /// > Unlike React.addons.cloneWithProps, key and ref from the original element will be preserved.
 /// > There is no special behavior for merging any props (unlike cloneWithProps).
 /// > See the [v0.13 RC2 blog post](https://facebook.github.io/react/blog/2015/03/03/react-v0.13-rc2.html) for additional details.
-ReactElement cloneElement(ReactElement element,
-    [Map props, Iterable children]) {
+ReactElement cloneElement(ReactElement element, [Map props, Iterable children]) {
   if (element == null) throw ArgumentError.notNull('element');
 
   var propsChangeset = preparePropsChangeset(element, props, children);
@@ -319,8 +300,7 @@ ReactElement cloneElement(ReactElement element,
 ///
 /// Returns `null` if the [instance] is not Dart-based _(an [Element] or a JS composite component)_.
 // ignore: deprecated_member_use
-T getDartComponent<T extends react.Component>(
-    /* ReactElement|ReactComponent|Element */ instance) {
+T getDartComponent<T extends react.Component>(/* ReactElement|ReactComponent|Element */ instance) {
   if (instance is Element) {
     return null;
   }
@@ -329,7 +309,8 @@ T getDartComponent<T extends react.Component>(
     if (isValidElement(instance)) {
       // `print` instead of `ValidationUtil.warn` so that this message shows up
       // in the test output when running `ddev test`.
-      print(unindent('''
+      print(unindent(
+          '''
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
           * WARNING: `getDartComponent`
           *
@@ -352,7 +333,8 @@ T getDartComponent<T extends react.Component>(
           *     var dartInstance = getDartComponent(jsInstance);
           *
           * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-          '''));
+          '''
+      ));
     }
     return true;
   }
@@ -410,22 +392,18 @@ CallbackRef chainRef(ReactElement element, CallbackRef newCallbackRef) {
         'The existing ref is a String ref and cannot be chained');
   }
 
-  if (existingRef is Function) {
-    // Callback refs
+  if (existingRef is Function) { // Callback refs
     void chainedRef(ref) {
       // For Dart components, the existing ref is a function passed to the JS that wraps the Dart
       // callback ref and converts the JS instance to the Dart component.
       // So, we need to undo the wrapping around this chained ref and pass in the JS instance.
-      existingRef(ref is react.Component
-          ? ref.jsThis
-          : ref); // ignore: deprecated_member_use
+      existingRef(ref is react.Component ? ref.jsThis : ref); // ignore: deprecated_member_use
 
       if (newCallbackRef != null) newCallbackRef(ref);
     }
 
     return chainedRef;
-  } else {
-    // Assume it's a ref object created by createRef
+  } else { // Assume it's a ref object created by createRef
     assert(existingRef is! Ref,
         'should be a JsRef; the factory that created `element` should never let a Dart ref get here');
     void chainedRef(ref) {
@@ -436,12 +414,7 @@ CallbackRef chainRef(ReactElement element, CallbackRef newCallbackRef) {
       // Update `.current` manually on the ref object.
       // As per https://github.com/facebook/react/issues/13029 it should be fine to set current this way.
       // Use setProperty so we don't have to expose a `JsRef.current` setter, which could be misused.
-      setProperty(
-          existingRef,
-          'current',
-          ref is react.Component
-              ? ref.jsThis
-              : ref); // ignore: deprecated_member_use
+      setProperty(existingRef, 'current', ref is react.Component ? ref.jsThis : ref); // ignore: deprecated_member_use
 
       if (newCallbackRef != null) newCallbackRef(ref);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,4 +54,3 @@ dependency_overrides:
     git:
       url: https://github.com/cleandart/react-dart.git
       ref: 5.5.0-wip
-

--- a/test/over_react/component/memo_test.dart
+++ b/test/over_react/component/memo_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library memo_test;
+
+import 'package:over_react/src/util/memo.dart';
+import 'package:test/test.dart';
+import 'package:over_react/over_react.dart';
+import 'fixtures/basic_ui_component.dart';
+
+part 'memo_test.over_react.g.dart';
+
+main() {
+  group('memo -', () {
+    test('errors when wrapping a UiComponent', () {
+      expect(
+          () => memo<BasicUiComponentProps>((props) {
+                return (BasicUiComponent())();
+              })(BasicUiComponent),
+          throwsArgumentError);
+    });
+  });
+}
+
+@Factory()
+UiFactory<BasicProps> Basic = _$Basic;
+
+@Props()
+class _$BasicProps extends UiProps {
+  String childId;
+}
+
+@Component2()
+class BasicComponent extends UiComponent2<BasicProps> {
+  @override
+  render() => 'basic component';
+}

--- a/test/over_react/component/memo_test.dart
+++ b/test/over_react/component/memo_test.dart
@@ -15,34 +15,101 @@
 library memo_test;
 
 import 'package:over_react/src/util/memo.dart';
+import 'package:over_react_test/over_react_test.dart';
 import 'package:test/test.dart';
 import 'package:over_react/over_react.dart';
 import 'fixtures/basic_ui_component.dart';
 
 part 'memo_test.over_react.g.dart';
 
+int renderCount = 0;
+mixin FunctionCustomPropsProps on UiProps {
+  int testProp;
+}
+
+UiFactory<FunctionCustomPropsProps> FunctionCustomProps = uiFunction(
+  (props) {
+    renderCount++;
+    return Dom.div()(Dom.div()('prop id: ${props.id}'),
+        Dom.div()('test Prop: ${props.testProp}'));
+  },
+  $FunctionCustomPropsConfig, // ignore: undefined_identifier
+);
+
 main() {
   group('memo -', () {
     test('errors when wrapping a UiComponent', () {
-      expect(
-          () => memo<BasicUiComponentProps>((props) {
-                return (BasicUiComponent())();
-              })(BasicUiComponent),
+      expect(() => memo<BasicUiComponentProps>(BasicUiComponent),
           throwsArgumentError);
+    });
+
+    test('errors when wrapping a UiComponent2', () {
+      expect(() => memo<BasicUiComponent2Props>(BasicUiComponent2),
+          throwsArgumentError);
+    });
+
+    test('wraps a function component', () {
+      UiFactory<UiProps> FunctionTest = uiFunction(
+        (props) {
+          return Dom.div()('prop id: ${props.id}');
+        },
+        FunctionComponentConfig(),
+      );
+
+      UiFactory<UiProps> FunctionMemo = memo<UiProps>(FunctionTest);
+      mount(FunctionMemo()());
+
+      expect(isValidElementOfType(FunctionMemo()(), FunctionTest), isTrue);
+    });
+
+    test('wraps a function component with custom props', () {
+      UiFactory<FunctionCustomPropsProps> FunctionCustomPropsMemo =
+          memo<FunctionCustomPropsProps>(FunctionCustomProps);
+      mount(FunctionCustomPropsMemo()());
+
+      expect(
+          isValidElementOfType(
+              FunctionCustomPropsMemo()(), FunctionCustomProps),
+          isTrue);
+    });
+
+    test('memoizes based on props', () {
+      renderCount = 0;
+      UiFactory<FunctionCustomPropsProps> FunctionCustomPropsMemo =
+          memo<FunctionCustomPropsProps>(FunctionCustomProps);
+      final testJacket = mount((FunctionCustomPropsMemo()..testProp = 1)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testProp = 1)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testProp = 1)());
+
+      expect(renderCount, equals(1));
+    });
+
+    test('memoizes based on areEqual parameter', () {
+      renderCount = 0;
+      UiFactory<FunctionCustomPropsProps> FunctionCustomPropsMemo =
+          memo<FunctionCustomPropsProps>(FunctionCustomProps,
+              areEqual: ((prevProps, nextProps) {
+        return prevProps.testProp == nextProps.testProp - 1;
+      }));
+      final testJacket = mount((FunctionCustomPropsMemo()..testProp = 1)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testProp = 2)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testProp = 4)());
+
+      expect(renderCount, equals(2));
     });
   });
 }
 
 @Factory()
-UiFactory<BasicProps> Basic = _$Basic;
+UiFactory<BasicUiComponent2Props> BasicUiComponent2 = _$BasicUiComponent2;
 
 @Props()
-class _$BasicProps extends UiProps {
+class _$BasicUiComponent2Props extends UiProps {
   String childId;
 }
 
 @Component2()
-class BasicComponent extends UiComponent2<BasicProps> {
+class BasicUiComponent2Component extends UiComponent2<BasicUiComponent2Props> {
   @override
   render() => 'basic component';
 }

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -10,62 +10,71 @@ part of 'memo_test.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
-final $BasicComponentFactory = registerComponent2(
-  () => _$BasicComponent(),
-  builderFactory: _$Basic,
-  componentClass: BasicComponent,
+final $BasicUiComponent2ComponentFactory = registerComponent2(
+  () => _$BasicUiComponent2Component(),
+  builderFactory: _$BasicUiComponent2,
+  componentClass: BasicUiComponent2Component,
   isWrapper: false,
   parentType: null,
-  displayName: 'Basic',
+  displayName: 'BasicUiComponent2',
 );
 
-abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
+abstract class _$BasicUiComponent2PropsAccessorsMixin
+    implements _$BasicUiComponent2Props {
   @override
   Map get props;
 
-  /// <!-- Generated from [_$BasicProps.childId] -->
+  /// <!-- Generated from [_$BasicUiComponent2Props.childId] -->
   @override
   String get childId =>
-      props[_$key__childId___$BasicProps] ??
+      props[_$key__childId___$BasicUiComponent2Props] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
-  /// <!-- Generated from [_$BasicProps.childId] -->
+  /// <!-- Generated from [_$BasicUiComponent2Props.childId] -->
   @override
-  set childId(String value) => props[_$key__childId___$BasicProps] = value;
+  set childId(String value) =>
+      props[_$key__childId___$BasicUiComponent2Props] = value;
   /* GENERATED CONSTANTS */
-  static const PropDescriptor _$prop__childId___$BasicProps =
-      PropDescriptor(_$key__childId___$BasicProps);
-  static const String _$key__childId___$BasicProps = 'BasicProps.childId';
+  static const PropDescriptor _$prop__childId___$BasicUiComponent2Props =
+      PropDescriptor(_$key__childId___$BasicUiComponent2Props);
+  static const String _$key__childId___$BasicUiComponent2Props =
+      'BasicUiComponent2Props.childId';
 
-  static const List<PropDescriptor> $props = [_$prop__childId___$BasicProps];
-  static const List<String> $propKeys = [_$key__childId___$BasicProps];
+  static const List<PropDescriptor> $props = [
+    _$prop__childId___$BasicUiComponent2Props
+  ];
+  static const List<String> $propKeys = [
+    _$key__childId___$BasicUiComponent2Props
+  ];
 }
 
-const PropsMeta _$metaForBasicProps = PropsMeta(
-  fields: _$BasicPropsAccessorsMixin.$props,
-  keys: _$BasicPropsAccessorsMixin.$propKeys,
+const PropsMeta _$metaForBasicUiComponent2Props = PropsMeta(
+  fields: _$BasicUiComponent2PropsAccessorsMixin.$props,
+  keys: _$BasicUiComponent2PropsAccessorsMixin.$propKeys,
 );
 
-class BasicProps extends _$BasicProps with _$BasicPropsAccessorsMixin {
-  static const PropsMeta meta = _$metaForBasicProps;
+class BasicUiComponent2Props extends _$BasicUiComponent2Props
+    with _$BasicUiComponent2PropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForBasicUiComponent2Props;
 }
 
-_$$BasicProps _$Basic([Map backingProps]) => backingProps == null
-    ? _$$BasicProps$JsMap(JsBackedMap())
-    : _$$BasicProps(backingProps);
+_$$BasicUiComponent2Props _$BasicUiComponent2([Map backingProps]) =>
+    backingProps == null
+        ? _$$BasicUiComponent2Props$JsMap(JsBackedMap())
+        : _$$BasicUiComponent2Props(backingProps);
 
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-abstract class _$$BasicProps extends _$BasicProps
-    with _$BasicPropsAccessorsMixin
-    implements BasicProps {
-  _$$BasicProps._();
+abstract class _$$BasicUiComponent2Props extends _$BasicUiComponent2Props
+    with _$BasicUiComponent2PropsAccessorsMixin
+    implements BasicUiComponent2Props {
+  _$$BasicUiComponent2Props._();
 
-  factory _$$BasicProps(Map backingMap) {
+  factory _$$BasicUiComponent2Props(Map backingMap) {
     if (backingMap == null || backingMap is JsBackedMap) {
-      return _$$BasicProps$JsMap(backingMap);
+      return _$$BasicUiComponent2Props$JsMap(backingMap);
     } else {
-      return _$$BasicProps$PlainMap(backingMap);
+      return _$$BasicUiComponent2Props$PlainMap(backingMap);
     }
   }
 
@@ -76,18 +85,18 @@ abstract class _$$BasicProps extends _$BasicProps
   /// The `ReactComponentFactory` associated with the component built by this class.
   @override
   ReactComponentFactoryProxy get componentFactory =>
-      super.componentFactory ?? $BasicComponentFactory;
+      super.componentFactory ?? $BasicUiComponent2ComponentFactory;
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
-  String get propKeyNamespace => 'BasicProps.';
+  String get propKeyNamespace => 'BasicUiComponent2Props.';
 }
 
 // Concrete props implementation that can be backed by any [Map].
-class _$$BasicProps$PlainMap extends _$$BasicProps {
+class _$$BasicUiComponent2Props$PlainMap extends _$$BasicUiComponent2Props {
   // This initializer of `_props` to an empty map, as well as the reassignment
   // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicProps$PlainMap(Map backingMap)
+  _$$BasicUiComponent2Props$PlainMap(Map backingMap)
       : this._props = {},
         super._() {
     this._props = backingMap ?? {};
@@ -101,10 +110,10 @@ class _$$BasicProps$PlainMap extends _$$BasicProps {
 
 // Concrete props implementation that can only be backed by [JsMap],
 // allowing dart2js to compile more optimal code for key-value pair reads/writes.
-class _$$BasicProps$JsMap extends _$$BasicProps {
+class _$$BasicUiComponent2Props$JsMap extends _$$BasicUiComponent2Props {
   // This initializer of `_props` to an empty map, as well as the reassignment
   // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$BasicProps$JsMap(JsBackedMap backingMap)
+  _$$BasicUiComponent2Props$JsMap(JsBackedMap backingMap)
       : this._props = JsBackedMap(),
         super._() {
     this._props = backingMap ?? JsBackedMap();
@@ -120,11 +129,11 @@ class _$$BasicProps$JsMap extends _$$BasicProps {
 //
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
-class _$BasicComponent extends BasicComponent {
-  _$$BasicProps$JsMap _cachedTypedProps;
+class _$BasicUiComponent2Component extends BasicUiComponent2Component {
+  _$$BasicUiComponent2Props$JsMap _cachedTypedProps;
 
   @override
-  _$$BasicProps$JsMap get props => _cachedTypedProps;
+  _$$BasicUiComponent2Props$JsMap get props => _cachedTypedProps;
 
   @override
   set props(Map value) {
@@ -140,18 +149,129 @@ class _$BasicComponent extends BasicComponent {
   }
 
   @override
-  _$$BasicProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
-      _$$BasicProps$JsMap(backingMap);
+  _$$BasicUiComponent2Props$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$BasicUiComponent2Props$JsMap(backingMap);
 
   @override
-  _$$BasicProps typedPropsFactory(Map backingMap) => _$$BasicProps(backingMap);
+  _$$BasicUiComponent2Props typedPropsFactory(Map backingMap) =>
+      _$$BasicUiComponent2Props(backingMap);
 
   /// Let `UiComponent` internals know that this class has been generated.
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from _$BasicProps.
+  /// The default consumed props, taken from _$BasicUiComponent2Props.
   /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
-  final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForBasicUiComponent2Props
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $FunctionCustomPropsProps on FunctionCustomPropsProps {
+  static const PropsMeta meta = _$metaForFunctionCustomPropsProps;
+  @override
+  int get testProp =>
+      props[_$key__testProp__FunctionCustomPropsProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set testProp(int value) =>
+      props[_$key__testProp__FunctionCustomPropsProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__testProp__FunctionCustomPropsProps =
+      PropDescriptor(_$key__testProp__FunctionCustomPropsProps);
+  static const String _$key__testProp__FunctionCustomPropsProps =
+      'FunctionCustomPropsProps.testProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__testProp__FunctionCustomPropsProps
+  ];
+  static const List<String> $propKeys = [
+    _$key__testProp__FunctionCustomPropsProps
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForFunctionCustomPropsProps = PropsMeta(
+  fields: $FunctionCustomPropsProps.$props,
+  keys: $FunctionCustomPropsProps.$propKeys,
+);
+
+final FunctionComponentConfig<_$$FunctionCustomPropsProps>
+    $FunctionCustomPropsConfig = FunctionComponentConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$FunctionCustomPropsProps(map),
+          jsMap: (map) => _$$FunctionCustomPropsProps$JsMap(map),
+        ),
+        displayName: 'FunctionCustomProps');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$FunctionCustomPropsProps extends UiProps
+    with
+        FunctionCustomPropsProps,
+        $FunctionCustomPropsProps // If this generated mixin is undefined, it's likely because FunctionCustomPropsProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of FunctionCustomPropsProps.
+{
+  _$$FunctionCustomPropsProps._();
+
+  factory _$$FunctionCustomPropsProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$FunctionCustomPropsProps$JsMap(backingMap);
+    } else {
+      return _$$FunctionCustomPropsProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$FunctionCustomPropsProps$PlainMap extends _$$FunctionCustomPropsProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FunctionCustomPropsProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$FunctionCustomPropsProps$JsMap extends _$$FunctionCustomPropsProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$FunctionCustomPropsProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
 }

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -1,0 +1,157 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'memo_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $BasicComponentFactory = registerComponent2(
+  () => _$BasicComponent(),
+  builderFactory: _$Basic,
+  componentClass: BasicComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'Basic',
+);
+
+abstract class _$BasicPropsAccessorsMixin implements _$BasicProps {
+  @override
+  Map get props;
+
+  /// <!-- Generated from [_$BasicProps.childId] -->
+  @override
+  String get childId =>
+      props[_$key__childId___$BasicProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  /// <!-- Generated from [_$BasicProps.childId] -->
+  @override
+  set childId(String value) => props[_$key__childId___$BasicProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__childId___$BasicProps =
+      PropDescriptor(_$key__childId___$BasicProps);
+  static const String _$key__childId___$BasicProps = 'BasicProps.childId';
+
+  static const List<PropDescriptor> $props = [_$prop__childId___$BasicProps];
+  static const List<String> $propKeys = [_$key__childId___$BasicProps];
+}
+
+const PropsMeta _$metaForBasicProps = PropsMeta(
+  fields: _$BasicPropsAccessorsMixin.$props,
+  keys: _$BasicPropsAccessorsMixin.$propKeys,
+);
+
+class BasicProps extends _$BasicProps with _$BasicPropsAccessorsMixin {
+  static const PropsMeta meta = _$metaForBasicProps;
+}
+
+_$$BasicProps _$Basic([Map backingProps]) => backingProps == null
+    ? _$$BasicProps$JsMap(JsBackedMap())
+    : _$$BasicProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+abstract class _$$BasicProps extends _$BasicProps
+    with _$BasicPropsAccessorsMixin
+    implements BasicProps {
+  _$$BasicProps._();
+
+  factory _$$BasicProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$BasicProps$JsMap(backingMap);
+    } else {
+      return _$$BasicProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $BasicComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'BasicProps.';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+class _$$BasicProps$PlainMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+class _$$BasicProps$JsMap extends _$$BasicProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$BasicProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$BasicComponent extends BasicComponent {
+  _$$BasicProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$BasicProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$BasicProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$BasicProps$JsMap(backingMap);
+
+  @override
+  _$$BasicProps typedPropsFactory(Map backingMap) => _$$BasicProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$BasicProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [_$metaForBasicProps];
+}

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -23,20 +23,29 @@ import 'package:over_react/over_react.dart';
 import 'package:react/react_client.dart';
 import 'package:test/test.dart';
 
-import 'over_react/component/_deprecated/abstract_transition_test.dart' as deprecated_abstract_transition_test;
-import 'over_react/component/abstract_transition_test.dart' as abstract_transition_test;
+import 'over_react/component/_deprecated/abstract_transition_test.dart'
+    as deprecated_abstract_transition_test;
+import 'over_react/component/abstract_transition_test.dart'
+    as abstract_transition_test;
 import 'over_react/component/dom_components_test.dart' as dom_components_test;
 import 'over_react/component/error_boundary_test.dart' as error_boundary_test;
-import 'over_react/component/_deprecated/error_boundary_mixin_test.dart' as deprecated_error_boundary_mixin_test;
-import 'over_react/component/_deprecated/error_boundary_test.dart' as deprecated_error_boundary_test;
+import 'over_react/component/_deprecated/error_boundary_mixin_test.dart'
+    as deprecated_error_boundary_mixin_test;
+import 'over_react/component/_deprecated/error_boundary_test.dart'
+    as deprecated_error_boundary_test;
 import 'over_react/component/forward_ref_test.dart' as forward_ref_test;
+import 'over_react/component/memo_test.dart' as memo_test;
 import 'over_react/component/prop_mixins_test.dart' as prop_mixins_test;
 import 'over_react/component/prop_typedefs_test.dart' as prop_typedefs_test;
-import 'over_react/component/pure_component_mixin_test.dart' as pure_component_mixin_test;
-import 'over_react/component/_deprecated/resize_sensor_test.dart' as deprecated_resize_sensor_test;
+import 'over_react/component/pure_component_mixin_test.dart'
+    as pure_component_mixin_test;
+import 'over_react/component/_deprecated/resize_sensor_test.dart'
+    as deprecated_resize_sensor_test;
 import 'over_react/component/resize_sensor_test.dart' as resize_sensor_test;
-import 'over_react/component/fragment_component_test.dart' as fragment_component_test;
-import 'over_react/component/strictmode_component_test.dart' as strictmode_component_test;
+import 'over_react/component/fragment_component_test.dart'
+    as fragment_component_test;
+import 'over_react/component/strictmode_component_test.dart'
+    as strictmode_component_test;
 import 'over_react/component/context_test.dart' as context_test;
 import 'over_react/component/typed_factory_test.dart' as typed_factory_test;
 
@@ -52,6 +61,7 @@ void main() {
   deprecated_error_boundary_mixin_test.main();
   deprecated_error_boundary_test.main();
   forward_ref_test.main();
+  memo_test.main();
   dom_components_test.main();
   prop_mixins_test.main();
   prop_typedefs_test.main();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We'd like a typed `memo` util to wrap the react-dart memo function to memoize function components.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Add `memo` with support for over_react typing for function components
- Loosen types in signature of `registerComponentTypeAlias` so function components can be registered accordingly
- Add `enforceFunctionComponent` util
- Add unit tests for `memo`

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
