### PR TITLE
CPLAT-12620 Make factory config syntax use private variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ that you get for free from OverReact, you're ready to start building your own cu
       );
     },
     // The generated props config will match the factory name.
-    $FooConfig, // ignore: undefined_identifier
+    _$FooConfig, // ignore: undefined_identifier
   );
 
   mixin FooProps on UiProps {

--- a/doc/new_boilerplate_migration.md
+++ b/doc/new_boilerplate_migration.md
@@ -731,7 +731,7 @@ UiFactory<FooProps> Foo = uiFunction(
   (props) {
     return 'foo: ${props.foo}'; 
   },
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
 ); 
 
 mixin FooProps on UiProps {
@@ -761,7 +761,7 @@ UiFactory<FooProps> Foo = uiFunction(
 
     return 'foo: $foo'; 
   },
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
 ); 
 ```
 
@@ -792,14 +792,14 @@ UiFactory<FooBarProps> FooBar = uiFunction(
 
     return (Foo()..addUnconsumedProps(props, consumedProps))();
   },
-  $FooBarConfig, // ignore: undefined_identifier
+  _$FooBarConfig, // ignore: undefined_identifier
 ); 
 
 UiFactory<FooPropsMixin> Foo = uiFunction(
   (props) {
     return 'foo: ${props.passedProp}'; 
   },
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
 ); 
 ```
 
@@ -823,7 +823,7 @@ UiFactory<FooProps> Foo = uiFunction(
   (props) {
     return 'foo: ${props.foo}'; 
   }, 
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
   getPropTypes: (keyFor) => {
     keyFor((p) => p.foo): (props, info) {
       if (props.foo == 'bar') {
@@ -889,7 +889,7 @@ UiFactory<FooProps> Foo = uiForwardRef(
       )('Click me!'),
     );
   },
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
 );
 ```
 

--- a/doc/props_mixin_component_composition.md
+++ b/doc/props_mixin_component_composition.md
@@ -168,7 +168,7 @@ UiFactory<FooBazProps> FooBaz = uiFunction(
       return (Dom.li()..key = bizzle)(bizzle);
     }
   },
-  $FooBazConfig, // ignore: undefined_identifier
+  _$FooBazConfig, // ignore: undefined_identifier
 );
 ```
 

--- a/example/builder/src/function_component.dart
+++ b/example/builder/src/function_component.dart
@@ -36,7 +36,7 @@ UiFactory<BasicProps> Basic = uiForwardRef(
           props.basic3, 'children: ${props.children}'),
     );
   },
-  $BasicConfig, // ignore: undefined_identifier
+  _$BasicConfig, // ignore: undefined_identifier
 );
 
 UiFactory<BasicProps> Simple = uiFunction(
@@ -52,7 +52,7 @@ UiFactory<BasicProps> Simple = uiFunction(
       (Foo()..content = props.basic2)(),
     );
   },
-  $SimpleConfig, // ignore: undefined_identifier
+  _$SimpleConfig, // ignore: undefined_identifier
 );
 
 mixin FooProps on UiProps {
@@ -61,7 +61,7 @@ mixin FooProps on UiProps {
 
 UiFactory<FooProps> Foo = uiFunction(
   (props) => Dom.div()('forwarded prop: ${props.content}'),
-  $FooConfig, // ignore: undefined_identifier
+  _$FooConfig, // ignore: undefined_identifier
 );
 
 ReactElement functionComponentContent() {

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -123,19 +123,25 @@ const PropsMeta _$metaForFooProps = PropsMeta(
   keys: $FooProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$BasicProps> $BasicConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$BasicProps> _$BasicConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$BasicProps(map),
       jsMap: (map) => _$$BasicProps$JsMap(map),
     ),
     displayName: 'Basic');
 
-final UiFactoryConfig<_$$BasicProps> $SimpleConfig = UiFactoryConfig(
+@Deprecated('Use `_\$BasicConfig` instead.')
+final UiFactoryConfig<_$$BasicProps> $BasicConfig = _$BasicConfig;
+
+final UiFactoryConfig<_$$BasicProps> _$SimpleConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$BasicProps(map),
       jsMap: (map) => _$$BasicProps$JsMap(map),
     ),
     displayName: 'Simple');
+
+@Deprecated('Use `_\$SimpleConfig` instead.')
+final UiFactoryConfig<_$$BasicProps> $SimpleConfig = _$SimpleConfig;
 
 // Concrete props implementation.
 //
@@ -209,12 +215,15 @@ class _$$BasicProps$JsMap extends _$$BasicProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$FooProps> $FooConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$FooProps> _$FooConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$FooProps(map),
       jsMap: (map) => _$$FooProps$JsMap(map),
     ),
     displayName: 'Foo');
+
+@Deprecated('Use `_\$FooConfig` instead.')
+final UiFactoryConfig<_$$FooProps> $FooConfig = _$FooConfig;
 
 // Concrete props implementation.
 //

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -130,8 +130,9 @@ final UiFactoryConfig<_$$BasicProps> _$BasicConfig = UiFactoryConfig(
     ),
     displayName: 'Basic');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$BasicConfig` instead.')
+@Deprecated(r'Use the private variable, _$BasicConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$BasicProps> $BasicConfig = _$BasicConfig;
 
 final UiFactoryConfig<_$$BasicProps> _$SimpleConfig = UiFactoryConfig(
@@ -141,8 +142,9 @@ final UiFactoryConfig<_$$BasicProps> _$SimpleConfig = UiFactoryConfig(
     ),
     displayName: 'Simple');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$SimpleConfig` instead.')
+@Deprecated(r'Use the private variable, _$SimpleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$BasicProps> $SimpleConfig = _$SimpleConfig;
 
 // Concrete props implementation.
@@ -224,8 +226,9 @@ final UiFactoryConfig<_$$FooProps> _$FooConfig = UiFactoryConfig(
     ),
     displayName: 'Foo');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$FooConfig` instead.')
+@Deprecated(r'Use the private variable, _$FooConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$FooProps> $FooConfig = _$FooConfig;
 
 // Concrete props implementation.

--- a/example/builder/src/function_component.over_react.g.dart
+++ b/example/builder/src/function_component.over_react.g.dart
@@ -130,7 +130,8 @@ final UiFactoryConfig<_$$BasicProps> _$BasicConfig = UiFactoryConfig(
     ),
     displayName: 'Basic');
 
-@Deprecated('Use `_\$BasicConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$BasicConfig` instead.')
 final UiFactoryConfig<_$$BasicProps> $BasicConfig = _$BasicConfig;
 
 final UiFactoryConfig<_$$BasicProps> _$SimpleConfig = UiFactoryConfig(
@@ -140,7 +141,8 @@ final UiFactoryConfig<_$$BasicProps> _$SimpleConfig = UiFactoryConfig(
     ),
     displayName: 'Simple');
 
-@Deprecated('Use `_\$SimpleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$SimpleConfig` instead.')
 final UiFactoryConfig<_$$BasicProps> $SimpleConfig = _$SimpleConfig;
 
 // Concrete props implementation.
@@ -222,7 +224,8 @@ final UiFactoryConfig<_$$FooProps> _$FooConfig = UiFactoryConfig(
     ),
     displayName: 'Foo');
 
-@Deprecated('Use `_\$FooConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$FooConfig` instead.')
 final UiFactoryConfig<_$$FooProps> $FooConfig = _$FooConfig;
 
 // Concrete props implementation.

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -39,7 +39,7 @@ UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
         )
     );
   },
-  $SomeParentConfig, // ignore: undefined_identifier
+  _$SomeParentConfig, // ignore: undefined_identifier
 );
 
 class SomeChildProps = UiProps with SharedPropsMixin;
@@ -51,5 +51,5 @@ UiFactory<SomeChildProps> SomeChild = uiFunction((props) {
     )
   );
 },
-  $SomeChildConfig, // ignore: undefined_identifier
+  _$SomeChildConfig, // ignore: undefined_identifier
 );

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -82,7 +82,8 @@ final UiFactoryConfig<_$$SomeParentProps> _$SomeParentConfig = UiFactoryConfig(
     ),
     displayName: 'SomeParent');
 
-@Deprecated('Use `_\$SomeParentConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$SomeParentConfig` instead.')
 final UiFactoryConfig<_$$SomeParentProps> $SomeParentConfig =
     _$SomeParentConfig;
 
@@ -170,7 +171,8 @@ final UiFactoryConfig<_$$SomeChildProps> _$SomeChildConfig = UiFactoryConfig(
     ),
     displayName: 'SomeChild');
 
-@Deprecated('Use `_\$SomeChildConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$SomeChildConfig` instead.')
 final UiFactoryConfig<_$$SomeChildProps> $SomeChildConfig = _$SomeChildConfig;
 
 // Concrete props implementation.

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -75,12 +75,16 @@ const PropsMeta _$metaForSharedPropsMixin = PropsMeta(
   keys: $SharedPropsMixin.$propKeys,
 );
 
-final UiFactoryConfig<_$$SomeParentProps> $SomeParentConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$SomeParentProps> _$SomeParentConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$SomeParentProps(map),
       jsMap: (map) => _$$SomeParentProps$JsMap(map),
     ),
     displayName: 'SomeParent');
+
+@Deprecated('Use `_\$SomeParentConfig` instead.')
+final UiFactoryConfig<_$$SomeParentProps> $SomeParentConfig =
+    _$SomeParentConfig;
 
 // Concrete props implementation.
 //
@@ -159,12 +163,15 @@ class _$$SomeParentProps$JsMap extends _$$SomeParentProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$SomeChildProps> $SomeChildConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$SomeChildProps> _$SomeChildConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$SomeChildProps(map),
       jsMap: (map) => _$$SomeChildProps$JsMap(map),
     ),
     displayName: 'SomeChild');
+
+@Deprecated('Use `_\$SomeChildConfig` instead.')
+final UiFactoryConfig<_$$SomeChildProps> $SomeChildConfig = _$SomeChildConfig;
 
 // Concrete props implementation.
 //

--- a/example/builder/src/functional_consumed_props.over_react.g.dart
+++ b/example/builder/src/functional_consumed_props.over_react.g.dart
@@ -82,8 +82,9 @@ final UiFactoryConfig<_$$SomeParentProps> _$SomeParentConfig = UiFactoryConfig(
     ),
     displayName: 'SomeParent');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$SomeParentConfig` instead.')
