### PR TITLE
CPLAT-12194 Enable functional components to use consumed props

### DIFF
--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -770,7 +770,7 @@ UiFactory<FooProps> Foo = uiFunction(
 Because functional components have no instance that track consumed props, the syntax for passing unconsumed 
 props changes within functional components.
 
-`UiProps` exposes a field `staticMeta` that can be used to generate an iterable containing props meta of specific mixins. 
+`UiProps` exposes a field `staticMeta` that can be used to generate an iterable containing props meta for specific mixins. 
 This is similar to accessing `propsMeta` within a class based component. Using the iterable returned from `staticMeta`'s 
 APIs (such as `forMixins`), we can generate unconsumed props and pass them to a child component.
 

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -13,9 +13,9 @@ _Preview of new boilerplate:_
         * [Use Mixin-Based Props Declaration that Disallows Subclassing](#use-mixin-based-props-declaration-that-disallows-subclassing)
         * [Consume props from all props mixins by default](#consume-props-from-all-props-mixins-by-default)
     * [Examples](#examples)
-* __[Function Component Boilerplate *(coming soon)*](#function-component-boilerplate-coming-soon)__
+* __[Function Component Boilerplate](#function-component-boilerplate)__
     * [Constraints](#function-component-constraints)
-    * [Design](#design)
+    * [Syntax](#syntax)
 * __[Upgrading Existing Code](#upgrading-existing-code)__
 
 ## Background
@@ -720,7 +720,7 @@ props, and boilerplate shouldn't change shape drastically when doing so.
 don't allow generic type inference of the `props` arg in the function 
 closure.
 
-### Design
+### Syntax
 
 ```dart
 import 'package:over_react/over_react.dart';
@@ -765,6 +765,44 @@ UiFactory<FooProps> Foo = uiFunction(
 ); 
 ```
 
+#### With Consumed Props
+
+Because functional components have no instance that track consumed props, the syntax for passing unconsumed 
+props changes within functional components.
+
+`UiProps` exposes a field `staticMeta` that can be used to generate an iterable containing props meta of specific mixins. 
+This is similar to accessing `propsMeta` within a class based component. Using the iterable returned from `staticMeta`'s 
+APIs (such as `forMixins`), we can generate unconsumed props and pass them to a child component.
+
+This is done like so:
+```dart
+mixin FooPropsMixin on UiProps {
+  String passedProp;
+}
+
+mixin BarPropsMixin on UiProps {
+  String nonPassedProp;
+}
+
+class FooBarProps = UiProps with BarPropsMixin, FooPropsMixin;
+
+UiFactory<FooBarProps> FooBar = uiFunction(
+  (props) {
+    final consumedProps = props.staticMeta.forMixins({BarPropsMixin});
+
+    return (Foo()..addUnconsumedProps(props, consumedProps))();
+  },
+  $FooBarConfig, // ignore: undefined_identifier
+); 
+
+UiFactory<FooPropsMixin> Foo = uiFunction(
+  (props) {
+    return 'foo: ${props.passedProp}'; 
+  },
+  $FooConfig, // ignore: undefined_identifier
+); 
+```
+
 #### With UiProps
 
 ```dart
@@ -778,7 +816,7 @@ UiFactory<UiProps> Foo = uiFunction(
 );
 ```
 
-#### With propTypes
+#### With propTypes (Coming soon!)
 
 ```dart
 UiFactory<FooProps> Foo = uiFunction(
@@ -799,7 +837,7 @@ UiFactory<FooProps> Foo = uiFunction(
 `getPropTypes` provides a way to set up prop validation within the 
 same variable initializer.
 
-#### Local function components using just a props mixin (no top-level Factory necessary)
+#### Local function components using just a props mixin - no top-level Factory necessary (Coming soon!)
 
 ```dart
 import 'package:over_react/over_react.dart';

--- a/doc/props_mixin_component_composition.md
+++ b/doc/props_mixin_component_composition.md
@@ -117,7 +117,7 @@ main() {
 
 Produces the following HTML:
 ```html
-<div class="bar foo__bar foo__bar--abc">
+<div class="foo foo__bar foo__bar--abc">
   Qux: 234
   <div class="foo__bar__bizzles">
     Bizzles: 
@@ -196,7 +196,7 @@ main() {
 
 Produces the following HTML:
 ```html
-<div class="bar foo__baz foo__baz--abc">
+<div class="foo foo__baz foo__baz--abc">
   Qux: 234
   <div class="foo__baz__bizzles">
     Bizzles: 

--- a/doc/props_mixin_component_composition.md
+++ b/doc/props_mixin_component_composition.md
@@ -4,24 +4,25 @@ In our core `UiProps` documentation, the pattern of [composing multiple props mi
 
 This example builds on that, showing a lightweight example a common use-case for such composition. 
 
-We'll show two components 
+We'll show three components 
 
-1. A `Bar` component that has its own props API - and default rendering behavior when rendered standalone.
-2. A `FooBar` component that has its own props API, in addition to the `Bar` props API. This allows consumers to set props declared in `BarPropsMixin`, which will be forwarded to the `Bar` component it renders.
+1. A `Foo` component that has its own props API - and default rendering behavior when rendered standalone.
+1. A `FooBar` component that has its own props API, in addition to the `Foo` props API. This allows consumers to set props declared in `FooPropsMixin`, which will be forwarded to the `Foo` component it renders.
+1. A `FooBaz` component, the functional version of `FooBar`.
 
-### Bar Component
+### Foo Component
 ```dart
 import 'package:over_react/over_react.dart';
 
-part 'bar.over_react.g.dart';
+part 'foo.over_react.g.dart';
 
-UiFactory<BarPropsMixin> Bar = _$Bar; // ignore: undefined_identifier
+UiFactory<FooPropsMixin> Foo = _$Foo; // ignore: undefined_identifier
 
-mixin BarPropsMixin on UiProps {
+mixin FooPropsMixin on UiProps {
   Set<int> qux;
 }
 
-class BarComponent extends UiComponent2<BarPropsMixin> {
+class FooComponent extends UiComponent2<FooPropsMixin> {
   @override
   get defaultProps => (newProps()
     ..qux = {1, 2, 3}
@@ -31,7 +32,7 @@ class BarComponent extends UiComponent2<BarPropsMixin> {
   render() {
     return (Dom.div()
       ..modifyProps(addUnconsumedDomProps)
-      ..className = (forwardingClassNameBuilder()..add('bar'))
+      ..className = (forwardingClassNameBuilder()..add('foo'))
     )(
       'Qux: ', 
       props.qux.map((n) => n),
@@ -44,36 +45,36 @@ class BarComponent extends UiComponent2<BarPropsMixin> {
 __Which, when rendered on its own - produces the following HTML:__
 
 ```html
-<div class="bar">Qux: 123</div>
+<div class="foo">Qux: 123</div>
 ```
 
-### Composing Bar using the FooBar component
+### Composing Foo using the FooBar component
 
-To compose the `Bar` component using `FooBar`, we'll expose the prop API for both the `BarPropsMixin` and the `FooPropsMixin` like so:
+To compose the `Foo` component using `FooBar`, we'll expose the prop API for both the `FooPropsMixin` and the `BarPropsMixin` like so:
 ```dart
 import 'package:over_react/over_react.dart';
-import 'bar.dart';
+import 'foo.dart';
 
 part 'foo_bar.over_react.g.dart';
 
 UiFactory<FooBarProps> FooBar = _$FooBar; // ignore: undefined_identifier
 
-mixin FooPropsMixin on UiProps {
+mixin BarPropsMixin on UiProps {
   bool baz;
   Set<String> bizzles;
 }
 
-class FooBarProps = UiProps with FooPropsMixin, BarPropsMixin;
+class FooBarProps = UiProps with BarPropsMixin, FooPropsMixin;
 
 class FooBarComponent extends UiComponent2<FooBarProps> {
-  // Only consume the props found within FooPropsMixin, so that any prop values 
-  // found in BarPropsMixin get forwarded to the child Bar component via `addUnconsumedProps`.
+  // Only consume the props found within BarPropsMixin, so that any prop values 
+  // found in FooPropsMixin get forwarded to the child Foo component via `addUnconsumedProps`.
   @override
-  get consumedProps => propsMeta.forMixins({FooPropsMixin});
+  get consumedProps => propsMeta.forMixins({BarPropsMixin});
 
   @override
   render() {
-    return (Bar()
+    return (Foo()
       ..modifyProps(addUnconsumedProps)
       ..className = (forwardingClassNameBuilder()..add('foo__bar'))
     )(
@@ -119,6 +120,85 @@ Produces the following HTML:
 <div class="bar foo__bar foo__bar--abc">
   Qux: 234
   <div class="foo__bar__bizzles">
+    Bizzles: 
+    <ol>
+      <li>a</li>
+      <li>b</li>
+      <li>c</li>
+    </ol>
+  </div>
+</div>
+```
+
+### Composing Foo using the FooBaz component
+
+To compose the `Foo` component using `FooBaz`, a functional component, we'll expose the prop API for both the `FooPropsMixin` and the `BazPropsMixin` like so:
+```dart
+import 'package:over_react/over_react.dart';
+import 'foo.dart';
+
+part 'foo_baz.over_react.g.dart';
+
+mixin BarPropsMixin on UiProps {
+  bool baz;
+  Set<String> bizzles;
+}
+
+class FooBazProps = UiProps with BarPropsMixin, FooPropsMixin;
+
+UiFactory<FooBazProps> FooBaz = uiFunction(
+  (props) {
+    // Only consume the props found within BarPropsMixin, so that any prop values 
+    // found in FooPropsMixin get forwarded to the child Foo component via `addUnconsumedProps`.
+    final consumedProps = props.staticMeta.forMixins({BarPropsMixin});
+
+    return (Foo()
+      ..addUnconsumedProps(props, consumedProps)
+      ..className = (forwardingClassNameBuilder()..add('foo__baz'))
+    )(
+      (Dom.div()..className = 'foo__baz__bizzles')(
+        'Bizzles: ',
+        Dom.ol()(
+          props.bizzles.map(_renderBizzleItem).toList(),
+        ),
+      ),
+    );
+    
+    ReactElement _renderBizzleItem(String bizzle) {
+      return (Dom.li()..key = bizzle)(bizzle);
+    }
+  },
+  $FooBazConfig, // ignore: undefined_identifier
+);
+```
+
+Which, when composed / rendered like so:
+```dart
+import 'dart:html';
+import 'package:over_react/react_dom.dart' as react_dom;
+import 'package:over_react/over_react.dart';
+
+// An example of where the `FooBaz` component might be exported from
+import 'package:my_package_name/foobaz.dart';
+
+@override
+main() {
+  final abcFooBaz = (FooBaz()
+    ..className = 'foo_baz--abc'
+    ..aria.label = 'I am FooBaz!'
+    ..qux = {2, 3, 4}
+    ..bizzles = {'a', 'b', 'c'}
+  )();
+
+  react_dom.render(abcFooBaz, querySelector('#some_element_id'));
+}
+```
+
+Produces the following HTML:
+```html
+<div class="bar foo__baz foo__baz--abc">
+  Qux: 234
+  <div class="foo__baz__bizzles">
     Bizzles: 
     <ol>
       <li>a</li>

--- a/example/builder/main.dart
+++ b/example/builder/main.dart
@@ -23,6 +23,8 @@ import './src/basic_library.dart';
 import './src/generic_inheritance_sub.dart';
 import './src/generic_inheritance_super.dart';
 import './src/function_component.dart' as function;
+import 'src/functional_consumed_props.dart';
+import 'src/new_class_consumed_props.dart';
 
 main() {
   react_dom.render(
@@ -59,6 +61,14 @@ main() {
           ' - ',
           componentConstructorsByName[name]().toString(),
         )).toList(),
+        (SomeParent()
+          ..aParentProp = 'parent'
+          ..aPropToBePassed = 'passed'
+        )(),
+          (SomeClassParent()
+            ..aParentProp = 'classParent'
+            ..aPropToBePassed = 'passed'
+          )()
       ), querySelector('#content')
   );
 }

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$SubProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPropsMixin, and check that $SuperPropsMixin is exported/imported properly.
         SuperPropsMixin: $SuperPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPropsMixin, and check that $SubPropsMixin is exported/imported properly.

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$SubProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPropsMixin, and check that $SuperPropsMixin is exported/imported properly.
         SuperPropsMixin: $SuperPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPropsMixin, and check that $SubPropsMixin is exported/imported properly.

--- a/example/builder/src/abstract_inheritance.over_react.g.dart
+++ b/example/builder/src/abstract_inheritance.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$SubProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPropsMixin, and check that $SuperPropsMixin is exported/imported properly.
+        SuperPropsMixin: $SuperPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPropsMixin, and check that $SubPropsMixin is exported/imported properly.
+        SubPropsMixin: $SubPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });

--- a/example/builder/src/basic.over_react.g.dart
+++ b/example/builder/src/basic.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
+        BasicProps: $BasicProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BasicPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ExamplePropsMixin, and check that $ExamplePropsMixin is exported/imported properly.
         ExamplePropsMixin: $ExamplePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BasicPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPartOfLibPropsMixin, and check that $BasicPartOfLibPropsMixin is exported/imported properly.
@@ -434,7 +434,7 @@ abstract class _$$SubPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SuperPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPartOfLibPropsMixin, and check that $SuperPartOfLibPropsMixin is exported/imported properly.
         SuperPartOfLibPropsMixin: $SuperPartOfLibPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SubPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPartOfLibPropsMixin, and check that $SubPartOfLibPropsMixin is exported/imported properly.

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$BasicPartOfLibProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ExamplePropsMixin, and check that $ExamplePropsMixin is exported/imported properly.
+        ExamplePropsMixin: $ExamplePropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BasicPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPartOfLibPropsMixin, and check that $BasicPartOfLibPropsMixin is exported/imported properly.
+        BasicPartOfLibPropsMixin: $BasicPartOfLibPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -424,6 +432,14 @@ abstract class _$$SubPartOfLibProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SuperPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPartOfLibPropsMixin, and check that $SuperPartOfLibPropsMixin is exported/imported properly.
+        SuperPartOfLibPropsMixin: $SuperPartOfLibPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SubPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPartOfLibPropsMixin, and check that $SubPartOfLibPropsMixin is exported/imported properly.
+        SubPartOfLibPropsMixin: $SubPartOfLibPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/basic_library.over_react.g.dart
+++ b/example/builder/src/basic_library.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BasicPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ExamplePropsMixin, and check that $ExamplePropsMixin is exported/imported properly.
         ExamplePropsMixin: $ExamplePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BasicPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPartOfLibPropsMixin, and check that $BasicPartOfLibPropsMixin is exported/imported properly.
@@ -434,7 +434,7 @@ abstract class _$$SubPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SuperPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPartOfLibPropsMixin, and check that $SuperPartOfLibPropsMixin is exported/imported properly.
         SuperPartOfLibPropsMixin: $SuperPartOfLibPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SubPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPartOfLibPropsMixin, and check that $SubPartOfLibPropsMixin is exported/imported properly.

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });

--- a/example/builder/src/basic_with_state.over_react.g.dart
+++ b/example/builder/src/basic_with_state.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
+        BasicProps: $BasicProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$BasicProps<T, U extends UiProps> extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
+        BasicPropsMixin: $BasicPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BasicProps<T, U extends UiProps> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
         BasicPropsMixin: $BasicPropsMixin.meta,
       });

--- a/example/builder/src/basic_with_type_params.over_react.g.dart
+++ b/example/builder/src/basic_with_type_params.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BasicProps<T, U extends UiProps> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
         BasicPropsMixin: $BasicPropsMixin.meta,
       });

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -166,7 +166,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });
@@ -245,7 +245,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -164,6 +164,9 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -237,6 +240,9 @@ abstract class _$$FooProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -166,7 +166,10 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
+        BasicProps: $BasicProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -242,7 +245,10 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -1,0 +1,54 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+// ignore_for_file: uri_has_not_been_generated
+part 'functional_consumed_props.over_react.g.dart';
+
+mixin ParentOnlyPropsMixin on UiProps {
+  String aParentProp;
+}
+
+mixin SharedPropsMixin on UiProps {
+  String aPropToBePassed;
+}
+
+class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
+
+UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
+    final meta = UiPropsMeta(props).meta;
+    meta.consume(ParentOnlyPropsMixin);
+
+    return (
+      Dom.div()(
+        'The parent prop is: ${props.aParentProp}',
+        (SomeChild()..modifyProps((propsToChange) => meta.deriveUnconsumedProps(props, propsToChange)))(),
+      )
+    );
+  },
+  $SomeParentConfig, // ignore: undefined_identifier
+);
+
+class SomeChildProps = UiProps with SharedPropsMixin;
+
+UiFactory<SomeChildProps> SomeChild = uiFunction((props) {
+  return (
+    Fragment()(
+      'The passed prop value is ${props.aPropToBePassed}',
+    )
+  );
+},
+  $SomeChildConfig, // ignore: undefined_identifier
+);

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -28,7 +28,7 @@ mixin SharedPropsMixin on UiProps {
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
-    final consumedProps = UiPropsMeta(props).meta.forMixin(ParentOnlyPropsMixin);
+    final consumedProps = props.staticMeta.forMixin(ParentOnlyPropsMixin);
 
     return (
         Dom.div()(

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -28,14 +28,14 @@ mixin SharedPropsMixin on UiProps {
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
-    final consumedProps = props.staticMeta.forMixin(ParentOnlyPropsMixin);
+    final consumedProps = props.staticMeta.forMixins({ParentOnlyPropsMixin});
 
     return (
         Dom.div()(
           Dom.div()(
             'The parent prop is: ${props.aParentProp}',
           ),
-          (SomeChild()..addUnconsumedProps(props, consumedProps.inList()))(),
+          (SomeChild()..addUnconsumedProps(props, consumedProps))(),
         )
     );
   },

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -35,7 +35,7 @@ UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
           Dom.div()(
             'The parent prop is: ${props.aParentProp}',
           ),
-          (SomeChild()..addUnconsumedProps(props, consumedProps))(),
+          (SomeChild()..addUnconsumedProps(props, consumedProps.inList()))(),
         )
     );
   },

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -28,14 +28,15 @@ mixin SharedPropsMixin on UiProps {
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
-    final meta = UiPropsMeta(props).meta;
-    meta.consume(ParentOnlyPropsMixin);
+    final consumedProps = UiPropsMeta(props).meta.forMixin(ParentOnlyPropsMixin);
 
     return (
-      Dom.div()(
-        'The parent prop is: ${props.aParentProp}',
-        (SomeChild()..modifyProps((propsToChange) => meta.deriveUnconsumedProps(props, propsToChange)))(),
-      )
+        Dom.div()(
+          Dom.div()(
+            'The parent prop is: ${props.aParentProp}',
+          ),
+          (SomeChild()..addUnconsumedProps(props, consumedProps))(),
+        )
     );
   },
   $SomeParentConfig, // ignore: undefined_identifier

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -114,7 +114,7 @@ abstract class _$$SomeParentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
         ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
@@ -196,7 +196,7 @@ abstract class _$$SomeChildProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
         SharedPropsMixin: $SharedPropsMixin.meta,
       });

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -1,0 +1,240 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'functional_consumed_props.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $ParentOnlyPropsMixin on ParentOnlyPropsMixin {
+  static const PropsMeta meta = _$metaForParentOnlyPropsMixin;
+  @override
+  String get aParentProp =>
+      props[_$key__aParentProp__ParentOnlyPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set aParentProp(String value) =>
+      props[_$key__aParentProp__ParentOnlyPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__aParentProp__ParentOnlyPropsMixin =
+      PropDescriptor(_$key__aParentProp__ParentOnlyPropsMixin);
+  static const String _$key__aParentProp__ParentOnlyPropsMixin =
+      'ParentOnlyPropsMixin.aParentProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__aParentProp__ParentOnlyPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__aParentProp__ParentOnlyPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForParentOnlyPropsMixin = PropsMeta(
+  fields: $ParentOnlyPropsMixin.$props,
+  keys: $ParentOnlyPropsMixin.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $SharedPropsMixin on SharedPropsMixin {
+  static const PropsMeta meta = _$metaForSharedPropsMixin;
+  @override
+  String get aPropToBePassed =>
+      props[_$key__aPropToBePassed__SharedPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set aPropToBePassed(String value) =>
+      props[_$key__aPropToBePassed__SharedPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__aPropToBePassed__SharedPropsMixin =
+      PropDescriptor(_$key__aPropToBePassed__SharedPropsMixin);
+  static const String _$key__aPropToBePassed__SharedPropsMixin =
+      'SharedPropsMixin.aPropToBePassed';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__aPropToBePassed__SharedPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__aPropToBePassed__SharedPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForSharedPropsMixin = PropsMeta(
+  fields: $SharedPropsMixin.$props,
+  keys: $SharedPropsMixin.$propKeys,
+);
+
+final UiFactoryConfig<_$$SomeParentProps> $SomeParentConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$SomeParentProps(map),
+      jsMap: (map) => _$$SomeParentProps$JsMap(map),
+    ),
+    displayName: 'SomeParent');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SomeParentProps extends UiProps
+    with
+        ParentOnlyPropsMixin,
+        $ParentOnlyPropsMixin, // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
+        SharedPropsMixin,
+        $SharedPropsMixin // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+    implements
+        SomeParentProps {
+  _$$SomeParentProps._();
+
+  factory _$$SomeParentProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$SomeParentProps$JsMap(backingMap);
+    } else {
+      return _$$SomeParentProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
+        ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeParentProps$PlainMap extends _$$SomeParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeParentProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeParentProps$JsMap extends _$$SomeParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeParentProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$SomeChildProps> $SomeChildConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$SomeChildProps(map),
+      jsMap: (map) => _$$SomeChildProps$JsMap(map),
+    ),
+    displayName: 'SomeChild');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SomeChildProps extends UiProps
+    with
+        SharedPropsMixin,
+        $SharedPropsMixin // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+    implements
+        SomeChildProps {
+  _$$SomeChildProps._();
+
+  factory _$$SomeChildProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$SomeChildProps$JsMap(backingMap);
+    } else {
+      return _$$SomeChildProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeChildProps$PlainMap extends _$$SomeChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeChildProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeChildProps$JsMap extends _$$SomeChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeChildProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -114,7 +114,7 @@ abstract class _$$SomeParentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
         ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
@@ -196,7 +196,7 @@ abstract class _$$SomeChildProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
         SharedPropsMixin: $SharedPropsMixin.meta,
       });

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$GenericSubProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
+        GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because GenericSubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSubPropsMixin, and check that $GenericSubPropsMixin is exported/imported properly.
+        GenericSubPropsMixin: $GenericSubPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$GenericSubProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
         GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because GenericSubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSubPropsMixin, and check that $GenericSubPropsMixin is exported/imported properly.

--- a/example/builder/src/generic_inheritance_sub.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_sub.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$GenericSubProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
         GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because GenericSubPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSubPropsMixin, and check that $GenericSubPropsMixin is exported/imported properly.

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$GenericSuperProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
         GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
       });

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$GenericSuperProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
+        GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/generic_inheritance_super.over_react.g.dart
+++ b/example/builder/src/generic_inheritance_super.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$GenericSuperProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because GenericSuperPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of GenericSuperPropsMixin, and check that $GenericSuperPropsMixin is exported/imported properly.
         GenericSuperPropsMixin: $GenericSuperPropsMixin.meta,
       });

