### PR TITLE
RM-81159 RM-81158 Release over_react 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # OverReact Changelog
 
+## [3.8.1](https://github.com/Workiva/over_react/compare/3.8.0...3.8.1)
+
+__Bug Fixes__
+  - [#623] Include deprecation annotations on legacy props mixins
+
+__Other Changes__
+  - [#487] Readme Improvements
+  - [#619] Redux example app: Replace deprecated ExpansionPanel with new Accordion from MaterialUi
+
 ## [3.8.0](https://github.com/Workiva/over_react/compare/3.7.0...3.8.0)
 
 __New Features__

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.8.0
+version: 3.8.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.8.0
+  over_react: 3.8.1
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
The latest release of over_react includes:

__Bug Fixes__
  - #623 Include deprecation annotations on legacy props mixins

__Other Changes__
  - #487 Readme Improvements
  - #619 Redux example app: Replace deprecated ExpansionPanel with new Accordion from MaterialUi