### PR TITLE
Consumer testing for Dart 2.12 JsBackedMap fix in react-dart

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -32,3 +32,7 @@ dev_dependencies:
 dependency_overrides:
   over_react:
     path: '../../../'
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: CPLAT-13185-fix-jsbackedmap-dart-2.12

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,3 +51,9 @@ workiva:
   core_checks:
     version: 1
     react_boilerplate: disabled
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: CPLAT-13185-fix-jsbackedmap-dart-2.12

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -12,4 +12,8 @@ dev_dependencies:
 dependency_overrides:
   # Pull in the local copy of over_react so it pulls in the local copy of the plugin
   over_react:
-      path: ../../..
+    path: ../../..
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: CPLAT-13185-fix-jsbackedmap-dart-2.12

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -44,3 +44,9 @@ dev_dependencies:
 # dependency_overrides:
 #   over_react:
 #     path: /Users/me/workspaces/over_react
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: CPLAT-13185-fix-jsbackedmap-dart-2.12


### PR DESCRIPTION
Consumer testing for: https://github.com/Workiva/react-dart/pull/305