### PR TITLE
Update OverReact syntax to support Dart 2.9+

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   color: any
   memoize: ^2.0.0
   meta: ^1.0.0
-  over_react: ">=3.1.5 <5.0.0"
+  over_react: ^4.1.0
   json_annotation: ^3.0.0
   redux: ">=3.0.0 <5.0.0"
   redux_dev_tools: ">=0.4.0 <0.6.0"

--- a/example/boilerplate_versions/mixin_based/pre_dart_2_9/basic.dart
+++ b/example/boilerplate_versions/mixin_based/pre_dart_2_9/basic.dart
@@ -16,7 +16,7 @@ import 'package:over_react/over_react.dart';
 
 part 'basic.over_react.g.dart';
 
-UiFactory<BasicProps> Basic = _$Basic; // ignore: undefined_identifier, invalid_assignment
+UiFactory<BasicProps> Basic = castUiFactory(_$Basic); // ignore: undefined_identifier
 
 mixin BasicProps on UiProps {
   @Deprecated('This is deprecated')

--- a/example/boilerplate_versions/mixin_based/pre_dart_2_9/function_component.dart
+++ b/example/boilerplate_versions/mixin_based/pre_dart_2_9/function_component.dart
@@ -21,7 +21,7 @@ UiFactory<FunctionComponentProps> FunctionComponent = uiFunction(
     return Dom.div()('This is a pre-Dart 2.9.0 function component.');
   },
   // ignore: deprecated_member_use_from_same_package
-  $FunctionComponentConfig, // ignore: undefined_identifier
+  _$FunctionComponentConfig, // ignore: undefined_identifier
 );
 
 mixin FunctionComponentProps on UiProps {}

--- a/example/boilerplate_versions/mixin_based/pre_dart_2_9/hoc.dart
+++ b/example/boilerplate_versions/mixin_based/pre_dart_2_9/hoc.dart
@@ -22,7 +22,7 @@ part 'hoc.over_react.g.dart';
 UiFactory<HocProps> Hoc = connect<ExampleState, HocProps>(
   mapStateToPropsWithOwnProps: (state, props) => Hoc(),
   mapDispatchToPropsWithOwnProps: (state, props) => Hoc(),
-)(_$Hoc); // ignore: undefined_identifier, argument_type_not_assignable
+)(castUiFactory(_$Hoc)); // ignore: undefined_identifier
 
 mixin HocProps on UiProps {
   String foo;
@@ -34,7 +34,7 @@ class HocComponent extends UiComponent2<HocProps> {
 }
 
 UiFactory<HocWithTwoFactoriesProps> HocWithTwoFactories =
-    _$HocWithTwoFactories; // ignore: undefined_identifier, invalid_assignment
+    castUiFactory(_$HocWithTwoFactories); // ignore: undefined_identifier
 
 UiFactory<HocWithTwoFactoriesProps> ConnectedHocWithTwoFactories =
     connect<ExampleState, HocWithTwoFactoriesProps>(

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -635,7 +635,7 @@ main() {
   });
 }
 
-UiFactory<TransitionerProps> Transitioner = _$Transitioner; // ignore: undefined_identifier, invalid_assignment
+UiFactory<TransitionerProps> Transitioner = castUiFactory(_$Transitioner); // ignore: undefined_identifier
 
 mixin TransitionerPropsMixin on UiProps {
   Callback onHandlePreShowing;

--- a/test/over_react/component/fixtures/pure_test_components.dart
+++ b/test/over_react/component/fixtures/pure_test_components.dart
@@ -17,7 +17,7 @@ import 'package:over_react/src/component/test_fixtures/redraw_counter_component_
 
 part 'pure_test_components.over_react.g.dart';
 
-UiFactory<PureTestWrapperProps> PureTestWrapper = _$PureTestWrapper; // ignore: undefined_identifier, invalid_assignment
+UiFactory<PureTestWrapperProps> PureTestWrapper = castUiFactory(_$PureTestWrapper); // ignore: undefined_identifier
 
 class PureTestWrapperProps = UiProps with SharedPureTestPropsMixin;
 
@@ -47,7 +47,7 @@ class PureTestWrapperComponent extends UiComponent2<PureTestWrapperProps>
   void handleChildFunc() {}
 }
 
