### PR TITLE
Consume react-dart 6.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   memoize: ^2.0.0
   meta: ^1.1.6
   path: ^1.5.1
-  react: ^5.7.0
-  redux: ">=3.0.0 <5.0.0"
+  react: ^6.0.0  redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.0
   w_common: ^1.13.0


### PR DESCRIPTION
Consume [react-dart 6.0.0](https://github.com/Workiva/react-dart/releases/tag/6.0.0)

Pull Requests included in release:
* Major changes:
	* [RM-93030 Release react-dart 6.0.0](https://github.com/Workiva/react-dart/pull/285)
* Patch changes:
	* [Add credit to original authors/maintainers](https://github.com/Workiva/react-dart/pull/295)
	* [Set up Workiva Build, move build steps since Travis which no longer runs](https://github.com/Workiva/react-dart/pull/296)
	* [Set up Github actions CI](https://github.com/Workiva/react-dart/pull/297)


Requested by: @rmconsole7-wk
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?pull_number=672&repo_name=Workiva%2Fover_react)