### PR TITLE
Remove namespace from example import

### DIFF
--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -30,7 +30,7 @@ import 'package:over_react/component_base.dart';
 /// > __NOTE:__ This should only be used to wrap function components.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart' as react;
+/// import 'package:over_react/over_react.dart';
 ///
 /// UiFactory<UiProps> MemoExample = memo<UiProps>(uiFunction(
 ///   (props) {
@@ -48,7 +48,7 @@ import 'package:over_react/component_base.dart';
 /// function to the [areEqual] argument as shown in the example below.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart' as react;
+/// import 'package:over_react/over_react.dart';
 ///
 /// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo<MemoWithComparisonProps>(uiFunction(
 ///   (props) {


### PR DESCRIPTION
This fixes a couple of typos that were missed in #613