-UiFactory<PureTestProps> PureTest = _$PureTest; // ignore: undefined_identifier, invalid_assignment
+UiFactory<PureTestProps> PureTest = castUiFactory(_$PureTest); // ignore: undefined_identifier
 
 mixin PureTestPropsMixin on UiProps {
   bool childBoolProp;

--- a/test/over_react/component/ref_util_test.dart
+++ b/test/over_react/component/ref_util_test.dart
@@ -318,7 +318,7 @@ void testForwardRefWith(dynamic factory,
   });
 }
 
-UiFactory<BasicProps> Basic = _$Basic; // ignore: undefined_identifier, invalid_assignment
+UiFactory<BasicProps> Basic = castUiFactory(_$Basic); // ignore: undefined_identifier
 
 mixin BasicProps on UiProps {
   String childId;

--- a/test/over_react/component/with_transition_test.dart
+++ b/test/over_react/component/with_transition_test.dart
@@ -466,7 +466,7 @@ main() {
   });
 }
 
-UiFactory<WithTransitionTesterProps> WithTransitionTester = _$WithTransitionTester; // ignore: undefined_identifier, invalid_assignment
+UiFactory<WithTransitionTesterProps> WithTransitionTester = castUiFactory(_$WithTransitionTester); // ignore: undefined_identifier
 
 class WithTransitionTesterProps = UiProps
     with

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.dart
@@ -154,7 +154,7 @@ class TestUiStateBaseClass extends UiState {
   bool get $isClassGenerated => true;
 }
 