+@Deprecated(r'Use the private variable, _$SomeParentConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$SomeParentProps> $SomeParentConfig =
     _$SomeParentConfig;
 
@@ -171,8 +172,9 @@ final UiFactoryConfig<_$$SomeChildProps> _$SomeChildConfig = UiFactoryConfig(
     ),
     displayName: 'SomeChild');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$SomeChildConfig` instead.')
+@Deprecated(r'Use the private variable, _$SomeChildConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$SomeChildProps> $SomeChildConfig = _$SomeChildConfig;
 
 // Concrete props implementation.

--- a/example/hooks/use_callback_example.dart
+++ b/example/hooks/use_callback_example.dart
@@ -39,5 +39,5 @@ UiFactory<UseCallbackExampleProps> UseCallbackExample = uiFunction(
       (Dom.button()..onClick = incrementDelta)('Increment delta'),
     );
   },
-  $UseCallbackExampleConfig, // ignore: undefined_identifier
+  _$UseCallbackExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -34,7 +34,8 @@ final UiFactoryConfig<_$$UseCallbackExampleProps> _$UseCallbackExampleConfig =
         ),
         displayName: 'UseCallbackExample');
 
-@Deprecated('Use `_\$UseCallbackExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseCallbackExampleConfig` instead.')
 final UiFactoryConfig<_$$UseCallbackExampleProps> $UseCallbackExampleConfig =
     _$UseCallbackExampleConfig;
 

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -26,13 +26,17 @@ const PropsMeta _$metaForUseCallbackExampleProps = PropsMeta(
   keys: $UseCallbackExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseCallbackExampleProps> $UseCallbackExampleConfig =
+final UiFactoryConfig<_$$UseCallbackExampleProps> _$UseCallbackExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseCallbackExampleProps(map),
           jsMap: (map) => _$$UseCallbackExampleProps$JsMap(map),
         ),
         displayName: 'UseCallbackExample');
+
+@Deprecated('Use `_\$UseCallbackExampleConfig` instead.')
+final UiFactoryConfig<_$$UseCallbackExampleProps> $UseCallbackExampleConfig =
+    _$UseCallbackExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_callback_example.over_react.g.dart
+++ b/example/hooks/use_callback_example.over_react.g.dart
@@ -34,8 +34,9 @@ final UiFactoryConfig<_$$UseCallbackExampleProps> _$UseCallbackExampleConfig =
         ),
         displayName: 'UseCallbackExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseCallbackExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseCallbackExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseCallbackExampleProps> $UseCallbackExampleConfig =
     _$UseCallbackExampleConfig;
 

--- a/example/hooks/use_context_example.dart
+++ b/example/hooks/use_context_example.dart
@@ -28,7 +28,7 @@ UiFactory<UseContextExampleProps> UseContextExample = uiFunction(
       Dom.div()('useContext counter value is ${context['renderCount']}'),
     );
   },
-  $UseContextExampleConfig, // ignore: undefined_identifier
+  _$UseContextExampleConfig, // ignore: undefined_identifier
 );
 
 mixin NewContextProviderProps on UiProps {}
@@ -55,5 +55,5 @@ UiFactory<NewContextProviderProps> NewContextProvider = uiFunction(
       (TestNewContext.Provider()..value = provideMap)(props.children),
     );
   },
-  $NewContextProviderConfig, // ignore: undefined_identifier
+  _$NewContextProviderConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -53,7 +53,8 @@ final UiFactoryConfig<_$$UseContextExampleProps> _$UseContextExampleConfig =
         ),
         displayName: 'UseContextExample');
 
-@Deprecated('Use `_\$UseContextExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseContextExampleConfig` instead.')
 final UiFactoryConfig<_$$UseContextExampleProps> $UseContextExampleConfig =
     _$UseContextExampleConfig;
 
@@ -137,7 +138,8 @@ final UiFactoryConfig<_$$NewContextProviderProps> _$NewContextProviderConfig =
         ),
         displayName: 'NewContextProvider');
 
-@Deprecated('Use `_\$NewContextProviderConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$NewContextProviderConfig` instead.')
 final UiFactoryConfig<_$$NewContextProviderProps> $NewContextProviderConfig =
     _$NewContextProviderConfig;
 

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -45,13 +45,17 @@ const PropsMeta _$metaForNewContextProviderProps = PropsMeta(
   keys: $NewContextProviderProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseContextExampleProps> $UseContextExampleConfig =
+final UiFactoryConfig<_$$UseContextExampleProps> _$UseContextExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseContextExampleProps(map),
           jsMap: (map) => _$$UseContextExampleProps$JsMap(map),
         ),
         displayName: 'UseContextExample');
+
+@Deprecated('Use `_\$UseContextExampleConfig` instead.')
+final UiFactoryConfig<_$$UseContextExampleProps> $UseContextExampleConfig =
+    _$UseContextExampleConfig;
 
 // Concrete props implementation.
 //
@@ -125,13 +129,17 @@ class _$$UseContextExampleProps$JsMap extends _$$UseContextExampleProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$NewContextProviderProps> $NewContextProviderConfig =
+final UiFactoryConfig<_$$NewContextProviderProps> _$NewContextProviderConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$NewContextProviderProps(map),
           jsMap: (map) => _$$NewContextProviderProps$JsMap(map),
         ),
         displayName: 'NewContextProvider');
+
+@Deprecated('Use `_\$NewContextProviderConfig` instead.')
+final UiFactoryConfig<_$$NewContextProviderProps> $NewContextProviderConfig =
+    _$NewContextProviderConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_context_example.over_react.g.dart
+++ b/example/hooks/use_context_example.over_react.g.dart
@@ -53,8 +53,9 @@ final UiFactoryConfig<_$$UseContextExampleProps> _$UseContextExampleConfig =
         ),
         displayName: 'UseContextExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseContextExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseContextExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseContextExampleProps> $UseContextExampleConfig =
     _$UseContextExampleConfig;
 
@@ -138,8 +139,9 @@ final UiFactoryConfig<_$$NewContextProviderProps> _$NewContextProviderConfig =
         ),
         displayName: 'NewContextProvider');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$NewContextProviderConfig` instead.')
+@Deprecated(r'Use the private variable, _$NewContextProviderConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$NewContextProviderProps> $NewContextProviderConfig =
     _$NewContextProviderConfig;
 

--- a/example/hooks/use_debug_value_example.dart
+++ b/example/hooks/use_debug_value_example.dart
@@ -60,7 +60,7 @@ UiFactory<FriendListItemProps> FriendListItem = uiFunction(
       props.friend['name'],
     );
   },
-  $FriendListItemConfig, // ignore: undefined_identifier
+  _$FriendListItemConfig, // ignore: undefined_identifier
 );
 
 mixin UseDebugValueExampleProps on UiProps {}
@@ -72,5 +72,5 @@ UiFactory<UseDebugValueExampleProps> UseDebugValueExample = uiFunction(
     (FriendListItem()..friend = {'id': 3, 'name': 'user 3'})(),
     (FriendListItem()..friend = {'id': 4, 'name': 'user 4'})(),
   ),
-  $UseDebugValueExampleConfig, // ignore: undefined_identifier
+  _$UseDebugValueExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -66,8 +66,9 @@ final UiFactoryConfig<_$$FriendListItemProps> _$FriendListItemConfig =
         ),
         displayName: 'FriendListItem');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$FriendListItemConfig` instead.')
+@Deprecated(r'Use the private variable, _$FriendListItemConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$FriendListItemProps> $FriendListItemConfig =
     _$FriendListItemConfig;
 
@@ -151,8 +152,9 @@ final UiFactoryConfig<_$$UseDebugValueExampleProps>
         ),
         displayName: 'UseDebugValueExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseDebugValueExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseDebugValueExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseDebugValueExampleProps>
     $UseDebugValueExampleConfig = _$UseDebugValueExampleConfig;
 

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -66,7 +66,8 @@ final UiFactoryConfig<_$$FriendListItemProps> _$FriendListItemConfig =
         ),
         displayName: 'FriendListItem');
 
-@Deprecated('Use `_\$FriendListItemConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$FriendListItemConfig` instead.')
 final UiFactoryConfig<_$$FriendListItemProps> $FriendListItemConfig =
     _$FriendListItemConfig;
 
@@ -150,7 +151,8 @@ final UiFactoryConfig<_$$UseDebugValueExampleProps>
         ),
         displayName: 'UseDebugValueExample');
 
-@Deprecated('Use `_\$UseDebugValueExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseDebugValueExampleConfig` instead.')
 final UiFactoryConfig<_$$UseDebugValueExampleProps>
     $UseDebugValueExampleConfig = _$UseDebugValueExampleConfig;
 

--- a/example/hooks/use_debug_value_example.over_react.g.dart
+++ b/example/hooks/use_debug_value_example.over_react.g.dart
@@ -58,13 +58,17 @@ const PropsMeta _$metaForUseDebugValueExampleProps = PropsMeta(
   keys: $UseDebugValueExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$FriendListItemProps> $FriendListItemConfig =
+final UiFactoryConfig<_$$FriendListItemProps> _$FriendListItemConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$FriendListItemProps(map),
           jsMap: (map) => _$$FriendListItemProps$JsMap(map),
         ),
         displayName: 'FriendListItem');
+
+@Deprecated('Use `_\$FriendListItemConfig` instead.')
+final UiFactoryConfig<_$$FriendListItemProps> $FriendListItemConfig =
+    _$FriendListItemConfig;
 
 // Concrete props implementation.
 //
@@ -139,12 +143,16 @@ class _$$FriendListItemProps$JsMap extends _$$FriendListItemProps {
 }
 
 final UiFactoryConfig<_$$UseDebugValueExampleProps>
-    $UseDebugValueExampleConfig = UiFactoryConfig(
+    _$UseDebugValueExampleConfig = UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseDebugValueExampleProps(map),
           jsMap: (map) => _$$UseDebugValueExampleProps$JsMap(map),
         ),
         displayName: 'UseDebugValueExample');
+
+@Deprecated('Use `_\$UseDebugValueExampleConfig` instead.')
+final UiFactoryConfig<_$$UseDebugValueExampleProps>
+    $UseDebugValueExampleConfig = _$UseDebugValueExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_imperative_handle_example.dart
+++ b/example/hooks/use_imperative_handle_example.dart
@@ -49,7 +49,7 @@ UiFactory<FancyInputProps> FancyInput = uiForwardRef(
       ..onChange = (e) => props.updater(e.target.value)
     )();
   },
-  $FancyInputConfig, // ignore: undefined_identifier
+  _$FancyInputConfig, // ignore: undefined_identifier
 );
 
 mixin UseImperativeHandleExampleProps on UiProps {}
@@ -71,5 +71,5 @@ UiFactory<UseImperativeHandleExampleProps> UseImperativeHandleExample =
       )('Focus Input'),
     );
   },
-  $UseImperativeHandleExampleConfig, // ignore: undefined_identifier
+  _$UseImperativeHandleExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -77,7 +77,8 @@ final UiFactoryConfig<_$$FancyInputProps> _$FancyInputConfig = UiFactoryConfig(
     ),
     displayName: 'FancyInput');
 
-@Deprecated('Use `_\$FancyInputConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$FancyInputConfig` instead.')
 final UiFactoryConfig<_$$FancyInputProps> $FancyInputConfig =
     _$FancyInputConfig;
 
@@ -161,7 +162,8 @@ final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
         ),
         displayName: 'UseImperativeHandleExample');
 
-@Deprecated('Use `_\$UseImperativeHandleExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseImperativeHandleExampleConfig` instead.')
 final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
     $UseImperativeHandleExampleConfig = _$UseImperativeHandleExampleConfig;
 

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -77,8 +77,9 @@ final UiFactoryConfig<_$$FancyInputProps> _$FancyInputConfig = UiFactoryConfig(
     ),
     displayName: 'FancyInput');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$FancyInputConfig` instead.')