--- a/example/builder/src/namespaced_imports.over_react.g.dart
+++ b/example/builder/src/namespaced_imports.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because pm.ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of pm.ExamplePropsMixin, and check that pm.$ExamplePropsMixin is exported/imported properly.
+        pm.ExamplePropsMixin: pm.$ExamplePropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
+        BasicPropsMixin: $BasicPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/namespaced_imports.over_react.g.dart
+++ b/example/builder/src/namespaced_imports.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because pm.ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of pm.ExamplePropsMixin, and check that pm.$ExamplePropsMixin is exported/imported properly.
         pm.ExamplePropsMixin: pm.$ExamplePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.

--- a/example/builder/src/namespaced_imports.over_react.g.dart
+++ b/example/builder/src/namespaced_imports.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because pm.ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of pm.ExamplePropsMixin, and check that pm.$ExamplePropsMixin is exported/imported properly.
         pm.ExamplePropsMixin: pm.$ExamplePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -32,13 +32,14 @@ class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
   @override
   render() {
-    final meta = UiPropsMeta(props).meta;
-    meta.consume(ParentOnlyPropsMixin);
+    final meta = UiPropsMeta(props).meta.forMixin(ParentOnlyPropsMixin);
 
     return (
         Dom.div()(
-          'The parent prop is: ${props.aParentProp}',
-          (SomeClassChild()..modifyProps((propsToChange) => meta.deriveUnconsumedProps(props, propsToChange)))(),
+          Dom.div()(
+            'The parent prop is: ${props.aParentProp}',
+          ),
+          (SomeClassChild()..addUnconsumedProps(props, meta))(),
         )
     );
   }
@@ -52,8 +53,8 @@ class SomeClassChildComponent extends UiComponent2<SomeChildProps> {
   @override
   render() {
     return (
-        Fragment()(
-          'The passed prop value is ${props.aPropToBePassed}',
+        Dom.div()(
+          'The passed prop value is: ${props.aPropToBePassed}',
         )
     );
   }

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -32,7 +32,7 @@ class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
   @override
   render() {
-    final meta = UiPropsMeta(props).meta.forMixin(ParentOnlyPropsMixin);
+    final meta = UiPropsMeta(props).staticMeta.forMixin(ParentOnlyPropsMixin);
 
     return (
         Dom.div()(

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -32,7 +32,7 @@ class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
   @override
   render() {
-    final meta = UiPropsMeta(props).staticMeta.forMixins({ParentOnlyPropsMixin});
+    final meta = props.staticMeta.forMixins({ParentOnlyPropsMixin});
 
     return (
         Dom.div()(

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -1,0 +1,60 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react/over_react.dart';
+
+// ignore_for_file: uri_has_not_been_generated
+part 'new_class_consumed_props.over_react.g.dart';
+
+UiFactory<SomeParentProps> SomeClassParent = _$SomeClassParent; // ignore: undefined_identifier
+
+mixin ParentOnlyPropsMixin on UiProps {
+  String aParentProp;
+}
+
+mixin SharedPropsMixin on UiProps {
+  String aPropToBePassed;
+}
+
+class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
+
+class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
+  @override
+  render() {
+    final meta = UiPropsMeta(props).meta;
+    meta.consume(ParentOnlyPropsMixin);
+
+    return (
+        Dom.div()(
+          'The parent prop is: ${props.aParentProp}',
+          (SomeClassChild()..modifyProps((propsToChange) => meta.deriveUnconsumedProps(props, propsToChange)))(),
+        )
+    );
+  }
+}
+
+UiFactory<SomeChildProps> SomeClassChild = _$SomeClassChild; // ignore: undefined_identifier
+
+class SomeChildProps = UiProps with SharedPropsMixin;
+
+class SomeClassChildComponent extends UiComponent2<SomeChildProps> {
+  @override
+  render() {
+    return (
+        Fragment()(
+          'The passed prop value is ${props.aPropToBePassed}',
+        )
+    );
+  }
+}

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -32,14 +32,14 @@ class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
   @override
   render() {
-    final meta = UiPropsMeta(props).staticMeta.forMixin(ParentOnlyPropsMixin);
+    final meta = UiPropsMeta(props).staticMeta.forMixins({ParentOnlyPropsMixin});
 
     return (
         Dom.div()(
           Dom.div()(
             'The parent prop is: ${props.aParentProp}',
           ),
-          (SomeClassChild()..addUnconsumedProps(props, meta.inList()))(),
+          (SomeClassChild()..addUnconsumedProps(props, meta))(),
         )
     );
   }

--- a/example/builder/src/new_class_consumed_props.dart
+++ b/example/builder/src/new_class_consumed_props.dart
@@ -39,7 +39,7 @@ class SomeClassParentComponent extends UiComponent2<SomeParentProps> {
           Dom.div()(
             'The parent prop is: ${props.aParentProp}',
           ),
-          (SomeClassChild()..addUnconsumedProps(props, meta))(),
+          (SomeClassChild()..addUnconsumedProps(props, meta.inList()))(),
         )
     );
   }

--- a/example/builder/src/new_class_consumed_props.over_react.g.dart
+++ b/example/builder/src/new_class_consumed_props.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$SomeParentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
         ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
@@ -211,7 +211,7 @@ abstract class _$$SomeChildProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
         SharedPropsMixin: $SharedPropsMixin.meta,
       });

--- a/example/builder/src/new_class_consumed_props.over_react.g.dart
+++ b/example/builder/src/new_class_consumed_props.over_react.g.dart
@@ -1,0 +1,372 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'new_class_consumed_props.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $SomeClassParentComponentFactory = registerComponent2(
+  () => _$SomeClassParentComponent(),
+  builderFactory: _$SomeClassParent,
+  componentClass: SomeClassParentComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'SomeClassParent',
+);
+
+_$$SomeParentProps _$SomeClassParent([Map backingProps]) => backingProps == null
+    ? _$$SomeParentProps$JsMap(JsBackedMap())
+    : _$$SomeParentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SomeParentProps extends UiProps
+    with
+        ParentOnlyPropsMixin,
+        $ParentOnlyPropsMixin, // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
+        SharedPropsMixin,
+        $SharedPropsMixin // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+    implements
+        SomeParentProps {
+  _$$SomeParentProps._();
+
+  factory _$$SomeParentProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$SomeParentProps$JsMap(backingMap);
+    } else {
+      return _$$SomeParentProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $SomeClassParentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
+        ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeParentProps$PlainMap extends _$$SomeParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeParentProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeParentProps$JsMap extends _$$SomeParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeParentProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$SomeClassParentComponent extends SomeClassParentComponent {
+  _$$SomeParentProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$SomeParentProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$SomeParentProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$SomeParentProps$JsMap(backingMap);
+
+  @override
+  _$$SomeParentProps typedPropsFactory(Map backingMap) =>
+      _$$SomeParentProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by SomeParentProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
+        ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $SomeClassChildComponentFactory = registerComponent2(
+  () => _$SomeClassChildComponent(),
+  builderFactory: _$SomeClassChild,
+  componentClass: SomeClassChildComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'SomeClassChild',
+);
+
+_$$SomeChildProps _$SomeClassChild([Map backingProps]) => backingProps == null
+    ? _$$SomeChildProps$JsMap(JsBackedMap())
+    : _$$SomeChildProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SomeChildProps extends UiProps
+    with
+        SharedPropsMixin,
+        $SharedPropsMixin // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+    implements
+        SomeChildProps {
+  _$$SomeChildProps._();
+
+  factory _$$SomeChildProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$SomeChildProps$JsMap(backingMap);
+    } else {
+      return _$$SomeChildProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $SomeClassChildComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeChildProps$PlainMap extends _$$SomeChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeChildProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$SomeChildProps$JsMap extends _$$SomeChildProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$SomeChildProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$SomeClassChildComponent extends SomeClassChildComponent {
+  _$$SomeChildProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$SomeChildProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$SomeChildProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$SomeChildProps$JsMap(backingMap);
+
+  @override
+  _$$SomeChildProps typedPropsFactory(Map backingMap) =>
+      _$$SomeChildProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by SomeChildProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
+        SharedPropsMixin: $SharedPropsMixin.meta,
+      });
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $ParentOnlyPropsMixin on ParentOnlyPropsMixin {
+  static const PropsMeta meta = _$metaForParentOnlyPropsMixin;
+  @override
+  String get aParentProp =>
+      props[_$key__aParentProp__ParentOnlyPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set aParentProp(String value) =>
+      props[_$key__aParentProp__ParentOnlyPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__aParentProp__ParentOnlyPropsMixin =
+      PropDescriptor(_$key__aParentProp__ParentOnlyPropsMixin);
+  static const String _$key__aParentProp__ParentOnlyPropsMixin =
+      'ParentOnlyPropsMixin.aParentProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__aParentProp__ParentOnlyPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__aParentProp__ParentOnlyPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForParentOnlyPropsMixin = PropsMeta(
+  fields: $ParentOnlyPropsMixin.$props,
+  keys: $ParentOnlyPropsMixin.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $SharedPropsMixin on SharedPropsMixin {
+  static const PropsMeta meta = _$metaForSharedPropsMixin;
+  @override
+  String get aPropToBePassed =>
+      props[_$key__aPropToBePassed__SharedPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set aPropToBePassed(String value) =>
+      props[_$key__aPropToBePassed__SharedPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__aPropToBePassed__SharedPropsMixin =
+      PropDescriptor(_$key__aPropToBePassed__SharedPropsMixin);
+  static const String _$key__aPropToBePassed__SharedPropsMixin =
+      'SharedPropsMixin.aPropToBePassed';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__aPropToBePassed__SharedPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__aPropToBePassed__SharedPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForSharedPropsMixin = PropsMeta(
+  fields: $SharedPropsMixin.$props,
+  keys: $SharedPropsMixin.$propKeys,
+);

--- a/example/builder/src/new_class_consumed_props.over_react.g.dart
+++ b/example/builder/src/new_class_consumed_props.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$SomeParentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ParentOnlyPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ParentOnlyPropsMixin, and check that $ParentOnlyPropsMixin is exported/imported properly.
         ParentOnlyPropsMixin: $ParentOnlyPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
@@ -211,7 +211,7 @@ abstract class _$$SomeChildProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPropsMixin, and check that $SharedPropsMixin is exported/imported properly.
         SharedPropsMixin: $SharedPropsMixin.meta,
       });

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$_PrivateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because _PrivateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _PrivateProps, and check that $_PrivateProps is exported/imported properly.
         _PrivateProps: $_PrivateProps.meta,
       });

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$_PrivateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because _PrivateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _PrivateProps, and check that $_PrivateProps is exported/imported properly.
         _PrivateProps: $_PrivateProps.meta,
       });

--- a/example/builder/src/private_component.over_react.g.dart
+++ b/example/builder/src/private_component.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$_PrivateProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because _PrivateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _PrivateProps, and check that $_PrivateProps is exported/imported properly.
+        _PrivateProps: $_PrivateProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$FormActionInputProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FormActionInputProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FormActionInputProps, and check that $FormActionInputProps is exported/imported properly.
         FormActionInputProps: $FormActionInputProps.meta,
       });

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$FormActionInputProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FormActionInputProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FormActionInputProps, and check that $FormActionInputProps is exported/imported properly.
+        FormActionInputProps: $FormActionInputProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/private_factory_public_component.over_react.g.dart
+++ b/example/builder/src/private_factory_public_component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$FormActionInputProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FormActionInputProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FormActionInputProps, and check that $FormActionInputProps is exported/imported properly.
         FormActionInputProps: $FormActionInputProps.meta,
       });

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
         BasicPropsMixin: $BasicPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
+        BasicPropsMixin: $BasicPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
+        TransitionPropsMixin: $TransitionPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/builder/src/with_legacy_props_mixin.over_react.g.dart
+++ b/example/builder/src/with_legacy_props_mixin.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPropsMixin, and check that $BasicPropsMixin is exported/imported properly.
         BasicPropsMixin: $BasicPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$MyContextComponentProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because MyContextComponentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyContextComponentProps, and check that $MyContextComponentProps is exported/imported properly.
+        MyContextComponentProps: $MyContextComponentProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$MyContextComponentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because MyContextComponentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyContextComponentProps, and check that $MyContextComponentProps is exported/imported properly.
         MyContextComponentProps: $MyContextComponentProps.meta,
       });

--- a/example/context/components/my_context_component.over_react.g.dart
+++ b/example/context/components/my_context_component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$MyContextComponentProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because MyContextComponentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyContextComponentProps, and check that $MyContextComponentProps is exported/imported properly.
         MyContextComponentProps: $MyContextComponentProps.meta,
       });

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$MyProviderProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because MyProviderProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyProviderProps, and check that $MyProviderProps is exported/imported properly.
         MyProviderProps: $MyProviderProps.meta,
       });

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$MyProviderProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because MyProviderProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyProviderProps, and check that $MyProviderProps is exported/imported properly.
         MyProviderProps: $MyProviderProps.meta,
       });

--- a/example/context/components/my_provider_component.over_react.g.dart
+++ b/example/context/components/my_provider_component.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$MyProviderProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because MyProviderProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of MyProviderProps, and check that $MyProviderProps is exported/imported properly.
+        MyProviderProps: $MyProviderProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -61,6 +61,9 @@ abstract class _$$UseCallbackExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$UseCallbackExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseCallbackExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseCallbackExampleProps, and check that $UseCallbackExampleProps is exported/imported properly.
         UseCallbackExampleProps: $UseCallbackExampleProps.meta,
       });

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -63,7 +63,10 @@ abstract class _$$UseCallbackExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseCallbackExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseCallbackExampleProps, and check that $UseCallbackExampleProps is exported/imported properly.
+        UseCallbackExampleProps: $UseCallbackExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -82,7 +82,7 @@ abstract class _$$UseContextExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseContextExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseContextExampleProps, and check that $UseContextExampleProps is exported/imported properly.
         UseContextExampleProps: $UseContextExampleProps.meta,
       });