-UiFactory<TestPropsMixin> Test = _$Test; // ignore: undefined_identifier, invalid_assignment
+UiFactory<TestPropsMixin> Test = castUiFactory(_$Test); // ignore: undefined_identifier
 
 mixin TestPropsMixin on UiProps {
   String stringProp;
@@ -174,7 +174,7 @@ mixin TestPropsMixin on UiProps {
 // ---
 
 UiFactory<TestCustomNamespaceProps> TestCustomNamespace =
-    _$TestCustomNamespace; // ignore: undefined_identifier, invalid_assignment
+    castUiFactory(_$TestCustomNamespace); // ignore: undefined_identifier
 
 @PropsMixin(keyNamespace: 'custom mixin namespace**')
 mixin TestCustomNamespacePropsMixin on UiProps {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
@@ -78,7 +78,7 @@ class FooComponent290 extends UiComponent2<Foo290Props> {
 UiFactory<FooProps> Foo = connect<Null, FooProps>(
   mapStateToPropsWithOwnProps: (state, props) => Foo(),
   mapDispatchToPropsWithOwnProps: (state, props) => Foo(),
-)(_$Foo); // ignore: undefined_identifier, argument_type_not_assignable
+)(castUiFactory(_$Foo)); // ignore: undefined_identifier
 
 mixin FooProps on UiProps {
   String foo;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
@@ -237,8 +237,8 @@ class ComponentTest290Component extends UiComponent2<ComponentTest290Props> {
   }
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
+// ignore: undefined_identifier
+UiFactory<ComponentTestProps> ComponentTest = castUiFactory(_$ComponentTest);
 
 mixin ComponentTestProps on UiProps {
   String stringProp;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_error_boundary_component.dart
@@ -14,7 +14,7 @@
 
 part of '../component_integration_test.dart';
 
-UiFactory<IsErrorBoundaryProps> IsErrorBoundary = _$IsErrorBoundary; // ignore: undefined_identifier, invalid_assignment
+UiFactory<IsErrorBoundaryProps> IsErrorBoundary = castUiFactory(_$IsErrorBoundary); // ignore: undefined_identifier
 
 mixin IsErrorBoundaryProps on UiProps {}
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_not_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_not_error_boundary_component.dart
@@ -14,7 +14,7 @@
 
 part of '../component_integration_test.dart';
 
-UiFactory<IsNotErrorBoundaryProps> IsNotErrorBoundary = _$IsNotErrorBoundary; // ignore: undefined_identifier, invalid_assignment
+UiFactory<IsNotErrorBoundaryProps> IsNotErrorBoundary = castUiFactory(_$IsNotErrorBoundary); // ignore: undefined_identifier
 
 mixin IsNotErrorBoundaryProps on UiProps {}
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
@@ -167,8 +167,8 @@ mixin TestPropsMixin on UiProps {
   dynamic propsMixinProp;
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
+// ignore: undefined_identifier
+UiFactory<ComponentTestProps> ComponentTest = castUiFactory(_$ComponentTest);
 
 mixin ComponentTestPropsMixin on UiProps {
   String stringProp;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
@@ -211,8 +211,8 @@ void main() {
   });
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
+// ignore: undefined_identifier
+UiFactory<ComponentTestProps> ComponentTest = castUiFactory(_$ComponentTest);
 
 mixin ComponentTestProps on UiProps {
   @requiredProp

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.dart
@@ -31,7 +31,7 @@ main() {
   });
 }
 
-UiFactory<TestProps> Test = _$Test; // ignore: undefined_identifier, invalid_assignment
+UiFactory<TestProps> Test = castUiFactory(_$Test); // ignore: undefined_identifier
 
 mixin BasePropsMixin on UiProps {
   Object foo;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.dart
@@ -84,8 +84,8 @@ main() {
   });
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<DoNotGenerateAccessorTestProps> DoNotGenerateAccessorTest = _$DoNotGenerateAccessorTest;
+// ignore: undefined_identifier
+UiFactory<DoNotGenerateAccessorTestProps> DoNotGenerateAccessorTest = castUiFactory(_$DoNotGenerateAccessorTest);
 
 mixin DoNotGenerateAccessorTestProps on UiProps {
   dynamic generated1Prop;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -418,7 +418,7 @@ UiFactory<TestProps> TestPublic = uiFunction(
       ..addProp('data-prop-custom-key-and-namespace-prop',
           props.customKeyAndNamespaceProp))('rendered content');
   },
-  $TestPublicConfig, // ignore: undefined_identifier, deprecated_member_use_from_same_package
+  _$TestPublicConfig, // ignore: undefined_identifier, deprecated_member_use_from_same_package
 );
 
 UiFactory<TestProps> TestCustom = uiFunction(

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.dart
@@ -102,7 +102,7 @@ main() {
 }
 
 
-UiFactory<NamespacedAccessorTestProps> NamespacedAccessorTest = _$NamespacedAccessorTest; // ignore: undefined_identifier, invalid_assignment
+UiFactory<NamespacedAccessorTestProps> NamespacedAccessorTest = castUiFactory(_$NamespacedAccessorTest); // ignore: undefined_identifier
 
 @Props(keyNamespace: 'custom props class namespace**')
 mixin NamespacedAccessorTestProps on UiProps {

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.dart
@@ -31,8 +31,8 @@ main() {
   });
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<FooProps> Foo = _$Foo;
+// ignore: undefined_identifier
+UiFactory<FooProps> Foo = castUiFactory(_$Foo);
 
 mixin FooProps on UiProps {
   String _privateProp;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.dart
@@ -86,7 +86,7 @@ main() {
   });
 }
 
-UiFactory<TestProps> Test = _$Test; // ignore: undefined_identifier, invalid_assignment
+UiFactory<TestProps> Test = castUiFactory(_$Test); // ignore: undefined_identifier
 
 mixin TestProps on UiProps {
   String stringProp;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -164,7 +164,7 @@ main() {
   });
 }
 
-UiFactory<TestProps> Test = _$Test; // ignore: undefined_identifier, invalid_assignment
+UiFactory<TestProps> Test = castUiFactory(_$Test); // ignore: undefined_identifier
 
 mixin TestPropsMixin on UiProps {
   String test;

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.dart
@@ -210,8 +210,8 @@ void main() {
   });
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
+// ignore: undefined_identifier
+UiFactory<ComponentTestProps> ComponentTest = castUiFactory(_$ComponentTest);
 
 mixin ComponentTestProps on UiProps {
   @Accessor(isRequired: true, requiredErrorMessage: 'This Prop is Required for testing purposes.')

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.dart
@@ -72,7 +72,7 @@ main() {
   });
 }
 
-UiFactory<StatefulComponentTestProps> StatefulComponentTest = _$StatefulComponentTest; // ignore: undefined_identifier, invalid_assignment
+UiFactory<StatefulComponentTestProps> StatefulComponentTest = castUiFactory(_$StatefulComponentTest); // ignore: undefined_identifier
 
 mixin StatefulComponentTestProps on UiProps {
   /// Used to test if a component has the capability to set state via this.setState.

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.dart
@@ -36,8 +36,8 @@ main() {
   });
 }
 
-// ignore: undefined_identifier, invalid_assignment
-UiFactory<FooProps> Foo = _$Foo;
+// ignore: undefined_identifier
+UiFactory<FooProps> Foo = castUiFactory(_$Foo);
 
 mixin FooProps on UiProps {
   String stringProp;

--- a/test_fixtures/source_files/mixin_based/basic.dart
+++ b/test_fixtures/source_files/mixin_based/basic.dart
@@ -2,7 +2,7 @@ import 'package:over_react/over_react.dart';
 
 part 'basic.over_react.g.dart';
 
-UiFactory<BasicProps> Basic = _$Basic; // ignore: undefined_identifier
+UiFactory<BasicProps> Basic = castUiFactory(_$Basic); // ignore: undefined_identifier
 
 mixin BasicProps on UiProps {
   @deprecated

--- a/test_fixtures/source_files/mixin_based/missing_over_react_g_part/part.dart
+++ b/test_fixtures/source_files/mixin_based/missing_over_react_g_part/part.dart
@@ -1,6 +1,6 @@
 part of 'library.dart';
 
-UiFactory<BasicPartOfLibProps> BasicPartOfLib = _$BasicPartOfLib; // ignore: undefined_identifier
+UiFactory<BasicPartOfLibProps> BasicPartOfLib = castUiFactory(_$BasicPartOfLib); // ignore: undefined_identifier
 
 mixin BasicPartOfLibProps on UiProps {
   String basicProp;

--- a/test_fixtures/source_files/mixin_based/part_of_basic_library.dart
+++ b/test_fixtures/source_files/mixin_based/part_of_basic_library.dart
@@ -1,6 +1,6 @@
 part of basic.library;
 
-UiFactory<BasicPartOfLibProps> BasicPartOfLib = _$BasicPartOfLib; // ignore: undefined_identifier
+UiFactory<BasicPartOfLibProps> BasicPartOfLib = castUiFactory(_$BasicPartOfLib); // ignore: undefined_identifier
 
 class BasicPartOfLibProps = UiProps with ExamplePropsMixin, BasicPartOfLibPropsMixin;
 class BasicPartOfLibState = UiState with ExampleStateMixin, BasicPartOfLibStateMixin;

--- a/test_fixtures/source_files/mixin_based/part_of_basic_library_2.dart
+++ b/test_fixtures/source_files/mixin_based/part_of_basic_library_2.dart
@@ -16,7 +16,7 @@ abstract class SuperPartOfLibComponent<T extends SuperPartOfLibPropsMixin> exten
   }
 }
 
-UiFactory<SubPartOfLibProps> SubPartOfLib = _$SubPartOfLib; // ignore: undefined_identifier
+UiFactory<SubPartOfLibProps> SubPartOfLib = castUiFactory(_$SubPartOfLib); // ignore: undefined_identifier
 
 class SubPartOfLibProps = UiProps with SuperPartOfLibPropsMixin, SubPartOfLibPropsMixin;
 

--- a/test_fixtures/source_files/mixin_based/type_parameters.dart
+++ b/test_fixtures/source_files/mixin_based/type_parameters.dart
@@ -25,14 +25,14 @@ mixin DoubleProps<A, B> on UiProps {
 
 // Test shorthand syntax
 
-UiFactory<SingleProps> Single = _$Single; // ignore: undefined_identifier
-UiFactory<SingleWithBoundProps> SingleWithBound = _$SingleWithBound; // ignore: undefined_identifier
-UiFactory<DoubleProps> Double = _$Double; // ignore: undefined_identifier
+UiFactory<SingleProps> Single = castUiFactory(_$Single); // ignore: undefined_identifier
+UiFactory<SingleWithBoundProps> SingleWithBound = castUiFactory(_$SingleWithBound); // ignore: undefined_identifier
+UiFactory<DoubleProps> Double = castUiFactory(_$Double); // ignore: undefined_identifier
 
 // Test that the generated class impl has the correct generic params
 // and passes the specified generic params to uses the mixins correctly.
 
-UiFactory<ConcreteNoneProps> ConcreteNone = _$ConcreteNone; // ignore: undefined_identifier
+UiFactory<ConcreteNoneProps> ConcreteNone = castUiFactory(_$ConcreteNone); // ignore: undefined_identifier
 class ConcreteNoneProps = UiProps
     with
         NoneProps,
@@ -43,7 +43,7 @@ class ConcreteNoneProps = UiProps
 
 // Test that the generated class impl works when passing its generic params to mixins.
 
-UiFactory<ConcreteArgsProps> ConcreteArgs = _$ConcreteArgs; // ignore: undefined_identifier
+UiFactory<ConcreteArgsProps> ConcreteArgs = castUiFactory(_$ConcreteArgs); // ignore: undefined_identifier
 class ConcreteArgsProps<U, V extends Iterable> = UiProps
     with
         NoneProps,

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  over_react: ^3.5.3
+  over_react: ^4.1.0
 dev_dependencies:
   build_runner: ^1.0.0
   build_web_compilers: ^2.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.1.0
+  over_react: ^4.1.0
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
## Motivation
In order to enable Workiva to transition to Dart >=2.9.0 with ease, a slight update to OverReact factory syntax
is required.

__Important:__
1. Remember to update your snippets in order to prevent accidental regressions in boilerplate. [Here](https://github.com/Workiva/over_react/blob/master/snippets/README.md)
is the reference for OverReact snippets.
1. To prevent incompatible boilerplate from being introduced, a react-boilerplate core-check has been activated. This
core check will fail if the incompatible mixin based boilerplate is introduced again to a project that has migrated already.

> For more information on why this migration is important, see [this wiki update](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=182026853).

__NOTE:__ Only the mixin based boilerplate factories will be migrated. In other words, if your factory is still
using the `@Factory` annotation, it will not be migrated to the Dart 2.9-compatible boilerplate and must first
be [migrated to the mixin based syntax](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md#upgrading-existing-code).
For additional reference, [here](https://github.com/Workiva/web_skin_dart/blob/master/doc/Component2-Migration-Guide.md)
are the instructions to migrate for projects depedent on Web Skin Dart.

## Changes
Below are two examples of the minor tweaks that will occur. For a reference of all the small changes that will occur
(including to the `connect` syntax), refer to option #2 [here](https://jsfiddle.net/greglittlefieldwf/onemhutb/show).
Note that `ignore` comments are not included in those examples.

1. Switch factory declarations to use the new syntax.
    ```diff
    UiFactory<FooProps> Foo = 
    -    _$Foo; // ignore: undefined_identifier, invalid_assignment
    +   castUiFactory(_$Foo); // ignore: undefined_identifier
    ```
1. For functional components, use the private config instead of the public one.
    ```diff
    UiFactory<FooProps> Foo = uiFunction(
      (props) {
        return 'Foo';
      },
    -  $FooConfig, // ignore: undefined_identifier
    +  _$FooConfig, // ignore: undefined_identifier
    );
    ```
1. Bump minimum over_react version to be compatible with the new syntax.

## Release Notes
Migrate mixin based factories to the Dart 2.9-compatible boilerplate.

## QA
These changes are not expected to require any special form of QA. As long as CI performs analysis on Dart code and runs a Dart build,
a passing CI is sufficient to merge these changes.

For more information or questions, reach out to us in the #support-ui-platform Slack channel.


[_Created by Sourcegraph campaign `Workiva/dart2_9_boilerplate_migration`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/campaigns/dart2_9_boilerplate_migration)