### PR TITLE
Test CI with prop validation moved to getDerivedStateFromProps

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -35,5 +35,5 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 6.0.0-wip
+      ref: test-proptypes-in-getDerivedStateFromProps
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 6.0.0-wip
+      ref: test-proptypes-in-getDerivedStateFromProps
   over_react_test:
     git:
       url: https://github.com/Workiva/over_react_test.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,3 @@ dependency_overrides:
     git:
       url: https://github.com/cleandart/react-dart.git
       ref: test-proptypes-in-getDerivedStateFromProps
-  over_react_test:
-    git:
-      url: https://github.com/Workiva/over_react_test.git
-      ref: widen-over-react-constraint

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -16,4 +16,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 6.0.0-wip
+      ref: test-proptypes-in-getDerivedStateFromProps

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -48,4 +48,4 @@ dependency_overrides:
   react:
     git:
       url: https://github.com/cleandart/react-dart.git
-      ref: 6.0.0-wip
+      ref: test-proptypes-in-getDerivedStateFromProps


### PR DESCRIPTION
(Do Not Merge) This pr tests CI when depending on [this branch](https://github.com/cleandart/react-dart/pull/292) of react-dart.