@@ -162,7 +162,7 @@ abstract class _$$NewContextProviderProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because NewContextProviderProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NewContextProviderProps, and check that $NewContextProviderProps is exported/imported properly.
         NewContextProviderProps: $NewContextProviderProps.meta,
       });

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -80,6 +80,9 @@ abstract class _$$UseContextExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -154,6 +157,9 @@ abstract class _$$NewContextProviderProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -82,7 +82,10 @@ abstract class _$$UseContextExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseContextExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseContextExampleProps, and check that $UseContextExampleProps is exported/imported properly.
+        UseContextExampleProps: $UseContextExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -159,7 +162,10 @@ abstract class _$$NewContextProviderProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because NewContextProviderProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NewContextProviderProps, and check that $NewContextProviderProps is exported/imported properly.
+        NewContextProviderProps: $NewContextProviderProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -93,6 +93,9 @@ abstract class _$$FriendListItemProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -167,6 +170,9 @@ abstract class _$$UseDebugValueExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -95,7 +95,10 @@ abstract class _$$FriendListItemProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FriendListItemProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FriendListItemProps, and check that $FriendListItemProps is exported/imported properly.
+        FriendListItemProps: $FriendListItemProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -172,7 +175,10 @@ abstract class _$$UseDebugValueExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseDebugValueExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseDebugValueExampleProps, and check that $UseDebugValueExampleProps is exported/imported properly.
+        UseDebugValueExampleProps: $UseDebugValueExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -95,7 +95,7 @@ abstract class _$$FriendListItemProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FriendListItemProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FriendListItemProps, and check that $FriendListItemProps is exported/imported properly.
         FriendListItemProps: $FriendListItemProps.meta,
       });
@@ -175,7 +175,7 @@ abstract class _$$UseDebugValueExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseDebugValueExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseDebugValueExampleProps, and check that $UseDebugValueExampleProps is exported/imported properly.
         UseDebugValueExampleProps: $UseDebugValueExampleProps.meta,
       });

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -106,7 +106,10 @@ abstract class _$$FancyInputProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FancyInputProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FancyInputProps, and check that $FancyInputProps is exported/imported properly.
+        FancyInputProps: $FancyInputProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -183,7 +186,10 @@ abstract class _$$UseImperativeHandleExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseImperativeHandleExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseImperativeHandleExampleProps, and check that $UseImperativeHandleExampleProps is exported/imported properly.
+        UseImperativeHandleExampleProps: $UseImperativeHandleExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -104,6 +104,9 @@ abstract class _$$FancyInputProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -178,6 +181,9 @@ abstract class _$$UseImperativeHandleExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -106,7 +106,7 @@ abstract class _$$FancyInputProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FancyInputProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FancyInputProps, and check that $FancyInputProps is exported/imported properly.
         FancyInputProps: $FancyInputProps.meta,
       });
@@ -186,7 +186,7 @@ abstract class _$$UseImperativeHandleExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseImperativeHandleExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseImperativeHandleExampleProps, and check that $UseImperativeHandleExampleProps is exported/imported properly.
         UseImperativeHandleExampleProps: $UseImperativeHandleExampleProps.meta,
       });

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -63,7 +63,10 @@ abstract class _$$UseLayoutEffectProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseLayoutEffectProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseLayoutEffectProps, and check that $UseLayoutEffectProps is exported/imported properly.
+        UseLayoutEffectProps: $UseLayoutEffectProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -61,6 +61,9 @@ abstract class _$$UseLayoutEffectProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$UseLayoutEffectProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseLayoutEffectProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseLayoutEffectProps, and check that $UseLayoutEffectProps is exported/imported properly.
         UseLayoutEffectProps: $UseLayoutEffectProps.meta,
       });

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -61,6 +61,9 @@ abstract class _$$UseMemoExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -63,7 +63,10 @@ abstract class _$$UseMemoExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseMemoExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseMemoExampleProps, and check that $UseMemoExampleProps is exported/imported properly.
+        UseMemoExampleProps: $UseMemoExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$UseMemoExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseMemoExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseMemoExampleProps, and check that $UseMemoExampleProps is exported/imported properly.
         UseMemoExampleProps: $UseMemoExampleProps.meta,
       });

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -78,7 +78,7 @@ abstract class _$$UseReducerExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseReducerExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseReducerExampleProps, and check that $UseReducerExampleProps is exported/imported properly.
         UseReducerExampleProps: $UseReducerExampleProps.meta,
       });

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -76,6 +76,9 @@ abstract class _$$UseReducerExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -78,7 +78,10 @@ abstract class _$$UseReducerExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseReducerExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseReducerExampleProps, and check that $UseReducerExampleProps is exported/imported properly.
+        UseReducerExampleProps: $UseReducerExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -63,7 +63,10 @@ abstract class _$$UseRefExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseRefExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseRefExampleProps, and check that $UseRefExampleProps is exported/imported properly.
+        UseRefExampleProps: $UseRefExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -61,6 +61,9 @@ abstract class _$$UseRefExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$UseRefExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseRefExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseRefExampleProps, and check that $UseRefExampleProps is exported/imported properly.
         UseRefExampleProps: $UseRefExampleProps.meta,
       });

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$UseStateExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because UseStateExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseStateExampleProps, and check that $UseStateExampleProps is exported/imported properly.
         UseStateExampleProps: $UseStateExampleProps.meta,
       });

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -61,6 +61,9 @@ abstract class _$$UseStateExampleProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -63,7 +63,10 @@ abstract class _$$UseStateExampleProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because UseStateExampleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of UseStateExampleProps, and check that $UseStateExampleProps is exported/imported properly.
+        UseStateExampleProps: $UseStateExampleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/builder/codegen/component_generator.dart
+++ b/lib/src/builder/codegen/component_generator.dart
@@ -172,16 +172,7 @@ class _ComponentGenerator extends ComponentGenerator {
 
   @override
   void _generateAdditionalComponentBody() {
-    outputContentsBuffer
-      ..writeln()
-      ..writeln('  @override')
-      ..writeln('  PropsMetaCollection get propsMeta => const PropsMetaCollection({');
-    for (final name in declaration.allPropsMixins) {
-      final names = TypedMapNames(name.name);
-      outputContentsBuffer.write('    ${generatedMixinWarningCommentLine(names, isProps: true)}');
-      outputContentsBuffer.writeln('    ${names.consumerName}: ${names.publicGeneratedMetaName},');
-    }
-    outputContentsBuffer.writeln('  });');
+    generatePropsMeta(outputContentsBuffer, declaration.allPropsMixins);
   }
 }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -226,7 +226,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
 
       if (allPropsMixins != null) {
         generatePropsMeta(buffer, allPropsMixins,
-            classType: 'PropsMetaCollection', fieldName: r'$meta');
+            classType: 'PropsMetaCollection', fieldName: r'staticMeta');
       }
     }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -226,7 +226,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
 
       if (allPropsMixins != null) {
         generatePropsMeta(buffer, allPropsMixins,
-            classType: 'PropsInstanceMeta', fieldName: r'$meta', isConst: false);
+            classType: 'PropsMetaCollection', fieldName: r'$meta');
       }
     }
 
@@ -379,9 +379,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         factoryNames =
             declaration.factories.map((factory) => FactoryNames(factory.name.name)).toList(),
         member = declaration.props.either,
-        allPropsMixins = declaration.props.either.nodeHelper.mixins
-            ?.map<Identifier>((mixin) => mixin.name)
-            ?.toList(),
+        allPropsMixins = declaration.allPropsMixins,
         isProps = true,
         componentFactoryName = 'null',
         isFunctionComponentDeclaration = declaration.factories.first.shouldGenerateConfig,

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -134,6 +134,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
   String _generateConcretePropsOrStateImpl({
     String componentFactoryName,
     String propKeyNamespace,
+    List<Identifier> allPropsMixins,
   }) {
     if (isProps) {
       if (componentFactoryName == null || propKeyNamespace == null) {
@@ -222,6 +223,10 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
             '  /// The default namespace for the prop getters/setters generated for this class.')
         ..writeln('  @override')
         ..writeln('  String get propKeyNamespace => ${stringLiteral(propKeyNamespace)};');
+
+      if (allPropsMixins != null) {
+        generatePropsMeta(buffer, allPropsMixins, classType: 'PropsInstanceMeta', fieldName: r'$meta', isConst: false);
+      }
     }
 
     // End of class body
@@ -345,10 +350,13 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
   @override
   final Version version;
 
+  final List<Identifier> allPropsMixins;
+
   _TypedMapImplGenerator.props(ClassComponentDeclaration declaration)
       : names = TypedMapNames(declaration.props.either.name.name),
         factoryNames = [FactoryNames(declaration.factory.name.name)],
         member = declaration.props.either,
+        allPropsMixins = declaration.allPropsMixins,
         isProps = true,
         componentFactoryName = ComponentNames(declaration.component.name.name).componentFactoryName,
         isFunctionComponentDeclaration = false,
@@ -358,6 +366,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       : names = TypedMapNames(declaration.state.either.name.name),
         factoryNames = [FactoryNames(declaration.factory.name.name)],
         member = declaration.state.either,
+        allPropsMixins = null,
         isProps = false,
         componentFactoryName = ComponentNames(declaration.component.name.name).componentFactoryName,
         isFunctionComponentDeclaration = false,
@@ -369,6 +378,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         factoryNames =
             declaration.factories.map((factory) => FactoryNames(factory.name.name)).toList(),
         member = declaration.props.either,
+        allPropsMixins = declaration.props.either.nodeHelper.mixins?.map<Identifier>((mixin) => mixin.name)?.toList(),
         isProps = true,
         componentFactoryName = 'null',
         isFunctionComponentDeclaration = declaration.factories.first.shouldGenerateConfig,
@@ -403,6 +413,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       componentFactoryName: componentFactoryName,
       // This doesn't really apply to the new boilerplate
       propKeyNamespace: '',
+      allPropsMixins: allPropsMixins,
     ));
   }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -225,7 +225,8 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
         ..writeln('  String get propKeyNamespace => ${stringLiteral(propKeyNamespace)};');
 
       if (allPropsMixins != null) {
-        generatePropsMeta(buffer, allPropsMixins, classType: 'PropsInstanceMeta', fieldName: r'$meta', isConst: false);
+        generatePropsMeta(buffer, allPropsMixins,
+            classType: 'PropsInstanceMeta', fieldName: r'$meta', isConst: false);
       }
     }
 
@@ -378,7 +379,9 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         factoryNames =
             declaration.factories.map((factory) => FactoryNames(factory.name.name)).toList(),
         member = declaration.props.either,
-        allPropsMixins = declaration.props.either.nodeHelper.mixins?.map<Identifier>((mixin) => mixin.name)?.toList(),
+        allPropsMixins = declaration.props.either.nodeHelper.mixins
+            ?.map<Identifier>((mixin) => mixin.name)
+            ?.toList(),
         isProps = true,
         componentFactoryName = 'null',
         isFunctionComponentDeclaration = declaration.factories.first.shouldGenerateConfig,

--- a/lib/src/builder/codegen/util.dart
+++ b/lib/src/builder/codegen/util.dart
@@ -73,12 +73,11 @@ void generatePropsMeta(
   List<Identifier> mixins, {
   String classType = 'PropsMetaCollection',
   String fieldName = 'propsMeta',
-  bool isConst = true,
 }) {
   buffer
     ..writeln()
     ..writeln('  @override')
-    ..writeln('  $classType get $fieldName => ${isConst ? 'const' : ''} $classType({');
+    ..writeln('  $classType get $fieldName => const $classType({');
   for (final name in mixins) {
     final names = TypedMapNames(name.name);
     buffer.write('    ${generatedMixinWarningCommentLine(names, isProps: true)}');

--- a/lib/src/builder/codegen/util.dart
+++ b/lib/src/builder/codegen/util.dart
@@ -68,7 +68,9 @@ String generatedMixinWarningCommentLine(TypedMapNames mixinNames, {@required boo
   return value;
 }
 
-void generatePropsMeta(StringBuffer buffer, List<Identifier> mixins, {
+void generatePropsMeta(
+  StringBuffer buffer,
+  List<Identifier> mixins, {
   String classType = 'PropsMetaCollection',
   String fieldName = 'propsMeta',
   bool isConst = true,

--- a/lib/src/builder/codegen/util.dart
+++ b/lib/src/builder/codegen/util.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
@@ -65,4 +66,21 @@ String generatedMixinWarningCommentLine(TypedMapNames mixinNames, {@required boo
   assert(value.endsWith('\n'));
 
   return value;
+}
+
+void generatePropsMeta(StringBuffer buffer, List<Identifier> mixins, {
+  String classType = 'PropsMetaCollection',
+  String fieldName = 'propsMeta',
+  bool isConst = true,
+}) {
+  buffer
+    ..writeln()
+    ..writeln('  @override')
+    ..writeln('  $classType get $fieldName => ${isConst ? 'const' : ''} $classType({');
+  for (final name in mixins) {
+    final names = TypedMapNames(name.name);
+    buffer.write('    ${generatedMixinWarningCommentLine(names, isProps: true)}');
+    buffer.writeln('    ${names.consumerName}: ${names.publicGeneratedMetaName},');
+  }
+  buffer.writeln('  });');
 }

--- a/lib/src/builder/parsing/declarations.dart
+++ b/lib/src/builder/parsing/declarations.dart
@@ -221,6 +221,17 @@ mixin _TypedMapMixinShorthandDeclaration {
   }
 }
 
+extension on Union<BoilerplateProps, BoilerplatePropsMixin> {
+  /// Retrieves all of the mixins related to a props class declaration.
+  ///
+  /// This is the safest way to retrieve that information because it takes
+  /// into account the nature of the [Union] typing of `props`.
+  List<Identifier> get allPropsMixins => this.switchCase(
+        (a) => a.nodeHelper.mixins.map((name) => name.name).toList(),
+        (b) => [b.name],
+      );
+}
+
 /// A boilerplate declaration for a class-based component declared using the new mixin-based
 /// boilerplate.
 ///
@@ -238,11 +249,7 @@ class ClassComponentDeclaration extends BoilerplateDeclaration
   @override
   get type => DeclarationType.classComponentDeclaration;
 
-  /// All the props mixins related to this component declaration
-  List<Identifier> get allPropsMixins => props.switchCase(
-        (a) => a.nodeHelper.mixins.map((name) => name.name).toList(),
-        (b) => [b.name],
-      );
+  List<Identifier> get allPropsMixins => props.allPropsMixins;
 
   @override
   void validate(ErrorCollector errorCollector) {
@@ -277,6 +284,8 @@ class PropsMapViewOrFunctionComponentDeclaration extends BoilerplateDeclaration
   ///
   /// Can be either [BoilerplateProps] or [BoilerplatePropsMixin], but not both.
   final Union<BoilerplateProps, BoilerplatePropsMixin> props;
+
+  List<Identifier> get allPropsMixins => props.allPropsMixins;
 
   @override
   get _members => [...factories, props.either];

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -151,6 +151,9 @@ abstract class _$$TransitionPropsMixin extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -153,7 +153,10 @@ abstract class _$$TransitionPropsMixin extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
+        TransitionPropsMixin: $TransitionPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -153,7 +153,7 @@ abstract class _$$TransitionPropsMixin extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
         TransitionPropsMixin: $TransitionPropsMixin.meta,
       });

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$ErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ErrorBoundaryProps, and check that $ErrorBoundaryProps is exported/imported properly.
         ErrorBoundaryProps: $ErrorBoundaryProps.meta,
       });

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$ErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ErrorBoundaryProps, and check that $ErrorBoundaryProps is exported/imported properly.
         ErrorBoundaryProps: $ErrorBoundaryProps.meta,
       });

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$ErrorBoundaryProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ErrorBoundaryProps, and check that $ErrorBoundaryProps is exported/imported properly.
+        ErrorBoundaryProps: $ErrorBoundaryProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$RecoverableErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because v2.ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.ErrorBoundaryProps, and check that v2.$ErrorBoundaryProps is exported/imported properly.
         v2.ErrorBoundaryProps: v2.$ErrorBoundaryProps.meta,
       });

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$RecoverableErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because v2.ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.ErrorBoundaryProps, and check that v2.$ErrorBoundaryProps is exported/imported properly.
         v2.ErrorBoundaryProps: v2.$ErrorBoundaryProps.meta,
       });

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -61,6 +61,12 @@ abstract class _$$RecoverableErrorBoundaryProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because v2.ErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.ErrorBoundaryProps, and check that v2.$ErrorBoundaryProps is exported/imported properly.
+        v2.ErrorBoundaryProps: v2.$ErrorBoundaryProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ResizeSensorProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ResizeSensorProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ResizeSensorProps, and check that $ResizeSensorProps is exported/imported properly.
         ResizeSensorProps: $ResizeSensorProps.meta,
       });

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ResizeSensorProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ResizeSensorProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ResizeSensorProps, and check that $ResizeSensorProps is exported/imported properly.
         ResizeSensorProps: $ResizeSensorProps.meta,
       });

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$ResizeSensorProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ResizeSensorProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ResizeSensorProps, and check that $ResizeSensorProps is exported/imported properly.
+        ResizeSensorProps: $ResizeSensorProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -36,14 +36,6 @@ class StrictModeProps extends component_base.UiProps
   PropsMetaCollection get staticMeta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
 
   @override
-  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) =>
-      throw UnimplementedError('StrictModeProps instances do not implement addUnconsumedProps');
-
-  @override
-  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) =>
-      throw UnimplementedError('StrictModeProps instances do not implement addUnconsumedDomProps');
-
-  @override
   final Map props;
 
   @override

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -20,6 +20,8 @@ import 'package:react/react_client.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react.dart' as react;
 
