### PR TITLE
Preparations for React 17 compatibility

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   color: any
   memoize: ^2.0.0
   meta: ^1.0.0
-  over_react: ^3.1.5
+  over_react: ">=3.12.0 <5.0.0"
   json_annotation: ^3.0.0
   redux: ">=3.0.0 <5.0.0"
   redux_dev_tools: ">=0.4.0 <0.6.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   memoize: ^2.0.0
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^5.7.0
+  react: ">=5.7.0 <7.0.0"
   redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  over_react: ^3.5.3
+  over_react: ">=3.12.0 <5.0.0"
 dev_dependencies:
   build_runner: ^1.0.0
   build_web_compilers: ^2.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 3.12.1
+  over_react: ">=3.12.1 <5.0.0"
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review, merge and release.

## Motivation
React 17 was released at the end of October and came with some exciting benefits. For the full list, see the [ReactJS blog post](https://reactjs.org/blog/2020/10/20/react-v17.html).

For Workiva, upgrading so promptly is even more exciting because it:
1. supports our Material-UI (MUI) effort. [MUI will support React 17](https://github.com/mui-org/material-ui/blob/next/CHANGELOG.md#500-alpha15) in their next major release. This major is the one that Client Platform will use as the corner stone for the MUI effort. Therefore, to be compatible, Workiva should adopt React 17 as well.
1. helps with the [Microfrontends effort](https://wiki.atl.workiva.net/display/CP/Microfrontends). This is primarily because React 17 updated how event delegation works and made it safer to embed React trees within each other. These changes, along with others, provide more options when implementing a Microfrontends architecture by making React more compatible with the ShadowDOM.

Wdesk is currently using ReactJS `16.13.1`, and the Client Platform team has been working to upgrade our Dart wrappers to be compatible with the latest major version of ReactJS (`17.x`). Now that major releases of the `react` (`6.0.0`) and `over_react` (`4.0.0`) packages are ready to release, __its time to begin making the entire Workiva front-end ecosystem compatible!__

## Changes
This upgrade will be fundamentally simpler than the React 16 upgrade and will be much easier in comparison.

All changes/fixes will be handled by Client Platform before repo owners are requested for review(s).

1. Raise the upper bounds of the `react` / `over_react` dependencies to allow the new major release versions to be pulled in once all downstream dependencies are also compatible.
1. Fix any CI failures.
1. Find and address any other code affected by breaking changes or known edge cases, which may not have been caught by CI.
    - [ ] [Event delegation changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation)
    - [ ] [use(Layout)Effect cleanup timing changes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#effect-cleanup-timing)
    - [ ] [`onScroll` events no longer bubble](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#aligning-with-browsers)

### Release Notes
Make this library compatible with ReactJS 17.

## QA Instructions
> __TODO:__ Link the related testing PR here when this PR begins to be tested
>
> [React 17 Testing PR]() (currently a no-op until the TODO is resolved)

- [ ] Verify all breaking changes to be addressed have been checked off in the Changes section
- [ ] Using the React 17 testing PR also made into this repo:
    - [ ] Verify CI passed
    - [ ] Manually test areas without functional test coverage.

## References
> [More information about React 17](https://reactjs.org/blog/2020/10/20/react-v17.html)
>
> [The 6.0.0 react-dart release](https://github.com/cleandart/react-dart/pull/285)
>
> [The 4.0.0 over_react release](https://github.com/Workiva/over_react/pull/647)


[_Created by Sourcegraph campaign `Workiva/react_17_rollout`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/react_17_rollout)