+@Deprecated(r'Use the private variable, _$FancyInputConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$FancyInputProps> $FancyInputConfig =
     _$FancyInputConfig;
 
@@ -163,7 +164,9 @@ final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
         displayName: 'UseImperativeHandleExample');
 
 @Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseImperativeHandleExampleConfig` instead.')
+    r'Use the private variable, _$UseImperativeHandleExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
     $UseImperativeHandleExampleConfig = _$UseImperativeHandleExampleConfig;
 

--- a/example/hooks/use_imperative_handle_example.over_react.g.dart
+++ b/example/hooks/use_imperative_handle_example.over_react.g.dart
@@ -70,12 +70,16 @@ const PropsMeta _$metaForUseImperativeHandleExampleProps = PropsMeta(
   keys: $UseImperativeHandleExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$FancyInputProps> $FancyInputConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$FancyInputProps> _$FancyInputConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$FancyInputProps(map),
       jsMap: (map) => _$$FancyInputProps$JsMap(map),
     ),
     displayName: 'FancyInput');
+
+@Deprecated('Use `_\$FancyInputConfig` instead.')
+final UiFactoryConfig<_$$FancyInputProps> $FancyInputConfig =
+    _$FancyInputConfig;
 
 // Concrete props implementation.
 //
@@ -150,12 +154,16 @@ class _$$FancyInputProps$JsMap extends _$$FancyInputProps {
 }
 
 final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
-    $UseImperativeHandleExampleConfig = UiFactoryConfig(
+    _$UseImperativeHandleExampleConfig = UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseImperativeHandleExampleProps(map),
           jsMap: (map) => _$$UseImperativeHandleExampleProps$JsMap(map),
         ),
         displayName: 'UseImperativeHandleExample');
+
+@Deprecated('Use `_\$UseImperativeHandleExampleConfig` instead.')
+final UiFactoryConfig<_$$UseImperativeHandleExampleProps>
+    $UseImperativeHandleExampleConfig = _$UseImperativeHandleExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_layout_effect_example.dart
+++ b/example/hooks/use_layout_effect_example.dart
@@ -42,5 +42,5 @@ UiFactory<UseLayoutEffectProps> UseLayoutEffectExample = uiFunction(
       )(),
     );
   },
-  $UseLayoutEffectExampleConfig, // ignore: undefined_identifier
+  _$UseLayoutEffectExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -26,13 +26,17 @@ const PropsMeta _$metaForUseLayoutEffectProps = PropsMeta(
   keys: $UseLayoutEffectProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseLayoutEffectProps> $UseLayoutEffectExampleConfig =
+final UiFactoryConfig<_$$UseLayoutEffectProps> _$UseLayoutEffectExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseLayoutEffectProps(map),
           jsMap: (map) => _$$UseLayoutEffectProps$JsMap(map),
         ),
         displayName: 'UseLayoutEffectExample');
+
+@Deprecated('Use `_\$UseLayoutEffectExampleConfig` instead.')
+final UiFactoryConfig<_$$UseLayoutEffectProps> $UseLayoutEffectExampleConfig =
+    _$UseLayoutEffectExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -35,7 +35,9 @@ final UiFactoryConfig<_$$UseLayoutEffectProps> _$UseLayoutEffectExampleConfig =
         displayName: 'UseLayoutEffectExample');
 
 @Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseLayoutEffectExampleConfig` instead.')
+    r'Use the private variable, _$UseLayoutEffectExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseLayoutEffectProps> $UseLayoutEffectExampleConfig =
     _$UseLayoutEffectExampleConfig;
 

--- a/example/hooks/use_layout_effect_example.over_react.g.dart
+++ b/example/hooks/use_layout_effect_example.over_react.g.dart
@@ -34,7 +34,8 @@ final UiFactoryConfig<_$$UseLayoutEffectProps> _$UseLayoutEffectExampleConfig =
         ),
         displayName: 'UseLayoutEffectExample');
 
-@Deprecated('Use `_\$UseLayoutEffectExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseLayoutEffectExampleConfig` instead.')
 final UiFactoryConfig<_$$UseLayoutEffectProps> $UseLayoutEffectExampleConfig =
     _$UseLayoutEffectExampleConfig;
 

--- a/example/hooks/use_memo_example.dart
+++ b/example/hooks/use_memo_example.dart
@@ -44,5 +44,5 @@ UiFactory<UseMemoExampleProps> UseMemoExample = uiFunction(
       )('+'),
     );
   },
-  $UseMemoExampleConfig, // ignore: undefined_identifier
+  _$UseMemoExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -26,13 +26,17 @@ const PropsMeta _$metaForUseMemoExampleProps = PropsMeta(
   keys: $UseMemoExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseMemoExampleProps> $UseMemoExampleConfig =
+final UiFactoryConfig<_$$UseMemoExampleProps> _$UseMemoExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseMemoExampleProps(map),
           jsMap: (map) => _$$UseMemoExampleProps$JsMap(map),
         ),
         displayName: 'UseMemoExample');
+
+@Deprecated('Use `_\$UseMemoExampleConfig` instead.')
+final UiFactoryConfig<_$$UseMemoExampleProps> $UseMemoExampleConfig =
+    _$UseMemoExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -34,8 +34,9 @@ final UiFactoryConfig<_$$UseMemoExampleProps> _$UseMemoExampleConfig =
         ),
         displayName: 'UseMemoExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseMemoExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseMemoExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseMemoExampleProps> $UseMemoExampleConfig =
     _$UseMemoExampleConfig;
 

--- a/example/hooks/use_memo_example.over_react.g.dart
+++ b/example/hooks/use_memo_example.over_react.g.dart
@@ -34,7 +34,8 @@ final UiFactoryConfig<_$$UseMemoExampleProps> _$UseMemoExampleConfig =
         ),
         displayName: 'UseMemoExample');
 
-@Deprecated('Use `_\$UseMemoExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseMemoExampleConfig` instead.')
 final UiFactoryConfig<_$$UseMemoExampleProps> $UseMemoExampleConfig =
     _$UseMemoExampleConfig;
 

--- a/example/hooks/use_reducer_example.dart
+++ b/example/hooks/use_reducer_example.dart
@@ -59,5 +59,5 @@ UiFactory<UseReducerExampleProps> UseReducerExample = uiFunction(
       )('reset'),
     );
   },
-  $UseReducerExampleConfig, // ignore: undefined_identifier
+  _$UseReducerExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -49,7 +49,8 @@ final UiFactoryConfig<_$$UseReducerExampleProps> _$UseReducerExampleConfig =
         ),
         displayName: 'UseReducerExample');
 
-@Deprecated('Use `_\$UseReducerExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseReducerExampleConfig` instead.')
 final UiFactoryConfig<_$$UseReducerExampleProps> $UseReducerExampleConfig =
     _$UseReducerExampleConfig;
 

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -41,13 +41,17 @@ const PropsMeta _$metaForUseReducerExampleProps = PropsMeta(
   keys: $UseReducerExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseReducerExampleProps> $UseReducerExampleConfig =
+final UiFactoryConfig<_$$UseReducerExampleProps> _$UseReducerExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseReducerExampleProps(map),
           jsMap: (map) => _$$UseReducerExampleProps$JsMap(map),
         ),
         displayName: 'UseReducerExample');
+
+@Deprecated('Use `_\$UseReducerExampleConfig` instead.')
+final UiFactoryConfig<_$$UseReducerExampleProps> $UseReducerExampleConfig =
+    _$UseReducerExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_reducer_example.over_react.g.dart
+++ b/example/hooks/use_reducer_example.over_react.g.dart
@@ -49,8 +49,9 @@ final UiFactoryConfig<_$$UseReducerExampleProps> _$UseReducerExampleConfig =
         ),
         displayName: 'UseReducerExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseReducerExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseReducerExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseReducerExampleProps> $UseReducerExampleConfig =
     _$UseReducerExampleConfig;
 

--- a/example/hooks/use_ref_example.dart
+++ b/example/hooks/use_ref_example.dart
@@ -43,5 +43,5 @@ UiFactory<UseRefExampleProps> UseRefExample = uiFunction(
       )('Update'),
     );
   },
-  $UseRefExampleConfig, // ignore: undefined_identifier
+  _$UseRefExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -26,13 +26,17 @@ const PropsMeta _$metaForUseRefExampleProps = PropsMeta(
   keys: $UseRefExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseRefExampleProps> $UseRefExampleConfig =
+final UiFactoryConfig<_$$UseRefExampleProps> _$UseRefExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseRefExampleProps(map),
           jsMap: (map) => _$$UseRefExampleProps$JsMap(map),
         ),
         displayName: 'UseRefExample');
+
+@Deprecated('Use `_\$UseRefExampleConfig` instead.')
+final UiFactoryConfig<_$$UseRefExampleProps> $UseRefExampleConfig =
+    _$UseRefExampleConfig;
 
 // Concrete props implementation.
 //

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -34,7 +34,8 @@ final UiFactoryConfig<_$$UseRefExampleProps> _$UseRefExampleConfig =
         ),
         displayName: 'UseRefExample');
 
-@Deprecated('Use `_\$UseRefExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseRefExampleConfig` instead.')
 final UiFactoryConfig<_$$UseRefExampleProps> $UseRefExampleConfig =
     _$UseRefExampleConfig;
 

--- a/example/hooks/use_ref_example.over_react.g.dart
+++ b/example/hooks/use_ref_example.over_react.g.dart
@@ -34,8 +34,9 @@ final UiFactoryConfig<_$$UseRefExampleProps> _$UseRefExampleConfig =
         ),
         displayName: 'UseRefExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseRefExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseRefExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseRefExampleProps> $UseRefExampleConfig =
     _$UseRefExampleConfig;
 

--- a/example/hooks/use_state_example.dart
+++ b/example/hooks/use_state_example.dart
@@ -48,5 +48,5 @@ UiFactory<UseStateExampleProps> UseStateExample = uiFunction(
       Dom.p()('${count.value} is ${evenOdd.value}'),
     );
   },
-  $UseStateExampleConfig, // ignore: undefined_identifier
+  _$UseStateExampleConfig, // ignore: undefined_identifier
 );

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -34,7 +34,8 @@ final UiFactoryConfig<_$$UseStateExampleProps> _$UseStateExampleConfig =
         ),
         displayName: 'UseStateExample');
 
-@Deprecated('Use `_\$UseStateExampleConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$UseStateExampleConfig` instead.')
 final UiFactoryConfig<_$$UseStateExampleProps> $UseStateExampleConfig =
     _$UseStateExampleConfig;
 

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -34,8 +34,9 @@ final UiFactoryConfig<_$$UseStateExampleProps> _$UseStateExampleConfig =
         ),
         displayName: 'UseStateExample');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$UseStateExampleConfig` instead.')
+@Deprecated(r'Use the private variable, _$UseStateExampleConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$UseStateExampleProps> $UseStateExampleConfig =
     _$UseStateExampleConfig;
 

--- a/example/hooks/use_state_example.over_react.g.dart
+++ b/example/hooks/use_state_example.over_react.g.dart
@@ -26,13 +26,17 @@ const PropsMeta _$metaForUseStateExampleProps = PropsMeta(
   keys: $UseStateExampleProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$UseStateExampleProps> $UseStateExampleConfig =
+final UiFactoryConfig<_$$UseStateExampleProps> _$UseStateExampleConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$UseStateExampleProps(map),
           jsMap: (map) => _$$UseStateExampleProps$JsMap(map),
         ),
         displayName: 'UseStateExample');
+
+@Deprecated('Use `_\$UseStateExampleConfig` instead.')
+final UiFactoryConfig<_$$UseStateExampleProps> $UseStateExampleConfig =
+    _$UseStateExampleConfig;
 
 // Concrete props implementation.
 //

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -53,8 +53,7 @@ class FactoryNames {
   /// The name of the public generated function component props config for the factory.
   ///
   /// Example: `$FooConfig
