### PR TITLE
CPLAT-12205 Add WithTransition wrapper component to enable "controlled" transitions using props

### DIFF
--- a/lib/components.dart
+++ b/lib/components.dart
@@ -20,3 +20,4 @@ export 'src/component/abstract_transition_props.dart';
 export 'src/component/error_boundary.dart';
 export 'src/component/error_boundary_api.dart' show defaultErrorBoundaryLoggerName;
 export 'src/component/resize_sensor.dart' hide SafeAnimationFrameMixin;
+export 'src/component/with_transition.dart';

--- a/lib/over_react.dart
+++ b/lib/over_react.dart
@@ -35,7 +35,7 @@ export 'package:react/react_client/js_backed_map.dart' show JsBackedMap;
 
 export 'package:react/react_client.dart'
     // ignore: deprecated_member_use
-    show setClientConfiguration, ReactElement, ReactComponentFactoryProxy;
+    show setClientConfiguration, chainRefs, ReactElement, ReactComponentFactoryProxy;
 export 'package:react/react_client/react_interop.dart' show ReactErrorInfo, Ref;
 export 'package:react/hooks.dart' show StateHook, ReducerHook;
 

--- a/lib/src/component/_deprecated/abstract_transition_props.dart
+++ b/lib/src/component/_deprecated/abstract_transition_props.dart
@@ -33,7 +33,7 @@ abstract class $TransitionPropsMixin {
 
 /// Props that mirror the implementation of [AbstractTransitionProps], made available as a mixin for components
 /// that cannot extend directly from [AbstractTransitionComponent].
-@Deprecated('Use the `AbstractTransitionProps` mixin exported from `package:over_react/components.dart` instead. Will be removed in the 4.0.0 release.')
+@Deprecated('Use the `TransitionPropsMixin` mixin exported from `package:over_react/components.dart` instead. Will be removed in the 4.0.0 release.')
 @PropsMixin()
 abstract class _$TransitionPropsMixin {
   static final TransitionPropsMapView defaultProps = TransitionPropsMapView({})

--- a/lib/src/component/_deprecated/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/_deprecated/abstract_transition_props.over_react.g.dart
@@ -8,7 +8,7 @@ part of 'abstract_transition_props.dart';
 // **************************************************************************
 
 @Deprecated(
-    'Use the `AbstractTransitionProps` mixin exported from `package:over_react/components.dart` instead. Will be removed in the 4.0.0 release.')
+    'Use the `TransitionPropsMixin` mixin exported from `package:over_react/components.dart` instead. Will be removed in the 4.0.0 release.')
 abstract class TransitionPropsMixin implements _$TransitionPropsMixin {
   @override
   Map get props;

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -280,7 +280,7 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
     assert(_hasSingleValidChild(props));
 
     final childElement = props.children.single as ReactElement;
-    final childProps = domProps({...getProps(childElement)});
+    final childProps = domProps(getProps(childElement));
     final phaseProps = props.childPropsByPhase[state.$transitionPhase];
     final phaseClasses = ClassNameBuilder.fromProps(childProps)
       ..addFromProps(phaseProps);

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -281,7 +281,7 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
 
     final childElement = props.children.single as ReactElement;
     final childProps = domProps(getProps(childElement));
-    final phaseProps = props.childPropsByPhase[state.$transitionPhase];
+    final phaseProps = props.childPropsByPhase[state.$transitionPhase] ?? const {};
     final phaseClasses = ClassNameBuilder.fromProps(childProps)
       ..addFromProps(phaseProps);
 

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -243,12 +243,10 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
         _handlePreShowing();
         break;
       case TransitionPhase.SHOWING:
-        // NOTE: props.onWillShow is called within _handleShow in the handler that
-        // triggers an update to `$transitionPhase` that will result in this effect being processed.
+        props.onWillShow?.call();
         break;
       case TransitionPhase.HIDING:
-        // NOTE: props.onWillHide is called within _handleHide in the handler that
-        // triggers an update to `$transitionPhase` that will result in this effect being processed.
+        props.onWillHide?.call();
         _transitionNotGuaranteed = state.$transitionPhase == TransitionPhase.SHOWING;
         _handleHiding();
         break;
@@ -311,7 +309,6 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
   Map _stateToBeginShowing(WithTransitionProps tProps, TransitionPhase currentPhase) {
     if (_isOrWillBeShown(currentPhase)) return null;
 
-    tProps.onWillShow?.call();
     return newState()
       ..$transitionPhase = _hasTransitionIn(tProps) ? TransitionPhase.PRE_SHOWING : TransitionPhase.SHOWN;
   }
@@ -321,7 +318,6 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
   Map _stateToBeginHiding(WithTransitionProps tProps, TransitionPhase currentPhase) {
     if (_isOrWillBeHidden(currentPhase)) return null;
 
-    tProps.onWillHide?.call();
     return newState()
       ..$transitionPhase = _hasTransitionOut(tProps) ? TransitionPhase.HIDING : TransitionPhase.HIDDEN;
   }

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -289,7 +289,7 @@ class WithTransitionComponent extends UiStatefulComponent2<WithTransitionProps, 
 
     return cloneElement(childElement, domProps()
       ..addTestId(childProps.getTestId())
-      ..addTestId('ovr.WithTransition.node')
+      ..addTestId('or.WithTransition.node')
       ..addProps(phaseProps)
       ..className = phaseClasses.toClassName()
       ..ref = chainRefs(childElement.ref, _transitionNodeRef)

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -1,0 +1,410 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library over_react.abstract_controlled_transition;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:over_react/over_react.dart';
+import 'package:over_react/components.dart' as v2;
+
+part 'with_transition.over_react.g.dart';
+
+mixin WithTransitionPropsMixin on UiProps {
+  /// Controls the visibility of the component.
+  ///
+  /// * When set to `true` - the component will begin to transition into a visible state.
+  /// * When set to `false` - the component will begin to transition into a hidden state.
+  ///
+  /// > Default: `false`
+  ///
+  /// > See: [WithTransition] for example usage.
+  bool isShown;
+
+  /// An optional map of props to apply to the single child based on the current transition phase.
+  ///
+  /// This provides you with the ability to add CSS classes / other DOM attributes based on the granular
+  /// transition states that are confined within the [WithTransition] component without having to
+  /// utilize state change callbacks to update your component's state.
+  ///
+  /// __NOTE:__ These values will override any prop values set on the child itself if the
+  /// key(s) in the `Map` are the same.
+  ///
+  /// __Example:__
+  ///
+  /// ```dart
+  /// UiFactory<WithTransitionExampleProps> WithTransitionExample = uiFunction(
+  ///   (props) {
+  ///     final isShown = useState(false);
+  ///
+  ///     (WithTransition()
+  ///       ..isShown = isShown.value
+  ///       ..childPropsByPhase = useMemo(() => {
+  ///         TransitionPhase.PRE_SHOWING: domProps()..className = 'before-showing',
+  ///         TransitionPhase.SHOWING: domProps()..className = 'showing',
+  ///         TransitionPhase.SHOWN: domProps()..className = 'shown',
+  ///         TransitionPhase.HIDING: domProps()..className = 'hiding',
+  ///         TransitionPhase.HIDDEN: domProps()..className = 'hidden',
+  ///       })
+  ///     )(
+  ///       // The child that has CSS transitions
+  ///     )
+  ///   },
+  ///   $WithTransitionExampleConfig, // ignore: undefined_identifier
+  /// );
+  /// ```
+  Map<TransitionPhase, Map> childPropsByPhase;
+
+  /// The amount of time to wait for a CSS transition to complete before assuming something went wrong
+  /// and canceling the subscription.
+  ///
+  /// If the CSS transition duration on the node is longer than `1s`, you will need to set this to a Duration
+  /// that is greater than or equal to the expected CSS duration of the node.
+  ///
+  /// > Default `const Duration(seconds: 1)`
+  Duration transitionTimeout;
+}
+
+class WithTransitionProps = UiProps with v2.TransitionPropsMixin, WithTransitionPropsMixin;
+
+/// A wrapper component that hooks into CSS transition(s) present on a single child passed to it.
+///
+/// For example, say you have an element that "fades" in/out using the `fade` CSS class to apply
+/// a CSS `transition`, and an `in` CSS class that - when present - changes the opacity from `0` to `1`.
+///
+/// Using this component, you can simply toggle the value of [WithTransitionPropsMixin.isShown] from `false` to
+/// `true` using your own state to make the node "fade in", and hook into the available prop callbacks like
+/// `onDidShow`, `onDidHide` to know when the CSS transition has completed.
+///
+/// ```dart
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/components.dart' show WithTransition;
+///
+/// mixin WithTransitionExampleProps on UiProps {
+///   bool initiallyShown;
+/// }
+///
+/// UiFactory<WithTransitionExampleProps> WithTransitionExample = uiFunction(
+///   (_props) {
+///     final defaultProps = useMemo(() {
+///       return WithTransitionExample()..initiallyShown = false;
+///     }, const []);
+///     final props = defaultProps..addProps(_props);
+///
+///     final isShown = useState(props.initiallyShown);
+///
+///     final classes = ClassNameBuilder.fromProps(props)
+///       ..add('fade')
+///       ..add('in', isShown.value);
+///
+///     return Dom.div()(
+///       Dom.div()(
+///         (Dom.button()
+///           ..type = 'button'
+///           ..onClick = (useCallback((_) {
+///             isShown.setWithUpdater((isShown) => !isShown);
+///           }, const []))
+///         )('Toggle Visibility'),
+///       ),
+///       (WithTransition()
+///         ..isShown = isShown.value
+///         ..onWillShow = () {
+///           // Do something that should happen before the CSS transition completes.
+///         }
+///         ..onDidShow = () {
+///           // Do something that shouldn't happen until the CSS transition completes.
+///         }
+///         ..onWillHide = () {
+///           // Do something that should happen before the CSS transition completes.
+///         }
+///         ..onDidHide = () {
+///           // Do something that shouldn't happen until the CSS transition completes.
+///         }
+///       )(
+///         (Dom.div()
+///           ..className = classes.toClassName()
+///         )(
+///           // Some children...
+///         ),
+///       )
+///     );
+///   },
+///   $WithTransitionExampleConfig, // ignore: undefined_identifier
+/// );
+/// ```
+///
+/// __Wrapping around custom components__
+///
+/// If you want to wrap around another component instead of around a single `Dom` element child as shown in the
+/// first example above, you must ensure that the value of `props.ref` is forwarded to the `Element` that has
+/// the CSS transition using `uiForwardRef`:
+///
+/// ```dart
+/// import 'package:over_react/over_react.dart';
+///
+/// mixin CustomChildProps on UiProps {}
+///
+/// UiFactory<CustomChildProps> CustomChild = uiForwardRef(
+///   (props, ref) {
+///     return (Dom.div()..ref = ref)(
+///       props.children,
+///     ),
+///   },
+///   $CustomChildConfig, // ignore: undefined_identifier
+/// );
+/// ```
+UiFactory<WithTransitionProps> WithTransition = memo(uiFunction(
+  (_props) {
+    // ----- Default Props ----- //
+    final defaultProps = useMemo(() {
+      return WithTransition()
+      ..isShown = false
+      ..transitionTimeout = const Duration(seconds: 1)
+      ..childPropsByPhase = const {
+        v2.TransitionPhase.PRE_SHOWING: {},
+        v2.TransitionPhase.SHOWING: {},
+        v2.TransitionPhase.SHOWN: {},
+        v2.TransitionPhase.HIDING: {},
+        v2.TransitionPhase.HIDDEN: {},
+      }
+      ..addProps(v2.TransitionPropsMixin.defaultProps);
+    }, const []);
+    final props = defaultProps..addProps(_props);
+
+    assert(_hasSingleValidChild(props));
+
+    // ----- State / Hooks ----- //
+    final transitionNodeRef = useRef<Element>();
+    final transitionPhaseDerivedFromProps = props.isShown ? TransitionPhase.SHOWN : TransitionPhase.HIDDEN;
+    final transitionPhase = useState(transitionPhaseDerivedFromProps);
+
+    /// Begin showing the node unless the [currentPhase] is already shown or is in the process of showing.
+    void _handleShow(WithTransitionProps tProps, TransitionPhase currentPhase) {
+      if (_isOrWillBeShown(currentPhase)) return;
+
+      tProps.onWillShow?.call();
+      transitionPhase.set(_hasTransitionIn(tProps) ? TransitionPhase.PRE_SHOWING : TransitionPhase.SHOWN);
+    }
+
+    /// Begin hiding node unless the [currentPhase] is already hidden or is in the process of hiding.
+    void _handleHide(WithTransitionProps tProps, TransitionPhase currentPhase) {
+      if (_isOrWillBeHidden(currentPhase)) return;
+
+      tProps.onWillHide?.call();
+      transitionPhase.set(
+          _hasTransitionOut(tProps) ? TransitionPhase.HIDING : TransitionPhase.HIDDEN);
+    }
+
+    // getDerivedStateFromProps
+    if (props.isShown && _isOrWillBeHidden(transitionPhase.value)) {
+      _handleShow(props, transitionPhase.value);
+    } else if (!props.isShown && _isOrWillBeShown(transitionPhase.value)) {
+      _handleHide(props, transitionPhase.value);
+    }
+
+    // ----- transitionend event handling ----- //
+
+    /// Whether the overlay is not guaranteed to transition in response to the current
+    /// state change.
+    ///
+    /// _Stored as variable as workaround for not adding breaking change to [handleHiding] API._
+    ///
+    /// A transition may not always occur when the state moves from SHOWING to HIDING
+    /// if the PRE_SHOWING-->SHOWING-->HIDING transition happens back-to-back.
+    ///
+    /// Better to not always transition when the user is ninja-toggling a transitionable
+    /// component than to break state changes waiting for a transition that will never happen.
+    final _transitionNotGuaranteed = useRef(false);
+
+    /// Timer used to determine if a transition timeout has occurred.
+    final _transitionEndTimer = useRef<Timer>();
+
+    /// Stream for listening to `transitionend` events on the node.
+    final _endTransitionSubscription = useRef<StreamSubscription>();
+
+    void _cancelTransitionEventListener() {
+      _endTransitionSubscription.current?.cancel();
+      _endTransitionSubscription.current = null;
+    }
+
+    void _cancelTransitionEndTimer() {
+      _transitionEndTimer.current?.cancel();
+      _transitionEndTimer.current = null;
+    }
+
+    /// Listens for the next `transitionend` event and invokes a callback after
+    /// the event is dispatched.
+    void onNextTransitionEnd(Function() complete) {
+      var transitionCount = _isOrWillBeHidden(transitionPhase.value) ? _transitionOutCount(props) : _transitionInCount(props);
+
+      _cancelTransitionEventListener();
+      _cancelTransitionEndTimer();
+
+      _transitionEndTimer.current = Timer(props.transitionTimeout, () {
+        assert(ValidationUtil.warn(
+            'The number of transitions expected to complete have not completed. Something is most likely wrong.',
+        ));
+
+        _cancelTransitionEventListener();
+
+        complete();
+      });
+
+      _endTransitionSubscription.current =
+          transitionNodeRef.current?.onTransitionEnd?.skip(transitionCount - 1)?.take(1)?.listen((_) {
+        _cancelTransitionEndTimer();
+
+        complete();
+      });
+    }
+
+    // ----- Effects (Lifecycle) ----- //
+
+    final _isMounted = useRef(false);
+
+    // Mount + Unmount
+    useEffect(() {
+      // componentDidMount
+      _isMounted.current = true;
+
+      // componentWillUnmount
+      return () {
+        _isMounted.current = false;
+
+        _cancelTransitionEndTimer();
+        _cancelTransitionEventListener();
+      };
+    }, const []);
+
+    // componentDidUpdate
+    useLayoutEffect(() {
+      if (!_isMounted.current) return;
+      _transitionNotGuaranteed.current = false;
+
+      if (transitionPhase.value != TransitionPhase.SHOWING) {
+        // Allows the AbstractWithTransitionComponent to handle state changes that interrupt state
+        // changes waiting on transitionend events.
+        _cancelTransitionEventListener();
+      }
+
+      /// Called when `transitionPhase` is `TransitionPhase.PRE_SHOWING`.
+      void _handlePreShowing() {
+        onNextTransitionEnd(() {
+          if (_isOrWillBeShown(transitionPhase.value)) {
+            transitionPhase.set(TransitionPhase.SHOWN);
+          }
+        });
+
+        transitionPhase.set(TransitionPhase.SHOWING);
+      }
+
+      /// Called when `transitionPhase` is `TransitionPhase.HIDING`.
+      void _handleHiding() {
+        if (_transitionNotGuaranteed.current) {
+          // No transition will occur, so kick off the state change manually.
+          transitionPhase.set(TransitionPhase.HIDDEN);
+
+          _cancelTransitionEventListener();
+          _cancelTransitionEndTimer();
+        } else {
+          onNextTransitionEnd(() {
+            if (_isMounted.current && transitionPhase.value == TransitionPhase.HIDING) {
+              transitionPhase.set(TransitionPhase.HIDDEN);
+            }
+          });
+        }
+      }
+
+      switch (transitionPhase.value) {
+        case TransitionPhase.PRE_SHOWING:
+          _handlePreShowing();
+          break;
+        case TransitionPhase.SHOWING:
+          // NOTE: props.onWillShow is called within _handleShow in the handler that
+          // triggers an update to `transitionPhase` that will result in this effect being processed.
+          break;
+        case TransitionPhase.HIDING:
+          // NOTE: props.onWillHide is called within _handleHide in the handler that
+          // triggers an update to `transitionPhase` that will result in this effect being processed.
+          _transitionNotGuaranteed.current = transitionPhase.value == TransitionPhase.SHOWING;
+          _handleHiding();
+          break;
+        case TransitionPhase.HIDDEN:
+          props.onDidHide?.call();
+          break;
+        case TransitionPhase.SHOWN:
+          props.onDidShow?.call();
+          break;
+      }
+    }, [transitionPhase.value]);
+
+    // ----- Rendering ----- //
+
+    // NOTE: This cast is safe because we validate that it is a ReactElement via `_hasSingleValidChild`.
+    final childElement = props.children.single as ReactElement;
+    final childProps = domProps({...getProps(childElement)});
+    final phaseProps = props.childPropsByPhase[transitionPhase.value];
+    final phaseClasses = ClassNameBuilder.fromProps(childProps)
+      ..addFromProps(phaseProps);
+
+    return cloneElement(childElement, domProps()
+      ..addTestId(childProps.getTestId())
+      ..addTestId('ovr.WithTransition.node')
+      ..addProps(phaseProps)
+      ..className = phaseClasses.toClassName()
+      ..ref = chainRefs(childElement.ref, transitionNodeRef)
+    );
+  },
+  $WithTransitionConfig, // ignore: undefined_identifier
+));
+
+bool _hasSingleValidChild(WithTransitionProps props) {
+  if (props.children.length == 1 && isValidElement(props.children.single)) return true;
+
+  throw PropError.value(props.children, 'children',
+      'WithValidation only accepts a single child which must be a valid ReactElement.');
+}
+
+bool _isOrWillBeHidden(TransitionPhase currentPhase) =>
+    currentPhase == TransitionPhase.HIDING ||
+    currentPhase == TransitionPhase.HIDDEN;
+
+bool _isOrWillBeShown(TransitionPhase currentPhase) =>
+    currentPhase == TransitionPhase.PRE_SHOWING ||
+    currentPhase == TransitionPhase.SHOWING ||
+    currentPhase == TransitionPhase.SHOWN;
+
+/// Returns the value of [v2.TransitionPropsMixin.transitionCount], falling back to `null` for backwards compatibility.
+int _getTransitionCount(WithTransitionProps props) => props?.transitionCount ?? 1;
+
+/// Whether transitions are enabled based on the [props] provided.
+bool _hasTransition(WithTransitionProps props) => _getTransitionCount(props) > 0;
+
+/// Whether the [Element] rendered by the [WithTransition] component will emit a `transitionend` event when showing.
+bool _hasTransitionIn(WithTransitionProps props) => _hasTransition(props) && _transitionInCount(props) > 0;
+
+/// Whether the [Element] rendered by the [WithTransition] component will emit a `transitionend` event when hiding.
+bool _hasTransitionOut(WithTransitionProps props) => _hasTransition(props) && _transitionOutCount(props) > 0;
+
+/// The number of `transitionend` events that occur when the [Element]
+/// rendered by the [WithTransition] component is shown.
+///
+/// Defaults to `1` to match previous behavior in the case where `props.transitionCount` is `null`.
+int _transitionInCount(WithTransitionProps props) => props?.transitionInCount ?? _getTransitionCount(props);
+
+/// The number of `transitionend` events that occur when the transition node is hidden.
+///
+/// Defaults to `1` to match previous behavior in the case where `props.transitionCount` is `null`.
+int _transitionOutCount(WithTransitionProps props) => props?.transitionOutCount ?? _getTransitionCount(props);

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -7,6 +7,234 @@ part of 'with_transition.dart';
 // OverReactBuilder (package:over_react/src/builder.dart)
 // **************************************************************************
 
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $WithTransitionComponentFactory = registerComponent2(
+  () => _$WithTransitionComponent(),
+  builderFactory: _$WithTransition,
+  componentClass: WithTransitionComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'WithTransition',
+);
+
+_$$WithTransitionProps _$WithTransition([Map backingProps]) =>
+    backingProps == null
+        ? _$$WithTransitionProps$JsMap(JsBackedMap())
+        : _$$WithTransitionProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$WithTransitionProps extends UiProps
+    with
+        v2.TransitionPropsMixin,
+        v2.$TransitionPropsMixin, // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
+        WithTransitionPropsMixin,
+        $WithTransitionPropsMixin // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+    implements
+        WithTransitionProps {
+  _$$WithTransitionProps._();
+
+  factory _$$WithTransitionProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$WithTransitionProps$JsMap(backingMap);
+    } else {
+      return _$$WithTransitionProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $WithTransitionComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionProps$PlainMap extends _$$WithTransitionProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionProps$JsMap extends _$$WithTransitionProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete state implementation.
+//
+// Implements constructor and backing map.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$WithTransitionState extends UiState
+    with
+        WithTransitionState,
+        $WithTransitionState // If this generated mixin is undefined, it's likely because WithTransitionState is not a valid `mixin`-based state mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionState.
+{
+  _$$WithTransitionState._();
+
+  factory _$$WithTransitionState(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$WithTransitionState$JsMap(backingMap);
+    } else {
+      return _$$WithTransitionState$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiState` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+}
+
+// Concrete state implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionState$PlainMap extends _$$WithTransitionState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionState$PlainMap(Map backingMap)
+      : this._state = {},
+        super._() {
+    this._state = backingMap ?? {};
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  Map get state => _state;
+  Map _state;
+}
+
+// Concrete state implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionState$JsMap extends _$$WithTransitionState {
+  // This initializer of `_state` to an empty map, as well as the reassignment
+  // of `_state` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionState$JsMap(JsBackedMap backingMap)
+      : this._state = JsBackedMap(),
+        super._() {
+    this._state = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing state map proxied by this class.
+  @override
+  JsBackedMap get state => _state;
+  JsBackedMap _state;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$WithTransitionComponent extends WithTransitionComponent {
+  _$$WithTransitionProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$WithTransitionProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$WithTransitionProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$WithTransitionProps$JsMap(backingMap);
+
+  @override
+  _$$WithTransitionProps typedPropsFactory(Map backingMap) =>
+      _$$WithTransitionProps(backingMap);
+
+  _$$WithTransitionState$JsMap _cachedTypedState;
+  @override
+  _$$WithTransitionState$JsMap get state => _cachedTypedState;
+
+  @override
+  set state(Map value) {
+    assert(
+        value is JsBackedMap,
+        'Component2.state should only be set via '
+        'initialState or setState.');
+    super.state = value;
+    _cachedTypedState = typedStateFactoryJs(value);
+  }
+
+  @override
+  _$$WithTransitionState$JsMap typedStateFactoryJs(JsBackedMap backingMap) =>
+      _$$WithTransitionState$JsMap(backingMap);
+
+  @override
+  _$$WithTransitionState typedStateFactory(Map backingMap) =>
+      _$$WithTransitionState(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by WithTransitionProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
+        v2.TransitionPropsMixin: v2.$TransitionPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
+      });
+}
+
 @Deprecated('This API is for use only within generated code.'
     ' Do not reference it in your code, as it may change at any time.'
     ' EXCEPTION: this may be used in legacy boilerplate until'
@@ -69,79 +297,38 @@ const PropsMeta _$metaForWithTransitionPropsMixin = PropsMeta(
   keys: $WithTransitionPropsMixin.$propKeys,
 );
 
-final UiFactoryConfig<_$$WithTransitionProps> $WithTransitionConfig =
-    UiFactoryConfig(
-        propsFactory: PropsFactory(
-          map: (map) => _$$WithTransitionProps(map),
-          jsMap: (map) => _$$WithTransitionProps$JsMap(map),
-        ),
-        displayName: 'WithTransition');
-
-// Concrete props implementation.
-//
-// Implements constructor and backing map, and links up to generated component factory.
 @Deprecated('This API is for use only within generated code.'
-    ' Do not reference it in your code, as it may change at any time.')
-abstract class _$$WithTransitionProps extends UiProps
-    with
-        v2.TransitionPropsMixin,
-        v2.$TransitionPropsMixin, // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
-        WithTransitionPropsMixin,
-        $WithTransitionPropsMixin // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
-    implements
-        WithTransitionProps {
-  _$$WithTransitionProps._();
-
-  factory _$$WithTransitionProps(Map backingMap) {
-    if (backingMap == null || backingMap is JsBackedMap) {
-      return _$$WithTransitionProps$JsMap(backingMap);
-    } else {
-      return _$$WithTransitionProps$PlainMap(backingMap);
-    }
-  }
-
-  /// Let `UiProps` internals know that this class has been generated.
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $WithTransitionState on WithTransitionState {
+  static const StateMeta meta = _$metaForWithTransitionState;
   @override
-  bool get $isClassGenerated => true;
-
-  /// The default namespace for the prop getters/setters generated for this class.
+  @protected
+  TransitionPhase get $transitionPhase =>
+      state[_$key__$transitionPhase__WithTransitionState] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
-  String get propKeyNamespace => '';
+  @protected
+  set $transitionPhase(TransitionPhase value) =>
+      state[_$key__$transitionPhase__WithTransitionState] = value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor _$prop__$transitionPhase__WithTransitionState =
+      StateDescriptor(_$key__$transitionPhase__WithTransitionState);
+  static const String _$key__$transitionPhase__WithTransitionState =
+      'WithTransitionState.\$transitionPhase';
+
+  static const List<StateDescriptor> $state = [
+    _$prop__$transitionPhase__WithTransitionState
+  ];
+  static const List<String> $stateKeys = [
+    _$key__$transitionPhase__WithTransitionState
+  ];
 }
 
-// Concrete props implementation that can be backed by any [Map].
 @Deprecated('This API is for use only within generated code.'
     ' Do not reference it in your code, as it may change at any time.')
-class _$$WithTransitionProps$PlainMap extends _$$WithTransitionProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$WithTransitionProps$PlainMap(Map backingMap)
-      : this._props = {},
-        super._() {
-    this._props = backingMap ?? {};
-  }
-
-  /// The backing props map proxied by this class.
-  @override
-  Map get props => _props;
-  Map _props;
-}
-
-// Concrete props implementation that can only be backed by [JsMap],
-// allowing dart2js to compile more optimal code for key-value pair reads/writes.
-@Deprecated('This API is for use only within generated code.'
-    ' Do not reference it in your code, as it may change at any time.')
-class _$$WithTransitionProps$JsMap extends _$$WithTransitionProps {
-  // This initializer of `_props` to an empty map, as well as the reassignment
-  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
-  _$$WithTransitionProps$JsMap(JsBackedMap backingMap)
-      : this._props = JsBackedMap(),
-        super._() {
-    this._props = backingMap ?? JsBackedMap();
-  }
-
-  /// The backing props map proxied by this class.
-  @override
-  JsBackedMap get props => _props;
-  JsBackedMap _props;
-}
+const StateMeta _$metaForWithTransitionState = StateMeta(
+  fields: $WithTransitionState.$state,
+  keys: $WithTransitionState.$stateKeys,
+);

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -1,0 +1,147 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'with_transition.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $WithTransitionPropsMixin on WithTransitionPropsMixin {
+  static const PropsMeta meta = _$metaForWithTransitionPropsMixin;
+  @override
+  bool get isShown =>
+      props[_$key__isShown__WithTransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set isShown(bool value) =>
+      props[_$key__isShown__WithTransitionPropsMixin] = value;
+  @override
+  Map<TransitionPhase, Map> get childPropsByPhase =>
+      props[_$key__childPropsByPhase__WithTransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set childPropsByPhase(Map<TransitionPhase, Map> value) =>
+      props[_$key__childPropsByPhase__WithTransitionPropsMixin] = value;
+  @override
+  Duration get transitionTimeout =>
+      props[_$key__transitionTimeout__WithTransitionPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set transitionTimeout(Duration value) =>
+      props[_$key__transitionTimeout__WithTransitionPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__isShown__WithTransitionPropsMixin =
+      PropDescriptor(_$key__isShown__WithTransitionPropsMixin);
+  static const PropDescriptor
+      _$prop__childPropsByPhase__WithTransitionPropsMixin =
+      PropDescriptor(_$key__childPropsByPhase__WithTransitionPropsMixin);
+  static const PropDescriptor
+      _$prop__transitionTimeout__WithTransitionPropsMixin =
+      PropDescriptor(_$key__transitionTimeout__WithTransitionPropsMixin);
+  static const String _$key__isShown__WithTransitionPropsMixin =
+      'WithTransitionPropsMixin.isShown';
+  static const String _$key__childPropsByPhase__WithTransitionPropsMixin =
+      'WithTransitionPropsMixin.childPropsByPhase';
+  static const String _$key__transitionTimeout__WithTransitionPropsMixin =
+      'WithTransitionPropsMixin.transitionTimeout';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__isShown__WithTransitionPropsMixin,
+    _$prop__childPropsByPhase__WithTransitionPropsMixin,
+    _$prop__transitionTimeout__WithTransitionPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__isShown__WithTransitionPropsMixin,
+    _$key__childPropsByPhase__WithTransitionPropsMixin,
+    _$key__transitionTimeout__WithTransitionPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForWithTransitionPropsMixin = PropsMeta(
+  fields: $WithTransitionPropsMixin.$props,
+  keys: $WithTransitionPropsMixin.$propKeys,
+);
+
+final UiFactoryConfig<_$$WithTransitionProps> $WithTransitionConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$WithTransitionProps(map),
+          jsMap: (map) => _$$WithTransitionProps$JsMap(map),
+        ),
+        displayName: 'WithTransition');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$WithTransitionProps extends UiProps
+    with
+        v2.TransitionPropsMixin,
+        v2.$TransitionPropsMixin, // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
+        WithTransitionPropsMixin,
+        $WithTransitionPropsMixin // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+    implements
+        WithTransitionProps {
+  _$$WithTransitionProps._();
+
+  factory _$$WithTransitionProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$WithTransitionProps$JsMap(backingMap);
+    } else {
+      return _$$WithTransitionProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionProps$PlainMap extends _$$WithTransitionProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionProps$JsMap extends _$$WithTransitionProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}

--- a/test/over_react/component/with_transition_test.dart
+++ b/test/over_react/component/with_transition_test.dart
@@ -31,7 +31,7 @@ part 'with_transition_test.over_react.g.dart';
 main() {
   group('WithTransition', () {
     TestJacket<WithTransitionTesterComponent> jacket;
-    Element getRootNode() => queryByTestId(jacket.mountNode, 'ovr.WithTransition.node');
+    Element getRootNode() => queryByTestId(jacket.mountNode, 'or.WithTransition.node');
     void expectNodeInTransitionPhase(TransitionPhase phase, {String reason}) {
       expect(
         getRootNode(),

--- a/test/over_react/component/with_transition_test.dart
+++ b/test/over_react/component/with_transition_test.dart
@@ -1,0 +1,522 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+@TestOn('browser')
+library with_transition_test;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:meta/meta.dart';
+import 'package:over_react/over_react.dart' hide TransitionPropsMixin, $TransitionPropsMixin, AbstractTransitionProps, AbstractTransitionState, AbstractTransitionComponent;
+import 'package:over_react/components.dart';
+import 'package:over_react_test/over_react_test.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/test_util.dart';
+
+part 'with_transition_test.over_react.g.dart';
+
+/// Main entry point for AbstractTransition testing
+main() {
+  group('WithTransition', () {
+    TestJacket<WithTransitionTesterComponent> jacket;
+    Element getRootNode() => queryByTestId(jacket.mountNode, 'ovr.WithTransition.node');
+    void expectNodeInTransitionPhase(TransitionPhase phase, {String reason}) {
+      expect(
+        getRootNode(),
+        hasAttr(WithTransitionTesterComponent.attrName, WithTransitionTesterComponent.testAttrByPhase[phase]),
+        reason: reason,
+      );
+    }
+
+    tearDown(() {
+      jacket = null;
+    });
+
+    group('renders correct initially when props.isShown is', () {
+      test('true', () {
+        jacket = mount((WithTransitionTester()..isShown = true)());
+        expectNodeInTransitionPhase(TransitionPhase.SHOWN);
+      });
+
+      test('false', () {
+        jacket = mount((WithTransitionTester()..isShown = false)());
+        expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+      });
+    });
+
+    group('props.isShown', () {
+      group('hides the component when changed from true to false', () {
+        test('when the component transitions', () async {
+          jacket = mount((WithTransitionTester()..isShown = true)());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()..isShown = false)());
+          expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+          await Future.delayed(Duration.zero);
+          expectNodeInTransitionPhase(TransitionPhase.HIDING,
+              reason: 'should still be waiting for a transition event');
+
+          await triggerTransitionEnd(getRootNode());
+
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+        });
+
+        test('when the component does not transition', () {
+          jacket = mount((WithTransitionTester()
+            ..transitionCount = 0
+            ..isShown = true
+          )());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()
+            ..transitionCount = 0
+            ..isShown = false
+          )());
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+        });
+      });
+
+      group('shows the component when changed from false to true', () {
+        test('when the component transitions', () async {
+          jacket = mount((WithTransitionTester()..isShown = false)());
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()..isShown = true)());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWING);
+
+          await Future.delayed(Duration.zero);
+          expectNodeInTransitionPhase(TransitionPhase.SHOWING,
+              reason: 'should still be waiting for a transition event');
+
+          await triggerTransitionEnd(getRootNode());
+
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN);
+        });
+
+        test('when the component does not transition', () {
+          jacket = mount((WithTransitionTester()
+            ..transitionCount = 0
+            ..isShown = false
+          )());
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()
+            ..transitionCount = 0
+            ..isShown = true
+          )());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN);
+        });
+      });
+
+      group('toggles the visibility of the component when it has not yet finished', () {
+        test('hiding', () async {
+          jacket = mount((WithTransitionTester()..isShown = true)());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()..isShown = false)());
+          expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+          jacket.rerender((WithTransitionTester()..isShown = true)());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWING);
+
+          await Future.delayed(Duration.zero);
+          expectNodeInTransitionPhase(TransitionPhase.SHOWING,
+              reason: 'should still be waiting for a transition event');
+
+          await triggerTransitionEnd(getRootNode());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN);
+        });
+
+        test('showing', () async {
+          jacket = mount((WithTransitionTester()..isShown = false)());
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN, reason: 'test setup sanity check');
+
+          jacket.rerender((WithTransitionTester()..isShown = true)());
+          expectNodeInTransitionPhase(TransitionPhase.SHOWING);
+
+          jacket.rerender((WithTransitionTester()..isShown = false)());
+          expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+          await Future.delayed(Duration.zero);
+          expectNodeInTransitionPhase(TransitionPhase.HIDING,
+              reason: 'should still be waiting for a transition event');
+
+          await triggerTransitionEnd(getRootNode());
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+        });
+      });
+
+      group('toggles the visibility of the component properly, waiting for correct number of `onTransitionEnd` when the number of transitions', () {
+        Future<Null> sharedTests(ReactElement renderedElement, {
+          @required int expectedTransitionInCount,
+          @required int expectedTransitionOutCount,
+        }) async {
+          if (expectedTransitionInCount < 0) throw ArgumentError.value(expectedTransitionInCount, 'expectedTransitionInCount', 'must be greater than 0');
+          if (expectedTransitionOutCount < 0) throw ArgumentError.value(expectedTransitionOutCount, 'expectedTransitionOutCount', 'must be greater than 0');
+
+          jacket = mount(renderedElement);
+
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN, reason: 'test setup sanity check');
+
+          jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = true));
+
+          if (expectedTransitionInCount != 0) {
+            expectNodeInTransitionPhase(TransitionPhase.SHOWING);
+
+            for (var i = 0; i < expectedTransitionInCount; i++) {
+              await Future.delayed(Duration.zero);
+              expectNodeInTransitionPhase(TransitionPhase.SHOWING,
+                  reason: 'should still be waiting for a transition event');
+
+              await triggerTransitionEnd(getRootNode());
+            }
+          }
+
+          expectNodeInTransitionPhase(TransitionPhase.SHOWN);
+
+          jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = false));
+
+          if (expectedTransitionOutCount != 0) {
+            expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+            for (var i = 0; i < expectedTransitionOutCount; i++) {
+              await Future.delayed(Duration.zero);
+              expectNodeInTransitionPhase(TransitionPhase.HIDING,
+                  reason: 'should still be waiting for a transition event');
+
+              await triggerTransitionEnd(getRootNode());
+            }
+          }
+
+          expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+        }
+
+        group('is specified via props.transitionCount and is', () {
+          test('less than 0 (should behave like 0)', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = -2)(),
+              expectedTransitionInCount: 0,
+              expectedTransitionOutCount: 0,
+            );
+          });
+
+          test('null (should behave like the default, 1, for backwards compatibility)', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = null)(),
+              expectedTransitionInCount: 1,
+              expectedTransitionOutCount: 1,
+            );
+          });
+
+          test('0', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = 0)(),
+              expectedTransitionInCount: 0,
+              expectedTransitionOutCount: 0,
+            );
+          });
+
+          test('1', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = 1)(),
+              expectedTransitionInCount: 1,
+              expectedTransitionOutCount: 1,
+            );
+          });
+
+          test('2', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = 2)(),
+              expectedTransitionInCount: 2,
+              expectedTransitionOutCount: 2,
+            );
+          });
+        });
+
+        group('is specified via props.transitionCount and', () {
+          test('props.transitionInCount', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = 3
+              ..transitionInCount = 2)(),
+              expectedTransitionInCount: 2,
+              expectedTransitionOutCount: 3,
+            );
+          });
+
+          test('props.transitionOutCount', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionCount = 2
+              ..transitionOutCount = 3)(),
+              expectedTransitionInCount: 2,
+              expectedTransitionOutCount: 3,
+            );
+          });
+        });
+
+        test('is specified via props.transitionInCount props.transitionOutCount:', () async {
+          await sharedTests((WithTransitionTester()
+            ..isShown = false
+            ..transitionInCount = 2
+            ..transitionOutCount = 3)(),
+            expectedTransitionInCount: 2,
+            expectedTransitionOutCount: 3,
+          );
+        });
+
+        group('is zero for only one of showing/hiding:', () {
+          test('zero for showing', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionInCount = 0
+              ..transitionOutCount = 3)(),
+              expectedTransitionInCount: 0,
+              expectedTransitionOutCount: 3,
+            );
+          });
+
+          test('zero for hiding', () async {
+            await sharedTests((WithTransitionTester()
+              ..isShown = false
+              ..transitionInCount = 2
+              ..transitionOutCount = 0)(),
+              expectedTransitionInCount: 2,
+              expectedTransitionOutCount: 0,
+            );
+          });
+        });
+      });
+    });
+
+    group('calls the appropriate callback(s) when it is', () {
+      List calls;
+      ReactElement elementWithCallbacks;
+
+      setUp(() {
+        calls = [];
+        elementWithCallbacks = (WithTransitionTester()
+          ..onWillHide = (() => calls.add('onWillHide'))
+          ..onDidHide = (() => calls.add('onDidHide'))
+          ..onWillShow = (() => calls.add('onWillShow'))
+          ..onDidShow = (() => calls.add('onDidShow'))
+        )();
+      });
+
+      tearDown(() {
+        elementWithCallbacks = null;
+      });
+
+      test('hiding', () async {
+        jacket = mount(cloneElement(elementWithCallbacks, WithTransitionTester()..isShown = true));
+        expect(calls, isEmpty, reason: 'test setup sanity check');
+
+        jacket.rerender(cloneElement(elementWithCallbacks, WithTransitionTester()..isShown = false));
+        await triggerTransitionEnd(getRootNode());
+
+        expect(calls, orderedEquals(['onWillHide', 'onDidHide']));
+      });
+
+      test('showing', () async {
+        jacket = mount(cloneElement(elementWithCallbacks, WithTransitionTester()..isShown = false));
+        expect(calls, isEmpty, reason: 'test setup sanity check');
+
+        jacket.rerender(cloneElement(elementWithCallbacks, WithTransitionTester()..isShown = true));
+        await triggerTransitionEnd(getRootNode());
+
+        expect(calls, orderedEquals(['onWillShow', 'onDidShow']));
+      });
+    });
+
+    group('transition timeout', () {
+      bool warningsWereEnabled;
+
+      setUp(() {
+        warningsWereEnabled = ValidationUtil.WARNINGS_ENABLED;
+        ValidationUtil.WARNINGS_ENABLED = false;
+        startRecordingValidationWarnings();
+      });
+
+      tearDown(() {
+        ValidationUtil.WARNINGS_ENABLED = warningsWereEnabled;
+        stopRecordingValidationWarnings();
+      });
+
+      test('occurs after the duration specified in props.timeoutDuration has elapsed', () async {
+        final renderedElement = (WithTransitionTester()
+          ..isShown = true
+          ..transitionCount = 1
+          ..transitionTimeout = const Duration(seconds: 0)
+        )();
+        jacket = mount(renderedElement);
+        expectNodeInTransitionPhase(TransitionPhase.SHOWN, reason: 'test setup sanity check');
+
+        jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = false));
+
+        expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+        await Future.delayed(Duration.zero);
+
+        expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+
+        verifyValidationWarning(
+          'The number of transitions expected to complete have not completed. Something is most likely wrong.'
+        );
+      });
+
+      test('does not occur when shown and hidden rapidly', () async {
+        final renderedElement = (WithTransitionTester()..isShown = false)();
+        jacket = mount(renderedElement);
+        jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = true));
+
+        expectNodeInTransitionPhase(TransitionPhase.SHOWING);
+
+        jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = false));
+
+        expectNodeInTransitionPhase(TransitionPhase.HIDING);
+
+        await triggerTransitionEnd(getRootNode());
+
+        expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+
+        rejectValidationWarning(anything);
+      });
+    }, tags: 'ddc');
+
+    group('props.childPropsByPhase', () {
+      test('properly merges CSS classes with child CSS classes', () {
+        jacket = mount((WithTransitionTester()
+          ..isShown = true
+          ..childPropsByPhase = {
+            TransitionPhase.SHOWN: (domProps()..className = 'shown'),
+          }
+        )());
+        expect(getRootNode(), hasExactClasses([
+          'shown',
+          WithTransitionTesterComponent.childClassName,
+        ]));
+      });
+
+      test('can be a map with keys for only certain transition phases', () async {
+        final renderedElement = (WithTransitionTester()
+          ..isShown = true
+          ..childPropsByPhase = {
+            TransitionPhase.HIDDEN: WithTransitionTesterComponent.childPropsByPhase[TransitionPhase.HIDDEN],
+          }
+        )();
+        jacket = mount(renderedElement);
+        expect(getRootNode(),
+          isNot(hasAttr(WithTransitionTesterComponent.attrName, WithTransitionTesterComponent.testAttrByPhase[TransitionPhase.SHOWN])),
+          reason: 'Test setup sanity check: the "shown" phase should not have a key set within props.childPropsByPhase',
+        );
+
+        expect(() => jacket.rerender(cloneElement(renderedElement, WithTransitionTester()..isShown = false)),
+            returnsNormally);
+
+        await triggerTransitionEnd(getRootNode());
+        expectNodeInTransitionPhase(TransitionPhase.HIDDEN);
+      });
+    });
+
+    test('preserves consumer refs on the child', () async {
+      jacket = mount(WithTransitionTester()());
+      await Future.microtask(() {});
+      expect(jacket.getDartInstance().consumerChildNodeRef.current, isA<Element>());
+    });
+
+    group('throws', () {
+      group('when invalid children are provided:', () {
+        test('no child', () {
+          expect(() => mount(WithTransition()()), throwsPropError_Value([], 'children'));
+        });
+
+        test('more than one child', () {
+          final child1 = Dom.div()('one');
+          final child2 = Dom.div()('two');
+          expect(() => mount(WithTransition()(
+            child1,
+            child2,
+          )), throwsPropError_Value([child1, child2], 'children'));
+        });
+
+        test('a single child that is not a ReactElement', () {
+          const child = 'one';
+          expect(() => mount(WithTransition()(child)), throwsPropError_Value([child], 'children'));
+        });
+      });
+    }, tags: 'ddc');
+  });
+}
+
+UiFactory<WithTransitionTesterProps> WithTransitionTester = _$WithTransitionTester;
+
+class WithTransitionTesterProps = UiProps
+    with
+        WithTransitionPropsMixin,
+        TransitionPropsMixin
+    implements WithTransitionProps;
+
+class WithTransitionTesterComponent extends UiComponent2<WithTransitionTesterProps> {
+  final consumerChildNodeRef = createRef<Element>();
+
+  @override
+  get defaultProps => (newProps()
+    ..addProps(TransitionPropsMixin.defaultProps)
+    ..isShown = true
+    ..transitionTimeout = const Duration(seconds: 1)
+  );
+
+  @override
+  get consumedProps => const [];
+
+  @override
+  render() {
+    return (WithTransition()
+      ..childPropsByPhase = childPropsByPhase
+      ..modifyProps(addUnconsumedProps)
+    )(
+      (Dom.div()
+        ..className = childClassName
+        ..ref = consumerChildNodeRef
+      )(props.children),
+    );
+  }
+
+  static const childClassName = 'with-transition-tester-child';
+
+  static const testAttrByPhase = {
+    TransitionPhase.SHOWN: 'shown',
+    TransitionPhase.HIDDEN: 'hidden',
+    TransitionPhase.HIDING: 'hiding',
+    TransitionPhase.PRE_SHOWING: 'pre-showing',
+    TransitionPhase.SHOWING: 'showing',
+  };
+
+  static const attrName = AbstractTransitionComponent.transitionPhaseTestAttr;
+
+  static final childPropsByPhase = {
+    TransitionPhase.SHOWN: {attrName: testAttrByPhase[TransitionPhase.SHOWN]},
+    TransitionPhase.HIDDEN: {attrName: testAttrByPhase[TransitionPhase.HIDDEN]},
+    TransitionPhase.HIDING: {attrName: testAttrByPhase[TransitionPhase.HIDING]},
+    TransitionPhase.PRE_SHOWING: {attrName: testAttrByPhase[TransitionPhase.PRE_SHOWING]},
+    TransitionPhase.SHOWING: {attrName: testAttrByPhase[TransitionPhase.SHOWING]},
+  };
+}

--- a/test/over_react/component/with_transition_test.dart
+++ b/test/over_react/component/with_transition_test.dart
@@ -27,7 +27,7 @@ import '../../test_util/test_util.dart';
 
 part 'with_transition_test.over_react.g.dart';
 
-/// Main entry point for AbstractTransition testing
+/// Main entry point for WithTransition testing
 main() {
   group('WithTransition', () {
     TestJacket<WithTransitionTesterComponent> jacket;

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'with_transition_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $WithTransitionTesterComponentFactory = registerComponent2(
+  () => _$WithTransitionTesterComponent(),
+  builderFactory: _$WithTransitionTester,
+  componentClass: WithTransitionTesterComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'WithTransitionTester',
+);
+
+_$$WithTransitionTesterProps _$WithTransitionTester([Map backingProps]) =>
+    backingProps == null
+        ? _$$WithTransitionTesterProps$JsMap(JsBackedMap())
+        : _$$WithTransitionTesterProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$WithTransitionTesterProps extends UiProps
+    with
+        WithTransitionPropsMixin,
+        $WithTransitionPropsMixin, // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        TransitionPropsMixin,
+        $TransitionPropsMixin // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TransitionPropsMixin.
+    implements
+        WithTransitionTesterProps {
+  _$$WithTransitionTesterProps._();
+
+  factory _$$WithTransitionTesterProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$WithTransitionTesterProps$JsMap(backingMap);
+    } else {
+      return _$$WithTransitionTesterProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $WithTransitionTesterComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionTesterProps$PlainMap
+    extends _$$WithTransitionTesterProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionTesterProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$WithTransitionTesterProps$JsMap extends _$$WithTransitionTesterProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$WithTransitionTesterProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$WithTransitionTesterComponent extends WithTransitionTesterComponent {
+  _$$WithTransitionTesterProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$WithTransitionTesterProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$WithTransitionTesterProps$JsMap typedPropsFactoryJs(
+          JsBackedMap backingMap) =>
+      _$$WithTransitionTesterProps$JsMap(backingMap);
+
+  @override
+  _$$WithTransitionTesterProps typedPropsFactory(Map backingMap) =>
+      _$$WithTransitionTesterProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by WithTransitionTesterProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TransitionPropsMixin.
+        TransitionPropsMixin: $TransitionPropsMixin.meta,
+      });
+}

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -26,6 +26,8 @@ import 'over_react/component/_deprecated/abstract_transition_test.dart'
     as deprecated_abstract_transition_test;
 import 'over_react/component/abstract_transition_test.dart'
     as abstract_transition_test;
+import 'over_react/component/with_transition_test.dart'
+    as with_transition_test;
 import 'over_react/component/dom_components_test.dart' as dom_components_test;
 import 'over_react/component/error_boundary_test.dart' as error_boundary_test;
 import 'over_react/component/_deprecated/error_boundary_mixin_test.dart'
@@ -54,6 +56,7 @@ void main() {
   pure_component_mixin_test.main();
   deprecated_abstract_transition_test.main();
   abstract_transition_test.main();
+  with_transition_test.main();
   error_boundary_test.main();
   deprecated_error_boundary_mixin_test.main();
   deprecated_error_boundary_test.main();


### PR DESCRIPTION
## Motivation
Currently, `AbstractTransitionComponent`s can only be programmatically shown/hidden using the `show` / `hide` / `toggle` API methods on the instance.

With React 16 componentry - this is not ideal since calling the methods from a parent component requires the use of a `ref`, and the child component is no longer guaranteed to have been mounted when the parent component is. This makes it very difficult to hide/show things within data-driven applications without having to work around runtime race conditions.

## Changes
1. Add the `WithTransition` wrapper component. 
    This component is designed to have identical behavior to `AbstractTransitionComponent`, but allows the consumer to control the behavior using the value of `props.isShown`.
2. Add tests.

#### Release Notes
Add `WithTransition` wrapper component to enable "controlled" transitions using props

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
