### PR TITLE
RM-85606 RM-85605 Release over_react 3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [3.10.2](https://github.com/Workiva/over_react/compare/3.10.1...3.10.2)
+
+- Bump `react` minimum version to 5.6.1 to pull in the [Chrome 86 DDC workaround](https://github.com/cleandart/react-dart/pull/280)
+
 ## [3.10.1](https://github.com/Workiva/over_react/compare/3.10.0...3.10.1)
 
 - [#500] Improve error messages for boilerplate-related issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.10.1
+version: 3.10.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.10.1
+  over_react: 3.10.2
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* [Misc cleanup](https://github.com/Workiva/over_react/pull/630)
* [Check in changed generated files](https://github.com/Workiva/over_react/pull/632)
* [CPLAT-12194 Enable functional components to use consumed props](https://github.com/Workiva/over_react/pull/633)
* [bump react to 5.6.1](https://github.com/Workiva/over_react/pull/635)
* [Clean up lints](https://github.com/Workiva/over_react/pull/638)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/3.10.1...Workiva:release_over_react_3.10.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/3.10.1...3.10.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)