-  @Deprecated('The public config is incompatible with Dart >2.9.0 and will be '
-      'removed. Use `privateConfigName` instead.')
+  @Deprecated('The public config is deprecated and will be removed. Use `privateConfigName` instead.')
   String get publicConfigName => '$_prefix$publicGeneratedPrefix${unprefixedConsumerName}Config';
 }
 

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -48,14 +48,14 @@ class FactoryNames {
   /// The name of the private generated function component props config for the factory.
   ///
   /// Example: `_$FooConfig
-  String get privateConfigName => '_\$${consumerName}Config';
+  String get privateConfigName => '$_prefix$privateSourcePrefix${unprefixedConsumerName}Config';
 
   /// The name of the public generated function component props config for the factory.
   ///
   /// Example: `$FooConfig
   @Deprecated('The public config is incompatible with Dart >2.9.0 and will be '
       'removed. Use `privateConfigName` instead.')
-  String get publicConfigName => '\$${consumerName}Config';
+  String get publicConfigName => '$_prefix$publicGeneratedPrefix${unprefixedConsumerName}Config';
 }
 
 /// A set of names of the different generated members for a given component class.

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -47,12 +47,14 @@ class FactoryNames {
 
   /// The name of the private generated function component props config for the factory.
   ///
-  /// Example: `$FooConfig
-  String get privateConfigName => '_$publicConfigName';
+  /// Example: `_$FooConfig
+  String get privateConfigName => '_\$${consumerName}Config';
 
   /// The name of the public generated function component props config for the factory.
   ///
   /// Example: `$FooConfig
+  @Deprecated('The public config is incompatible with Dart >2.9.0 and will be '
+      'removed. Use `privateConfigName` instead.')
   String get publicConfigName => '\$${consumerName}Config';
 }
 

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -45,10 +45,15 @@ class FactoryNames {
   /// - Output: `_$Foo`
   String get implName => '$_prefix$privateSourcePrefix$unprefixedConsumerName';
 
-  /// The name of the generated function component props config for the factory.
+  /// The name of the private generated function component props config for the factory.
   ///
   /// Example: `$FooConfig
-  String get configName => '\$${consumerName}Config';
+  String get privateConfigName => '_$publicConfigName';
+
+  /// The name of the public generated function component props config for the factory.
+  ///
+  /// Example: `$FooConfig
+  String get publicConfigName => '\$${consumerName}Config';
 }
 
 /// A set of names of the different generated members for a given component class.

--- a/lib/src/builder/codegen/names.dart
+++ b/lib/src/builder/codegen/names.dart
@@ -53,7 +53,8 @@ class FactoryNames {
   /// The name of the public generated function component props config for the factory.
   ///
   /// Example: `$FooConfig
-  @Deprecated('The public config is deprecated and will be removed. Use `privateConfigName` instead.')
+  @Deprecated(
+      'The public config is deprecated and will be removed. Use `privateConfigName` instead.')
   String get publicConfigName => '$_prefix$publicGeneratedPrefix${unprefixedConsumerName}Config';
 }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -390,11 +390,14 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
 
   String _generateUiFactoryConfig(FactoryNames factoryName) {
     return 'final UiFactoryConfig<${names.implName}> '
-        '${factoryName.configName} = UiFactoryConfig(\n'
+        '${factoryName.privateConfigName} = UiFactoryConfig(\n'
         'propsFactory: PropsFactory(\n'
         'map: (map) => ${names.implName}(map),\n'
         'jsMap: (map) => ${names.jsMapImplName}(map),),\n'
-        'displayName: \'${factoryName.consumerName}\');\n\n';
+        'displayName: \'${factoryName.consumerName}\');\n\n'
+        '@Deprecated(\'Use `_\\${factoryName.publicConfigName}` instead.\')\n'
+        'final UiFactoryConfig<${names.implName}> '
+        '${factoryName.publicConfigName} = ${factoryName.privateConfigName};\n\n';
   }
 
   @override

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -395,8 +395,9 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         'map: (map) => ${names.implName}(map),\n'
         'jsMap: (map) => ${names.jsMapImplName}(map),),\n'
         'displayName: \'${factoryName.consumerName}\');\n\n'
-        '@Deprecated(\'Use `_\\${factoryName.publicConfigName}` instead.\')\n'
+        '@Deprecated(r\'This member is incompatible with Dart >2.9.0. Use `${factoryName.privateConfigName}` instead.\')\n'
         'final UiFactoryConfig<${names.implName}> '
+        // ignore: deprecated_member_use_from_same_package
         '${factoryName.publicConfigName} = ${factoryName.privateConfigName};\n\n';
   }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -395,7 +395,9 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         'map: (map) => ${names.implName}(map),\n'
         'jsMap: (map) => ${names.jsMapImplName}(map),),\n'
         'displayName: \'${factoryName.consumerName}\');\n\n'
