### PR TITLE
RM-88572 RM-88571 Release over_react 3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## [3.12.1](https://github.com/Workiva/over_react/compare/3.12.0...3.12.1)
+- [#643] Use `propsOrStateMapsEqual` in `memo` so that function tearoffs don't cause unnecessary rerenders. 
+
 ## [3.12.0](https://github.com/Workiva/over_react/compare/3.11.0...3.12.0)
 - [#641] Expose new event helper APIs. In react-dart, using the `SyntheticEvent` class constructors were deprecated. 
 New event helpers were added as a replacement, and to make their usage convenient, these helpers have been exposed directly via OverReact. 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 3.12.0
+version: 3.12.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 authors:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.12.0
+  over_react: 3.12.1
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Use propsOrStateMapsEqual in memo so that tearoffs don't cause unnecessary rerenders](https://github.com/Workiva/over_react/pull/643)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/3.12.0...Workiva:release_over_react_3.12.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/3.12.0...3.12.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)