+import '../../over_react.dart';
+
 class StrictModeProps extends component_base.UiProps
     with builder_helpers.GeneratedClass
     implements builder_helpers.UiProps {
@@ -29,6 +31,9 @@ class StrictModeProps extends component_base.UiProps
 
   @override
   ReactComponentFactoryProxy componentFactory = react.StrictMode;
+
+  @override
+  PropsInstanceMeta get $meta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
 
   @override
   final Map props;

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -33,7 +33,7 @@ class StrictModeProps extends component_base.UiProps
   ReactComponentFactoryProxy componentFactory = react.StrictMode;
 
   @override
-  PropsInstanceMeta get $meta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
+  PropsMetaCollection get $meta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
 
   @override
   final Map props;

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -33,7 +33,15 @@ class StrictModeProps extends component_base.UiProps
   ReactComponentFactoryProxy componentFactory = react.StrictMode;
 
   @override
-  PropsMetaCollection get $meta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
+  PropsMetaCollection get staticMeta => throw UnimplementedError('StrictModeProps instances do not implement instance meta');
+
+  @override
+  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('StrictModeProps instances do not implement addUnconsumedProps');
+
+  @override
+  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('StrictModeProps instances do not implement addUnconsumedDomProps');
 
   @override
   final Map props;

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -34,9 +34,9 @@ _$$WithTransitionProps _$WithTransition([Map backingProps]) =>
 abstract class _$$WithTransitionProps extends UiProps
     with
         v2.TransitionPropsMixin,
-        v2.$TransitionPropsMixin, // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
+        v2.$TransitionPropsMixin, // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.TransitionPropsMixin, and check that v2.$TransitionPropsMixin is exported/imported properly.
         WithTransitionPropsMixin,
-        $WithTransitionPropsMixin // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        $WithTransitionPropsMixin // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
     implements
         WithTransitionProps {
   _$$WithTransitionProps._();
@@ -61,6 +61,14 @@ abstract class _$$WithTransitionProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.TransitionPropsMixin, and check that v2.$TransitionPropsMixin is exported/imported properly.
+        v2.TransitionPropsMixin: v2.$TransitionPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
+        WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -108,7 +116,7 @@ class _$$WithTransitionProps$JsMap extends _$$WithTransitionProps {
 abstract class _$$WithTransitionState extends UiState
     with
         WithTransitionState,
-        $WithTransitionState // If this generated mixin is undefined, it's likely because WithTransitionState is not a valid `mixin`-based state mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionState.
+        $WithTransitionState // If this generated mixin is undefined, it's likely because WithTransitionState is not a valid `mixin`-based state mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionState, and check that $WithTransitionState is exported/imported properly.
 {
   _$$WithTransitionState._();
 
@@ -228,9 +236,9 @@ class _$WithTransitionComponent extends WithTransitionComponent {
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
-        // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of v2.TransitionPropsMixin.
+        // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.TransitionPropsMixin, and check that v2.$TransitionPropsMixin is exported/imported properly.
         v2.TransitionPropsMixin: v2.$TransitionPropsMixin.meta,
-        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
         WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
       });
 }

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$WithTransitionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.TransitionPropsMixin, and check that v2.$TransitionPropsMixin is exported/imported properly.
         v2.TransitionPropsMixin: v2.$TransitionPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$WithTransitionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because v2.TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of v2.TransitionPropsMixin, and check that v2.$TransitionPropsMixin is exported/imported properly.
         v2.TransitionPropsMixin: v2.$TransitionPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -14,8 +14,6 @@
 
 library over_react.component_declaration.builder_helpers;
 
-import 'package:over_react/src/util/map_util.dart';
-
 import '../../component_base.dart';
 import '../../over_react.dart';
 import './component_base.dart' as component_base;
@@ -134,56 +132,6 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
   /// This can be used to derive consumed props by usage in conjunction with [addUnconsumedProps]
   /// and [addUnconsumedDomProps].
   @toBeGenerated PropsMetaCollection get staticMeta => throw UngeneratedError(member: #meta);
-
-  /// Copies key-value pairs from the provided [props] map into this map,
-  /// excluding those with keys found in [consumedProps].
-  ///
-  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
-  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
-  /// `allExceptForMixins`, and `all`.
-  ///
-  /// __Example:__
-  ///
-  /// ```dart
-  /// // within a functional component (wrapped in `uiFunction`)
-  /// // Consider props in FooProps "consumed"...
-  /// final consumedProps = props.staticMeta.forMixins({FooProps});
-  /// // ...and filter them out when forwarding props to Bar.
-  /// return (Bar()..addUnconsumedProps(props, consumedProps))();
-  /// ```
-  ///
-  /// To only add DOM props, use [addUnconsumedDomProps].
-  ///
-  /// Related: [UiComponent2]'s `addUnconsumedProps`
-  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) {
-    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
-    forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys);
-  }
-
-  /// Copies DOM only key-value pairs from the provided [props] map into this map,
-  /// excluding those with keys found in [consumedProps].
-  ///
-  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
-  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
-  /// `allExceptForMixins`, and `all`.
-  ///
-  /// __Example:__
-  ///
-  /// ```dart
-  /// // within a functional component (wrapped in `uiFunction`)
-  /// // Consider props in FooProps "consumed"...
-  /// final consumedProps = [PropsMeta.forSimpleKey('className')];
-  /// // ...and filter them out when forwarding props to Bar.
-  /// return (Bar()..addUnconsumedDomProps(props, consumedProps))();
-  /// ```
-  ///
-  /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
-  ///
-  /// Related: [UiComponent2]'s `addUnconsumedDomProps`
-  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) {
-    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
-    forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys, onlyCopyDomProps: true);
-  }
 }
 
 /// A [dart.collection.MapView]-like class with strongly-typed getters/setters for React state.

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -135,37 +135,53 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
   /// and [addUnconsumedDomProps].
   @toBeGenerated PropsMetaCollection get staticMeta => throw UngeneratedError(member: #meta);
 
-  /// Copies props from the provided [props] instance to this [UiProps] instance,
-  /// filtering out props found in [consumedProps].
+  /// Copies key-value pairs from the provided [props] map into this map,
+  /// excluding those with keys found in [consumedProps].
   ///
   /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
   /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
   /// `allExceptForMixins`, and `all`.
+  ///
+  /// __Example:__
+  ///
+  /// ```dart
+  /// // within a functional component (wrapped in `uiFunction`)
+  /// // Consider props in FooProps "consumed"...
+  /// final consumedProps = props.staticMeta.forMixins({FooProps});
+  /// // ...and filter them out when forwarding props to Bar.
+  /// return (Bar()..addUnconsumedProps(props, consumedProps))();
+  /// ```
   ///
   /// To only add DOM props, use [addUnconsumedDomProps].
   ///
   /// Related: [UiComponent2]'s `addUnconsumedProps`
   void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) {
-    // It's safe for this to be `null` because `forwardUnconsumedPropsV2` uses
-    // `null` as a flag to short circuit for a minor performance boost.
-    final consumedPropKeys = consumedProps?.map((consumedProps) => consumedProps.keys);
+    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
     forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys);
   }
 
-  /// Copies DOM props from the provided [props] instance to this [UiProps] instance,
-  /// filtering out props found in [consumedProps].
+  /// Copies DOM only key-value pairs from the provided [props] map into this map,
+  /// excluding those with keys found in [consumedProps].
   ///
   /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
   /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
   /// `allExceptForMixins`, and `all`.
   ///
+  /// __Example:__
+  ///
+  /// ```dart
+  /// // within a functional component (wrapped in `uiFunction`)
+  /// // Consider props in FooProps "consumed"...
+  /// final consumedProps = [PropsMeta.forSimpleKey('className')];
+  /// // ...and filter them out when forwarding props to Bar.
+  /// return (Bar()..addUnconsumedDomProps(props, consumedProps))();
+  /// ```
+  ///
   /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
   ///
   /// Related: [UiComponent2]'s `addUnconsumedDomProps`
   void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) {
-    // It's safe for this to be `null` because `forwardUnconsumedPropsV2` uses
-    // `null` as a flag to short circuit for a minor performance boost.
-    final consumedPropKeys = consumedProps?.map((consumedProps) => consumedProps.keys);
+    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
     forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys, onlyCopyDomProps: true);
   }
 }

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -152,27 +152,10 @@ extension UiPropsMeta on UiProps {
   /// To only add DOM props, use [addUnconsumedDomProps].
   ///
   /// Related: [UiComponent2]'s `addUnconsumedProps`
-  void addUnconsumedProps(Map props, /*PropsMeta || Iterable<PropsMeta>*/ dynamic consumedProps) {
-    // It's safe for this to be `null` because `_forwardUnconsumedProps` uses
+  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) {
+    // It's safe for this to be `null` because `forwardUnconsumedPropsV2` uses
     // `null` as a flag to short circuit for a minor performance boost.
-    Iterable<Iterable> consumedPropKeys;
-
-    assert(consumedProps is Iterable || consumedProps is PropsMeta,
-        UiPropsMeta.consumedPropsAssertMessage);
-
-    if (consumedProps is Iterable) {
-      consumedPropKeys = consumedProps.map((consumedProps) {
-        assert(consumedProps is PropsMeta, UiPropsMeta.consumedPropsAssertMessage);
-        if (consumedProps is PropsMeta) {
-          return consumedProps.keys;
-        }
-
-        return null;
-      });
-    } else if (consumedProps is PropsMeta){
-      consumedPropKeys = [consumedProps.keys];
-    }
-
+    final consumedPropKeys = consumedProps?.map((consumedProps) => consumedProps.keys);
     forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys);
   }
 
