### PR TITLE
CPLAT-12196: @Component2 annotation parity for function components

### DIFF
--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -225,7 +225,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) forwardRef<TProps extends UiProps>
     }
 
     ReactComponentFactoryProxy hoc = react_interop.forwardRef(wrapProps, displayName: displayName);
-    setComponentTypeMeta(hoc, isHoc: true, parentType: factory().componentFactory);
+    setComponentTypeMeta(hoc.type, isHoc: true, parentType: factory().componentFactory.type);
 
     TProps forwardedFactory([Map props]) {
       return factory(props)..componentFactory = hoc;

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -438,5 +438,7 @@ UiFactory<TProps> uiForwardRef<TProps extends bh.UiProps>(
     return builder..componentFactory = factory;
   }
 
+  registerComponentTypeAlias(factory, _uiFactory);
+
   return _uiFactory;
 }

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -135,14 +135,16 @@ class Component {
 /// If utilizing legacy boilerplate, must be accompanied by a [Factory] and [Props]
 /// declaration.
 ///
-/// See also: `UiFactoryTypeMeta`, which can be used to provide configuration
-/// to function components, which don't have this annotation.
+/// See also: `UiFactory.setTypeMeta` (via extension UiFactoryTypeMeta),
+/// which can be used to provide configuration to function components,
+/// which don't have this annotation.
 class Component2 implements Component { // ignore: deprecated_member_use_from_same_package
   /// Whether the component clones or passes through its children and needs to be
   /// treated as if it were the wrapped component when passed in to `isComponentOfType`.
   ///
-  /// See also: `UiFactoryTypeMeta.subtypeOf`, which can be used to set this
-  /// field on function components, which don't have this annotation.
+  /// See also: `UiFactory.setTypeMeta` (via extension UiFactoryTypeMeta),
+  /// which can be used to provide configuration to function components,
+  /// which don't have this annotation.
   @override
   final bool isWrapper;
 
@@ -163,8 +165,9 @@ class Component2 implements Component { // ignore: deprecated_member_use_from_sa
 
   /// The component class of this component's "parent type".
   ///
-  /// See also: `UiFactoryTypeMeta.subtypeOf`, which can be used to set this
-  /// field on function components, which don't have this annotation.
+  /// See also: `UiFactory.setTypeMeta` (via extension UiFactoryTypeMeta),
+  /// which can be used to provide configuration to function components,
+  /// which don't have this annotation.
   ///
   /// Used to enable inheritance in component type-checking in `isComponentOfType`.
   ///

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -134,9 +134,15 @@ class Component {
 ///
 /// If utilizing legacy boilerplate, must be accompanied by a [Factory] and [Props]
 /// declaration.
+///
+/// See also: `UiFactoryTypeMeta`, which can be used to provide configuration
+/// to function components, which don't have this annotation.
 class Component2 implements Component { // ignore: deprecated_member_use_from_same_package
   /// Whether the component clones or passes through its children and needs to be
   /// treated as if it were the wrapped component when passed in to `isComponentOfType`.
+  ///
+  /// See also: `UiFactoryTypeMeta.subtypeOf`, which can be used to set this
+  /// field on function components, which don't have this annotation.
   @override
   final bool isWrapper;
 
@@ -156,6 +162,9 @@ class Component2 implements Component { // ignore: deprecated_member_use_from_sa
   final bool isErrorBoundary;
 
   /// The component class of this component's "parent type".
+  ///
+  /// See also: `UiFactoryTypeMeta.subtypeOf`, which can be used to set this
+  /// field on function components, which don't have this annotation.
   ///
   /// Used to enable inheritance in component type-checking in `isComponentOfType`.
   ///

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -37,7 +37,7 @@ import 'component_type_checking.dart';
 import 'disposable_manager_proxy.dart';
 import 'util.dart';
 
-export 'component_type_checking.dart' show isComponentOfType, isValidElementOfType;
+export 'component_type_checking.dart' show isComponentOfType, isValidElementOfType, UiFactoryTypeMeta;
 
 /// Helper function that wraps react.registerComponent, and allows attachment of additional
 /// component factory metadata.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -70,7 +70,7 @@ ReactDartComponentFactoryProxy registerComponent(react.Component Function() dart
   registerComponentTypeAlias(reactComponentFactory, builderFactory);
   registerComponentTypeAlias(reactComponentFactory, componentClass);
 
-  setComponentTypeMeta(reactComponentFactory, isWrapper: isWrapper, parentType: parentType);
+  setComponentTypeMeta(reactComponentFactory.type, isWrapper: isWrapper, parentType: parentType?.type);
 
   return reactComponentFactory;
 }

--- a/lib/src/component_declaration/component_base_2.dart
+++ b/lib/src/component_declaration/component_base_2.dart
@@ -75,7 +75,7 @@ ReactDartComponentFactoryProxy2 registerComponent2(react.Component2 Function() d
   registerComponentTypeAlias(reactComponentFactory, builderFactory);
   registerComponentTypeAlias(reactComponentFactory, componentClass);
 
-  setComponentTypeMeta(reactComponentFactory, isWrapper: isWrapper, parentType: parentType);
+  setComponentTypeMeta(reactComponentFactory.type, isWrapper: isWrapper, parentType: parentType?.type);
 
   return reactComponentFactory;
 }

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -96,7 +96,7 @@ extension UiFactoryTypeMeta on UiFactory {
     // These are separate arguments because it's very difficult to tell
     // the difference between a UiFactory and a ReactClass at runtime.
     UiFactory subtypeOfFactory,
-    dynamic subtypeOfRaw,
+    dynamic /*ReactClass|JS component function|string*/ subtypeOfRaw,
     bool isWrapper = false,
   }) {
     if (subtypeOfFactory != null && subtypeOfRaw != null) {
@@ -110,15 +110,14 @@ extension UiFactoryTypeMeta on UiFactory {
         : subtypeOfRaw;
 
     final type = this().componentFactory.type;
-    // Fetch the old meta and preserve the value of isHoc for now.
-    // isHoc's implementation/usage seems incomplete and may be removed,
-    // so we won't expose it as an argument, at least for now.
-    final oldMeta = getComponentTypeMeta(type);
     setComponentTypeMeta(
       type,
       parentType: parentType,
       isWrapper: isWrapper,
-      isHoc: oldMeta.isHoc,
+      // Fetch the old meta and preserve the value of isHoc for now.
+      // isHoc's implementation/usage seems incomplete and may be removed,
+      // so we won't expose it as an argument, at least for now.
+      isHoc: getComponentTypeMeta(type).isHoc,
     );
   }
 }
@@ -146,8 +145,8 @@ const String _componentTypeMetaKey = '_componentTypeMeta';
 ///
 /// This meta is retrievable via [getComponentTypeMeta].
 void setComponentTypeMeta(
-  ReactClass type, {
-  @required dynamic parentType,
+  dynamic /* ReactClass|JS component function|string */ type, {
+  @required dynamic  /* ReactClass|JS component function|string */ parentType,
   bool isWrapper = false,
   bool isHoc = false,
 }) {
@@ -228,7 +227,7 @@ class ComponentTypeMeta {
   ///
   /// > See: `subtypeOf` (within [annotations.Component2])
   // ignore: deprecated_member_use
-  final dynamic parentType;
+  final dynamic /*ReactClass|JS component function|string*/ parentType;
 
   ComponentTypeMeta(
       {this.parentType, this.isWrapper = false, this.isHoc = false})

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -37,13 +37,13 @@ extension UiFactoryTypeMeta on UiFactory {
   /// Sets metadata for the underlying component class/type associated with this
   /// factory, functionally equivalent to the [annotations.Component2] annotation.
   ///
-  /// However, unlike the annotation, this can be use for function components.
+  /// However, unlike the annotation, this can be used for function components.
   ///
   /// ## subtypeOf arguments: [subtypeOfFactory]/[subtypeOfRaw]
   ///
   /// The raw JS component type that is this component's "parent type".
   ///
-  /// Used to enable inheritance in component type-checking in `isComponentOfType`.
+  /// Used to enable inheritance in component type-checking in [isComponentOfType].
   ///
   /// [subtypeOfRaw] accepts the raw underlying type, and
   /// [subtypeOfFactory] accepts a factory, for convenience.

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -380,7 +380,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
     /// into Dart code (e.g., those passed into mapStateToPropsWithOwnProps/areOwnPropsEqual)
     /// without needing unwrapping/conversion.
     final hocFactoryProxy = ReactDartComponentFactoryProxy2(hoc);
-    setComponentTypeMeta(hocFactoryProxy, isHoc: true, parentType: dartComponentFactory);
+    setComponentTypeMeta(hocFactoryProxy.type, isHoc: true, parentType: dartComponentFactory.type);
 
     TProps connectedFactory([Map props]) {
       return (factory(props)..componentFactory = hocFactoryProxy);

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -84,8 +84,8 @@ UiFactory<TProps> memo<TProps extends UiProps>(UiFactory<TProps> factory,
     hoc = react_interop.memo2(factory().componentFactory, areEqual: propsOrStateMapsEqual);
   }
 
-  setComponentTypeMeta(hoc,
-      isHoc: true, parentType: factory().componentFactory);
+  setComponentTypeMeta(hoc.type,
+      isHoc: true, parentType: factory().componentFactory.type);
 
   TProps forwardedFactory([Map props]) {
     return factory(props)..componentFactory = hoc;

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -1377,7 +1377,7 @@ main() {
             var meta = getComponentTypeMeta(reactComponentFactory.type);
 
             expect(meta, isNot(same(const ComponentTypeMeta.none())), reason: 'should have stored a new meta instance');
-            expect(meta.parentType, equals(parentFactory));
+            expect(meta.parentType, equals(parentFactory.type));
           });
         });
 
@@ -1418,7 +1418,7 @@ main() {
       var meta = getComponentTypeMeta(reactComponentFactory.type);
 
       expect(meta, isNot(same(const ComponentTypeMeta.none())), reason: 'should have stored a new meta instance');
-      expect(meta.parentType, equals(parentFactory));
+      expect(meta.parentType, equals(parentFactory.type));
       expect(getComponentTypeFromAlias(TestRegisterComponentClassAlias), equals(reactComponentFactory.type));
     });
 
@@ -1436,7 +1436,7 @@ main() {
       var meta = getComponentTypeMeta(reactComponentFactory.type);
 
       expect(meta, isNot(same(const ComponentTypeMeta.none())), reason: 'should have stored a new meta instance');
-      expect(meta.parentType, equals(parentFactory));
+      expect(meta.parentType, equals(parentFactory.type));
       expect(getComponentTypeFromAlias(TestRegisterComponentClassAlias), equals(reactComponentFactory.type));
     });
   });

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -212,7 +212,7 @@ main() {
     });
 
     void sharedAliasTests(void Function(dynamic alias) testBody) {
-      group('an alias', () {
+      group('an alias, when the argument is', () {
         test('a UiFactory', () {
           // This need to be a new instance every test run, which is why we
           // don't set it up within the group.
@@ -234,7 +234,7 @@ main() {
     }
 
     void sharedBadTypeTests(void Function(dynamic badType) testBody) {
-      group('a bad type', () {
+      group('a bad type, when the argument is', () {
         test('null', () => testBody(null));
         test('a primitive', () => testBody(1));
         test('a string', () => testBody('I am a string'));
@@ -260,10 +260,10 @@ main() {
                   ? 'cannot set type metadata on strings'
                   : 'must pass in the raw JS component type'));
         });
-      }, tags: 'no-dart2js');
+      }, tags: 'ddc');
     });
 
-    group('ComponentTypeMeta constrictor', () {
+    group('ComponentTypeMeta constructor', () {
       // other behavior is tested functionally as part of the shared suite and other callers like setComponentTypeMeta and its callers
 
       group('asserts that the parentType argument is not', () {
@@ -273,10 +273,20 @@ main() {
         });
 
         sharedBadTypeTests((badType) {
-          expect(() => ComponentTypeMeta(parentType: badType),
-              throwsAssertionErrorContaining('must pass in the raw JS component type'));
+          if (badType == null) {
+            expect(
+                () => ComponentTypeMeta(parentType: badType), returnsNormally,
+                reason: 'null parentTypes are permitted');
+          } else if (badType is String) {
+            expect(
+                () => ComponentTypeMeta(parentType: badType), returnsNormally,
+                reason: 'string parentTypes are permitted');
+          } else {
+            expect(() => ComponentTypeMeta(parentType: badType),
+                throwsAssertionErrorContaining('must pass in the raw JS component type'));
+          }
         });
-      });
+      }, tags: 'ddc');
     });
   });
 }

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -15,6 +15,7 @@
 library over_react.component_declaration.component_type_checking_test;
 
 import 'package:js/js.dart';
+import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react_redux.dart' show connect;
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
@@ -45,6 +46,8 @@ import 'component2_type_checking_test/type_inheritance/subtype2.dart';
 import 'component2_type_checking_test/type_inheritance/subsubtype_of_component1.dart';
 import 'component2_type_checking_test/type_inheritance/subtype_of_component1.dart';
 
+import 'function_type_checking_test/components.dart' as function;
+
 main() {
   group('Component1', () {
     testComponentTypeChecking(
@@ -52,7 +55,6 @@ main() {
       TestSubtype: TestSubtype,
       TestSubsubtype: TestSubsubtype,
       TestExtendtype: TestExtendtype,
-      TestExtendtypeComponent: TestExtendtypeComponent,
       TestAbstractComponent: TestAbstractComponent,
       TestA: TestA,
       TestAComponent: TestAComponent,
@@ -62,6 +64,7 @@ main() {
       TwoLevelWrapper: TwoLevelWrapper,
     );
   });
+
   group('Component2', () {
     testComponentTypeChecking(
       isComponent2: true,
@@ -69,7 +72,6 @@ main() {
       TestSubtype: TestSubtype2,
       TestSubsubtype: TestSubsubtype2,
       TestExtendtype: TestExtendtype2,
-      TestExtendtypeComponent: TestExtendtype2Component,
       TestAbstractComponent: TestAbstract2Component,
       TestA: TestA2,
       TestAComponent: TestA2Component,
@@ -79,6 +81,7 @@ main() {
       TwoLevelWrapper: TwoLevelWrapper2,
     );
   });
+
   group('Component2 (subtypeOf: Component1)', () {
     testComponentTypeChecking(
       isComponent2: true,
@@ -86,7 +89,6 @@ main() {
       TestSubtype: TestSubtypeOfComponent1,
       TestSubsubtype: TestSubsubtypeOfComponent1,
       TestExtendtype: TestExtendtype2,
-      TestExtendtypeComponent: TestExtendtype2Component,
       TestAbstractComponent: TestAbstract2Component,
       TestA: TestA2,
       TestAComponent: TestA2Component,
@@ -96,22 +98,38 @@ main() {
       TwoLevelWrapper: TwoLevelWrapper2,
     );
   });
+
+  group('Function component', () {
+    testComponentTypeChecking(
+      isComponent2: true,
+      TestParent: function.TestParent,
+      TestSubtype: function.TestSubtype,
+      TestSubsubtype: function.TestSubsubtype,
+      TestExtendtype: function.TestExtendtype,
+      TestAbstractComponent: TestAbstract2Component,
+      TestA: function.TestA,
+      TestAComponent: null,
+      TestB: function.TestB,
+      TestBComponent: null,
+      OneLevelWrapper: function.OneLevelWrapper,
+      TwoLevelWrapper: function.TwoLevelWrapper,
+    );
+  });
 }
 
 testComponentTypeChecking({
   bool isComponent2 = false,
-  UiFactory TestParent,
-  UiFactory TestSubtype,
-  UiFactory TestSubsubtype,
-  UiFactory TestExtendtype,
-  Type TestExtendtypeComponent,
-  Type TestAbstractComponent,
-  UiFactory TestA,
-  Type TestAComponent,
-  UiFactory TestB,
-  Type TestBComponent,
-  UiFactory OneLevelWrapper,
-  UiFactory TwoLevelWrapper,
+  @required UiFactory TestParent,
+  @required UiFactory TestSubtype,
+  @required UiFactory TestSubsubtype,
+  @required UiFactory TestExtendtype,
+  @required Type TestAbstractComponent,
+  @required UiFactory TestA,
+  @required Type TestAComponent,
+  @required UiFactory TestB,
+  @required Type TestBComponent,
+  @required UiFactory OneLevelWrapper,
+  @required UiFactory TwoLevelWrapper,
 }) {
   group('type checking:', () {
     group('getComponentTypeFromAlias', () {
@@ -218,7 +236,7 @@ testComponentTypeChecking({
 
           test('that contains all of a component\'s parent abstract types', () {
             expect(
-                getParentTypes(getComponentTypeFromAlias(TestExtendtypeComponent)),
+                getParentTypes(getComponentTypeFromAlias(TestExtendtype)),
                 orderedEquals([
                   getComponentTypeFromAlias(TestAbstractComponent),
                 ]));
@@ -252,9 +270,11 @@ testComponentTypeChecking({
           expect(isComponentOfType(TestA()(), TestA().componentFactory), isTrue);
         });
 
-        test('a component and its component class', () {
-          expect(isComponentOfType(TestA()(), TestAComponent), isTrue);
-        });
+        if (TestAComponent != null) {
+          test('a component and its component class', () {
+            expect(isComponentOfType(TestA()(), TestAComponent), isTrue);
+          });
+        }
 
         test('a component and its component type', () {
           expect(isComponentOfType(TestA()(), TestA()().type), isTrue);
@@ -268,9 +288,11 @@ testComponentTypeChecking({
           expect(isComponentOfType(TestA()(), TestB().componentFactory), isFalse);
         });
 
-        test('a component and a component class for a different component', () {
-          expect(isComponentOfType(TestA()(), TestBComponent), isFalse);
-        });
+        if (TestBComponent != null) {
+          test('a component and a component class for a different component', () {
+            expect(isComponentOfType(TestA()(), TestBComponent), isFalse);
+          });
+        }
 
         test('a component and a component type for a different component', () {
           expect(isComponentOfType(TestA()(), TestB()().type), isFalse);

--- a/test/over_react/component_declaration/function_type_checking_test/components.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.dart
@@ -1,0 +1,72 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//library test_component2.test_b;
+
+import 'package:over_react/over_react.dart';
+
+import '../component2_type_checking_test/type_inheritance/abstract_inheritance/abstract2.dart' show $TestAbstract2ComponentFactory;
+
+part 'components.over_react.g.dart';
+
+mixin TestAProps on UiProps {}
+UiFactory<TestAProps> TestA = uiFunction(
+  (props) {}, $TestAConfig,
+);
+
+mixin TestBProps on UiProps {}
+UiFactory<TestBProps> TestB = uiFunction(
+  (props) {}, $TestBConfig,
+);
+
+mixin TestParentProps on UiProps {}
+UiFactory<TestParentProps> TestParent = uiFunction(
+  (props) {},
+  $TestParentConfig,
+);
+
+mixin TestSubtypeProps on UiProps {}
+UiFactory<TestSubtypeProps> TestSubtype = uiFunction(
+  (props) {},
+  $TestSubtypeConfig,
+)..parentType = TestParent;
+
+mixin TestSubsubtypeProps on UiProps {}
+UiFactory<TestSubsubtypeProps> TestSubsubtype = uiFunction(
+  (props) {},
+  $TestSubsubtypeConfig,
+)..parentType = TestSubtype;
+
+
+mixin TestExtendtypeProps on UiProps {}
+UiFactory<TestExtendtypeProps> TestExtendtype = uiFunction(
+  (props) {},
+  $TestExtendtypeConfig,
+)..parentType = $TestAbstract2ComponentFactory;
+
+mixin OneLevelWrapperProps on UiProps {}
+UiFactory<OneLevelWrapperProps> OneLevelWrapper = uiFunction(
+  (props) {
+    return Dom.div()(props.children.single);
+  },
+  $OneLevelWrapperConfig,
+)..isWrapper = true;
+
+mixin TwoLevelWrapperProps on UiProps {}
+UiFactory<OneLevelWrapperProps> TwoLevelWrapper = uiFunction(
+  (props) {
+    return Dom.div()(props.children.single);
+  },
+  $TwoLevelWrapperConfig,
+)..isWrapper = true;

--- a/test/over_react/component_declaration/function_type_checking_test/components.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.dart
@@ -40,20 +40,20 @@ mixin TestSubtypeProps on UiProps {}
 UiFactory<TestSubtypeProps> TestSubtype = uiFunction(
   (props) {},
   $TestSubtypeConfig,
-)..parentType = TestParent;
+)..setTypeMeta(subtypeOfFactory: TestParent);
 
 mixin TestSubsubtypeProps on UiProps {}
 UiFactory<TestSubsubtypeProps> TestSubsubtype = uiFunction(
   (props) {},
   $TestSubsubtypeConfig,
-)..parentType = TestSubtype;
+)..setTypeMeta(subtypeOfFactory: TestSubtype);
 
 
 mixin TestExtendtypeProps on UiProps {}
 UiFactory<TestExtendtypeProps> TestExtendtype = uiFunction(
   (props) {},
   $TestExtendtypeConfig,
-)..parentType = $TestAbstract2ComponentFactory;
+)..setTypeMeta(subtypeOfRaw: $TestAbstract2ComponentFactory.type);
 
 mixin OneLevelWrapperProps on UiProps {}
 UiFactory<OneLevelWrapperProps> OneLevelWrapper = uiFunction(
@@ -61,7 +61,7 @@ UiFactory<OneLevelWrapperProps> OneLevelWrapper = uiFunction(
     return Dom.div()(props.children.single);
   },
   $OneLevelWrapperConfig,
-)..isWrapper = true;
+)..setTypeMeta(isWrapper: true);
 
 mixin TwoLevelWrapperProps on UiProps {}
 UiFactory<OneLevelWrapperProps> TwoLevelWrapper = uiFunction(
@@ -69,4 +69,4 @@ UiFactory<OneLevelWrapperProps> TwoLevelWrapper = uiFunction(
     return Dom.div()(props.children.single);
   },
   $TwoLevelWrapperConfig,
-)..isWrapper = true;
+)..setTypeMeta(isWrapper: true);

--- a/test/over_react/component_declaration/function_type_checking_test/components.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.dart
@@ -1,4 +1,4 @@
-// Copyright 2016 Workiva Inc.
+// Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//library test_component2.test_b;
-
 import 'package:over_react/over_react.dart';
 
-import '../component2_type_checking_test/type_inheritance/abstract_inheritance/abstract2.dart' show $TestAbstract2ComponentFactory;
+import '../component2_type_checking_test/type_inheritance/abstract_inheritance/abstract2.dart' show $TestAbstract2ComponentFactory, TestAbstract2Component;
 
 part 'components.over_react.g.dart';
 
@@ -64,9 +62,25 @@ UiFactory<OneLevelWrapperProps> OneLevelWrapper = uiFunction(
 )..setTypeMeta(isWrapper: true);
 
 mixin TwoLevelWrapperProps on UiProps {}
-UiFactory<OneLevelWrapperProps> TwoLevelWrapper = uiFunction(
+UiFactory<TwoLevelWrapperProps> TwoLevelWrapper = uiFunction(
   (props) {
     return Dom.div()(props.children.single);
   },
   $TwoLevelWrapperConfig,
 )..setTypeMeta(isWrapper: true);
+
+UiFactory<DoNotReferenceThisFactoryExceptForInASingleTestProps> DoNotReferenceThisFactoryExceptForInASingleTest = _$DoNotReferenceThisFactoryExceptForInASingleTest;
+mixin DoNotReferenceThisFactoryExceptForInASingleTestProps on UiProps {}
+@Component2(subtypeOf: TestAbstract2Component)
+class DoNotReferenceThisFactoryExceptForInASingleTestComponentn extends UiComponent2<DoNotReferenceThisFactoryExceptForInASingleTestProps> {
+  @override
+  render() {}
+}
+
+mixin TestUninitializedParentProps on UiProps {}
+UiFactory<TestUninitializedParentProps> TestUninitializedParent = uiFunction(
+  (props) {
+    return Dom.div()(props.children.single);
+  },
+  $TestUninitializedParentConfig,
+)..setTypeMeta(subtypeOfFactory: DoNotReferenceThisFactoryExceptForInASingleTest);

--- a/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
@@ -1,0 +1,724 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'components.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestAProps on TestAProps {
+  static const PropsMeta meta = _$metaForTestAProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestAProps = PropsMeta(
+  fields: $TestAProps.$props,
+  keys: $TestAProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestBProps on TestBProps {
+  static const PropsMeta meta = _$metaForTestBProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestBProps = PropsMeta(
+  fields: $TestBProps.$props,
+  keys: $TestBProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestParentProps on TestParentProps {
+  static const PropsMeta meta = _$metaForTestParentProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestParentProps = PropsMeta(
+  fields: $TestParentProps.$props,
+  keys: $TestParentProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestSubtypeProps on TestSubtypeProps {
+  static const PropsMeta meta = _$metaForTestSubtypeProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestSubtypeProps = PropsMeta(
+  fields: $TestSubtypeProps.$props,
+  keys: $TestSubtypeProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestSubsubtypeProps on TestSubsubtypeProps {
+  static const PropsMeta meta = _$metaForTestSubsubtypeProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestSubsubtypeProps = PropsMeta(
+  fields: $TestSubsubtypeProps.$props,
+  keys: $TestSubsubtypeProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestExtendtypeProps on TestExtendtypeProps {
+  static const PropsMeta meta = _$metaForTestExtendtypeProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestExtendtypeProps = PropsMeta(
+  fields: $TestExtendtypeProps.$props,
+  keys: $TestExtendtypeProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $OneLevelWrapperProps on OneLevelWrapperProps {
+  static const PropsMeta meta = _$metaForOneLevelWrapperProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForOneLevelWrapperProps = PropsMeta(
+  fields: $OneLevelWrapperProps.$props,
+  keys: $OneLevelWrapperProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TwoLevelWrapperProps on TwoLevelWrapperProps {
+  static const PropsMeta meta = _$metaForTwoLevelWrapperProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTwoLevelWrapperProps = PropsMeta(
+  fields: $TwoLevelWrapperProps.$props,
+  keys: $TwoLevelWrapperProps.$propKeys,
+);
+
+final UiFactoryConfig<_$$TestAProps> $TestAConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$TestAProps(map),
+      jsMap: (map) => _$$TestAProps$JsMap(map),
+    ),
+    displayName: 'TestA');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestAProps extends UiProps
+    with
+        TestAProps,
+        $TestAProps // If this generated mixin is undefined, it's likely because TestAProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestAProps, and check that $TestAProps is exported/imported properly.
+{
+  _$$TestAProps._();
+
+  factory _$$TestAProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestAProps$JsMap(backingMap);
+    } else {
+      return _$$TestAProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestAProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestAProps, and check that $TestAProps is exported/imported properly.
+        TestAProps: $TestAProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestAProps$PlainMap extends _$$TestAProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestAProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestAProps$JsMap extends _$$TestAProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestAProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestBProps> $TestBConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$TestBProps(map),
+      jsMap: (map) => _$$TestBProps$JsMap(map),
+    ),
+    displayName: 'TestB');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestBProps extends UiProps
+    with
+        TestBProps,
+        $TestBProps // If this generated mixin is undefined, it's likely because TestBProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestBProps, and check that $TestBProps is exported/imported properly.
+{
+  _$$TestBProps._();
+
+  factory _$$TestBProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestBProps$JsMap(backingMap);
+    } else {
+      return _$$TestBProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestBProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestBProps, and check that $TestBProps is exported/imported properly.
+        TestBProps: $TestBProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestBProps$PlainMap extends _$$TestBProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestBProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestBProps$JsMap extends _$$TestBProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestBProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestParentProps> $TestParentConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$TestParentProps(map),
+      jsMap: (map) => _$$TestParentProps$JsMap(map),
+    ),
+    displayName: 'TestParent');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestParentProps extends UiProps
+    with
+        TestParentProps,
+        $TestParentProps // If this generated mixin is undefined, it's likely because TestParentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestParentProps, and check that $TestParentProps is exported/imported properly.
+{
+  _$$TestParentProps._();
+
+  factory _$$TestParentProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestParentProps$JsMap(backingMap);
+    } else {
+      return _$$TestParentProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestParentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestParentProps, and check that $TestParentProps is exported/imported properly.
+        TestParentProps: $TestParentProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestParentProps$PlainMap extends _$$TestParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestParentProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestParentProps$JsMap extends _$$TestParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestParentProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestSubtypeProps> $TestSubtypeConfig = UiFactoryConfig(
+    propsFactory: PropsFactory(
+      map: (map) => _$$TestSubtypeProps(map),
+      jsMap: (map) => _$$TestSubtypeProps$JsMap(map),
+    ),
+    displayName: 'TestSubtype');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestSubtypeProps extends UiProps
+    with
+        TestSubtypeProps,
+        $TestSubtypeProps // If this generated mixin is undefined, it's likely because TestSubtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestSubtypeProps, and check that $TestSubtypeProps is exported/imported properly.
+{
+  _$$TestSubtypeProps._();
+
+  factory _$$TestSubtypeProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestSubtypeProps$JsMap(backingMap);
+    } else {
+      return _$$TestSubtypeProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestSubtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestSubtypeProps, and check that $TestSubtypeProps is exported/imported properly.
+        TestSubtypeProps: $TestSubtypeProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestSubtypeProps$PlainMap extends _$$TestSubtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubtypeProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestSubtypeProps$JsMap extends _$$TestSubtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubtypeProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestSubsubtypeProps> $TestSubsubtypeConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$TestSubsubtypeProps(map),
+          jsMap: (map) => _$$TestSubsubtypeProps$JsMap(map),
+        ),
+        displayName: 'TestSubsubtype');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestSubsubtypeProps extends UiProps
+    with
+        TestSubsubtypeProps,
+        $TestSubsubtypeProps // If this generated mixin is undefined, it's likely because TestSubsubtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestSubsubtypeProps, and check that $TestSubsubtypeProps is exported/imported properly.
+{
+  _$$TestSubsubtypeProps._();
+
+  factory _$$TestSubsubtypeProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestSubsubtypeProps$JsMap(backingMap);
+    } else {
+      return _$$TestSubsubtypeProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestSubsubtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestSubsubtypeProps, and check that $TestSubsubtypeProps is exported/imported properly.
+        TestSubsubtypeProps: $TestSubsubtypeProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestSubsubtypeProps$PlainMap extends _$$TestSubsubtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubsubtypeProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestSubsubtypeProps$JsMap extends _$$TestSubsubtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestSubsubtypeProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestExtendtypeProps> $TestExtendtypeConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$TestExtendtypeProps(map),
+          jsMap: (map) => _$$TestExtendtypeProps$JsMap(map),
+        ),
+        displayName: 'TestExtendtype');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestExtendtypeProps extends UiProps
+    with
+        TestExtendtypeProps,
+        $TestExtendtypeProps // If this generated mixin is undefined, it's likely because TestExtendtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestExtendtypeProps, and check that $TestExtendtypeProps is exported/imported properly.
+{
+  _$$TestExtendtypeProps._();
+
+  factory _$$TestExtendtypeProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestExtendtypeProps$JsMap(backingMap);
+    } else {
+      return _$$TestExtendtypeProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestExtendtypeProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestExtendtypeProps, and check that $TestExtendtypeProps is exported/imported properly.
+        TestExtendtypeProps: $TestExtendtypeProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestExtendtypeProps$PlainMap extends _$$TestExtendtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestExtendtypeProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestExtendtypeProps$JsMap extends _$$TestExtendtypeProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestExtendtypeProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$OneLevelWrapperProps> $OneLevelWrapperConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$OneLevelWrapperProps(map),
+          jsMap: (map) => _$$OneLevelWrapperProps$JsMap(map),
+        ),
+        displayName: 'OneLevelWrapper');
+
+final UiFactoryConfig<_$$OneLevelWrapperProps> $TwoLevelWrapperConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$OneLevelWrapperProps(map),
+          jsMap: (map) => _$$OneLevelWrapperProps$JsMap(map),
+        ),
+        displayName: 'TwoLevelWrapper');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$OneLevelWrapperProps extends UiProps
+    with
+        OneLevelWrapperProps,
+        $OneLevelWrapperProps // If this generated mixin is undefined, it's likely because OneLevelWrapperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of OneLevelWrapperProps, and check that $OneLevelWrapperProps is exported/imported properly.
+{
+  _$$OneLevelWrapperProps._();
+
+  factory _$$OneLevelWrapperProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$OneLevelWrapperProps$JsMap(backingMap);
+    } else {
+      return _$$OneLevelWrapperProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because OneLevelWrapperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of OneLevelWrapperProps, and check that $OneLevelWrapperProps is exported/imported properly.
+        OneLevelWrapperProps: $OneLevelWrapperProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$OneLevelWrapperProps$PlainMap extends _$$OneLevelWrapperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$OneLevelWrapperProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$OneLevelWrapperProps$JsMap extends _$$OneLevelWrapperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$OneLevelWrapperProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}

--- a/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
@@ -7,6 +7,173 @@ part of 'components.dart';
 // OverReactBuilder (package:over_react/src/builder.dart)
 // **************************************************************************
 
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $DoNotReferenceThisFactoryExceptForInASingleTestComponentnFactory =
+    registerComponent2(
+  () => _$DoNotReferenceThisFactoryExceptForInASingleTestComponentn(),
+  builderFactory: _$DoNotReferenceThisFactoryExceptForInASingleTest,
+  componentClass: DoNotReferenceThisFactoryExceptForInASingleTestComponentn,
+  isWrapper: false,
+  parentType: $TestAbstract2ComponentFactory,
+  /* from `subtypeOf: TestAbstract2Component` */
+  displayName: 'DoNotReferenceThisFactoryExceptForInASingleTest',
+);
+
+_$$DoNotReferenceThisFactoryExceptForInASingleTestProps
+    _$DoNotReferenceThisFactoryExceptForInASingleTest([Map backingProps]) =>
+        backingProps == null
+            ? _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap(
+                JsBackedMap())
+            : _$$DoNotReferenceThisFactoryExceptForInASingleTestProps(
+                backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$DoNotReferenceThisFactoryExceptForInASingleTestProps
+    extends UiProps
+    with
+        DoNotReferenceThisFactoryExceptForInASingleTestProps,
+        $DoNotReferenceThisFactoryExceptForInASingleTestProps // If this generated mixin is undefined, it's likely because DoNotReferenceThisFactoryExceptForInASingleTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotReferenceThisFactoryExceptForInASingleTestProps, and check that $DoNotReferenceThisFactoryExceptForInASingleTestProps is exported/imported properly.
+{
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps._();
+
+  factory _$$DoNotReferenceThisFactoryExceptForInASingleTestProps(
+      Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap(
+          backingMap);
+    } else {
+      return _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$PlainMap(
+          backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ??
+      $DoNotReferenceThisFactoryExceptForInASingleTestComponentnFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because DoNotReferenceThisFactoryExceptForInASingleTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotReferenceThisFactoryExceptForInASingleTestProps, and check that $DoNotReferenceThisFactoryExceptForInASingleTestProps is exported/imported properly.
+        DoNotReferenceThisFactoryExceptForInASingleTestProps:
+            $DoNotReferenceThisFactoryExceptForInASingleTestProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$PlainMap
+    extends _$$DoNotReferenceThisFactoryExceptForInASingleTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$PlainMap(
+      Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap
+    extends _$$DoNotReferenceThisFactoryExceptForInASingleTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap(
+      JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$DoNotReferenceThisFactoryExceptForInASingleTestComponentn
+    extends DoNotReferenceThisFactoryExceptForInASingleTestComponentn {
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap
+      _cachedTypedProps;
+
+  @override
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap get props =>
+      _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps = typedPropsFactoryJs(getBackingMap(value));
+  }
+
+  @override
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap
+      typedPropsFactoryJs(JsBackedMap backingMap) =>
+          _$$DoNotReferenceThisFactoryExceptForInASingleTestProps$JsMap(
+              backingMap);
+
+  @override
+  _$$DoNotReferenceThisFactoryExceptForInASingleTestProps typedPropsFactory(
+          Map backingMap) =>
+      _$$DoNotReferenceThisFactoryExceptForInASingleTestProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by DoNotReferenceThisFactoryExceptForInASingleTestProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because DoNotReferenceThisFactoryExceptForInASingleTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of DoNotReferenceThisFactoryExceptForInASingleTestProps, and check that $DoNotReferenceThisFactoryExceptForInASingleTestProps is exported/imported properly.
+        DoNotReferenceThisFactoryExceptForInASingleTestProps:
+            $DoNotReferenceThisFactoryExceptForInASingleTestProps.meta,
+      });
+}
+
 @Deprecated('This API is for use only within generated code.'
     ' Do not reference it in your code, as it may change at any time.'
     ' EXCEPTION: this may be used in legacy boilerplate until'
@@ -157,6 +324,47 @@ mixin $TwoLevelWrapperProps on TwoLevelWrapperProps {
 const PropsMeta _$metaForTwoLevelWrapperProps = PropsMeta(
   fields: $TwoLevelWrapperProps.$props,
   keys: $TwoLevelWrapperProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $DoNotReferenceThisFactoryExceptForInASingleTestProps
+    on DoNotReferenceThisFactoryExceptForInASingleTestProps {
+  static const PropsMeta meta =
+      _$metaForDoNotReferenceThisFactoryExceptForInASingleTestProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForDoNotReferenceThisFactoryExceptForInASingleTestProps =
+    PropsMeta(
+  fields: $DoNotReferenceThisFactoryExceptForInASingleTestProps.$props,
+  keys: $DoNotReferenceThisFactoryExceptForInASingleTestProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestUninitializedParentProps on TestUninitializedParentProps {
+  static const PropsMeta meta = _$metaForTestUninitializedParentProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestUninitializedParentProps = PropsMeta(
+  fields: $TestUninitializedParentProps.$props,
+  keys: $TestUninitializedParentProps.$propKeys,
 );
 
 final UiFactoryConfig<_$$TestAProps> $TestAConfig = UiFactoryConfig(
@@ -643,14 +851,6 @@ final UiFactoryConfig<_$$OneLevelWrapperProps> $OneLevelWrapperConfig =
         ),
         displayName: 'OneLevelWrapper');
 
-final UiFactoryConfig<_$$OneLevelWrapperProps> $TwoLevelWrapperConfig =
-    UiFactoryConfig(
-        propsFactory: PropsFactory(
-          map: (map) => _$$OneLevelWrapperProps(map),
-          jsMap: (map) => _$$OneLevelWrapperProps$JsMap(map),
-        ),
-        displayName: 'TwoLevelWrapper');
-
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
@@ -712,6 +912,168 @@ class _$$OneLevelWrapperProps$JsMap extends _$$OneLevelWrapperProps {
   // This initializer of `_props` to an empty map, as well as the reassignment
   // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
   _$$OneLevelWrapperProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TwoLevelWrapperProps> $TwoLevelWrapperConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$TwoLevelWrapperProps(map),
+          jsMap: (map) => _$$TwoLevelWrapperProps$JsMap(map),
+        ),
+        displayName: 'TwoLevelWrapper');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TwoLevelWrapperProps extends UiProps
+    with
+        TwoLevelWrapperProps,
+        $TwoLevelWrapperProps // If this generated mixin is undefined, it's likely because TwoLevelWrapperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TwoLevelWrapperProps, and check that $TwoLevelWrapperProps is exported/imported properly.
+{
+  _$$TwoLevelWrapperProps._();
+
+  factory _$$TwoLevelWrapperProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TwoLevelWrapperProps$JsMap(backingMap);
+    } else {
+      return _$$TwoLevelWrapperProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TwoLevelWrapperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TwoLevelWrapperProps, and check that $TwoLevelWrapperProps is exported/imported properly.
+        TwoLevelWrapperProps: $TwoLevelWrapperProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TwoLevelWrapperProps$PlainMap extends _$$TwoLevelWrapperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TwoLevelWrapperProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TwoLevelWrapperProps$JsMap extends _$$TwoLevelWrapperProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TwoLevelWrapperProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+final UiFactoryConfig<_$$TestUninitializedParentProps>
+    $TestUninitializedParentConfig = UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$TestUninitializedParentProps(map),
+          jsMap: (map) => _$$TestUninitializedParentProps$JsMap(map),
+        ),
+        displayName: 'TestUninitializedParent');
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestUninitializedParentProps extends UiProps
+    with
+        TestUninitializedParentProps,
+        $TestUninitializedParentProps // If this generated mixin is undefined, it's likely because TestUninitializedParentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestUninitializedParentProps, and check that $TestUninitializedParentProps is exported/imported properly.
+{
+  _$$TestUninitializedParentProps._();
+
+  factory _$$TestUninitializedParentProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestUninitializedParentProps$JsMap(backingMap);
+    } else {
+      return _$$TestUninitializedParentProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestUninitializedParentProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestUninitializedParentProps, and check that $TestUninitializedParentProps is exported/imported properly.
+        TestUninitializedParentProps: $TestUninitializedParentProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestUninitializedParentProps$PlainMap
+    extends _$$TestUninitializedParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestUninitializedParentProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestUninitializedParentProps$JsMap
+    extends _$$TestUninitializedParentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestUninitializedParentProps$JsMap(JsBackedMap backingMap)
       : this._props = JsBackedMap(),
         super._() {
     this._props = backingMap ?? JsBackedMap();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The `@Component2` annotation can't be used with function components, preventing consumers from specifying arguments like `isWrapper` and `subtypeOf`.

## Changes
- Add `setTypeMeta` extension method to `UiFactory`, providing parity with the `@Component2` annotation for function components
    - Add tests
- Tweak arguments to private `setComponentTypeMeta` and `ComponentTypeMeta` to use raw component types in case the `ReactComponentFactoryProxy` isn't available
    - Increase test coverage for these utilities

Examples of equivalent configuration for class-based vs function components:
```dart
// Class components:

@Component2(isWrapper: true)
class FooComponent extends UiComponent2<FooProps> { ... }

@Component2(subtypeOf: FooComponent)
class BarComponent ... {...}

// Function components:

UiFactory<FooProps> Foo = uiFunction(...)
  ..setComponentMeta(isWrapper: true);

UiFactory<FooProps> Bar = uiFunction(...)
  ..setComponentMeta(subtypeOfFactory: Foo);
```

#### Release Notes
- Add extension method `UiFactory.setComponentMeta`, which brings `@Component2` annotation configuration to function components

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Ensure test branch WSD is passing: https://github.com/Workiva/web_skin_dart/pull/1537
            - WSD has extensive usage of component subtyping, and is a good place to test for regressions related to these changes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