-        '@Deprecated(r\'This member is incompatible with Dart >2.9.0. Use `${factoryName.privateConfigName}` instead.\')\n'
+        '@Deprecated(r\'Use the private variable, ${factoryName.privateConfigName}, instead \'\n'
+        '\'and update the `over_react` lower bound to version 4.1.0. \'\n'
+        '\'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650\')\n'
         'final UiFactoryConfig<${names.implName}> '
         // ignore: deprecated_member_use_from_same_package
         '${factoryName.publicConfigName} = ${factoryName.privateConfigName};\n\n';

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -46,6 +46,7 @@ extension InitializerHelperTopLevel on TopLevelVariableDeclaration {
   /// Returns whether or not there is a generated config being used.
   bool get usesAGeneratedConfig {
     final generatedPrivateConfigName = FactoryNames(firstVariable.name.name).privateConfigName;
+    // ignore: deprecated_member_use_from_same_package
     final generatedPublicConfigName = FactoryNames(firstVariable.name.name).publicConfigName;
     return firstInitializer != null &&
         anyDescendantIdentifiers(firstInitializer, (identifier) {

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -45,10 +45,12 @@ extension InitializerHelperTopLevel on TopLevelVariableDeclaration {
 
   /// Returns whether or not there is a generated config being used.
   bool get usesAGeneratedConfig {
-    final generatedConfigName = FactoryNames(firstVariable.name.name).configName;
+    final generatedPrivateConfigName = FactoryNames(firstVariable.name.name).privateConfigName;
+    final generatedPublicConfigName = FactoryNames(firstVariable.name.name).publicConfigName;
     return firstInitializer != null &&
         anyDescendantIdentifiers(firstInitializer, (identifier) {
-          return identifier.nameWithoutPrefix == generatedConfigName;
+          return identifier.nameWithoutPrefix == generatedPrivateConfigName ||
+              identifier.nameWithoutPrefix == generatedPublicConfigName;
         });
   }
 }

--- a/lib/src/builder/parsing/members/factory.dart
+++ b/lib/src/builder/parsing/members/factory.dart
@@ -87,7 +87,7 @@ class BoilerplateFactory extends BoilerplateMember {
 
     final names = FactoryNames(factoryName);
     final generatedFactoryName = names.implName;
-    final generatedConfigName = names.configName;
+    final generatedConfigName = names.privateConfigName;
 
     final initializer = variable.initializer;
     final referencesGeneratedFactory = initializer != null &&

--- a/lib/src/component/hooks.dart
+++ b/lib/src/component/hooks.dart
@@ -34,7 +34,7 @@ import 'package:react/hooks.dart' as react_hooks;
 ///       )('+'),
 ///     );
 ///   },
-///   $UseStateExampleConfig, // ignore: undefined_identifier
+///   _$UseStateExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -62,7 +62,7 @@ StateHook<T> useState<T>(T initialValue) => react_hooks.useState<T>(initialValue
 ///       )('+'),
 ///     );
 ///   },
-///   $UseStateExampleConfig, // ignore: undefined_identifier
+///   _$UseStateExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -107,7 +107,7 @@ StateHook<T> useStateLazy<T>(T Function() init) => react_hooks.useStateLazy<T>(i
 ///       )('+'),
 ///     );
 ///   },
-///   $UseEffectExampleConfig, // ignore: undefined_identifier
+///   _$UseEffectExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -144,7 +144,7 @@ void useEffect(dynamic Function() sideEffect, [List<Object> dependencies]) => re
 ///       )('-'),
 ///     );
 ///   },
-///   $UseReducerExampleConfig, // ignore: undefined_identifier
+///   _$UseReducerExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -200,7 +200,7 @@ ReducerHook<TState, TAction, TInit> useReducer<TState, TAction, TInit>(
 ///       )('reset'),
 ///     );
 ///   },
-///   $UseReducerExampleConfig, // ignore: undefined_identifier
+///   _$UseReducerExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -239,7 +239,7 @@ ReducerHook<TState, TAction, TInit> useReducerLazy<TState, TAction, TInit>(
 ///       (Dom.button()..onClick = incrementDelta)('Increment delta'),
 ///     );
 ///   },
-///   $UseCallbackExampleConfig, // ignore: undefined_identifier
+///   _$UseCallbackExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -272,7 +272,7 @@ T useCallback<T extends Function>(T callback, List dependencies) => react_hooks.
 ///       ), // initially renders: 'The count from context is 0'
 ///     );
 ///   },
-///   $UseContextExampleConfig, // ignore: undefined_identifier
+///   _$UseContextExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -316,7 +316,7 @@ T useContext<T>(Context<T> context) => react_hooks.useContext(context.reactDartC
 ///       )('Update'),
 ///     );
 ///   },
-///   $UseRefExampleConfig, // ignore: undefined_identifier
+///   _$UseRefExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -354,7 +354,7 @@ Ref<T> useRef<T>([T initialValue]) => react_hooks.useRef(initialValue);
 ///       )('+'),
 ///     );
 ///   },
-///   $UseMemoExampleConfig, // ignore: undefined_identifier
+///   _$UseMemoExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -396,7 +396,7 @@ T useMemo<T>(T Function() createFunction, [List<dynamic> dependencies]) =>
 ///       )(),
 ///     );
 ///   },
-///   $UseLayoutEffectExampleConfig, // ignore: undefined_identifier
+///   _$UseLayoutEffectExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -446,7 +446,7 @@ void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies])
 ///       ..onChange = (e) => props.updater(e.target.value)
 ///     )();
 ///   },
-///   $FancyInputConfig, // ignore: undefined_identifier
+///   _$FancyInputConfig, // ignore: undefined_identifier
 /// );
 ///
 /// UiFactory<UseImperativeHandleExampleProps> UseImperativeHandleExample = uiFunction(
@@ -465,7 +465,7 @@ void useLayoutEffect(dynamic Function() sideEffect, [List<Object> dependencies])
 ///       )('Focus Input'),
 ///     );
 ///   },
-///   $UseImperativeHandleExampleConfig, // ignore: undefined_identifier
+///   _$UseImperativeHandleExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -529,7 +529,7 @@ void useImperativeHandle(dynamic ref, dynamic Function() createHandle, [List<dyn
 ///       props.friend['name'],
 ///     );
 ///   },
-///   $FriendListItemConfig, // ignore: undefined_identifier
+///   _$FriendListItemConfig, // ignore: undefined_identifier
 /// );
 ///
 /// UiFactory<UseDebugValueExampleProps> UseDebugValueExample = uiFunction(
@@ -539,7 +539,7 @@ void useImperativeHandle(dynamic ref, dynamic Function() createHandle, [List<dyn
 ///     (FriendListItem()..friend = {'id': 3, 'name': 'user 3'})(),
 ///     (FriendListItem()..friend = {'id': 4, 'name': 'user 4'})(),
 ///   ),
-///   $UseDebugValueExampleConfig, // ignore: undefined_identifier
+///   _$UseDebugValueExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -256,7 +256,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
 ///       ..className = 'FancyButton'
 ///     )(props.children);
 ///   },
-///   $FancyButtonConfig, // ignore: undefined_identifier
+///   _$FancyButtonConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -275,7 +275,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
 ///       ..className = 'FancyButton'
 ///     )(props.children);
 ///   },
-///   $FancyButtonConfig, // ignore: undefined_identifier
+///   _$FancyButtonConfig, // ignore: undefined_identifier
 /// );
 ///
 /// usageExample() {

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -82,7 +82,7 @@ part 'with_transition.over_react.g.dart';
 ///       )
 ///     );
 ///   },
-///   $WithTransitionExampleConfig, // ignore: undefined_identifier
+///   _$WithTransitionExampleConfig, // ignore: undefined_identifier
 /// );
 /// ```
 ///
@@ -103,7 +103,7 @@ part 'with_transition.over_react.g.dart';
 ///       props.children,
 ///     ),
 ///   },
-///   $CustomChildConfig, // ignore: undefined_identifier
+///   _$CustomChildConfig, // ignore: undefined_identifier
 /// );
 /// ```
 UiFactory<WithTransitionProps> WithTransition = _$WithTransition;
@@ -148,7 +148,7 @@ mixin WithTransitionPropsMixin on UiProps {
   ///       // The child that has CSS transitions
   ///     );
   ///   },
-  ///   $WithTransitionExampleConfig, // ignore: undefined_identifier
+  ///   _$WithTransitionExampleConfig, // ignore: undefined_identifier
   /// );
   /// ```
   Map<TransitionPhase, Map> childPropsByPhase;

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -42,7 +42,7 @@ export 'component_type_checking.dart'
 ///     );
 ///   },
 ///   // The generated props config will match the factory name.
-///   $FooConfig, // ignore: undefined_identifier
+///   _$FooConfig, // ignore: undefined_identifier
 /// );
 ///
 /// // Multiple function components can be declared with the same props.
@@ -53,7 +53,7 @@ export 'component_type_checking.dart'
 ///         ..isDisabled = true
 ///       )();
 ///   },
-///   $AnotherFooConfig, // ignore: undefined_identifier
+///   _$AnotherFooConfig, // ignore: undefined_identifier
 /// );
 ///
 /// mixin FooProps on UiProps {

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -37,7 +37,7 @@ import 'package:over_react/component_base.dart';
 ///   (props) {
 ///     // render using props
 ///   },
-///   $MemoExampleConfig, // ignore: undefined_identifier
+///   _$MemoExampleConfig, // ignore: undefined_identifier
 /// ));
 /// ```
 ///
@@ -55,7 +55,7 @@ import 'package:over_react/component_base.dart';
 ///   (props) {
 ///     // render using props
 ///   },
-///   $MemoWithComparisonConfig, // ignore: undefined_identifier
+///   _$MemoWithComparisonConfig, // ignore: undefined_identifier
 /// ), areEqual: (prevProps, nextProps) {
 ///   // Do some custom comparison logic to return a bool based on prevProps / nextProps
 /// });

--- a/test/over_react/component/memo_test.dart
+++ b/test/over_react/component/memo_test.dart
@@ -34,7 +34,7 @@ UiFactory<FunctionCustomPropsProps> FunctionCustomProps = uiFunction(
     return Dom.div()(Dom.div()('prop id: ${props.id}'),
         Dom.div()('test Prop: ${props.testProp}'));
   },
-  $FunctionCustomPropsConfig, // ignore: undefined_identifier
+  _$FunctionCustomPropsConfig, // ignore: undefined_identifier
 );
 
 main() {

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -223,7 +223,8 @@ final UiFactoryConfig<_$$FunctionCustomPropsProps> _$FunctionCustomPropsConfig =
         ),
         displayName: 'FunctionCustomProps');
 
-@Deprecated('Use `_\$FunctionCustomPropsConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$FunctionCustomPropsConfig` instead.')
 final UiFactoryConfig<_$$FunctionCustomPropsProps> $FunctionCustomPropsConfig =
     _$FunctionCustomPropsConfig;
 

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -223,8 +223,9 @@ final UiFactoryConfig<_$$FunctionCustomPropsProps> _$FunctionCustomPropsConfig =
         ),
         displayName: 'FunctionCustomProps');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$FunctionCustomPropsConfig` instead.')
+@Deprecated(r'Use the private variable, _$FunctionCustomPropsConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$FunctionCustomPropsProps> $FunctionCustomPropsConfig =
     _$FunctionCustomPropsConfig;
 

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -215,13 +215,17 @@ const PropsMeta _$metaForFunctionCustomPropsProps = PropsMeta(
   keys: $FunctionCustomPropsProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$FunctionCustomPropsProps> $FunctionCustomPropsConfig =
+final UiFactoryConfig<_$$FunctionCustomPropsProps> _$FunctionCustomPropsConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$FunctionCustomPropsProps(map),
           jsMap: (map) => _$$FunctionCustomPropsProps$JsMap(map),
         ),
         displayName: 'FunctionCustomProps');
+
+@Deprecated('Use `_\$FunctionCustomPropsConfig` instead.')
+final UiFactoryConfig<_$$FunctionCustomPropsProps> $FunctionCustomPropsConfig =
+    _$FunctionCustomPropsConfig;
 
 // Concrete props implementation.
 //

--- a/test/over_react/component/ref_util_test.dart
+++ b/test/over_react/component/ref_util_test.dart
@@ -336,12 +336,12 @@ final BasicUiFunction = uiFunction<BasicUiFunctionProps>(
   (props) {
     return props.children.isEmpty ? 'basic component' : props.children;
   },
-  $BasicUiFunctionConfig, // ignore: undefined_identifier
+  _$BasicUiFunctionConfig, // ignore: undefined_identifier
 );
 
 final TopLevelForwardUiRefFunction = uiForwardRef<SecondaryBasicUiFunctionProps>(
   (props, ref) {
     return (BasicUiFunction()..ref = ref)(props.children);
   },
-  $TopLevelForwardUiRefFunctionConfig, // ignore: undefined_identifier
+  _$TopLevelForwardUiRefFunctionConfig, // ignore: undefined_identifier
 );

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -205,7 +205,8 @@ final UiFactoryConfig<_$$BasicUiFunctionProps> _$BasicUiFunctionConfig =
         ),
         displayName: 'BasicUiFunction');
 
-@Deprecated('Use `_\$BasicUiFunctionConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$BasicUiFunctionConfig` instead.')
 final UiFactoryConfig<_$$BasicUiFunctionProps> $BasicUiFunctionConfig =
     _$BasicUiFunctionConfig;
 
@@ -289,7 +290,8 @@ final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
         ),
         displayName: 'TopLevelForwardUiRefFunction');
 
-@Deprecated('Use `_\$TopLevelForwardUiRefFunctionConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$TopLevelForwardUiRefFunctionConfig` instead.')
 final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
     $TopLevelForwardUiRefFunctionConfig = _$TopLevelForwardUiRefFunctionConfig;
 

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -205,8 +205,9 @@ final UiFactoryConfig<_$$BasicUiFunctionProps> _$BasicUiFunctionConfig =
         ),
         displayName: 'BasicUiFunction');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$BasicUiFunctionConfig` instead.')
+@Deprecated(r'Use the private variable, _$BasicUiFunctionConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$BasicUiFunctionProps> $BasicUiFunctionConfig =
     _$BasicUiFunctionConfig;
 
@@ -291,7 +292,9 @@ final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
         displayName: 'TopLevelForwardUiRefFunction');
 
 @Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$TopLevelForwardUiRefFunctionConfig` instead.')
+    r'Use the private variable, _$TopLevelForwardUiRefFunctionConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
     $TopLevelForwardUiRefFunctionConfig = _$TopLevelForwardUiRefFunctionConfig;
 

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -197,13 +197,17 @@ const PropsMeta _$metaForBasicUiFunctionProps = PropsMeta(
   keys: $BasicUiFunctionProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$BasicUiFunctionProps> $BasicUiFunctionConfig =
+final UiFactoryConfig<_$$BasicUiFunctionProps> _$BasicUiFunctionConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$BasicUiFunctionProps(map),
           jsMap: (map) => _$$BasicUiFunctionProps$JsMap(map),
         ),
         displayName: 'BasicUiFunction');
+
+@Deprecated('Use `_\$BasicUiFunctionConfig` instead.')
+final UiFactoryConfig<_$$BasicUiFunctionProps> $BasicUiFunctionConfig =
+    _$BasicUiFunctionConfig;
 
 // Concrete props implementation.
 //
@@ -278,12 +282,16 @@ class _$$BasicUiFunctionProps$JsMap extends _$$BasicUiFunctionProps {
 }
 
 final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
-    $TopLevelForwardUiRefFunctionConfig = UiFactoryConfig(
+    _$TopLevelForwardUiRefFunctionConfig = UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$SecondaryBasicUiFunctionProps(map),
           jsMap: (map) => _$$SecondaryBasicUiFunctionProps$JsMap(map),
         ),
         displayName: 'TopLevelForwardUiRefFunction');
+
+@Deprecated('Use `_\$TopLevelForwardUiRefFunctionConfig` instead.')
+final UiFactoryConfig<_$$SecondaryBasicUiFunctionProps>
+    $TopLevelForwardUiRefFunctionConfig = _$TopLevelForwardUiRefFunctionConfig;
 
 // Concrete props implementation.
 //

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -29,6 +29,10 @@ main() {
       functionComponentTestHelper(Test);
     });
 
+    group('with public generated props config (deprecated)', () {
+      functionComponentTestHelper(TestPublicConfig);
+    });
+
     group('with custom PropsFactory', () {
       functionComponentTestHelper(TestCustom, testId: 'testIdCustom');
     });
@@ -316,7 +320,7 @@ UiFactory<TestProps> BasicUiForwardRef = uiForwardRef(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $TestConfig, // ignore: undefined_identifier
+  _$TestConfig, // ignore: undefined_identifier
 );
 
 UiFactory<TestProps> CustomUiForwardRef = uiForwardRef(
@@ -350,7 +354,7 @@ final NoLHSUiForwardRefTest = uiForwardRef<TestProps>(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $NoLHSTestConfig, // ignore: undefined_identifier
+  _$NoLHSTestConfig, // ignore: undefined_identifier
 );
 
 UiFactory<TestProps> _UiForwardRef = uiForwardRef(
@@ -366,7 +370,7 @@ UiFactory<TestProps> _UiForwardRef = uiForwardRef(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $_TestConfig, // ignore: undefined_identifier
+  _$_TestConfig, // ignore: undefined_identifier
 );
 
 UiFactory<TestProps> Test = uiFunction(
@@ -381,7 +385,22 @@ UiFactory<TestProps> Test = uiFunction(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $TestConfig, // ignore: undefined_identifier
+  _$TestConfig, // ignore: undefined_identifier
+);
+
+UiFactory<TestProps> TestPublicConfig = uiFunction(
+      (props) {
+    return (Dom.div()
+      ..addTestId('testId')
+      ..addProp('data-prop-string-prop', props.stringProp)
+      ..addProp('data-prop-dynamic-prop', props.dynamicProp)
+      ..addProp('data-prop-untyped-prop', props.untypedProp)
+      ..addProp('data-prop-custom-key-prop', props.customKeyProp)
+      ..addProp('data-prop-custom-namespace-prop', props.customNamespaceProp)
+      ..addProp('data-prop-custom-key-and-namespace-prop',
+          props.customKeyAndNamespaceProp))('rendered content');
+  },
+  $TestConfig, // ignore: undefined_identifier, deprecated_member_use_from_same_package
 );
 
 UiFactory<TestProps> TestCustom = uiFunction(
@@ -413,7 +432,7 @@ final NoLHSTest = uiFunction<TestProps>(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $NoLHSTestConfig, // ignore: undefined_identifier
+  _$NoLHSTestConfig, // ignore: undefined_identifier
 );
 
 final _Test = uiFunction<TestProps>(
@@ -428,7 +447,7 @@ final _Test = uiFunction<TestProps>(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $_TestConfig, // ignore: undefined_identifier
+  _$_TestConfig, // ignore: undefined_identifier
 );
 
 mixin TestPropsMixin on UiProps {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -30,7 +30,7 @@ main() {
     });
 
     group('with public generated props config (deprecated)', () {
-      functionComponentTestHelper(TestPublicConfig);
+      functionComponentTestHelper(TestPublic);
     });
 
     group('with custom PropsFactory', () {
@@ -388,7 +388,7 @@ UiFactory<TestProps> Test = uiFunction(
   _$TestConfig, // ignore: undefined_identifier
 );
 
-UiFactory<TestProps> TestPublicConfig = uiFunction(
+UiFactory<TestProps> TestPublic = uiFunction(
       (props) {
     return (Dom.div()
       ..addTestId('testId')
@@ -400,7 +400,7 @@ UiFactory<TestProps> TestPublicConfig = uiFunction(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $TestConfig, // ignore: undefined_identifier, deprecated_member_use_from_same_package
+  $TestPublicConfig, // ignore: undefined_identifier, deprecated_member_use_from_same_package
 );
 
 UiFactory<TestProps> TestCustom = uiFunction(

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -178,26 +178,35 @@ const PropsMeta _$metaForAThirdPropsMixin = PropsMeta(
   keys: $AThirdPropsMixin.$propKeys,
 );
 
-final UiFactoryConfig<_$$TestProps> $TestConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$TestProps> _$TestConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$TestProps(map),
       jsMap: (map) => _$$TestProps$JsMap(map),
     ),
     displayName: 'Test');
 
-final UiFactoryConfig<_$$TestProps> $NoLHSTestConfig = UiFactoryConfig(
+@Deprecated('Use `_\$TestConfig` instead.')
+final UiFactoryConfig<_$$TestProps> $TestConfig = _$TestConfig;
+
+final UiFactoryConfig<_$$TestProps> _$NoLHSTestConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$TestProps(map),
       jsMap: (map) => _$$TestProps$JsMap(map),
     ),
     displayName: 'NoLHSTest');
 
-final UiFactoryConfig<_$$TestProps> $_TestConfig = UiFactoryConfig(
+@Deprecated('Use `_\$NoLHSTestConfig` instead.')
+final UiFactoryConfig<_$$TestProps> $NoLHSTestConfig = _$NoLHSTestConfig;
+
+final UiFactoryConfig<_$$TestProps> _$_TestConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$TestProps(map),
       jsMap: (map) => _$$TestProps$JsMap(map),
     ),
     displayName: '_Test');
+
+@Deprecated('Use `_\$_TestConfig` instead.')
+final UiFactoryConfig<_$$TestProps> $_TestConfig = _$_TestConfig;
 
 // Concrete props implementation.
 //

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -185,9 +185,22 @@ final UiFactoryConfig<_$$TestProps> _$TestConfig = UiFactoryConfig(
     ),
     displayName: 'Test');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$TestConfig` instead.')
+@Deprecated(r'Use the private variable, _$TestConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$TestProps> $TestConfig = _$TestConfig;
+
+final UiFactoryConfig<_$$TestProps> _$TestPublicConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$TestProps(map),
+      jsMap: (map) => _$$TestProps$JsMap(map),
+    ),
+    displayName: 'TestPublic');
+
+@Deprecated(r'Use the private variable, _$TestPublicConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
+final UiFactoryConfig<_$$TestProps> $TestPublicConfig = _$TestPublicConfig;
 
 final UiFactoryConfig<_$$TestProps> _$NoLHSTestConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
@@ -196,8 +209,9 @@ final UiFactoryConfig<_$$TestProps> _$NoLHSTestConfig = UiFactoryConfig(
     ),
     displayName: 'NoLHSTest');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$NoLHSTestConfig` instead.')
+@Deprecated(r'Use the private variable, _$NoLHSTestConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$TestProps> $NoLHSTestConfig = _$NoLHSTestConfig;
 
 final UiFactoryConfig<_$$TestProps> _$_TestConfig = UiFactoryConfig(
@@ -207,8 +221,9 @@ final UiFactoryConfig<_$$TestProps> _$_TestConfig = UiFactoryConfig(
     ),
     displayName: '_Test');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$_TestConfig` instead.')
+@Deprecated(r'Use the private variable, _$_TestConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$TestProps> $_TestConfig = _$_TestConfig;
 
 // Concrete props implementation.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.over_react.g.dart
@@ -185,7 +185,8 @@ final UiFactoryConfig<_$$TestProps> _$TestConfig = UiFactoryConfig(
     ),
     displayName: 'Test');
 
-@Deprecated('Use `_\$TestConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$TestConfig` instead.')
 final UiFactoryConfig<_$$TestProps> $TestConfig = _$TestConfig;
 
 final UiFactoryConfig<_$$TestProps> _$NoLHSTestConfig = UiFactoryConfig(
@@ -195,7 +196,8 @@ final UiFactoryConfig<_$$TestProps> _$NoLHSTestConfig = UiFactoryConfig(
     ),
     displayName: 'NoLHSTest');
 
-@Deprecated('Use `_\$NoLHSTestConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$NoLHSTestConfig` instead.')
 final UiFactoryConfig<_$$TestProps> $NoLHSTestConfig = _$NoLHSTestConfig;
 
 final UiFactoryConfig<_$$TestProps> _$_TestConfig = UiFactoryConfig(
@@ -205,7 +207,8 @@ final UiFactoryConfig<_$$TestProps> _$_TestConfig = UiFactoryConfig(
     ),
     displayName: '_Test');
 
-@Deprecated('Use `_\$_TestConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$_TestConfig` instead.')
 final UiFactoryConfig<_$$TestProps> $_TestConfig = _$_TestConfig;
 
 // Concrete props implementation.

--- a/test/vm_tests/builder/codegen/names_test.dart
+++ b/test/vm_tests/builder/codegen/names_test.dart
@@ -40,9 +40,9 @@ main() {
 
         test('consumerName', () => expect(names.consumerName, r'foo.Foo'));
         test('implName', () => expect(names.implName, r'foo._$Foo'));
-        test('privateConfigName', () => expect(names.privateConfigName, r'_$foo.FooConfig'));
+        test('privateConfigName', () => expect(names.privateConfigName, r'foo._$FooConfig'));
         // ignore: deprecated_member_use_from_same_package
-        test('publicConfigName', () => expect(names.publicConfigName, r'$foo.FooConfig'));
+        test('publicConfigName', () => expect(names.publicConfigName, r'foo.$FooConfig'));
       });
     });
 