@@ -186,27 +169,10 @@ extension UiPropsMeta on UiProps {
   /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
   ///
   /// Related: [UiComponent2]'s `addUnconsumedDomProps`
-  void addUnconsumedDomProps(Map props, /*PropsMeta || Iterable<PropsMeta>*/ dynamic consumedProps) {
-    // It's safe for this to be `null` because `_forwardUnconsumedProps` uses
+  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) {
+    // It's safe for this to be `null` because `forwardUnconsumedPropsV2` uses
     // `null` as a flag to short circuit for a minor performance boost.
-    Iterable<Iterable> consumedPropKeys;
-
-    assert(consumedProps is Iterable || consumedProps is PropsMeta,
-        UiPropsMeta.consumedPropsAssertMessage);
-
-    if (consumedProps is Iterable) {
-      consumedPropKeys = consumedProps.map((consumedProps) {
-        assert(consumedProps is PropsMeta, UiPropsMeta.consumedPropsAssertMessage);
-        if (consumedProps is PropsMeta) {
-          return consumedProps.keys;
-        }
-
-        return null;
-      });
-    } else if (consumedProps is PropsMeta){
-      consumedPropKeys = [consumedProps.keys];
-    }
-
+    final consumedPropKeys = consumedProps?.map((consumedProps) => consumedProps.keys);
     forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys, onlyCopyDomProps: true);
   }
 }

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -124,13 +124,7 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
       ' Will be removed in 4.0.0.')
   @toBeGenerated String get propKeyNamespace => throw UngeneratedError(member: #propKeyNamespace);
 
-  @toBeGenerated PropsMetaCollection get $meta => throw UngeneratedError(member: #meta);
-
   @override @toBeGenerated Map get props => throw UngeneratedError(member: #props);
-}
-
-extension UiPropsMeta on UiProps {
-  static const consumedPropsAssertMessage = 'consumedProps must be either an Iterable<PropsMeta> or PropsMeta';
 
   /// A collection of metadata for the prop fields in all prop mixins used by
   /// this props instance's generated props class.
@@ -139,8 +133,7 @@ extension UiPropsMeta on UiProps {
   ///
   /// This can be used to derive consumed props by usage in conjunction with [addUnconsumedProps]
   /// and [addUnconsumedDomProps].
-  PropsMetaCollection get staticMeta => $meta;
-
+  @toBeGenerated PropsMetaCollection get staticMeta => throw UngeneratedError(member: #meta);
 
   /// Copies props from the provided [props] instance to this [UiProps] instance,
   /// filtering out props found in [consumedProps].

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -139,7 +139,7 @@ extension UiPropsMeta on UiProps {
   ///
   /// This can be used to derive consumed props by usage in conjunction with [addUnconsumedProps]
   /// and [addUnconsumedDomProps].
-  PropsMetaCollection get meta => $meta;
+  PropsMetaCollection get staticMeta => $meta;
 
 
   /// Copies props from the provided [props] instance to this [UiProps] instance,

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -145,9 +145,10 @@ extension UiPropsMeta on UiProps {
   /// Copies props from the provided [props] instance to this [UiProps] instance,
   /// filtering out props found in [consumedProps].
   ///
-  /// [consumedProps] should be either a [PropsMeta] or `Iterable<PropsMeta>` instance.
-  /// These are both return types of [PropsMetaCollection]'s related APIs
-  /// (`forMixin`, `forMixins`, `allExceptForMixins`).
+  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`
+  /// and `allExceptForMixins`. `forMixin` can be used easily by then calling `.inList()`
+  /// on the returned [PropsMeta] instance.
   ///
   /// To only add DOM props, use [addUnconsumedDomProps].
   ///
@@ -162,9 +163,10 @@ extension UiPropsMeta on UiProps {
   /// Copies DOM props from the provided [props] instance to this [UiProps] instance,
   /// filtering out props found in [consumedProps].
   ///
-  /// [consumedProps] should be either a [PropsMeta] or `Iterable<PropsMeta>` instance.
-  /// These are both return types of [PropsMetaCollection]'s related APIs
-  /// (`forMixin`, `forMixins`, `allExceptForMixins`).
+  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`
+  /// and `allExceptForMixins`. `forMixin` can be used easily by then calling `.inList()`
+  /// on the returned [PropsMeta] instance.
   ///
   /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
   ///

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -124,14 +124,10 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
       ' Will be removed in 4.0.0.')
   @toBeGenerated String get propKeyNamespace => throw UngeneratedError(member: #propKeyNamespace);
 
-  @toBeGenerated PropsInstanceMeta get $meta => throw UngeneratedError(member: #meta);
+  @toBeGenerated PropsMetaCollection get $meta => throw UngeneratedError(member: #meta);
 
   @override @toBeGenerated Map get props => throw UngeneratedError(member: #props);
 }
-
-mixin PropsConsumptionMixin on PropsMetaCollection {}
-
-class PropsInstanceMeta = PropsMetaCollection with PropsConsumptionMixin;
 
 extension UiPropsMeta on UiProps {
   static const consumedPropsAssertMessage = 'consumedProps must be either an Iterable<PropsMeta> or PropsMeta';
@@ -143,7 +139,7 @@ extension UiPropsMeta on UiProps {
   ///
   /// This can be used to derive consumed props by usage in conjunction with [addUnconsumedProps]
   /// and [addUnconsumedDomProps].
-  PropsInstanceMeta get meta => $meta;
+  PropsMetaCollection get meta => $meta;
 
 
   /// Copies props from the provided [props] instance to this [UiProps] instance,

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -146,9 +146,8 @@ extension UiPropsMeta on UiProps {
   /// filtering out props found in [consumedProps].
   ///
   /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
-  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`
-  /// and `allExceptForMixins`. `forMixin` can be used easily by then calling `.inList()`
-  /// on the returned [PropsMeta] instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
+  /// `allExceptForMixins`, and `all`.
   ///
   /// To only add DOM props, use [addUnconsumedDomProps].
   ///
@@ -164,9 +163,8 @@ extension UiPropsMeta on UiProps {
   /// filtering out props found in [consumedProps].
   ///
   /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
-  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`
-  /// and `allExceptForMixins`. `forMixin` can be used easily by then calling `.inList()`
-  /// on the returned [PropsMeta] instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
+  /// `allExceptForMixins`, and `all`.
   ///
   /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
   ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -464,6 +464,56 @@ abstract class UiProps extends MapBase
     modifier(this);
   }
 
+  /// Copies key-value pairs from the provided [props] map into this map,
+  /// excluding those with keys found in [consumedProps].
+  ///
+  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
+  /// `allExceptForMixins`, and `all`.
+  ///
+  /// __Example:__
+  ///
+  /// ```dart
+  /// // within a functional component (wrapped in `uiFunction`)
+  /// // Consider props in FooProps "consumed"...
+  /// final consumedProps = props.staticMeta.forMixins({FooProps});
+  /// // ...and filter them out when forwarding props to Bar.
+  /// return (Bar()..addUnconsumedProps(props, consumedProps))();
+  /// ```
+  ///
+  /// To only add DOM props, use [addUnconsumedDomProps].
+  ///
+  /// Related: `UiComponent2`'s `addUnconsumedProps`
+  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) {
+    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
+    forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys);
+  }
+
+  /// Copies DOM only key-value pairs from the provided [props] map into this map,
+  /// excluding those with keys found in [consumedProps].
+  ///
+  /// [consumedProps] should be a `Iterable<PropsMeta>` instance.
+  /// This is the return type of [PropsMetaCollection]'s related APIs `forMixins`,
+  /// `allExceptForMixins`, and `all`.
+  ///
+  /// __Example:__
+  ///
+  /// ```dart
+  /// // within a functional component (wrapped in `uiFunction`)
+  /// // Consider props in FooProps "consumed"...
+  /// final consumedProps = [PropsMeta.forSimpleKey('className')];
+  /// // ...and filter them out when forwarding props to Bar.
+  /// return (Bar()..addUnconsumedDomProps(props, consumedProps))();
+  /// ```
+  ///
+  /// To add all unconsumed props, including DOM props, use [addUnconsumedProps].
+  ///
+  /// Related: `UiComponent2`'s `addUnconsumedDomProps`
+  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) {
+    final consumedPropKeys = consumedProps.map((consumedProps) => consumedProps.keys);
+    forwardUnconsumedPropsV2(props, propsToUpdate: this, keySetsToOmit: consumedPropKeys, onlyCopyDomProps: true);
+  }
+
   /// Whether [UiProps] is in a testing environment.
   ///
   /// Do not set this directly; Call [enableTestMode] or [disableTestMode] instead.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -818,12 +818,6 @@ class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
 
   @override
   String toString() => 'PropsMeta:$keys';
-
-  /// Wraps this instance in a [List].
-  ///
-  /// This is useful in conjunction with [UiProps]'s `addUnconsumedProps`,
-  /// which expects [PropsMeta] to be provided in a [List].
-  List<PropsMeta> inList() => [this];
 }
 
 /// Metadata for the state fields declared in a specific state class--
@@ -931,11 +925,4 @@ class PropsMetaCollection extends _AccessorMetaCollection<PropDescriptor, PropsM
 
   @override
   List<PropDescriptor> get props => fields;
-
-  /// Wraps this instance in a [List].
-  ///
-  /// This is useful in conjunction with [UiProps]'s `addUnconsumedProps`,
-  /// which expects [PropsMeta] to be provided in a [List].
-  @override
-  List<PropsMeta> inList() => [this];
 }

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -818,6 +818,12 @@ class PropsMeta implements ConsumedProps, AccessorMeta<PropDescriptor> {
 
   @override
   String toString() => 'PropsMeta:$keys';
+
+  /// Wraps this instance in a [List].
+  ///
+  /// This is useful in conjunction with [UiProps]'s `addUnconsumedProps`,
+  /// which expects [PropsMeta] to be provided in a [List].
+  List<PropsMeta> inList() => [this];
 }
 
 /// Metadata for the state fields declared in a specific state class--
@@ -925,4 +931,11 @@ class PropsMetaCollection extends _AccessorMetaCollection<PropDescriptor, PropsM
 
   @override
   List<PropDescriptor> get props => fields;
+
+  /// Wraps this instance in a [List].
+  ///
+  /// This is useful in conjunction with [UiProps]'s `addUnconsumedProps`,
+  /// which expects [PropsMeta] to be provided in a [List].
+  @override
+  List<PropsMeta> inList() => [this];
 }

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -165,9 +165,8 @@ class UiFactoryConfig<TProps extends UiProps> {
   @protected
   final PropsFactory<TProps> propsFactory;
   final String displayName;
-  final PropsMeta meta;
 
-  UiFactoryConfig({this.propsFactory, this.displayName, this.meta});
+  UiFactoryConfig({this.propsFactory, this.displayName});
 }
 
 /// Helper class to keep track of props factories used by [uiFunction],

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -165,8 +165,9 @@ class UiFactoryConfig<TProps extends UiProps> {
   @protected
   final PropsFactory<TProps> propsFactory;
   final String displayName;
+  final PropsMeta meta;
 
-  UiFactoryConfig({this.propsFactory, this.displayName});
+  UiFactoryConfig({this.propsFactory, this.displayName, this.meta});
 }
 
 /// Helper class to keep track of props factories used by [uiFunction],

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -142,8 +142,7 @@ void forwardUnconsumedPropsV2(Map props, {
   Iterable<Iterable> keySetsToOmit,
   Map propsToUpdate,
 }) {
-  if (onlyCopyDomProps) {
-    for (String key in props.keys) {
+    for (final key in props.keys) {
       if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
       if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
@@ -168,39 +167,11 @@ void forwardUnconsumedPropsV2(Map props, {
         }
       }
 
-      if (key.startsWith('aria-') ||
-          key.startsWith('data-') ||
-          _validDomProps.contains(key)) {
-        propsToUpdate[key] = props[key];
+      if (onlyCopyDomProps && !((key is String && (key.startsWith('aria-') ||
+          key.startsWith('data-'))) ||
+          _validDomProps.contains(key))) {
+        continue;
       }
-    }
-    return;
-  }
-
-  for (String key in props.keys) {
-    if (keysToOmit != null && keysToOmit.contains(key)) continue;
-
-    if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
-      // If the passed in value of [keySetsToOmit] comes from
-      // [addUnconsumedProps], there should only be a single index.
-      // Consequently, this case exists to give the opportunity for the loop
-      // to continue without initiating another loop (which is less
-      // performant than `.first.contains()`).
-      // TODO: further optimize this by identifying the best looping / data structure
-      if (keySetsToOmit.first.contains(key)) continue;
-
-      if (keySetsToOmit.length > 1) {
-        bool shouldContinue = false;
-        for (final keySet in keySetsToOmit) {
-          if (keySet.contains(key)) {
-            shouldContinue = true;
-            break;
-          }
-        }
-
-        if (shouldContinue) continue;
-      }
-    }
 
     if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
 

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 library over_react.map_util;
 
 import 'dart:collection';
@@ -75,6 +76,9 @@ Map getPropsToForward(Map props, {
 ///
 /// Based upon configuration, the function will overlook [props] that are not
 /// meant to be passed on, such as non-DOM props or specified values.
+///
+/// DEPRECATED: Use [forwardUnconsumedPropsV2] instead.
+@Deprecated('This implementation does not filter DOM props correctly. Use forwardUnconsumedPropsV2 instead.')
 void forwardUnconsumedProps(Map props, {
   bool omitReactProps = true,
   bool onlyCopyDomProps = false,
@@ -103,6 +107,64 @@ void forwardUnconsumedProps(Map props, {
       /// to continue without initiating another loop (which is less
       /// performant than `.first.contains()`).
       /// TODO: further optimize this by identifying the best looping / data structure
+      if (keySetsToOmit.first.contains(key)) continue;
+
+      if (keySetsToOmit.length > 1) {
+        bool shouldContinue = false;
+        for (final keySet in keySetsToOmit) {
+          if (keySet.contains(key)) {
+            shouldContinue = true;
+            break;
+          }
+        }
+
+        if (shouldContinue) continue;
+      }
+    }
+
+    if (omitReactProps && const ['key', 'ref', 'children'].contains(key)) continue;
+
+    propsToUpdate[key] = props[key];
+  }
+}
+
+/// Adds unconsumed props to a passed in [Map] reference ([propsToUpdate]).
+///
+/// Based upon configuration, the function will overlook [props] that are not
+/// meant to be passed on, such as non-DOM props or specified values.
+///
+/// Identical to [forwardUnconsumedProps], with the exception of properly filtering
+/// DOM props.
+void forwardUnconsumedPropsV2(Map props, {
+  bool omitReactProps = true,
+  bool onlyCopyDomProps = false,
+  Iterable keysToOmit,
+  Iterable<Iterable> keySetsToOmit,
+  Map propsToUpdate,
+}) {
+  if (onlyCopyDomProps) {
+    for (String key in props.keys) {
+      if (keysToOmit != null && keysToOmit.contains(key)) continue;
+
+      if (key.startsWith('aria-') ||
+          key.startsWith('data-') ||
+          _validDomProps.contains(key)) {
+        propsToUpdate[key] = props[key];
+      }
+    }
+    return;
+  }
+
+  for (String key in props.keys) {
+    if (keysToOmit != null && keysToOmit.contains(key)) continue;
+
+    if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
+      // If the passed in value of [keySetsToOmit] comes from
+      // [deriveUnconsumedProps], there should only be a single index.
+      // Consequently, this case exists to give the opportunity for the loop
+      // to continue without initiating another loop (which is less
+      // performant than `.first.contains()`).
+      // TODO: further optimize this by identifying the best looping / data structure
       if (keySetsToOmit.first.contains(key)) continue;
 
       if (keySetsToOmit.length > 1) {

--- a/lib/src/util/map_util.dart
+++ b/lib/src/util/map_util.dart
@@ -146,6 +146,28 @@ void forwardUnconsumedPropsV2(Map props, {
     for (String key in props.keys) {
       if (keysToOmit != null && keysToOmit.contains(key)) continue;
 
+      if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
+        // If the passed in value of [keySetsToOmit] comes from
+        // [addUnconsumedProps], there should only be a single index.
+        // Consequently, this case exists to give the opportunity for the loop
+        // to continue without initiating another loop (which is less
+        // performant than `.first.contains()`).
+        // TODO: further optimize this by identifying the best looping / data structure
+        if (keySetsToOmit != null && keySetsToOmit.first.contains(key)) continue;
+
+        if (keySetsToOmit.length > 1) {
+          bool shouldContinue = false;
+          for (final keySet in keySetsToOmit) {
+            if (keySet.contains(key)) {
+              shouldContinue = true;
+              break;
+            }
+          }
+
+          if (shouldContinue) continue;
+        }
+      }
+
       if (key.startsWith('aria-') ||
           key.startsWith('data-') ||
           _validDomProps.contains(key)) {
@@ -160,7 +182,7 @@ void forwardUnconsumedPropsV2(Map props, {
 
     if (keySetsToOmit != null && keySetsToOmit.isNotEmpty) {
       // If the passed in value of [keySetsToOmit] comes from
-      // [deriveUnconsumedProps], there should only be a single index.
+      // [addUnconsumedProps], there should only be a single index.
       // Consequently, this case exists to give the opportunity for the loop
       // to continue without initiating another loop (which is less
       // performant than `.first.contains()`).

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -22,6 +22,10 @@ import 'package:react/react_client.dart';
 /// A `MapView` helper that stubs in unimplemented pieces of [UiProps].
 ///
 /// Useful when you need a `MapView` for a `PropsMixin` that implements [UiProps].
+///
+/// DEPRECATED: Use new boilerplate mixin pattern instead (see the New Boilerplate Migration
+/// Guide for more information).
+@Deprecated('This pattern is deprecated in favor of the mixin props mixin pattern. See the New Boilerplate Migration guide for more information.')
 class UiPropsMapView extends MapView
     with
         ReactPropsMixin,

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -40,7 +40,7 @@ class UiPropsMapView extends MapView
   bool get $isClassGenerated =>
       throw UnimplementedError('@PropsMixin instances do not implement \$isClassGenerated');
 
-  PropsInstanceMeta get $meta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
+  PropsMetaCollection get $meta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
 
   String get propKeyNamespace =>
       throw UnimplementedError('@PropsMixin instances do not implement propKeyNamespace');

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -44,10 +44,16 @@ class UiPropsMapView extends MapView
   bool get $isClassGenerated =>
       throw UnimplementedError('@PropsMixin instances do not implement \$isClassGenerated');
 
-  PropsMetaCollection get $meta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
+  PropsMetaCollection get staticMeta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
 
   String get propKeyNamespace =>
       throw UnimplementedError('@PropsMixin instances do not implement propKeyNamespace');
+
+  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedProps');
+
+  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedDomProps');
 
   // ----- component_base.UiProps ----- //
 
@@ -73,6 +79,8 @@ class UiPropsMapView extends MapView
 
   @override
   String get testId => getTestId();
+
+
 
   @override
   Map get componentDefaultProps => throw UnimplementedError('@PropsMixin instances do not implement defaultProps');

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -49,12 +49,6 @@ class UiPropsMapView extends MapView
   String get propKeyNamespace =>
       throw UnimplementedError('@PropsMixin instances do not implement propKeyNamespace');
 
-  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) =>
-      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedProps');
-
-  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) =>
-      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedDomProps');
-
   // ----- component_base.UiProps ----- //
 
   @override
@@ -70,6 +64,14 @@ class UiPropsMapView extends MapView
       throw UnimplementedError('@PropsMixin instances do not implement modifyProps');
 
   @override
+  void addUnconsumedProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedProps');
+
+  @override
+  void addUnconsumedDomProps(Map props, Iterable<PropsMeta> consumedProps) =>
+      throw UnimplementedError('@PropsMixin instances do not implement addUnconsumedDomProps');
+
+  @override
   void addTestId(String value, {String key = defaultTestIdKey}) =>
       throw UnimplementedError('@PropsMixin instances do not implement addTestId');
 
@@ -79,8 +81,6 @@ class UiPropsMapView extends MapView
 
   @override
   String get testId => getTestId();
-
-
 
   @override
   Map get componentDefaultProps => throw UnimplementedError('@PropsMixin instances do not implement defaultProps');

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -40,6 +40,8 @@ class UiPropsMapView extends MapView
   bool get $isClassGenerated =>
       throw UnimplementedError('@PropsMixin instances do not implement \$isClassGenerated');
 
+  PropsInstanceMeta get $meta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
+
   String get propKeyNamespace =>
       throw UnimplementedError('@PropsMixin instances do not implement propKeyNamespace');
 

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$TransitionerProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because TransitionerPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionerPropsMixin, and check that $TransitionerPropsMixin is exported/imported properly.
+        TransitionerPropsMixin: $TransitionerPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
+        TransitionPropsMixin: $TransitionPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$TransitionerProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TransitionerPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionerPropsMixin, and check that $TransitionerPropsMixin is exported/imported properly.
         TransitionerPropsMixin: $TransitionerPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$TransitionerProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TransitionerPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionerPropsMixin, and check that $TransitionerPropsMixin is exported/imported properly.
         TransitionerPropsMixin: $TransitionerPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
+++ b/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$PureTestWrapperProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
+        SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -200,6 +206,14 @@ abstract class _$$PureTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
+        SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because PureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PureTestPropsMixin, and check that $PureTestPropsMixin is exported/imported properly.
+        PureTestPropsMixin: $PureTestPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
+++ b/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$PureTestWrapperProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
         SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
       });
@@ -208,7 +208,7 @@ abstract class _$$PureTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
         SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because PureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PureTestPropsMixin, and check that $PureTestPropsMixin is exported/imported properly.

--- a/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
+++ b/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$PureTestWrapperProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
         SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
       });
@@ -208,7 +208,7 @@ abstract class _$$PureTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SharedPureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SharedPureTestPropsMixin, and check that $SharedPureTestPropsMixin is exported/imported properly.
         SharedPureTestPropsMixin: $SharedPureTestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because PureTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PureTestPropsMixin, and check that $PureTestPropsMixin is exported/imported properly.

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -239,7 +239,10 @@ abstract class _$$FunctionCustomPropsProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FunctionCustomPropsProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FunctionCustomPropsProps, and check that $FunctionCustomPropsProps is exported/imported properly.
+        FunctionCustomPropsProps: $FunctionCustomPropsProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -237,6 +237,9 @@ abstract class _$$FunctionCustomPropsProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -239,7 +239,7 @@ abstract class _$$FunctionCustomPropsProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FunctionCustomPropsProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FunctionCustomPropsProps, and check that $FunctionCustomPropsProps is exported/imported properly.
         FunctionCustomPropsProps: $FunctionCustomPropsProps.meta,
       });

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });
@@ -234,7 +234,10 @@ abstract class _$$BasicUiFunctionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because BasicUiFunctionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicUiFunctionProps, and check that $BasicUiFunctionProps is exported/imported properly.
+        BasicUiFunctionProps: $BasicUiFunctionProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -312,7 +315,7 @@ abstract class _$$SecondaryBasicUiFunctionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicUiFunctionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicUiFunctionProps, and check that $BasicUiFunctionProps is exported/imported properly.
         BasicUiFunctionProps: $BasicUiFunctionProps.meta,
       });

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });
@@ -234,7 +234,7 @@ abstract class _$$BasicUiFunctionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicUiFunctionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicUiFunctionProps, and check that $BasicUiFunctionProps is exported/imported properly.
         BasicUiFunctionProps: $BasicUiFunctionProps.meta,
       });
@@ -315,7 +315,7 @@ abstract class _$$SecondaryBasicUiFunctionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicUiFunctionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicUiFunctionProps, and check that $BasicUiFunctionProps is exported/imported properly.
         BasicUiFunctionProps: $BasicUiFunctionProps.meta,
       });

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
+        BasicProps: $BasicProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -226,6 +232,9 @@ abstract class _$$BasicUiFunctionProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -301,6 +310,12 @@ abstract class _$$SecondaryBasicUiFunctionProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasicUiFunctionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicUiFunctionProps, and check that $BasicUiFunctionProps is exported/imported properly.
+        BasicUiFunctionProps: $BasicUiFunctionProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -34,9 +34,9 @@ _$$WithTransitionTesterProps _$WithTransitionTester([Map backingProps]) =>
 abstract class _$$WithTransitionTesterProps extends UiProps
     with
         WithTransitionPropsMixin,
-        $WithTransitionPropsMixin, // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        $WithTransitionPropsMixin, // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
         TransitionPropsMixin,
-        $TransitionPropsMixin // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TransitionPropsMixin.
+        $TransitionPropsMixin // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
     implements
         WithTransitionTesterProps {
   _$$WithTransitionTesterProps._();
@@ -61,6 +61,14 @@ abstract class _$$WithTransitionTesterProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
+        WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
+        TransitionPropsMixin: $TransitionPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -146,9 +154,9 @@ class _$WithTransitionTesterComponent extends WithTransitionTesterComponent {
 
   @override
   PropsMetaCollection get propsMeta => const PropsMetaCollection({
-        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of WithTransitionPropsMixin.
+        // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
         WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
-        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not exported. Check the declaration of TransitionPropsMixin.
+        // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.
         TransitionPropsMixin: $TransitionPropsMixin.meta,
       });
 }

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$WithTransitionTesterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
         WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$WithTransitionTesterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because WithTransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of WithTransitionPropsMixin, and check that $WithTransitionPropsMixin is exported/imported properly.
         WithTransitionPropsMixin: $WithTransitionPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TransitionPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TransitionPropsMixin, and check that $TransitionPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_helpers_test.dart
+++ b/test/over_react/component_declaration/builder_helpers_test.dart
@@ -65,8 +65,8 @@ main() {
         test('props',            () {expect(() => unimplemented.props,            throwsUngeneratedError);});
         test('propKeyNamespace', () {expect(() => unimplemented.propKeyNamespace, throwsUngeneratedError);});
         test('a map method',     () {expect(() => unimplemented.keys,             throwsUngeneratedError);});
-        test(r'meta (via $meta)',() {expect(() => unimplemented.$meta,            throwsUngeneratedError);});
-        test(r'meta (via UiPropsMeta.meta)', () {expect(() => UiPropsMeta(unimplemented).meta, throwsUngeneratedError);});
+        test(r'$meta (via $meta)',() {expect(() => unimplemented.$meta,            throwsUngeneratedError);});
+        test(r'$meta (via UiPropsMeta.staticMeta)', () {expect(() => unimplemented.staticMeta, throwsUngeneratedError);});
 
         testStubbedMapMembers(() => UnimplementedUiProps());
       });

--- a/test/over_react/component_declaration/builder_helpers_test.dart
+++ b/test/over_react/component_declaration/builder_helpers_test.dart
@@ -65,8 +65,7 @@ main() {
         test('props',            () {expect(() => unimplemented.props,            throwsUngeneratedError);});
         test('propKeyNamespace', () {expect(() => unimplemented.propKeyNamespace, throwsUngeneratedError);});
         test('a map method',     () {expect(() => unimplemented.keys,             throwsUngeneratedError);});
-        test(r'$meta (via $meta)',() {expect(() => unimplemented.$meta,            throwsUngeneratedError);});
-        test(r'$meta (via UiPropsMeta.staticMeta)', () {expect(() => unimplemented.staticMeta, throwsUngeneratedError);});
+        test('staticMeta',      () {expect(() => unimplemented.staticMeta,       throwsUngeneratedError);});
 
         testStubbedMapMembers(() => UnimplementedUiProps());
       });

--- a/test/over_react/component_declaration/builder_helpers_test.dart
+++ b/test/over_react/component_declaration/builder_helpers_test.dart
@@ -65,6 +65,8 @@ main() {
         test('props',            () {expect(() => unimplemented.props,            throwsUngeneratedError);});
         test('propKeyNamespace', () {expect(() => unimplemented.propKeyNamespace, throwsUngeneratedError);});
         test('a map method',     () {expect(() => unimplemented.keys,             throwsUngeneratedError);});
+        test(r'meta (via $meta)',() {expect(() => unimplemented.$meta,            throwsUngeneratedError);});
+        test(r'meta (via UiPropsMeta.meta)', () {expect(() => UiPropsMeta(unimplemented).meta, throwsUngeneratedError);});
 
         testStubbedMapMembers(() => UnimplementedUiProps());
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
@@ -565,7 +565,10 @@ abstract class _$$TestPropsMixin extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
+        TestPropsMixin: $TestPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -642,7 +645,7 @@ abstract class _$$TestCustomNamespaceProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestCustomNamespacePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespacePropsMixin, and check that $TestCustomNamespacePropsMixin is exported/imported properly.
         TestCustomNamespacePropsMixin: $TestCustomNamespacePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TestCustomNamespaceWithPropsAnnotationPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespaceWithPropsAnnotationPropsMixin, and check that $TestCustomNamespaceWithPropsAnnotationPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
@@ -563,6 +563,9 @@ abstract class _$$TestPropsMixin extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -637,6 +640,15 @@ abstract class _$$TestCustomNamespaceProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because TestCustomNamespacePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespacePropsMixin, and check that $TestCustomNamespacePropsMixin is exported/imported properly.
+        TestCustomNamespacePropsMixin: $TestCustomNamespacePropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TestCustomNamespaceWithPropsAnnotationPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespaceWithPropsAnnotationPropsMixin, and check that $TestCustomNamespaceWithPropsAnnotationPropsMixin is exported/imported properly.
+        TestCustomNamespaceWithPropsAnnotationPropsMixin:
+            $TestCustomNamespaceWithPropsAnnotationPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.over_react.g.dart
@@ -565,7 +565,7 @@ abstract class _$$TestPropsMixin extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
         TestPropsMixin: $TestPropsMixin.meta,
       });
@@ -645,7 +645,7 @@ abstract class _$$TestCustomNamespaceProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestCustomNamespacePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespacePropsMixin, and check that $TestCustomNamespacePropsMixin is exported/imported properly.
         TestCustomNamespacePropsMixin: $TestCustomNamespacePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TestCustomNamespaceWithPropsAnnotationPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestCustomNamespaceWithPropsAnnotationPropsMixin, and check that $TestCustomNamespaceWithPropsAnnotationPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$FooProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ComponentTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
