### PR TITLE
Use propsOrStateMapsEqual in memo so that tearoffs don't cause unnecessary rerenders

### DIFF
--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -32,11 +32,11 @@ import 'package:over_react/component_base.dart';
 /// ```dart
 /// import 'package:over_react/over_react.dart';
 ///
-/// UiFactory<UiProps> MemoExample = memo<UiProps>(uiFunction(
+/// UiFactory<UiProps> MemoExample = memo(uiFunction(
 ///   (props) {
 ///     // render using props
 ///   },
-///   UiFactoryConfig(displayName: 'MemoExample'),
+///   $MemoExampleConfig, // ignore: undefined_identifier
 /// ));
 /// ```
 ///
@@ -50,7 +50,7 @@ import 'package:over_react/component_base.dart';
 /// ```dart
 /// import 'package:over_react/over_react.dart';
 ///
-/// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo<MemoWithComparisonProps>(uiFunction(
+/// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo(uiFunction(
 ///   (props) {
 ///     // render using props
 ///   },

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -15,6 +15,7 @@
 library over_react.memo;
 
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
+import 'package:over_react/src/util/equality.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
 import 'package:over_react/component_base.dart';
@@ -43,7 +44,7 @@ import 'package:over_react/component_base.dart';
 /// `memo` only affects props changes. If your function component wrapped in `memo` has a
 /// `useState` or `useContext` Hook in its implementation, it will still rerender when `state` or `context` change.
 ///
-/// By default it will only shallowly compare complex objects in the props map.
+/// By default it will only shallowly compare complex objects in the props map using [propsOrStateMapsEqual].
 /// If you want control over the comparison, you can also provide a custom comparison
 /// function to the [areEqual] argument as shown in the example below.
 ///
@@ -80,7 +81,7 @@ UiFactory<TProps> memo<TProps extends UiProps>(UiFactory<TProps> factory,
 
     hoc = react_interop.memo2(factory().componentFactory, areEqual: wrapProps);
   } else {
-    hoc = react_interop.memo2(factory().componentFactory);
+    hoc = react_interop.memo2(factory().componentFactory, areEqual: propsOrStateMapsEqual);
   }
 
   setComponentTypeMeta(hoc,

--- a/test/over_react/component/memo_test.dart
+++ b/test/over_react/component/memo_test.dart
@@ -25,6 +25,7 @@ part 'memo_test.over_react.g.dart';
 int renderCount = 0;
 mixin FunctionCustomPropsProps on UiProps {
   int testProp;
+  Function() testFuncProp;
 }
 
 UiFactory<FunctionCustomPropsProps> FunctionCustomProps = uiFunction(
@@ -82,6 +83,24 @@ main() {
       testJacket.rerender((FunctionCustomPropsMemo()..testProp = 1)());
 
       expect(renderCount, equals(1));
+    });
+
+    // Asserts that propsOrStateMapsEqual is being used for the equality check
+    // when the consumer does not provide a custom `areEqual` parameter.
+    test('memoizes properly when a tear-off is passed as a function prop value', () {
+      renderCount = 0;
+      UiFactory<FunctionCustomPropsProps> FunctionCustomPropsMemo = memo(FunctionCustomProps);
+      void handleTestFunc() {}
+      void handleTestFunc2() {}
+      final testJacket = mount((FunctionCustomPropsMemo()..testFuncProp = handleTestFunc)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testFuncProp = handleTestFunc)());
+      testJacket.rerender((FunctionCustomPropsMemo()..testFuncProp = handleTestFunc)());
+
+      expect(renderCount, equals(1), reason: 'An identical tear-off value should not result in a re-render');
+
+      testJacket.rerender((FunctionCustomPropsMemo()..testFuncProp = handleTestFunc2)());
+
+      expect(renderCount, equals(2), reason: 'A different tear-off value should result in a re-render');
     });
 
     test('memoizes based on areEqual parameter', () {

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -181,17 +181,30 @@ mixin $FunctionCustomPropsProps on FunctionCustomPropsProps {
   @override
   set testProp(int value) =>
       props[_$key__testProp__FunctionCustomPropsProps] = value;
+  @override
+  Function() get testFuncProp =>
+      props[_$key__testFuncProp__FunctionCustomPropsProps] ??
+      null; // Add ` ?? null` to workaround DDC bug: <https://github.com/dart-lang/sdk/issues/36052>;
+  @override
+  set testFuncProp(Function() value) =>
+      props[_$key__testFuncProp__FunctionCustomPropsProps] = value;
   /* GENERATED CONSTANTS */
   static const PropDescriptor _$prop__testProp__FunctionCustomPropsProps =
       PropDescriptor(_$key__testProp__FunctionCustomPropsProps);
+  static const PropDescriptor _$prop__testFuncProp__FunctionCustomPropsProps =
+      PropDescriptor(_$key__testFuncProp__FunctionCustomPropsProps);
   static const String _$key__testProp__FunctionCustomPropsProps =
       'FunctionCustomPropsProps.testProp';
+  static const String _$key__testFuncProp__FunctionCustomPropsProps =
+      'FunctionCustomPropsProps.testFuncProp';
 
   static const List<PropDescriptor> $props = [
-    _$prop__testProp__FunctionCustomPropsProps
+    _$prop__testProp__FunctionCustomPropsProps,
+    _$prop__testFuncProp__FunctionCustomPropsProps
   ];
   static const List<String> $propKeys = [
-    _$key__testProp__FunctionCustomPropsProps
+    _$key__testProp__FunctionCustomPropsProps,
+    _$key__testFuncProp__FunctionCustomPropsProps
   ];
 }
 


### PR DESCRIPTION
## Motivation
[Tearoffs aren't guaranteed to be identical](https://github.com/dart-lang/sdk/issues/31665#issuecomment-352678783), and we don't want the use of them to trigger unnecessary rerenders in `memo`ized function components.

[Closely related to how we handled this same problem for `connect`ed components](https://github.com/Workiva/over_react/pull/608)

## Changes
1. Use `propsOrStateMapsEqual` for `areEqual` instead of default JS equality when the consumer does not specify their own custom handler for the `areEqual` parameter.
1. Note that we're using our own utility to do the default shallow comparison in the doc comment for `memo`.
1. Add a regression test.