--- a/test/vm_tests/builder/codegen/names_test.dart
+++ b/test/vm_tests/builder/codegen/names_test.dart
@@ -28,6 +28,8 @@ main() {
 
         test('consumerName', () => expect(names.consumerName, r'Foo'));
         test('implName', () => expect(names.implName, r'_$Foo'));
+        test('privateConfigName', () => expect(names.privateConfigName, r'_$FooConfig'));
+        test('publicConfigName', () => expect(names.publicConfigName, r'$FooConfig'));
       });
 
       group('prefixed -', () {
@@ -37,6 +39,8 @@ main() {
 
         test('consumerName', () => expect(names.consumerName, r'foo.Foo'));
         test('implName', () => expect(names.implName, r'foo._$Foo'));
+        test('privateConfigName', () => expect(names.privateConfigName, r'_$foo.FooConfig'));
+        test('publicConfigName', () => expect(names.publicConfigName, r'$foo.FooConfig'));
       });
     });
 

--- a/test/vm_tests/builder/codegen/names_test.dart
+++ b/test/vm_tests/builder/codegen/names_test.dart
@@ -29,6 +29,7 @@ main() {
         test('consumerName', () => expect(names.consumerName, r'Foo'));
         test('implName', () => expect(names.implName, r'_$Foo'));
         test('privateConfigName', () => expect(names.privateConfigName, r'_$FooConfig'));
+        // ignore: deprecated_member_use_from_same_package
         test('publicConfigName', () => expect(names.publicConfigName, r'$FooConfig'));
       });
 
@@ -40,6 +41,7 @@ main() {
         test('consumerName', () => expect(names.consumerName, r'foo.Foo'));
         test('implName', () => expect(names.implName, r'foo._$Foo'));
         test('privateConfigName', () => expect(names.privateConfigName, r'_$foo.FooConfig'));
+        // ignore: deprecated_member_use_from_same_package
         test('publicConfigName', () => expect(names.publicConfigName, r'$foo.FooConfig'));
       });
     });

--- a/test/vm_tests/builder/codegen_test.dart
+++ b/test/vm_tests/builder/codegen_test.dart
@@ -664,7 +664,7 @@ main() {
             'map: (map) => _\$\$$propsName(map),\n'
             'jsMap: (map) => _\$\$$propsName\$JsMap(map),),\n'
             'displayName: \'${factoryName}\');\n\n'
-            '@Deprecated(\'Use `_\\\$${factoryName}Config` instead.\')\n'
+            '@Deprecated(r\'This member is incompatible with Dart >2.9.0. Use `_\$${factoryName}Config` instead.\')\n'
             'final UiFactoryConfig<_\$\$$propsName> '
             '\$${factoryName}Config = _\$${factoryName}Config;\n\n';
         }

--- a/test/vm_tests/builder/codegen_test.dart
+++ b/test/vm_tests/builder/codegen_test.dart
@@ -663,8 +663,10 @@ main() {
             'propsFactory: PropsFactory(\n'
             'map: (map) => _\$\$$propsName(map),\n'
             'jsMap: (map) => _\$\$$propsName\$JsMap(map),),\n'
-            'displayName: \'${factoryName}\');\n\n'
-            '@Deprecated(r\'This member is incompatible with Dart >2.9.0. Use `_\$${factoryName}Config` instead.\')\n'
+            'displayName: \'$factoryName\');\n\n'
+            '@Deprecated(r\'Use the private variable, _\$${factoryName}Config, instead \'\n'
+            '\'and update the `over_react` lower bound to version 4.1.0. \'\n'
+            '\'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650\')\n'
             'final UiFactoryConfig<_\$\$$propsName> '
             '\$${factoryName}Config = _\$${factoryName}Config;\n\n';
         }

--- a/test/vm_tests/builder/codegen_test.dart
+++ b/test/vm_tests/builder/codegen_test.dart
@@ -659,11 +659,14 @@ main() {
       group('and generates props config for function components constructed with', () {
         String generatedConfig(String propsName, String factoryName) {
           return 'final UiFactoryConfig<_\$\$$propsName> '
-            '\$${factoryName}Config = UiFactoryConfig(\n'
+            '_\$${factoryName}Config = UiFactoryConfig(\n'
             'propsFactory: PropsFactory(\n'
             'map: (map) => _\$\$$propsName(map),\n'
             'jsMap: (map) => _\$\$$propsName\$JsMap(map),),\n'
-            'displayName: \'$factoryName\');\n';
+            'displayName: \'${factoryName}\');\n\n'
+            '@Deprecated(\'Use `_\\\$${factoryName}Config` instead.\')\n'
+            'final UiFactoryConfig<_\$\$$propsName> '
+            '\$${factoryName}Config = _\$${factoryName}Config;\n\n';
         }
 
         String generatedPropsMapsForConfig(String propsName) {
@@ -708,21 +711,21 @@ main() {
               (props) {
                 return Dom.div()();
               }, 
-              \$BarConfig, // ignore: undefined_identifier
+              _\$BarConfig, // ignore: undefined_identifier
             );
             
             UiFactory<BarPropsMixin> Foo = $wrapperFunction(
               (props) {
                 return Dom.div()();
               }, 
-              \$FooConfig, // ignore: undefined_identifier
+              _\$FooConfig, // ignore: undefined_identifier
             );
                         
             UiFactory<FooProps> Baz = $wrapperFunction(
               (props) {
                 return Dom.div()();
               }, 
-              \$BazConfig, // ignore: undefined_identifier
+              _\$BazConfig, // ignore: undefined_identifier
             );
             
             mixin UnusedPropsMixin on UiProps {}
@@ -743,7 +746,7 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  \$FooConfig, // ignore: undefined_identifier
+                  _\$FooConfig, // ignore: undefined_identifier
                 ));
                 
                 mixin FooPropsMixin on UiProps {}
@@ -752,6 +755,23 @@ main() {
             expect(implGenerator.outputContentsBuffer.toString(), contains(generatedPropsMapsForConfig('FooPropsMixin')));
 
             expect(implGenerator.outputContentsBuffer.toString(), contains(generatedConfig('FooPropsMixin', 'Foo')));
+          });
+
+          test('with public generated config', () {
+            setUpAndGenerate('''
+                UiFactory<FooProps> Foo = $wrapperFunction(
+                  (props) {
+                    return Dom.div()();
+                  }, 
+                  \$FooConfig, // ignore: undefined_identifier
+                );
+                
+                mixin FooProps on UiProps {}
+              ''');
+
+            expect(implGenerator.outputContentsBuffer.toString(), contains(generatedPropsMapsForConfig('FooProps')));
+
+            expect(implGenerator.outputContentsBuffer.toString(), contains(generatedConfig('FooProps', 'Foo')));
           });
         }
 