+        ComponentTestProps: $ComponentTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -331,6 +337,12 @@ abstract class _$$IsErrorBoundaryProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because IsErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsErrorBoundaryProps, and check that $IsErrorBoundaryProps is exported/imported properly.
+        IsErrorBoundaryProps: $IsErrorBoundaryProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -489,6 +501,12 @@ abstract class _$$IsNotErrorBoundaryProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because IsNotErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsNotErrorBoundaryProps, and check that $IsNotErrorBoundaryProps is exported/imported properly.
+        IsNotErrorBoundaryProps: $IsNotErrorBoundaryProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });
@@ -339,7 +339,7 @@ abstract class _$$IsErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because IsErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsErrorBoundaryProps, and check that $IsErrorBoundaryProps is exported/imported properly.
         IsErrorBoundaryProps: $IsErrorBoundaryProps.meta,
       });
@@ -503,7 +503,7 @@ abstract class _$$IsNotErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because IsNotErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsNotErrorBoundaryProps, and check that $IsNotErrorBoundaryProps is exported/imported properly.
         IsNotErrorBoundaryProps: $IsNotErrorBoundaryProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });
@@ -339,7 +339,7 @@ abstract class _$$IsErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because IsErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsErrorBoundaryProps, and check that $IsErrorBoundaryProps is exported/imported properly.
         IsErrorBoundaryProps: $IsErrorBoundaryProps.meta,
       });
@@ -503,7 +503,7 @@ abstract class _$$IsNotErrorBoundaryProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because IsNotErrorBoundaryProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of IsNotErrorBoundaryProps, and check that $IsNotErrorBoundaryProps is exported/imported properly.
         IsNotErrorBoundaryProps: $IsNotErrorBoundaryProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestPropsMixin, and check that $ComponentTestPropsMixin is exported/imported properly.
         ComponentTestPropsMixin: $ComponentTestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$ComponentTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestPropsMixin, and check that $ComponentTestPropsMixin is exported/imported properly.
+        ComponentTestPropsMixin: $ComponentTestPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
+        TestPropsMixin: $TestPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestPropsMixin, and check that $ComponentTestPropsMixin is exported/imported properly.
         ComponentTestPropsMixin: $ComponentTestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ComponentTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
+        ComponentTestProps: $ComponentTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
@@ -102,7 +102,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasePropsMixin, and check that $BasePropsMixin is exported/imported properly.
         BasePropsMixin: $BasePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because OverridePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of OverridePropsMixin, and check that $OverridePropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
@@ -100,6 +100,14 @@ abstract class _$$TestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BasePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasePropsMixin, and check that $BasePropsMixin is exported/imported properly.
+        BasePropsMixin: $BasePropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because OverridePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of OverridePropsMixin, and check that $OverridePropsMixin is exported/imported properly.
+        OverridePropsMixin: $OverridePropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.over_react.g.dart
@@ -102,7 +102,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasePropsMixin, and check that $BasePropsMixin is exported/imported properly.
         BasePropsMixin: $BasePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because OverridePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of OverridePropsMixin, and check that $OverridePropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$DoNotGenerateAccessorTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because DoNotGenerateAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotGenerateAccessorTestProps, and check that $DoNotGenerateAccessorTestProps is exported/imported properly.
+        DoNotGenerateAccessorTestProps: $DoNotGenerateAccessorTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$DoNotGenerateAccessorTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because DoNotGenerateAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotGenerateAccessorTestProps, and check that $DoNotGenerateAccessorTestProps is exported/imported properly.
         DoNotGenerateAccessorTestProps: $DoNotGenerateAccessorTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$DoNotGenerateAccessorTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because DoNotGenerateAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotGenerateAccessorTestProps, and check that $DoNotGenerateAccessorTestProps is exported/imported properly.
         DoNotGenerateAccessorTestProps: $DoNotGenerateAccessorTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -261,7 +261,7 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
       });
 
       test('and consumed props are correctly filtered', () {
-        final consumedProps = UiPropsMeta(initialProps).meta.forMixin(TestPropsMixin);
+        final consumedProps = initialProps.staticMeta.forMixin(TestPropsMixin);
         secondProps.addUnconsumedProps(initialProps, consumedProps.inList());
         expect(secondProps.stringProp, isNull);
         expect(secondProps.anotherProp, anotherProp);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -255,7 +255,7 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
       });
 
       test('', () {
-        secondProps.addUnconsumedProps(initialProps, null);
+        secondProps.addUnconsumedProps(initialProps, []);
         expect(secondProps.anotherProp, anotherProp);
         expect(secondProps.stringProp, stringProp);
       });
@@ -286,7 +286,7 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
       });
 
       test('', () {
-        secondProps.addUnconsumedDomProps(initialProps, null);
+        secondProps.addUnconsumedDomProps(initialProps, []);
         expect(secondProps.stringProp, isNull);
         expect(secondProps.anotherProp, isNull);
         expect(secondProps.className, className);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -261,8 +261,8 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
       });
 
       test('and consumed props are correctly filtered', () {
-        final consumedProps = initialProps.staticMeta.forMixin(TestPropsMixin);
-        secondProps.addUnconsumedProps(initialProps, consumedProps.inList());
+        final consumedProps = initialProps.staticMeta.forMixins({TestPropsMixin});
+        secondProps.addUnconsumedProps(initialProps, consumedProps);
         expect(secondProps.stringProp, isNull);
         expect(secondProps.anotherProp, anotherProp);
       });
@@ -294,7 +294,7 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
 
       test('and consumed props are correctly filtered', () {
         expect(initialProps.className, isNotNull, reason: 'Test setup sanity check');
-        secondProps.addUnconsumedDomProps(initialProps, PropsMeta(fields: [PropDescriptor('className')], keys: ['className']).inList());
+        secondProps.addUnconsumedDomProps(initialProps, [PropsMeta(fields: [PropDescriptor('className')], keys: ['className'])]);
         expect(secondProps.stringProp, isNull);
         expect(secondProps.anotherProp, isNull);
         expect(secondProps.className, isNull);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -192,14 +192,14 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
     test(
         'that returns a new props class implementation instance backed by an existing map',
         () {
-      Map existingMap = {'TestProps.stringProp': 'test'};
+      Map existingMap = {'TestPropsMixin.stringProp': 'test'};
       final props = factory(existingMap);
 
       expect(props.stringProp, equals('test'));
 
       props.stringProp = 'modified';
       expect(props.stringProp, equals('modified'));
-      expect(existingMap['TestProps.stringProp'], equals('modified'));
+      expect(existingMap['TestPropsMixin.stringProp'], equals('modified'));
     });
   });
 
@@ -208,18 +208,18 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
         'the props class name as a namespace and the prop name as the key by default',
         () {
       expect(factory()..stringProp = 'test',
-          containsPair('TestProps.stringProp', 'test'));
+          containsPair('TestPropsMixin.stringProp', 'test'));
 
       expect(
-          factory()..dynamicProp = 2, containsPair('TestProps.dynamicProp', 2));
+          factory()..dynamicProp = 2, containsPair('TestPropsMixin.dynamicProp', 2));
 
       expect(factory()..untypedProp = false,
-          containsPair('TestProps.untypedProp', false));
+          containsPair('TestPropsMixin.untypedProp', false));
     });
 
     test('custom prop keys', () {
       expect(factory()..customKeyProp = 'test',
-          containsPair('TestProps.custom key!', 'test'));
+          containsPair('TestPropsMixin.custom key!', 'test'));
     });
 
     test('custom prop key namespaces', () {
@@ -230,6 +230,71 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
     test('custom prop keys and namespaces', () {
       expect(factory()..customKeyAndNamespaceProp = 'test',
           containsPair('custom namespace~~custom key!', 'test'));
+    });
+  });
+
+  group('can pass along unconsumed props', () {
+    const stringProp = 'a string';
+    const anotherProp = 'this should be filtered';
+    const className = 'aClassName';
+
+
+    group('using `addUnconsumedProps`', () {
+      TestProps initialProps;
+      TestProps secondProps;
+
+      setUp(() {
+        initialProps = (factory()
+          ..stringProp = stringProp
+          ..anotherProp = anotherProp
+        );
+
+        secondProps = factory();
+      });
+
+
+      test('', () {
+        secondProps.addUnconsumedProps(initialProps, null);
+        expect(secondProps.anotherProp, anotherProp);
+        expect(secondProps.stringProp, stringProp);
+      });
+
+      test('and consumed props are correctly filtered', () {
+        final consumedProps = UiPropsMeta(initialProps).meta.forMixin(TestPropsMixin);
+        secondProps.addUnconsumedProps(initialProps, consumedProps.inList());
+        expect(secondProps.stringProp, isNull);
+        expect(secondProps.anotherProp, anotherProp);
+      });
+    });
+
+    group('using `addUnconsumedDomProps`', ()
+    {
+      TestProps initialProps;
+      TestProps secondProps;
+
+      setUp(() {
+        initialProps = (factory()
+          ..stringProp = stringProp
+          ..anotherProp = anotherProp
+          ..className = className
+        );
+
+        secondProps = factory();
+      });
+
+
+      test('', () {
+        secondProps.addUnconsumedDomProps(initialProps, null);
+        expect(secondProps.className, className);
+      });
+
+      test('and consumed props are correctly filtered', () {
+        expect(initialProps.className, isNotNull, reason: 'Test setup sanity check');
+        secondProps.addUnconsumedDomProps(initialProps, PropsMeta(fields: [PropDescriptor('className')], keys: ['className']).inList());
+        expect(secondProps.stringProp, isNull);
+        expect(secondProps.anotherProp, isNull);
+        expect(secondProps.className, isNull);
+      });
     });
   });
 }
@@ -362,7 +427,7 @@ final _Test = uiFunction<TestProps>(
   $_TestConfig, // ignore: undefined_identifier
 );
 
-mixin TestProps on UiProps {
+mixin TestPropsMixin on UiProps {
   String stringProp;
   dynamic dynamicProp;
   var untypedProp; // ignore: prefer_typing_uninitialized_variables
@@ -376,3 +441,13 @@ mixin TestProps on UiProps {
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   dynamic customKeyAndNamespaceProp;
 }
+
+mixin ASecondPropsMixin on UiProps {
+  String anotherProp;
+}
+
+mixin AThirdPropsMixin on UiProps {
+  String aPropsFromAThirdMixin;
+}
+
+class TestProps = UiProps with TestPropsMixin, ASecondPropsMixin, AThirdPropsMixin;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -238,7 +238,6 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
     const anotherProp = 'this should be filtered';
     const className = 'aClassName';
 
-
     group('using `addUnconsumedProps`', () {
       TestProps initialProps;
       TestProps secondProps;
@@ -250,8 +249,10 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
         );
 
         secondProps = factory();
-      });
 
+        expect(secondProps.stringProp, isNull, reason: 'Test setup sanity check');
+        expect(secondProps.anotherProp, isNull, reason: 'Test setup sanity check');
+      });
 
       test('', () {
         secondProps.addUnconsumedProps(initialProps, null);
@@ -280,11 +281,14 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
         );
 
         secondProps = factory();
-      });
 
