### PR TITLE
Fix/remove usages of CompileTimeErrorCode

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
@@ -1,5 +1,5 @@
 // ignore: deprecated_member_use
-import 'package:analyzer/analyzer.dart' show CompileTimeErrorCode, NodeLocator;
+import 'package:analyzer/analyzer.dart' show NodeLocator;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
@@ -62,17 +62,17 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
   computeErrors(result, collector) async {
     for (final error in result.errors) {
       final isBadFunction = const {
-        CompileTimeErrorCode.INVOCATION_OF_NON_FUNCTION,
-        CompileTimeErrorCode.INVOCATION_OF_NON_FUNCTION_EXPRESSION,
-      }.contains(error.errorCode);
+        'INVOCATION_OF_NON_FUNCTION',
+        'INVOCATION_OF_NON_FUNCTION_EXPRESSION',
+      }.contains(error.errorCode.name);
       final isBadArity = const {
-        CompileTimeErrorCode.NOT_ENOUGH_POSITIONAL_ARGUMENTS,
-        CompileTimeErrorCode.EXTRA_POSITIONAL_ARGUMENTS_COULD_BE_NAMED,
-        CompileTimeErrorCode.EXTRA_POSITIONAL_ARGUMENTS,
-      }.contains(error.errorCode);
+        'NOT_ENOUGH_POSITIONAL_ARGUMENTS',
+        'EXTRA_POSITIONAL_ARGUMENTS_COULD_BE_NAMED',
+        'EXTRA_POSITIONAL_ARGUMENTS',
+      }.contains(error.errorCode.name);
       final isVoidUsage = const {
-        CompileTimeErrorCode.USE_OF_VOID_RESULT,
-      }.contains(error.errorCode);
+        'USE_OF_VOID_RESULT',
+      }.contains(error.errorCode.name);
 
       if (isBadFunction || isBadArity || isVoidUsage) {
         final node = NodeLocator(error.offset, error.offset + error.length).searchWithin(result.unit);


### PR DESCRIPTION
## Motivation
- The contains checks weren't working properly since the error code objects weren't the same type, and would always be false
- CompileTimeErrorCode is part of analyzer.dart, which will be removed in a future version, and this prepares for that
    - This API doesn't seem to be treated as stable, either, since we're getting weird failures in Dart 2.7 CI

## Changes
Remove usages of CompileTimeErrorCode and hard code the errors instead

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Analyzer plugin CI passes in Dart 2.7
        - This diagnostic works as intended (or at least doesn't cause bad behavior) in the analyzer playground
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