@@ -796,7 +816,7 @@ main() {
                     ..ref = ref
                   )();
                 }, 
-                $UiForwardRefFooConfig,
+                _$UiForwardRefFooConfig,
               );
             ''');
 
@@ -843,7 +863,7 @@ main() {
               (props) {
                 return Dom.div()();
               }, 
-              $FooConfig, // ignore: undefined_identifier
+              _$FooConfig, // ignore: undefined_identifier
             );
             
             final Baz = uiFunction<FooPropsMixin>(

--- a/test/vm_tests/builder/declaration_parsing_test.dart
+++ b/test/vm_tests/builder/declaration_parsing_test.dart
@@ -1572,14 +1572,14 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  \$FooConfig, // ignore: undefined_identifier
+                  _\$FooConfig, // ignore: undefined_identifier
                 );
                 
                 final Bar = uiFunction<FooPropsMixin>(
                   (props) {
                     return Dom.div()();
                   },
-                  \$BarConfig, // ignore: undefined_identifier
+                  _\$BarConfig, // ignore: undefined_identifier
                 );
                 
                 UiFactory<FooPropsMixin> Baz = uiFunction<FooPropsMixin>(
@@ -1621,7 +1621,7 @@ main() {
                   (props) {
                     return Dom.div()();
                   },  
-                  \$FooConfig, // ignore: undefined_identifier
+                  _\$FooConfig, // ignore: undefined_identifier
                 );
                 mixin FooPropsMixin on UiProps {}
                 class FooProps = UiProps with FooPropsMixin;
@@ -1652,20 +1652,44 @@ main() {
               expect(declarations, isEmpty);
             });
 
+            test('with public generated config', () {
+              setUpAndParse('''
+                UiFactory<FooPropsMixin> Foo = uiFunction(
+                  (props) {
+                    return Dom.div()();
+                  },
+                  \$FooConfig, // ignore: undefined_identifier
+                );
+                
+                mixin FooPropsMixin on UiProps {}
+              ''');
+
+              expect(declarations, unorderedEquals([
+                isA<PropsMixinDeclaration>(),
+                isA<PropsMapViewOrFunctionComponentDeclaration>(),
+              ]));
+              final decl = declarations.firstWhereType<PropsMapViewOrFunctionComponentDeclaration>();
+
+              expect(decl.factories, hasLength(1));
+              expect(decl.factories.first.name.name, equals('Foo'));
+              expect(decl.props.b?.name?.name, 'FooPropsMixin');
+              expect(decl.version, Version.v4_mixinBased);
+            });
+
             test('wrapped in an hoc', () {
               setUpAndParse('''
                 UiFactory<FooPropsMixin> Foo = someHOC(uiFunction(
                   (props) {
                     return Dom.div()();
                   },
-                  \$FooConfig, // ignore: undefined_identifier
+                  _\$FooConfig, // ignore: undefined_identifier
                 ));
                 
                 final Bar = someHOC(uiFunction<FooPropsMixin>(
                   (props) {
                     return Dom.div()();
                   },
-                  \$BarConfig, // ignore: undefined_identifier
+                  _\$BarConfig, // ignore: undefined_identifier
                 ));
                 
                 final Foo2 = someHOC(uiFunction<FooPropsMixin>(
@@ -1708,21 +1732,21 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  \$FooConfig, // ignore: undefined_identifier
+                  _\$FooConfig, // ignore: undefined_identifier
                 );
                 
                 final Bar = uiFunction<FooPropsMixin>(
                   (props) {
                     return Dom.div()();
                   },
-                  \$BarConfig, // ignore: undefined_identifier
+                  _\$BarConfig, // ignore: undefined_identifier
                 );
                 
                 UiFactory<BarPropsMixin> Baz = uiFunction(
                   (props) {
                     return Dom.div()();
                   },
-                  \$BazConfig, // ignore: undefined_identifier
+                  _\$BazConfig, // ignore: undefined_identifier
                 );
                 
                 mixin FooPropsMixin on UiProps {}
@@ -1911,7 +1935,7 @@ main() {
                 (props) {
                   return Dom.div()();
                 },
-                $FooConfig, // ignore: undefined_identifier
+                _$FooConfig, // ignore: undefined_identifier
               );
             ''');
             verify(logger.severe(contains(errorFactoryOnly)));
@@ -1924,7 +1948,7 @@ main() {
                 (props) {
                   return Dom.div()();
                 },
-                $FooConfig, // ignore: undefined_identifier
+                _$FooConfig, // ignore: undefined_identifier
               );
             ''');
             verify(logger.severe(contains(errorFactoryOnly)));
@@ -1937,7 +1961,7 @@ main() {
                 (props) {
                   return Dom.div()();
                 }, 
-                $FooConfig, // ignore: undefined_identifier
+                _$FooConfig, // ignore: undefined_identifier
               );
             ''');
             verify(logger.severe(contains(errorFactoryOnly)));
@@ -1953,7 +1977,7 @@ main() {
                 (props) {
                   return Dom.div()();
                 },
-                $FooConfig, // ignore: undefined_identifier
+                _$FooConfig, // ignore: undefined_identifier
               );
             ''');
             verify(logger.severe(contains(errorFactoryOnly)));
@@ -1999,7 +2023,7 @@ main() {
             verify(logger.severe(contains('Factory variables are stubs for generated code, and must'
                 ' be initialized with an expression containing either'
                 ' the generated factory (_\$Foo) or'
-                ' the generated factory config (\$FooConfig).')));
+                ' the generated factory config (_\$FooConfig).')));
           });
 
           test('declared using multiple variables', () {
@@ -2024,7 +2048,7 @@ main() {
             verify(logger.severe(contains('Factory variables are stubs for generated code, and must'
                 ' be initialized with an expression containing either'
                 ' the generated factory (_\$Foo) or'
-                ' the generated factory config (\$FooConfig).')));
+                ' the generated factory config (_\$FooConfig).')));
           });
 
           test('private and declared with an invalid initializer', () {
@@ -2038,7 +2062,7 @@ main() {
             verify(logger.severe(contains('Factory variables are stubs for generated code, and must'
                 ' be initialized with an expression containing either'
                 ' the generated factory (_\$_Foo) or'
-                ' the generated factory config (\$_FooConfig).')));
+                ' the generated factory config (_\$_FooConfig).')));
           });
         });
 

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -75,6 +75,13 @@ main() {
         expect(InitializerHelperTopLevel(parseAndGetSingleWithType('''
           final Foo = uiFunction<FooPropsMixin>(
             (props) => Dom.div()(), 
+            _\$FooConfig, // ignore: undefined_identifier
+          );
+        ''')).usesAGeneratedConfig, true);
+
+        expect(InitializerHelperTopLevel(parseAndGetSingleWithType('''
+          final Foo = uiFunction<FooPropsMixin>(
+            (props) => Dom.div()(), 
             \$FooConfig, // ignore: undefined_identifier
           );
         ''')).usesAGeneratedConfig, true);
@@ -85,6 +92,13 @@ main() {
             UiFactoryConfig(),
           );
         ''')).usesAGeneratedConfig, false);
+
+        expect(InitializerHelperTopLevel(parseAndGetSingleWithType('''
+          final Foo = someHOC(uiFunction<FooPropsMixin>(
+            (props) => Dom.div()(), 
+            _\$FooConfig, // ignore: undefined_identifier
+          ));
+        ''')).usesAGeneratedConfig, true);
 
         expect(InitializerHelperTopLevel(parseAndGetSingleWithType('''
           final Foo = someHOC(uiFunction<FooPropsMixin>(

--- a/test/vm_tests/builder/parsing/members_test.dart
+++ b/test/vm_tests/builder/parsing/members_test.dart
@@ -266,7 +266,7 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  $FooConfig, // ignore: undefined_identifier
+                  _$FooConfig, // ignore: undefined_identifier
                 );
             '''), VersionConfidences.none());
             expect(factory.propsGenericArg?.typeNameWithoutPrefix, 'FooProps');
@@ -278,7 +278,7 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  $FooConfig, // ignore: undefined_identifier
+                  _$FooConfig, // ignore: undefined_identifier
                 );
             '''), VersionConfidences.none());
             expect(factory.propsGenericArg?.typeNameWithoutPrefix, 'FooProps');
@@ -290,7 +290,7 @@ main() {
                   (props) {
                     return Dom.div()();
                   },
-                  $FooConfig, // ignore: undefined_identifier
+                  _$FooConfig, // ignore: undefined_identifier
                 );
             '''), VersionConfidences.none());
             expect(factory.propsGenericArg, isNull);
@@ -307,6 +307,18 @@ main() {
         });
 
         test('returns true for function component factories', () {
+          final factory = BoilerplateFactory(parseAndGetSingleWithType(r'''
+              UiFactory Foo = uiFunction(
+                (props) {
+                  return Dom.div()();
+                },
+                _$FooConfig, // ignore: undefined_identifier
+              );
+          '''), VersionConfidences.none());
+          expect(factory.shouldGenerateConfig, isTrue);
+        });
+
+        test('returns true for function component factories with public config', () {
           final factory = BoilerplateFactory(parseAndGetSingleWithType(r'''
               UiFactory Foo = uiFunction(
                 (props) {
@@ -427,7 +439,7 @@ main() {
               contains('Factory variables are stubs for generated code, and must'
                   ' be initialized with an expression containing either'
                   ' the generated factory (_\$Foo) or'
-                  ' the generated factory config (\$FooConfig).'),
+                  ' the generated factory config (_\$FooConfig).'),
             ]);
           });
         });

