### PR TITLE
RM-85340 RM-85339 Release over_react 3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## [3.10.1](https://github.com/Workiva/over_react/compare/3.10.0...3.10.1)
+
+- [#500] Improve error messages for boilerplate-related issues
+    - This notably includes major improvements to build/analyzer errors for function components
+
 ## [3.10.0](https://github.com/Workiva/over_react/compare/3.9.0...3.10.0)
 - [#621] Add WithTransition wrapper component to enable "controlled" transitions using props
 * [#628] Fix Redux dev tools middleware console logging when `hierarchicalLoggingEnabled` is false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.10.0
+version: 3.10.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.10.0
+  over_react: 3.10.1
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Boilerplate error improvements](https://github.com/Workiva/over_react/pull/500)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/3.10.0...Workiva:release_over_react_3.10.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/3.10.0...3.10.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)