### PR TITLE
Test compatibility with redux v4.0.0

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -32,3 +32,4 @@ dev_dependencies:
 dependency_overrides:
   over_react:
     path: '../../../'
+  redux: 4.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,3 +48,6 @@ workiva:
   core_checks:
     version: 1
     react_boilerplate: disabled
+
+dependency_overrides:
+  redux: 4.0.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -13,3 +13,4 @@ dependency_overrides:
   # Pull in the local copy of over_react so it pulls in the local copy of the plugin
   over_react:
       path: ../../..
+  redux: 4.0.0


### PR DESCRIPTION
This PR tests that widening the range of the redux dependency is safe for your repo.
You'll also recieve a PR with the title "Prepare for redux v4.0.0", *which is the mergable PR*.
You can safely ignore this PR, it will be closed automatically once it is passing, and the aformentioned PR will be merged instead.
For more info, reach out to Michael Carter or `#support-process-builder` on Slack.

[_Created by Sourcegraph batch change `Workiva/redux_override_v4`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/redux_override_v4)