+        expect(secondProps.className, isNull, reason: 'Test setup sanity check');
+      });
 
       test('', () {
         secondProps.addUnconsumedDomProps(initialProps, null);
+        expect(secondProps.stringProp, isNull);
+        expect(secondProps.anotherProp, isNull);
         expect(secondProps.className, className);
       });
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -294,7 +294,7 @@ void functionComponentTestHelper(UiFactory<TestProps> factory,
 
       test('and consumed props are correctly filtered', () {
         expect(initialProps.className, isNotNull, reason: 'Test setup sanity check');
-        secondProps.addUnconsumedDomProps(initialProps, [PropsMeta(fields: [PropDescriptor('className')], keys: ['className'])]);
+        secondProps.addUnconsumedDomProps(initialProps, [PropsMeta.forSimpleKey('className')]);
         expect(secondProps.stringProp, isNull);
         expect(secondProps.anotherProp, isNull);
         expect(secondProps.className, isNull);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -233,7 +233,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
         TestPropsMixin: $TestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ASecondPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ASecondPropsMixin, and check that $ASecondPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -156,7 +156,10 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestProps, and check that $TestProps is exported/imported properly.
+        TestProps: $TestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -11,99 +11,171 @@ part of 'function_component_test.dart';
     ' Do not reference it in your code, as it may change at any time.'
     ' EXCEPTION: this may be used in legacy boilerplate until'
     ' it is transitioned to the new mixin-based boilerplate.')
-mixin $TestProps on TestProps {
-  static const PropsMeta meta = _$metaForTestProps;
+mixin $TestPropsMixin on TestPropsMixin {
+  static const PropsMeta meta = _$metaForTestPropsMixin;
   @override
   String get stringProp =>
-      props[_$key__stringProp__TestProps] ??
+      props[_$key__stringProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
-  set stringProp(String value) => props[_$key__stringProp__TestProps] = value;
+  set stringProp(String value) =>
+      props[_$key__stringProp__TestPropsMixin] = value;
   @override
   dynamic get dynamicProp =>
-      props[_$key__dynamicProp__TestProps] ??
+      props[_$key__dynamicProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
   set dynamicProp(dynamic value) =>
-      props[_$key__dynamicProp__TestProps] = value;
+      props[_$key__dynamicProp__TestPropsMixin] = value;
   @override
   get untypedProp =>
-      props[_$key__untypedProp__TestProps] ??
+      props[_$key__untypedProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
-  set untypedProp(value) => props[_$key__untypedProp__TestProps] = value;
+  set untypedProp(value) => props[_$key__untypedProp__TestPropsMixin] = value;
   @override
   @Accessor(key: 'custom key!')
   dynamic get customKeyProp =>
-      props[_$key__customKeyProp__TestProps] ??
+      props[_$key__customKeyProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
   @Accessor(key: 'custom key!')
   set customKeyProp(dynamic value) =>
-      props[_$key__customKeyProp__TestProps] = value;
+      props[_$key__customKeyProp__TestPropsMixin] = value;
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   dynamic get customNamespaceProp =>
-      props[_$key__customNamespaceProp__TestProps] ??
+      props[_$key__customNamespaceProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
   @Accessor(keyNamespace: 'custom namespace~~')
   set customNamespaceProp(dynamic value) =>
-      props[_$key__customNamespaceProp__TestProps] = value;
+      props[_$key__customNamespaceProp__TestPropsMixin] = value;
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   dynamic get customKeyAndNamespaceProp =>
-      props[_$key__customKeyAndNamespaceProp__TestProps] ??
+      props[_$key__customKeyAndNamespaceProp__TestPropsMixin] ??
       null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
   @override
   @Accessor(keyNamespace: 'custom namespace~~', key: 'custom key!')
   set customKeyAndNamespaceProp(dynamic value) =>
-      props[_$key__customKeyAndNamespaceProp__TestProps] = value;
+      props[_$key__customKeyAndNamespaceProp__TestPropsMixin] = value;
   /* GENERATED CONSTANTS */
-  static const PropDescriptor _$prop__stringProp__TestProps =
-      PropDescriptor(_$key__stringProp__TestProps);
-  static const PropDescriptor _$prop__dynamicProp__TestProps =
-      PropDescriptor(_$key__dynamicProp__TestProps);
-  static const PropDescriptor _$prop__untypedProp__TestProps =
-      PropDescriptor(_$key__untypedProp__TestProps);
-  static const PropDescriptor _$prop__customKeyProp__TestProps =
-      PropDescriptor(_$key__customKeyProp__TestProps);
-  static const PropDescriptor _$prop__customNamespaceProp__TestProps =
-      PropDescriptor(_$key__customNamespaceProp__TestProps);
-  static const PropDescriptor _$prop__customKeyAndNamespaceProp__TestProps =
-      PropDescriptor(_$key__customKeyAndNamespaceProp__TestProps);
-  static const String _$key__stringProp__TestProps = 'TestProps.stringProp';
-  static const String _$key__dynamicProp__TestProps = 'TestProps.dynamicProp';
-  static const String _$key__untypedProp__TestProps = 'TestProps.untypedProp';
-  static const String _$key__customKeyProp__TestProps = 'TestProps.custom key!';
-  static const String _$key__customNamespaceProp__TestProps =
+  static const PropDescriptor _$prop__stringProp__TestPropsMixin =
+      PropDescriptor(_$key__stringProp__TestPropsMixin);
+  static const PropDescriptor _$prop__dynamicProp__TestPropsMixin =
+      PropDescriptor(_$key__dynamicProp__TestPropsMixin);
+  static const PropDescriptor _$prop__untypedProp__TestPropsMixin =
+      PropDescriptor(_$key__untypedProp__TestPropsMixin);
+  static const PropDescriptor _$prop__customKeyProp__TestPropsMixin =
+      PropDescriptor(_$key__customKeyProp__TestPropsMixin);
+  static const PropDescriptor _$prop__customNamespaceProp__TestPropsMixin =
+      PropDescriptor(_$key__customNamespaceProp__TestPropsMixin);
+  static const PropDescriptor
+      _$prop__customKeyAndNamespaceProp__TestPropsMixin =
+      PropDescriptor(_$key__customKeyAndNamespaceProp__TestPropsMixin);
+  static const String _$key__stringProp__TestPropsMixin =
+      'TestPropsMixin.stringProp';
+  static const String _$key__dynamicProp__TestPropsMixin =
+      'TestPropsMixin.dynamicProp';
+  static const String _$key__untypedProp__TestPropsMixin =
+      'TestPropsMixin.untypedProp';
+  static const String _$key__customKeyProp__TestPropsMixin =
+      'TestPropsMixin.custom key!';
+  static const String _$key__customNamespaceProp__TestPropsMixin =
       'custom namespace~~customNamespaceProp';
-  static const String _$key__customKeyAndNamespaceProp__TestProps =
+  static const String _$key__customKeyAndNamespaceProp__TestPropsMixin =
       'custom namespace~~custom key!';
 
   static const List<PropDescriptor> $props = [
-    _$prop__stringProp__TestProps,
-    _$prop__dynamicProp__TestProps,
-    _$prop__untypedProp__TestProps,
-    _$prop__customKeyProp__TestProps,
-    _$prop__customNamespaceProp__TestProps,
-    _$prop__customKeyAndNamespaceProp__TestProps
+    _$prop__stringProp__TestPropsMixin,
+    _$prop__dynamicProp__TestPropsMixin,
+    _$prop__untypedProp__TestPropsMixin,
+    _$prop__customKeyProp__TestPropsMixin,
+    _$prop__customNamespaceProp__TestPropsMixin,
+    _$prop__customKeyAndNamespaceProp__TestPropsMixin
   ];
   static const List<String> $propKeys = [
-    _$key__stringProp__TestProps,
-    _$key__dynamicProp__TestProps,
-    _$key__untypedProp__TestProps,
-    _$key__customKeyProp__TestProps,
-    _$key__customNamespaceProp__TestProps,
-    _$key__customKeyAndNamespaceProp__TestProps
+    _$key__stringProp__TestPropsMixin,
+    _$key__dynamicProp__TestPropsMixin,
+    _$key__untypedProp__TestPropsMixin,
+    _$key__customKeyProp__TestPropsMixin,
+    _$key__customNamespaceProp__TestPropsMixin,
+    _$key__customKeyAndNamespaceProp__TestPropsMixin
   ];
 }
 
 @Deprecated('This API is for use only within generated code.'
     ' Do not reference it in your code, as it may change at any time.')
-const PropsMeta _$metaForTestProps = PropsMeta(
-  fields: $TestProps.$props,
-  keys: $TestProps.$propKeys,
+const PropsMeta _$metaForTestPropsMixin = PropsMeta(
+  fields: $TestPropsMixin.$props,
+  keys: $TestPropsMixin.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $ASecondPropsMixin on ASecondPropsMixin {
+  static const PropsMeta meta = _$metaForASecondPropsMixin;
+  @override
+  String get anotherProp =>
+      props[_$key__anotherProp__ASecondPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set anotherProp(String value) =>
+      props[_$key__anotherProp__ASecondPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__anotherProp__ASecondPropsMixin =
+      PropDescriptor(_$key__anotherProp__ASecondPropsMixin);
+  static const String _$key__anotherProp__ASecondPropsMixin =
+      'ASecondPropsMixin.anotherProp';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__anotherProp__ASecondPropsMixin
+  ];
+  static const List<String> $propKeys = [_$key__anotherProp__ASecondPropsMixin];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForASecondPropsMixin = PropsMeta(
+  fields: $ASecondPropsMixin.$props,
+  keys: $ASecondPropsMixin.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $AThirdPropsMixin on AThirdPropsMixin {
+  static const PropsMeta meta = _$metaForAThirdPropsMixin;
+  @override
+  String get aPropsFromAThirdMixin =>
+      props[_$key__aPropsFromAThirdMixin__AThirdPropsMixin] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set aPropsFromAThirdMixin(String value) =>
+      props[_$key__aPropsFromAThirdMixin__AThirdPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__aPropsFromAThirdMixin__AThirdPropsMixin =
+      PropDescriptor(_$key__aPropsFromAThirdMixin__AThirdPropsMixin);
+  static const String _$key__aPropsFromAThirdMixin__AThirdPropsMixin =
+      'AThirdPropsMixin.aPropsFromAThirdMixin';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__aPropsFromAThirdMixin__AThirdPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__aPropsFromAThirdMixin__AThirdPropsMixin
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForAThirdPropsMixin = PropsMeta(
+  fields: $AThirdPropsMixin.$props,
+  keys: $AThirdPropsMixin.$propKeys,
 );
 
 final UiFactoryConfig<_$$TestProps> $TestConfig = UiFactoryConfig(
@@ -134,9 +206,14 @@ final UiFactoryConfig<_$$TestProps> $_TestConfig = UiFactoryConfig(
     ' Do not reference it in your code, as it may change at any time.')
 abstract class _$$TestProps extends UiProps
     with
-        TestProps,
-        $TestProps // If this generated mixin is undefined, it's likely because TestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestProps, and check that $TestProps is exported/imported properly.
-{
+        TestPropsMixin,
+        $TestPropsMixin, // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
+        ASecondPropsMixin,
+        $ASecondPropsMixin, // If this generated mixin is undefined, it's likely because ASecondPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ASecondPropsMixin, and check that $ASecondPropsMixin is exported/imported properly.
+        AThirdPropsMixin,
+        $AThirdPropsMixin // If this generated mixin is undefined, it's likely because AThirdPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AThirdPropsMixin, and check that $AThirdPropsMixin is exported/imported properly.
+    implements
+        TestProps {
   _$$TestProps._();
 
   factory _$$TestProps(Map backingMap) {
@@ -157,8 +234,12 @@ abstract class _$$TestProps extends UiProps
 
   @override
   PropsMetaCollection get $meta => const PropsMetaCollection({
-        // If this generated mixin is undefined, it's likely because TestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestProps, and check that $TestProps is exported/imported properly.
-        TestProps: $TestProps.meta,
+        // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
+        TestPropsMixin: $TestPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ASecondPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ASecondPropsMixin, and check that $ASecondPropsMixin is exported/imported properly.
+        ASecondPropsMixin: $ASecondPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because AThirdPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AThirdPropsMixin, and check that $AThirdPropsMixin is exported/imported properly.
+        AThirdPropsMixin: $AThirdPropsMixin.meta,
       });
 }
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -154,6 +154,9 @@ abstract class _$$TestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$NamespacedAccessorTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because NamespacedAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NamespacedAccessorTestProps, and check that $NamespacedAccessorTestProps is exported/imported properly.
         NamespacedAccessorTestProps: $NamespacedAccessorTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$NamespacedAccessorTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because NamespacedAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NamespacedAccessorTestProps, and check that $NamespacedAccessorTestProps is exported/imported properly.
+        NamespacedAccessorTestProps: $NamespacedAccessorTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$NamespacedAccessorTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because NamespacedAccessorTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NamespacedAccessorTestProps, and check that $NamespacedAccessorTestProps is exported/imported properly.
         NamespacedAccessorTestProps: $NamespacedAccessorTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$FooProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
@@ -137,6 +137,9 @@ abstract class _$$TestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
@@ -139,7 +139,10 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestProps, and check that $TestProps is exported/imported properly.
+        TestProps: $TestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.over_react.g.dart
@@ -139,7 +139,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestProps, and check that $TestProps is exported/imported properly.
         TestProps: $TestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -153,17 +153,10 @@ main() {
 
     group('(props instance)', () {
       group('generates props meta utilities attached to the props instance', () {
-        group('that can be accessed', () {
-          test(r'directly via $meta', () {
-            expect(Test().$meta, isNotNull);
-            expect(Test().$meta, isA<PropsMetaCollection>());
-          });
-
-          test('via explicitly using the UiPropsMeta extension method', () {
+          test(r'that can be accessed directly via staticMeta', () {
             expect(Test().staticMeta, isNotNull);
             expect(Test().staticMeta, isA<PropsMetaCollection>());
           });
-        });
       });
 
       commonMetaTests(Test().staticMeta);

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -50,6 +50,12 @@ main() {
             reason:
                 'Because `foo` is part of a different mixin, metaForTestPropsMixin should not have access to it.');
       });
+
+      test('`inList()` returns the instance wrapped in a List', () {
+        final metaInList = emptyPropsMeta.inList();
+        expect(metaInList, hasLength(1));
+        expect(metaInList.first, emptyPropsMeta);
+      });
     });
 
     void commonMetaTests(PropsMetaCollection propsMeta) {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -52,9 +52,7 @@ main() {
       });
     });
 
-    group('(field)', () {
-      final propsMeta = _$TestComponent().propsMeta;
-
+    void commonMetaTests(PropsMetaCollection propsMeta) {
       test('provides access to the expected props', () {
         expect(propsMeta.props.length, 3);
         expect(propsMeta.props.map((prop) => prop.key), containsAll(expectedKeys));
@@ -147,6 +145,28 @@ main() {
           }, tags: 'no-ddc');
         });
       });
+    }
+
+    group('(field)', () {
+      commonMetaTests(_$TestComponent().propsMeta);
+    });
+
+    group('(props instance)', () {
+      group('generates props meta utilities attached to the props instance', () {
+        group('that can be accessed', () {
+          test(r'directly via $meta', () {
+            expect(Test().$meta, isNotNull);
+            expect(Test().$meta, isA<PropsMetaCollection>());
+          });
+
+          test('via explicitly using the UiPropsMeta extension method', () {
+            expect(UiPropsMeta(Test()).meta, isNotNull);
+            expect(UiPropsMeta(Test()).meta, isA<PropsMetaCollection>());
+          });
+        });
+      });
+
+      commonMetaTests(UiPropsMeta(Test()).meta);
     });
   });
 }

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -50,12 +50,6 @@ main() {
             reason:
                 'Because `foo` is part of a different mixin, metaForTestPropsMixin should not have access to it.');
       });
-
-      test('`inList()` returns the instance wrapped in a List', () {
-        final metaInList = emptyPropsMeta.inList();
-        expect(metaInList, hasLength(1));
-        expect(metaInList.first, emptyPropsMeta);
-      });
     });
 
     void commonMetaTests(PropsMetaCollection propsMeta) {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -166,13 +166,13 @@ main() {
           });
 
           test('via explicitly using the UiPropsMeta extension method', () {
-            expect(UiPropsMeta(Test()).meta, isNotNull);
-            expect(UiPropsMeta(Test()).meta, isA<PropsMetaCollection>());
+            expect(Test().staticMeta, isNotNull);
+            expect(Test().staticMeta, isA<PropsMetaCollection>());
           });
         });
       });
 
-      commonMetaTests(UiPropsMeta(Test()).meta);
+      commonMetaTests(Test().staticMeta);
     });
   });
 }

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -64,7 +64,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
         TestPropsMixin: $TestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because FooPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooPropsMixin, and check that $FooPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -62,6 +62,16 @@ abstract class _$$TestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
+        TestPropsMixin: $TestPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because FooPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooPropsMixin, and check that $FooPropsMixin is exported/imported properly.
+        FooPropsMixin: $FooPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BazPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BazPropsMixin, and check that $BazPropsMixin is exported/imported properly.
+        BazPropsMixin: $BazPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.over_react.g.dart
@@ -64,7 +64,7 @@ abstract class _$$TestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TestPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestPropsMixin, and check that $TestPropsMixin is exported/imported properly.
         TestPropsMixin: $TestPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because FooPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooPropsMixin, and check that $FooPropsMixin is exported/imported properly.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
         ComponentTestProps: $ComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ComponentTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ComponentTestProps, and check that $ComponentTestProps is exported/imported properly.
+        ComponentTestProps: $ComponentTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$StatefulComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because StatefulComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of StatefulComponentTestProps, and check that $StatefulComponentTestProps is exported/imported properly.
         StatefulComponentTestProps: $StatefulComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$StatefulComponentTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because StatefulComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of StatefulComponentTestProps, and check that $StatefulComponentTestProps is exported/imported properly.
+        StatefulComponentTestProps: $StatefulComponentTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$StatefulComponentTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because StatefulComponentTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of StatefulComponentTestProps, and check that $StatefulComponentTestProps is exported/imported properly.
         StatefulComponentTestProps: $StatefulComponentTestProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$FooProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -245,6 +245,30 @@ main() {
           expect(actual, equals(expected));
         });
 
+        test('when keySetsToOmit is null', () {
+          var actual = {};
+
+          functionToTest({
+            'prop 1': 'my prop #1',
+            'prop 2': 'my prop #2',
+            'prop 3': 'my prop #3',
+            'prop 4': 'my prop #4',
+            'prop 5': 'my prop #5',
+            'prop 6': 'my prop #6',
+          }, keySetsToOmit: null, propsToUpdate: actual);
+
+          var expected = {
+            'prop 1': 'my prop #1',
+            'prop 2': 'my prop #2',
+            'prop 3': 'my prop #3',
+            'prop 4': 'my prop #4',
+            'prop 5': 'my prop #5',
+            'prop 6': 'my prop #6',
+          };
+
+          expect(actual, equals(expected));
+        });
+
         test('with only valid DOM/SVG props', () {
           var actual = {};
 

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 library map_util_test;
 
 import 'package:over_react/over_react.dart';

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -302,38 +302,74 @@ main() {
     // for `forwardUnconsumedProps` and `forwardUnconsumedPropsV2` is useful
     // to demonstrate the change in behavior.
     void commonDomPropsFilteringTest(ForwardUnconsumedPropsFunction functionToTest, {bool shouldFilter = true}) {
-      test('(common DOM props filtering test) ${shouldFilter ? 'should' : 'shouldn\'t'} filter DOM props', () {
-        final actual = {};
-        const startingDomProps = {
-          'tabIndex': '0',
-          'className': 'my classname',
-          'cx': '0',
-          'stroke': 'red',
-          'data-test-prop': 'my data attr',
-          'aria-test-prop': 'my aria attr',
-        };
+      group('(common DOM props filtering test) ${shouldFilter ? 'should' : 'shouldn\'t'} filter DOM props', () {
+        test('when `keysToOmit` is set', () {
+          final actual = {};
+          const startingDomProps = {
+            'tabIndex': '0',
+            'className': 'my classname',
+            'cx': '0',
+            'stroke': 'red',
+            'data-test-prop': 'my data attr',
+            'aria-test-prop': 'my aria attr',
+          };
 
-        const mapWithDomAndCustomProps = {
-          ...startingDomProps,
-          'classNameBlacklist': 'my classname blacklist',
-          'custom prop': 'my custom prop',
-        };
+          const mapWithDomAndCustomProps = {
+            ...startingDomProps,
+            'classNameBlacklist': 'my classname blacklist',
+            'custom prop': 'my custom prop',
+          };
 
-        functionToTest(
-            mapWithDomAndCustomProps,
-            keysToOmit: [
-              'stroke',
-              'className',
-            ], onlyCopyDomProps: true, propsToUpdate: actual);
+          functionToTest(
+              mapWithDomAndCustomProps,
+              keysToOmit: [
+                'stroke',
+                'className',
+              ], onlyCopyDomProps: true, propsToUpdate: actual);
 
-        final expected = shouldFilter ? {
-          'tabIndex': '0',
-          'cx': '0',
-          'data-test-prop': 'my data attr',
-          'aria-test-prop': 'my aria attr',
-        } : startingDomProps;
+          final expected = shouldFilter ? {
+            'tabIndex': '0',
+            'cx': '0',
+            'data-test-prop': 'my data attr',
+            'aria-test-prop': 'my aria attr',
+          } : startingDomProps;
 
-        expect(actual, equals(expected));
+          expect(actual, equals(expected));
+        });
+
+        test('when `keySetsToOmit` is set', () {
+          final actual = {};
+          const startingDomProps = {
+            'tabIndex': '0',
+            'className': 'my classname',
+            'cx': '0',
+            'stroke': 'red',
+            'data-test-prop': 'my data attr',
+            'aria-test-prop': 'my aria attr',
+          };
+
+          const mapWithDomAndCustomProps = {
+            ...startingDomProps,
+            'classNameBlacklist': 'my classname blacklist',
+            'custom prop': 'my custom prop',
+          };
+
+          functionToTest(
+              mapWithDomAndCustomProps,
+              keySetsToOmit: [
+                ['stroke'],
+                ['className', 'tabIndex'],
+              ], onlyCopyDomProps: true, propsToUpdate: actual);
+
+          final expected = shouldFilter ? {
+            'cx': '0',
+            'data-test-prop': 'my data attr',
+            'aria-test-prop': 'my aria attr',
+          } : startingDomProps;
+
+          expect(actual, equals(expected));
+        });
+
       });
     }
     group('forwardUnconsumedProps', () {

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 @TestOn('browser')
 library react_util_test;
 

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -59,7 +59,7 @@ abstract class _$$BasicProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
         BasicProps: $BasicProps.meta,
       });

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -57,6 +57,12 @@ abstract class _$$BasicProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because BasicProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicProps, and check that $BasicProps is exported/imported properly.
+        BasicProps: $BasicProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -63,7 +63,7 @@ abstract class _$$BasicPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ExamplePropsMixin, and check that $ExamplePropsMixin is exported/imported properly.
         ExamplePropsMixin: $ExamplePropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BasicPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPartOfLibPropsMixin, and check that $BasicPartOfLibPropsMixin is exported/imported properly.
@@ -434,7 +434,7 @@ abstract class _$$SubPartOfLibProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SuperPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPartOfLibPropsMixin, and check that $SuperPartOfLibPropsMixin is exported/imported properly.
         SuperPartOfLibPropsMixin: $SuperPartOfLibPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because SubPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPartOfLibPropsMixin, and check that $SubPartOfLibPropsMixin is exported/imported properly.

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -61,6 +61,14 @@ abstract class _$$BasicPartOfLibProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because ExamplePropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ExamplePropsMixin, and check that $ExamplePropsMixin is exported/imported properly.
+        ExamplePropsMixin: $ExamplePropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BasicPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BasicPartOfLibPropsMixin, and check that $BasicPartOfLibPropsMixin is exported/imported properly.
+        BasicPartOfLibPropsMixin: $BasicPartOfLibPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -424,6 +432,14 @@ abstract class _$$SubPartOfLibProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SuperPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SuperPartOfLibPropsMixin, and check that $SuperPartOfLibPropsMixin is exported/imported properly.
+        SuperPartOfLibPropsMixin: $SuperPartOfLibPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because SubPartOfLibPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SubPartOfLibPropsMixin, and check that $SubPartOfLibPropsMixin is exported/imported properly.
+        SubPartOfLibPropsMixin: $SubPartOfLibPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
@@ -203,7 +203,7 @@ abstract class _$$SingleProps<T> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.
         SingleProps: $SingleProps.meta,
       });
@@ -281,7 +281,7 @@ abstract class _$$SingleWithBoundProps<S extends Pattern> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because SingleWithBoundProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleWithBoundProps, and check that $SingleWithBoundProps is exported/imported properly.
         SingleWithBoundProps: $SingleWithBoundProps.meta,
       });
@@ -360,7 +360,7 @@ abstract class _$$DoubleProps<A, B> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because DoubleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoubleProps, and check that $DoubleProps is exported/imported properly.
         DoubleProps: $DoubleProps.meta,
       });
@@ -448,7 +448,7 @@ abstract class _$$ConcreteNoneProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because NoneProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NoneProps, and check that $NoneProps is exported/imported properly.
         NoneProps: $NoneProps.meta,
         // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.
@@ -544,7 +544,7 @@ abstract class _$$ConcreteArgsProps<U, V extends Iterable> extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because NoneProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NoneProps, and check that $NoneProps is exported/imported properly.
         NoneProps: $NoneProps.meta,
         // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.

