### PR TITLE
RM-83168 Release over_react 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## [3.9.0](https://github.com/Workiva/over_react/compare/3.8.1...3.9.0)
+
+- [#620] Consume/update typing for forwardRef2/memo2 functions
+- [#625] Address analyzer lints / hints
+
 ## [3.8.1](https://github.com/Workiva/over_react/compare/3.8.0...3.8.1)
 
 __Bug Fixes__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [3.9.0](https://github.com/Workiva/over_react/compare/3.8.1...3.9.0)
 
-- [#620] Consume/update typing for forwardRef2/memo2 functions
+- [#620] Fix issue where `uiForwardRef`/`memo` components were being passed JSified props (by consuming [react-dart's `forwardRef2`/`memo2`](https://github.com/cleandart/react-dart/pull/275))
+- [#618] Add `makeMapStateToProps`/etc. arguments to `connect` to enable creation of closures specific to component instances
 - [#625] Address analyzer lints / hints
 
 ## [3.8.1](https://github.com/Workiva/over_react/compare/3.8.0...3.8.1)
@@ -2301,5 +2302,4 @@ Initial public release of the library.
 [#997]: https://github.com/Workiva/over_react/pull/997
 [#998]: https://github.com/Workiva/over_react/pull/998
 [#999]: https://github.com/Workiva/over_react/pull/999
-
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.8.1
+version: 3.9.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.8.1
+  over_react: 3.9.0
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
The latest release of over_react includes:

- #620 Consume/update typing for forwardRef2/memo2 functions
- #625 Address analyzer lints / hints