### PR TITLE
DO NOT MERGE React 17 Testing

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -30,5 +30,12 @@ dev_dependencies:
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: 6.0.0-wip
   over_react:
-    path: '../../../'
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: release_over_react_4.0.0
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,3 +47,13 @@ dev_dependencies:
   pedantic: ^1.8.0
   test: ^1.9.1
   yaml: ^2.2.1
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: 6.0.0-wip
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: release_over_react_4.0.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -10,6 +10,12 @@ dev_dependencies:
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:
-  # Pull in the local copy of over_react so it pulls in the local copy of the plugin
-  over_react:
-      path: ../../..
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: 6.0.0-wip
+  # Pull in the local copy of over_react so it pulls in the local copy of the plugin  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: release_over_react_4.0.0
+

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -44,3 +44,13 @@ dev_dependencies:
 # dependency_overrides:
 #   over_react:
 #     path: /Users/me/workspaces/over_react
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/cleandart/react-dart.git
+      ref: 6.0.0-wip
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: release_over_react_4.0.0


### PR DESCRIPTION
> __These changes / builds will first be reviewed by a member of the Client Platform team.__
>
> Repo owners will be notified when it is ready for additional review and testing.

## Motivation
We need a branch that forces ReactJS 17 compatible versions of `react` and `over_react` so that CI checks and manual smoke testing can be performed with ReactJS 17 running "under the hood".

## Changes
_All of the changes from the analogous master PR that opened up the upper bounds of the `react` and `over_react` dependencies, plus adding necessary dependency overrides to ensure that ReactJS 17 compatible versions of `react` and `over_react` dependencies are being used.

## Review
Please review: @greglittlefield-wf @aaronlademann-wf @joebingham-wk @sydneyjodon-wk

### QA Checklist
- [ ] Passing CI
    - [ ] Verify that the `pubspec.lock` artifact(s) in the CI builds contain the following dependency override refs:
      - `react`: `6.0.0-wip`
      - `over_react`: `release_over_react_4.0.0`
      - `web_skin_dart`: check the pubspec override _(if applicable)_

> [More information about React 17](https://reactjs.org/blog/2020/10/20/react-v17.html)
> [The 6.0.0 react-dart release](https://github.com/cleandart/react-dart/pull/285)
> [The 4.0.0 over_react release](https://github.com/Workiva/over_react/pull/647)


[_Created by Sourcegraph campaign `Workiva/react_17_testing`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/react_17_testing)