--- a/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
@@ -201,6 +201,12 @@ abstract class _$$SingleProps<T> extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.
+        SingleProps: $SingleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -273,6 +279,12 @@ abstract class _$$SingleWithBoundProps<S extends Pattern> extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SingleWithBoundProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleWithBoundProps, and check that $SingleWithBoundProps is exported/imported properly.
+        SingleWithBoundProps: $SingleWithBoundProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -346,6 +358,12 @@ abstract class _$$DoubleProps<A, B> extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because DoubleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoubleProps, and check that $DoubleProps is exported/imported properly.
+        DoubleProps: $DoubleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -428,6 +446,20 @@ abstract class _$$ConcreteNoneProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because NoneProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NoneProps, and check that $NoneProps is exported/imported properly.
+        NoneProps: $NoneProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.
+        SingleProps: $SingleProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleThatWontBeSpecifiedProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleThatWontBeSpecifiedProps, and check that $SingleThatWontBeSpecifiedProps is exported/imported properly.
+        SingleThatWontBeSpecifiedProps: $SingleThatWontBeSpecifiedProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleWithBoundProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleWithBoundProps, and check that $SingleWithBoundProps is exported/imported properly.
+        SingleWithBoundProps: $SingleWithBoundProps.meta,
+        // If this generated mixin is undefined, it's likely because DoubleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoubleProps, and check that $DoubleProps is exported/imported properly.
+        DoubleProps: $DoubleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -510,6 +542,20 @@ abstract class _$$ConcreteArgsProps<U, V extends Iterable> extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because NoneProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of NoneProps, and check that $NoneProps is exported/imported properly.
+        NoneProps: $NoneProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleProps, and check that $SingleProps is exported/imported properly.
+        SingleProps: $SingleProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleThatWontBeSpecifiedProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleThatWontBeSpecifiedProps, and check that $SingleThatWontBeSpecifiedProps is exported/imported properly.
+        SingleThatWontBeSpecifiedProps: $SingleThatWontBeSpecifiedProps.meta,
+        // If this generated mixin is undefined, it's likely because SingleWithBoundProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SingleWithBoundProps, and check that $SingleWithBoundProps is exported/imported properly.
+        SingleWithBoundProps: $SingleWithBoundProps.meta,
+        // If this generated mixin is undefined, it's likely because DoubleProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoubleProps, and check that $DoubleProps is exported/imported properly.
+        DoubleProps: $DoubleProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
         ButtonProps: $ButtonProps.meta,
       });

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$ButtonProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
+        ButtonProps: $ButtonProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/button.over_react.g.dart
+++ b/web/component2/src/demo_components/button.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
         ButtonProps: $ButtonProps.meta,
       });

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ButtonGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
         ButtonGroupProps: $ButtonGroupProps.meta,
       });

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$ButtonGroupProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
+        ButtonGroupProps: $ButtonGroupProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/button_group.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ButtonGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
         ButtonGroupProps: $ButtonGroupProps.meta,
       });

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ListGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ListGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupProps, and check that $ListGroupProps is exported/imported properly.
         ListGroupProps: $ListGroupProps.meta,
       });

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$ListGroupProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ListGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupProps, and check that $ListGroupProps is exported/imported properly.
+        ListGroupProps: $ListGroupProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/list_group.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ListGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ListGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupProps, and check that $ListGroupProps is exported/imported properly.
         ListGroupProps: $ListGroupProps.meta,
       });

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ListGroupItemProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ListGroupItemProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupItemProps, and check that $ListGroupItemProps is exported/imported properly.
         ListGroupItemProps: $ListGroupItemProps.meta,
       });

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ListGroupItemProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ListGroupItemProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupItemProps, and check that $ListGroupItemProps is exported/imported properly.
         ListGroupItemProps: $ListGroupItemProps.meta,
       });

--- a/web/component2/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component2/src/demo_components/list_group_item.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ListGroupItemProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ListGroupItemProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ListGroupItemProps, and check that $ListGroupItemProps is exported/imported properly.
+        ListGroupItemProps: $ListGroupItemProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ProgressProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ProgressProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ProgressProps, and check that $ProgressProps is exported/imported properly.
         ProgressProps: $ProgressProps.meta,
       });

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$ProgressProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ProgressProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ProgressProps, and check that $ProgressProps is exported/imported properly.
         ProgressProps: $ProgressProps.meta,
       });

--- a/web/component2/src/demo_components/progress.over_react.g.dart
+++ b/web/component2/src/demo_components/progress.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$ProgressProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ProgressProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ProgressProps, and check that $ProgressProps is exported/imported properly.
+        ProgressProps: $ProgressProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$PropTypesTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because PropTypesTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesTestProps, and check that $PropTypesTestProps is exported/imported properly.
         PropTypesTestProps: $PropTypesTestProps.meta,
       });

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$PropTypesTestProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because PropTypesTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesTestProps, and check that $PropTypesTestProps is exported/imported properly.
+        PropTypesTestProps: $PropTypesTestProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/prop_validation.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$PropTypesTestProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because PropTypesTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesTestProps, and check that $PropTypesTestProps is exported/imported properly.
         PropTypesTestProps: $PropTypesTestProps.meta,
       });

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$PropTypesWrapProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because PropTypesWrapProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesWrapProps, and check that $PropTypesWrapProps is exported/imported properly.
         PropTypesWrapProps: $PropTypesWrapProps.meta,
       });

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$PropTypesWrapProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because PropTypesWrapProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesWrapProps, and check that $PropTypesWrapProps is exported/imported properly.
         PropTypesWrapProps: $PropTypesWrapProps.meta,
       });

--- a/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
+++ b/web/component2/src/demo_components/prop_validation_wrap.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$PropTypesWrapProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because PropTypesWrapProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of PropTypesWrapProps, and check that $PropTypesWrapProps is exported/imported properly.
+        PropTypesWrapProps: $PropTypesWrapProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$TagProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because TagProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TagProps, and check that $TagProps is exported/imported properly.
+        TagProps: $TagProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$TagProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TagProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TagProps, and check that $TagProps is exported/imported properly.
         TagProps: $TagProps.meta,
       });

--- a/web/component2/src/demo_components/tag.over_react.g.dart
+++ b/web/component2/src/demo_components/tag.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$TagProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because TagProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TagProps, and check that $TagProps is exported/imported properly.
         TagProps: $TagProps.meta,
       });

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -63,6 +63,16 @@ abstract class _$$ToggleButtonProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
+        ButtonProps: $ButtonProps.meta,
+        // If this generated mixin is undefined, it's likely because ToggleButtonPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ToggleButtonPropsMixin, and check that $ToggleButtonPropsMixin is exported/imported properly.
+        ToggleButtonPropsMixin: $ToggleButtonPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because AbstractInputPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AbstractInputPropsMixin, and check that $AbstractInputPropsMixin is exported/imported properly.
+        AbstractInputPropsMixin: $AbstractInputPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -65,7 +65,7 @@ abstract class _$$ToggleButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
         ButtonProps: $ButtonProps.meta,
         // If this generated mixin is undefined, it's likely because ToggleButtonPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ToggleButtonPropsMixin, and check that $ToggleButtonPropsMixin is exported/imported properly.

--- a/web/component2/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button.over_react.g.dart
@@ -65,7 +65,7 @@ abstract class _$$ToggleButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonProps, and check that $ButtonProps is exported/imported properly.
         ButtonProps: $ButtonProps.meta,
         // If this generated mixin is undefined, it's likely because ToggleButtonPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ToggleButtonPropsMixin, and check that $ToggleButtonPropsMixin is exported/imported properly.

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -64,7 +64,7 @@ abstract class _$$ToggleButtonGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
         ButtonGroupProps: $ButtonGroupProps.meta,
         // If this generated mixin is undefined, it's likely because AbstractInputPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AbstractInputPropsMixin, and check that $AbstractInputPropsMixin is exported/imported properly.

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -64,7 +64,7 @@ abstract class _$$ToggleButtonGroupProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
         ButtonGroupProps: $ButtonGroupProps.meta,
         // If this generated mixin is undefined, it's likely because AbstractInputPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AbstractInputPropsMixin, and check that $AbstractInputPropsMixin is exported/imported properly.

--- a/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component2/src/demo_components/toggle_button_group.over_react.g.dart
@@ -62,6 +62,14 @@ abstract class _$$ToggleButtonGroupProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ButtonGroupProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ButtonGroupProps, and check that $ButtonGroupProps is exported/imported properly.
+        ButtonGroupProps: $ButtonGroupProps.meta,
+        // If this generated mixin is undefined, it's likely because AbstractInputPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AbstractInputPropsMixin, and check that $AbstractInputPropsMixin is exported/imported properly.
+        AbstractInputPropsMixin: $AbstractInputPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });
@@ -202,7 +202,7 @@ abstract class _$$LogProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because LogProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LogProps, and check that $LogProps is exported/imported properly.
         LogProps: $LogProps.meta,
       });
@@ -586,7 +586,10 @@ abstract class _$$FancyButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because FancyButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FancyButtonProps, and check that $FancyButtonProps is exported/imported properly.
+        FancyButtonProps: $FancyButtonProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -665,7 +668,7 @@ abstract class _$$Foo2Props extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because AnotherPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AnotherPropsMixin, and check that $AnotherPropsMixin is exported/imported properly.
         AnotherPropsMixin: $AnotherPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
@@ -746,7 +749,10 @@ abstract class _$$BazProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because BazProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BazProps, and check that $BazProps is exported/imported properly.
+        BazProps: $BazProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -823,7 +829,10 @@ abstract class _$$RefDemoProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because RefDemoProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoProps, and check that $RefDemoProps is exported/imported properly.
+        RefDemoProps: $RefDemoProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -900,7 +909,10 @@ abstract class _$$RefDemoSectionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because RefDemoSectionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoSectionProps, and check that $RefDemoSectionProps is exported/imported properly.
+        RefDemoSectionProps: $RefDemoSectionProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -976,7 +988,10 @@ abstract class _$$RefDemoHocProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({});
+  PropsMetaCollection get $meta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because RefDemoHocProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoHocProps, and check that $RefDemoHocProps is exported/imported properly.
+        RefDemoHocProps: $RefDemoHocProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$FooProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -194,6 +200,12 @@ abstract class _$$LogProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because LogProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LogProps, and check that $LogProps is exported/imported properly.
+        LogProps: $LogProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -572,6 +584,9 @@ abstract class _$$FancyButtonProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -648,6 +663,14 @@ abstract class _$$Foo2Props extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because AnotherPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AnotherPropsMixin, and check that $AnotherPropsMixin is exported/imported properly.
+        AnotherPropsMixin: $AnotherPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
+        FooProps: $FooProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -721,6 +744,9 @@ abstract class _$$BazProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -795,6 +821,9 @@ abstract class _$$RefDemoProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -869,6 +898,9 @@ abstract class _$$RefDemoSectionProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].
@@ -942,6 +974,9 @@ abstract class _$$RefDemoHocProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({});
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FooProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
         FooProps: $FooProps.meta,
       });
@@ -202,7 +202,7 @@ abstract class _$$LogProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because LogProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LogProps, and check that $LogProps is exported/imported properly.
         LogProps: $LogProps.meta,
       });
@@ -586,7 +586,7 @@ abstract class _$$FancyButtonProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FancyButtonProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FancyButtonProps, and check that $FancyButtonProps is exported/imported properly.
         FancyButtonProps: $FancyButtonProps.meta,
       });
@@ -668,7 +668,7 @@ abstract class _$$Foo2Props extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because AnotherPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of AnotherPropsMixin, and check that $AnotherPropsMixin is exported/imported properly.
         AnotherPropsMixin: $AnotherPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because FooProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FooProps, and check that $FooProps is exported/imported properly.
@@ -749,7 +749,7 @@ abstract class _$$BazProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BazProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BazProps, and check that $BazProps is exported/imported properly.
         BazProps: $BazProps.meta,
       });
@@ -829,7 +829,7 @@ abstract class _$$RefDemoProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because RefDemoProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoProps, and check that $RefDemoProps is exported/imported properly.
         RefDemoProps: $RefDemoProps.meta,
       });
@@ -909,7 +909,7 @@ abstract class _$$RefDemoSectionProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because RefDemoSectionProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoSectionProps, and check that $RefDemoSectionProps is exported/imported properly.
         RefDemoSectionProps: $RefDemoSectionProps.meta,
       });
@@ -988,7 +988,7 @@ abstract class _$$RefDemoHocProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because RefDemoHocProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RefDemoHocProps, and check that $RefDemoHocProps is exported/imported properly.
         RefDemoHocProps: $RefDemoHocProps.meta,
       });

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$LittleBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because LittleBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LittleBlockProps, and check that $LittleBlockProps is exported/imported properly.
         LittleBlockProps: $LittleBlockProps.meta,
       });

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$LittleBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because LittleBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LittleBlockProps, and check that $LittleBlockProps is exported/imported properly.
+        LittleBlockProps: $LittleBlockProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/components/little_block.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$LittleBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because LittleBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of LittleBlockProps, and check that $LittleBlockProps is exported/imported properly.
         LittleBlockProps: $LittleBlockProps.meta,
       });

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$BigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
+        FluxUiPropsMixin: $FluxUiPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.
+        BigBlockPropsMixin: $BigBlockPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$BigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
+        FluxUiPropsMixin: $FluxUiPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.
+        BigBlockPropsMixin: $BigBlockPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because BigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockPropsMixin, and check that $BigBlockPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
         ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
         ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
+        ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
+        ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
         ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
         ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
+        ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$RandomColorReduxProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because RandomColorReduxPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RandomColorReduxPropsMixin, and check that $RandomColorReduxPropsMixin is exported/imported properly.
         RandomColorReduxPropsMixin: $RandomColorReduxPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$RandomColorReduxProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because RandomColorReduxPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RandomColorReduxPropsMixin, and check that $RandomColorReduxPropsMixin is exported/imported properly.
+        RandomColorReduxPropsMixin: $RandomColorReduxPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/random_color_redux.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$RandomColorReduxProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because RandomColorReduxPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of RandomColorReduxPropsMixin, and check that $RandomColorReduxPropsMixin is exported/imported properly.
         RandomColorReduxPropsMixin: $RandomColorReduxPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
+        ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$BigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
+        FluxUiPropsMixin: $FluxUiPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
       });

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
       });

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -59,6 +59,12 @@ abstract class _$$BigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
+        FluxUiPropsMixin: $FluxUiPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
       });

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/big_block.over_react.g.dart
@@ -61,7 +61,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FluxUiPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FluxUiPropsMixin, and check that $FluxUiPropsMixin is exported/imported properly.
         FluxUiPropsMixin: $FluxUiPropsMixin.meta,
       });

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
         ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
         ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$ConnectFluxBigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ConnectFluxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectFluxBigBlockPropsMixin, and check that $ConnectFluxBigBlockPropsMixin is exported/imported properly.
+        ConnectFluxBigBlockPropsMixin: $ConnectFluxBigBlockPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -61,6 +61,14 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
+        ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
         ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/redux_big_block.over_react.g.dart
@@ -63,7 +63,7 @@ abstract class _$$ReduxBigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ReduxBigBlockPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ReduxBigBlockPropsMixin, and check that $ReduxBigBlockPropsMixin is exported/imported properly.
         ReduxBigBlockPropsMixin: $ReduxBigBlockPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
+        ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$BigBlockProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because BigBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockProps, and check that $BigBlockProps is exported/imported properly.
+        BigBlockProps: $BigBlockProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BigBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockProps, and check that $BigBlockProps is exported/imported properly.
         BigBlockProps: $BigBlockProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/big_block.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$BigBlockProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because BigBlockProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of BigBlockProps, and check that $BigBlockProps is exported/imported properly.
         BigBlockProps: $BigBlockProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
+        ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/components/should_not_update.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$ShouldNotUpdateProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because ShouldNotUpdateProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ShouldNotUpdateProps, and check that $ShouldNotUpdateProps is exported/imported properly.
         ShouldNotUpdateProps: $ShouldNotUpdateProps.meta,
       });

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$CounterProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
+        CounterPropsMixin: $CounterPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/dev_tools/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$CounterProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
+        CounterPropsMixin: $CounterPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/multiple_stores/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -60,6 +60,14 @@ abstract class _$$CounterProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
+        CounterPropsMixin: $CounterPropsMixin.meta,
+        // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.
+        ConnectPropsMixin: $ConnectPropsMixin.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
+++ b/web/over_react_redux/examples/simple/components/counter.over_react.g.dart
@@ -62,7 +62,7 @@ abstract class _$$CounterProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because CounterPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CounterPropsMixin, and check that $CounterPropsMixin is exported/imported properly.
         CounterPropsMixin: $CounterPropsMixin.meta,
         // If this generated mixin is undefined, it's likely because ConnectPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of ConnectPropsMixin, and check that $ConnectPropsMixin is exported/imported properly.

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -57,6 +57,12 @@ abstract class _$$FaultyProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FaultyProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyProps, and check that $FaultyProps is exported/imported properly.
+        FaultyProps: $FaultyProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FaultyProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FaultyProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyProps, and check that $FaultyProps is exported/imported properly.
         FaultyProps: $FaultyProps.meta,
       });

--- a/web/src/demos/faulty-component.over_react.g.dart
+++ b/web/src/demos/faulty-component.over_react.g.dart
@@ -59,7 +59,7 @@ abstract class _$$FaultyProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FaultyProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyProps, and check that $FaultyProps is exported/imported properly.
         FaultyProps: $FaultyProps.meta,
       });

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -58,6 +58,12 @@ abstract class _$$FaultyOnMountProps extends UiProps
   /// The default namespace for the prop getters/setters generated for this class.
   @override
   String get propKeyNamespace => '';
+
+  @override
+  PropsInstanceMeta get $meta => PropsInstanceMeta({
+        // If this generated mixin is undefined, it's likely because FaultyOnMountProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyOnMountProps, and check that $FaultyOnMountProps is exported/imported properly.
+        FaultyOnMountProps: $FaultyOnMountProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$FaultyOnMountProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsMetaCollection get $meta => const PropsMetaCollection({
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FaultyOnMountProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyOnMountProps, and check that $FaultyOnMountProps is exported/imported properly.
         FaultyOnMountProps: $FaultyOnMountProps.meta,
       });

--- a/web/src/demos/faulty-on-mount-component.over_react.g.dart
+++ b/web/src/demos/faulty-on-mount-component.over_react.g.dart
@@ -60,7 +60,7 @@ abstract class _$$FaultyOnMountProps extends UiProps
   String get propKeyNamespace => '';
 
   @override
-  PropsInstanceMeta get $meta => PropsInstanceMeta({
+  PropsMetaCollection get $meta => const PropsMetaCollection({
         // If this generated mixin is undefined, it's likely because FaultyOnMountProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of FaultyOnMountProps, and check that $FaultyOnMountProps is exported/imported properly.
         FaultyOnMountProps: $FaultyOnMountProps.meta,
       });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
In class based components, we have the API's `addUnconsumedProps` to facilitate passing along props more easily. We want the same behavior in functional components.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Create a new class (`PropsInstanceMeta`) that uses a mixin on `PropsMetaCollection` to manage consumed props operations (e0cde45)
- Add a property onto `UiProps` called `$meta` typed as `PropsInstanceMeta` (e0cde45)
- Update the builder to override the field on Component2 / functional component props instances (8855f7e)
- Add a mixin (`UiPropsMeta`) on `UiProps` that can be used to access `$meta`, along with adding APIs to derive consumed props (e0cde45)
- Add examples (51b5466)

### STILL LEFT TO DO:
- Receive feedback on the approach thus far
- Add doc comments / documentation
- Add tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Add APIs for using consumed props in functional components

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@aaronlademann-wf @greglittlefield-wf @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