--- a/test/vm_tests/builder/parsing/parsing_helpers.dart
+++ b/test/vm_tests/builder/parsing/parsing_helpers.dart
@@ -226,12 +226,12 @@ const mockComponentDeclarations = r'''
   // Function components
   UiFactory<FunctionFoo2Props> FunctionFoo = uiFunction(
     (props) => Dom.div()(),
-    $FunctionFooConfig, // ignore: undefined_identifier
+    _$FunctionFooConfig, // ignore: undefined_identifier
   );
   
   final FunctionFoo1 = uiFunction<FunctionFoo2Props>(
     (props) => Dom.div()(),
-    $FunctionFoo1Config, // ignore: undefined_identifier
+    _$FunctionFoo1Config, // ignore: undefined_identifier
   );
   
   UiFactory<_$FunctionFooProps> FunctionFoo2 = uiFunction(

--- a/web/component2/src/demos/ref.dart
+++ b/web/component2/src/demos/ref.dart
@@ -26,7 +26,7 @@ UiFactory<FancyButtonProps> FancyButton = uiForwardRef(
       ..className = classes.toClassName()
     )('Click me!');
   },
-  $FancyButtonConfig, // ignore: undefined_identifier
+  _$FancyButtonConfig, // ignore: undefined_identifier
 );
 
 //----------------------------------------------------------------------------//
@@ -190,7 +190,7 @@ final Baz = uiFunction<BazProps>(
       ..ref = props._forwardedRef
     )(props.children));
   },
-  $BazConfig, // ignore: undefined_identifier
+  _$BazConfig, // ignore: undefined_identifier
 );
 
 // -------------------------------- Demo Display Logic --------------------------------
@@ -261,7 +261,7 @@ UiFactory<RefDemoProps> RefDemoContainer = uiFunction(
       ),
     ));
   },
-  $RefDemoContainerConfig, // ignore: undefined_identifier
+  _$RefDemoContainerConfig, // ignore: undefined_identifier
 );
 
 void printButtonOuterHtml(Ref buttonRef) {
@@ -288,7 +288,7 @@ UiFactory<RefDemoSectionProps> RefDemoSection = uiFunction(
       ),
     ));
   },
-  $RefDemoSectionConfig, // ignore: undefined_identifier
+  _$RefDemoSectionConfig, // ignore: undefined_identifier
 );
 
 mixin RefDemoHocProps on UiProps {
@@ -302,5 +302,5 @@ UiFactory<RefDemoHocProps> RefDemoHoc = uiFunction(
       props.children,
     ));
   },
-  $RefDemoHocConfig, // ignore: undefined_identifier
+  _$RefDemoHocConfig, // ignore: undefined_identifier
 );

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -558,7 +558,8 @@ final UiFactoryConfig<_$$FancyButtonProps> _$FancyButtonConfig =
         ),
         displayName: 'FancyButton');
 
-@Deprecated('Use `_\$FancyButtonConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$FancyButtonConfig` instead.')
 final UiFactoryConfig<_$$FancyButtonProps> $FancyButtonConfig =
     _$FancyButtonConfig;
 
@@ -641,7 +642,8 @@ final UiFactoryConfig<_$$Foo2Props> _$Foo2Config = UiFactoryConfig(
     ),
     displayName: 'Foo2');
 
-@Deprecated('Use `_\$Foo2Config` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$Foo2Config` instead.')
 final UiFactoryConfig<_$$Foo2Props> $Foo2Config = _$Foo2Config;
 
 // Concrete props implementation.
@@ -728,7 +730,8 @@ final UiFactoryConfig<_$$BazProps> _$BazConfig = UiFactoryConfig(
     ),
     displayName: 'Baz');
 
-@Deprecated('Use `_\$BazConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$BazConfig` instead.')
 final UiFactoryConfig<_$$BazProps> $BazConfig = _$BazConfig;
 
 // Concrete props implementation.
@@ -811,7 +814,8 @@ final UiFactoryConfig<_$$RefDemoProps> _$RefDemoContainerConfig =
         ),
         displayName: 'RefDemoContainer');
 
-@Deprecated('Use `_\$RefDemoContainerConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoContainerConfig` instead.')
 final UiFactoryConfig<_$$RefDemoProps> $RefDemoContainerConfig =
     _$RefDemoContainerConfig;
 
@@ -895,7 +899,8 @@ final UiFactoryConfig<_$$RefDemoSectionProps> _$RefDemoSectionConfig =
         ),
         displayName: 'RefDemoSection');
 
-@Deprecated('Use `_\$RefDemoSectionConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoSectionConfig` instead.')
 final UiFactoryConfig<_$$RefDemoSectionProps> $RefDemoSectionConfig =
     _$RefDemoSectionConfig;
 
@@ -978,7 +983,8 @@ final UiFactoryConfig<_$$RefDemoHocProps> _$RefDemoHocConfig = UiFactoryConfig(
     ),
     displayName: 'RefDemoHoc');
 
-@Deprecated('Use `_\$RefDemoHocConfig` instead.')
+@Deprecated(
+    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoHocConfig` instead.')
 final UiFactoryConfig<_$$RefDemoHocProps> $RefDemoHocConfig =
     _$RefDemoHocConfig;
 

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -558,8 +558,9 @@ final UiFactoryConfig<_$$FancyButtonProps> _$FancyButtonConfig =
         ),
         displayName: 'FancyButton');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$FancyButtonConfig` instead.')
+@Deprecated(r'Use the private variable, _$FancyButtonConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$FancyButtonProps> $FancyButtonConfig =
     _$FancyButtonConfig;
 
@@ -642,8 +643,9 @@ final UiFactoryConfig<_$$Foo2Props> _$Foo2Config = UiFactoryConfig(
     ),
     displayName: 'Foo2');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$Foo2Config` instead.')
+@Deprecated(r'Use the private variable, _$Foo2Config, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$Foo2Props> $Foo2Config = _$Foo2Config;
 
 // Concrete props implementation.
@@ -730,8 +732,9 @@ final UiFactoryConfig<_$$BazProps> _$BazConfig = UiFactoryConfig(
     ),
     displayName: 'Baz');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$BazConfig` instead.')
+@Deprecated(r'Use the private variable, _$BazConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$BazProps> $BazConfig = _$BazConfig;
 
 // Concrete props implementation.
@@ -814,8 +817,9 @@ final UiFactoryConfig<_$$RefDemoProps> _$RefDemoContainerConfig =
         ),
         displayName: 'RefDemoContainer');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoContainerConfig` instead.')
+@Deprecated(r'Use the private variable, _$RefDemoContainerConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$RefDemoProps> $RefDemoContainerConfig =
     _$RefDemoContainerConfig;
 
@@ -899,8 +903,9 @@ final UiFactoryConfig<_$$RefDemoSectionProps> _$RefDemoSectionConfig =
         ),
         displayName: 'RefDemoSection');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoSectionConfig` instead.')
+@Deprecated(r'Use the private variable, _$RefDemoSectionConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$RefDemoSectionProps> $RefDemoSectionConfig =
     _$RefDemoSectionConfig;
 
@@ -983,8 +988,9 @@ final UiFactoryConfig<_$$RefDemoHocProps> _$RefDemoHocConfig = UiFactoryConfig(
     ),
     displayName: 'RefDemoHoc');
 
-@Deprecated(
-    r'This member is incompatible with Dart >2.9.0. Use `_$RefDemoHocConfig` instead.')
+@Deprecated(r'Use the private variable, _$RefDemoHocConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
 final UiFactoryConfig<_$$RefDemoHocProps> $RefDemoHocConfig =
     _$RefDemoHocConfig;
 

--- a/web/component2/src/demos/ref.over_react.g.dart
+++ b/web/component2/src/demos/ref.over_react.g.dart
@@ -550,12 +550,17 @@ const PropsMeta _$metaForRefDemoHocProps = PropsMeta(
   keys: $RefDemoHocProps.$propKeys,
 );
 
-final UiFactoryConfig<_$$FancyButtonProps> $FancyButtonConfig = UiFactoryConfig(
-    propsFactory: PropsFactory(
-      map: (map) => _$$FancyButtonProps(map),
-      jsMap: (map) => _$$FancyButtonProps$JsMap(map),
-    ),
-    displayName: 'FancyButton');
+final UiFactoryConfig<_$$FancyButtonProps> _$FancyButtonConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$FancyButtonProps(map),
+          jsMap: (map) => _$$FancyButtonProps$JsMap(map),
+        ),
+        displayName: 'FancyButton');
+
+@Deprecated('Use `_\$FancyButtonConfig` instead.')
+final UiFactoryConfig<_$$FancyButtonProps> $FancyButtonConfig =
+    _$FancyButtonConfig;
 
 // Concrete props implementation.
 //
@@ -629,12 +634,15 @@ class _$$FancyButtonProps$JsMap extends _$$FancyButtonProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$Foo2Props> $Foo2Config = UiFactoryConfig(
+final UiFactoryConfig<_$$Foo2Props> _$Foo2Config = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$Foo2Props(map),
       jsMap: (map) => _$$Foo2Props$JsMap(map),
     ),
     displayName: 'Foo2');
+
+@Deprecated('Use `_\$Foo2Config` instead.')
+final UiFactoryConfig<_$$Foo2Props> $Foo2Config = _$Foo2Config;
 
 // Concrete props implementation.
 //
@@ -713,12 +721,15 @@ class _$$Foo2Props$JsMap extends _$$Foo2Props {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$BazProps> $BazConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$BazProps> _$BazConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$BazProps(map),
       jsMap: (map) => _$$BazProps$JsMap(map),
     ),
     displayName: 'Baz');
+
+@Deprecated('Use `_\$BazConfig` instead.')
+final UiFactoryConfig<_$$BazProps> $BazConfig = _$BazConfig;
 
 // Concrete props implementation.
 //
@@ -792,13 +803,17 @@ class _$$BazProps$JsMap extends _$$BazProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$RefDemoProps> $RefDemoContainerConfig =
+final UiFactoryConfig<_$$RefDemoProps> _$RefDemoContainerConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$RefDemoProps(map),
           jsMap: (map) => _$$RefDemoProps$JsMap(map),
         ),
         displayName: 'RefDemoContainer');
+
+@Deprecated('Use `_\$RefDemoContainerConfig` instead.')
+final UiFactoryConfig<_$$RefDemoProps> $RefDemoContainerConfig =
+    _$RefDemoContainerConfig;
 
 // Concrete props implementation.
 //
@@ -872,13 +887,17 @@ class _$$RefDemoProps$JsMap extends _$$RefDemoProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$RefDemoSectionProps> $RefDemoSectionConfig =
+final UiFactoryConfig<_$$RefDemoSectionProps> _$RefDemoSectionConfig =
     UiFactoryConfig(
         propsFactory: PropsFactory(
           map: (map) => _$$RefDemoSectionProps(map),
           jsMap: (map) => _$$RefDemoSectionProps$JsMap(map),
         ),
         displayName: 'RefDemoSection');
+
+@Deprecated('Use `_\$RefDemoSectionConfig` instead.')
+final UiFactoryConfig<_$$RefDemoSectionProps> $RefDemoSectionConfig =
+    _$RefDemoSectionConfig;
 
 // Concrete props implementation.
 //
@@ -952,12 +971,16 @@ class _$$RefDemoSectionProps$JsMap extends _$$RefDemoSectionProps {
   JsBackedMap _props;
 }
 
-final UiFactoryConfig<_$$RefDemoHocProps> $RefDemoHocConfig = UiFactoryConfig(
+final UiFactoryConfig<_$$RefDemoHocProps> _$RefDemoHocConfig = UiFactoryConfig(
     propsFactory: PropsFactory(
       map: (map) => _$$RefDemoHocProps(map),
       jsMap: (map) => _$$RefDemoHocProps$JsMap(map),
     ),
     displayName: 'RefDemoHoc');
+
+@Deprecated('Use `_\$RefDemoHocConfig` instead.')
+final UiFactoryConfig<_$$RefDemoHocProps> $RefDemoHocConfig =
+    _$RefDemoHocConfig;
 
 // Concrete props implementation.
 //


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

In Dart 2.9, undefined_identifier errors can no longer be ignored - which causes analyzer errors in the over_react boilerplate when generated code has not yet been generated. To work around this, names beginning with `_$` are now assumed to be generated. The component factory boilerplate already uses the private `_$` prefix, but we need to update generated factory configs to also be private.

## Changes
  <!-- What this PR changes to fix the problem. -->
- f676b56 Updated code generation and parsing logic to support both private and public factory configs (deprecating the public config in favor of the private config)
- 1024112 Updated public factory config usages to private
- b49e726 Updated tests to test both private and public factory configs

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Update generated factory configs to be private.
## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI Passes
      - [ ] Verify examples still work as expected
      - [ ] Verify that tests adequately cover both public and private factory config syntax
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
