### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/app/over_react_redux/todo_client/test/unit/browser/components/app_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/app_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:async';
 

--- a/app/over_react_redux/todo_client/test/unit/browser/components/connected_todo_list_item_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/connected_todo_list_item_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 
 @TestOn('browser')

--- a/app/over_react_redux/todo_client/test/unit/browser/components/connected_todo_list_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/connected_todo_list_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react_redux.dart';

--- a/app/over_react_redux/todo_client/test/unit/browser/components/connected_user_list_item_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/connected_user_list_item_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:async';
 

--- a/app/over_react_redux/todo_client/test/unit/browser/components/connected_user_list_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/connected_user_list_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react_redux.dart';

--- a/app/over_react_redux/todo_client/test/unit/browser/components/create_input_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/create_input_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:async';
 import 'dart:html';

--- a/app/over_react_redux/todo_client/test/unit/browser/components/display_list_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/display_list_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:html';
 

--- a/app/over_react_redux/todo_client/test/unit/browser/components/js_interop_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/js_interop_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 @JS()
 library js_interop_test;

--- a/app/over_react_redux/todo_client/test/unit/browser/components/material_ui_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/material_ui_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';

--- a/app/over_react_redux/todo_client/test/unit/browser/components/todo_list_item_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/components/todo_list_item_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:async';
 import 'dart:html';

--- a/app/over_react_redux/todo_client/test/unit/browser/redux/models/todo_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/redux/models/todo_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:test/test.dart';
 

--- a/app/over_react_redux/todo_client/test/unit/browser/redux/models/user_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/redux/models/user_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'package:test/test.dart';
 

--- a/app/over_react_redux/todo_client/test/unit/browser/redux/store_test.dart
+++ b/app/over_react_redux/todo_client/test/unit/browser/redux/store_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser')
 import 'dart:convert';
 

--- a/app/over_react_redux/todo_client/web/main.dart
+++ b/app/over_react_redux/todo_client/web/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 
 import 'package:over_react/react_dom.dart' as react_dom;

--- a/example/boilerplate_versions/main.dart
+++ b/example/boilerplate_versions/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/example/builder/main.dart
+++ b/example/builder/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/example/context/main.dart
+++ b/example/context/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/example/hooks/main.dart
+++ b/example/hooks/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/_deprecated/abstract_transition_test.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component/_deprecated/error_boundary_mixin_test.dart
+++ b/test/over_react/component/_deprecated/error_boundary_mixin_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/_deprecated/error_boundary_test.dart
+++ b/test/over_react/component/_deprecated/error_boundary_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/_deprecated/resize_sensor_test.dart
+++ b/test/over_react/component/_deprecated/resize_sensor_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component/context_test.dart
+++ b/test/over_react/component/context_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/dom_components_test.dart
+++ b/test/over_react/component/dom_components_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/error_boundary_test.dart
+++ b/test/over_react/component/error_boundary_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/fragment_component_test.dart
+++ b/test/over_react/component/fragment_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/memo_test.dart
+++ b/test/over_react/component/memo_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component/prop_mixins_test.dart
+++ b/test/over_react/component/prop_mixins_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/prop_typedefs_test.dart
+++ b/test/over_react/component/prop_typedefs_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/pure_component_mixin_test.dart
+++ b/test/over_react/component/pure_component_mixin_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/ref_util_test.dart
+++ b/test/over_react/component/ref_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component/resize_sensor_test.dart
+++ b/test/over_react/component/resize_sensor_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/strictmode_component_test.dart
+++ b/test/over_react/component/strictmode_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/typed_factory_test.dart
+++ b/test/over_react/component/typed_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/typed_factory_test.over_react.g.dart
+++ b/test/over_react/component/typed_factory_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component/with_transition_test.dart
+++ b/test/over_react/component/with_transition_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_helpers_test.dart
+++ b/test/over_react/component_declaration/builder_helpers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/abstract_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/accessor_mixin_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/constant_required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/do_not_generate_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/namespaced_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/private_props_ddc_bug.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/stateful_component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/backwards_compatible/unassigned_prop_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_default_props_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/annotation_error_stateful_default_props_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/is_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/is_error_boundary_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/is_not_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test/is_not_error_boundary_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/accessor_mixin_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_error_boundary_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_not_error_boundary_component.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_test/is_not_error_boundary_component.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/component_integration_verbose_syntax_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/constant_required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/covariant_accessor_override_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/do_not_generate_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2017 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/function_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/namespaced_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/private_props_ddc_bug.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_map_view_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/props_meta_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/stateful_component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/unassigned_prop_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/component_type_checking_test.dart
+++ b/test/over_react/component_declaration/component_type_checking_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/basic.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/basic.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/flux_component_test/component2/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/handler_lifecycle.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/handler_precedence.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/prop_validation.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/redraw_on.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/basic.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/handler_lifecycle.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/handler_precedence.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/prop_validation.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/redraw_on.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/stateful/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/stateful/store_handlers.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/component2/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/store_handlers.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/flux_component_test/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/handler_lifecycle.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/handler_precedence.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/prop_validation.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/redraw_on.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/basic.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/handler_lifecycle.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/handler_lifecycle.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/handler_precedence.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/prop_validation.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/redraw_on.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/stateful/store_handlers.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/flux_component_test/store_handlers.dart
+++ b/test/over_react/component_declaration/flux_component_test/store_handlers.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/redux_component_test.dart
+++ b/test/over_react/component_declaration/redux_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/redux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/redux_component_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/component_declaration/redux_component_test/connect.dart
+++ b/test/over_react/component_declaration/redux_component_test/connect.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/redux_component_test/default.dart
+++ b/test/over_react/component_declaration/redux_component_test/default.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/component_declaration/redux_component_test/pure.dart
+++ b/test/over_react/component_declaration/redux_component_test/pure.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/dom/render_test.dart
+++ b/test/over_react/dom/render_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2018 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/dom/unmount_test.dart
+++ b/test/over_react/dom/unmount_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2018 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/cast_ui_factory_test.dart
+++ b/test/over_react/util/cast_ui_factory_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/cast_ui_factory_test.over_react.g.dart
+++ b/test/over_react/util/cast_ui_factory_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/util/class_names_test.dart
+++ b/test/over_react/util/class_names_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/constants_base_test.dart
+++ b/test/over_react/util/constants_base_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/css_value_util_test.dart
+++ b/test/over_react/util/css_value_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/util/equality_test.dart
+++ b/test/over_react/util/equality_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('browser || vm')
 import 'package:over_react/src/util/equality.dart';
 import 'package:test/test.dart';

--- a/test/over_react/util/guid_util_test.dart
+++ b/test/over_react/util/guid_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/handler_chain_util_test.dart
+++ b/test/over_react/util/handler_chain_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/hoc_test.dart
+++ b/test/over_react/util/hoc_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/map_util_test.dart
+++ b/test/over_react/util/map_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/pretty_print_test.dart
+++ b/test/over_react/util/pretty_print_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/prop_key_util_test_dart2.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/react_wrappers_test.dart
+++ b/test/over_react/util/react_wrappers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/rem_util_test.dart
+++ b/test/over_react/util/rem_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/safe_render_manager/safe_render_manager_helper_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_helper_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/string_util_test.dart
+++ b/test/over_react/util/string_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react/util/test_mode_test.dart
+++ b/test/over_react/util/test_mode_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_component_declaration_test.dart
+++ b/test/over_react_component_declaration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_dom_test.dart
+++ b/test/over_react_dom_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2018 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/connect_flux_integration_test.dart
+++ b/test/over_react_redux/connect_flux_integration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/connect_flux_test.dart
+++ b/test/over_react_redux/connect_flux_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/connect_test.dart
+++ b/test/over_react_redux/connect_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/hooks/use_dispatch_test.dart
+++ b/test/over_react_redux/hooks/use_dispatch_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react_redux/hooks/use_selector_test.dart
+++ b/test/over_react_redux/hooks/use_selector_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/hooks/use_store_test.dart
+++ b/test/over_react_redux/hooks/use_store_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/hooks/use_store_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_store_test.over_react.g.dart
@@ -1,3 +1,4 @@
+// @dart=2.7
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators

--- a/test/over_react_redux/redux_multi_provider_test.dart
+++ b/test/over_react_redux/redux_multi_provider_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux/value_mutation_checker_test.dart
+++ b/test/over_react_redux/value_mutation_checker_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_redux_test.dart
+++ b/test/over_react_redux_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/over_react_util_test.dart
+++ b/test/over_react_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/codegen/names_test.dart
+++ b/test/vm_tests/builder/codegen/names_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/codegen_test.dart
+++ b/test/vm_tests/builder/codegen_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/declaration_parsing_test.dart
+++ b/test/vm_tests/builder/declaration_parsing_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2016 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/over_react_builder_test.dart
+++ b/test/vm_tests/builder/over_react_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/ast_util/classish_declaration_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util/classish_declaration_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/error_collection.dart
+++ b/test/vm_tests/builder/parsing/error_collection.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/member_association_test.dart
+++ b/test/vm_tests/builder/parsing/member_association_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/members_test.dart
+++ b/test/vm_tests/builder/parsing/members_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/meta_test.dart
+++ b/test/vm_tests/builder/parsing/meta_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/parsing_version_test.dart
+++ b/test/vm_tests/builder/parsing/parsing_version_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/vm_tests/builder/parsing/util_test.dart
+++ b/test/vm_tests/builder/parsing/util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tool/travis_link_plugin_deps.dart
+++ b/tool/travis_link_plugin_deps.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:io';
 
 import 'package:io/ansi.dart' as ansi;

--- a/tools/analyzer_plugin/bin/plugin.dart
+++ b/tools/analyzer_plugin/bin/plugin.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:isolate';
 
 import 'package:over_react_analyzer_plugin/plugin_starter.dart';

--- a/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types_gen.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types_gen.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 /// Generates allowedHtmlElementsForAttribute for use in dom_prop_types.dart
 void main() {
   final supportedElements = <String, List<String>>{};

--- a/tools/analyzer_plugin/playground/web/dom_prop_types.dart
+++ b/tools/analyzer_plugin/playground/web/dom_prop_types.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:over_react/over_react.dart';
 
 main() {

--- a/tools/analyzer_plugin/playground/web/missing_required_props.dart
+++ b/tools/analyzer_plugin/playground/web/missing_required_props.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:over_react/over_react.dart';
 
 part 'missing_required_props.over_react.g.dart';

--- a/tools/analyzer_plugin/test/integration/assists/add_props_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/add_props_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 
 import 'package:analyzer_plugin/utilities/assist/assist.dart';

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 
 import 'package:analyzer_plugin/utilities/assist/assist.dart';

--- a/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 
 import 'package:over_react_analyzer_plugin/src/diagnostic/arrow_function_prop.dart';

--- a/tools/analyzer_plugin/test/unit/fluent_interface_util/cascade_read_test.dart
+++ b/tools/analyzer_plugin/test/unit/fluent_interface_util/cascade_read_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
 import 'package:test/test.dart';
 

--- a/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 import 'package:test/test.dart';

--- a/tools/analyzer_plugin/test/unit/util/boilerplate_utils_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/boilerplate_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart';

--- a/tools/analyzer_plugin/test/unit/util/component_usage_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/component_usage_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_analyzer_plugin/src/component_usage.dart';
 import 'package:over_react_analyzer_plugin/src/util/util.dart';

--- a/tools/analyzer_plugin/tool/doc.dart
+++ b/tools/analyzer_plugin/tool/doc.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Adapted from https://github.com/dart-lang/linter/blob/aab17d378181df057ca7dbd4f1b4889b3babad52/tool/doc.dart
 //
 // Copyright 2015, the Dart project authors. All rights reserved.

--- a/tools/analyzer_plugin/tool/init_local_dev.dart
+++ b/tools/analyzer_plugin/tool/init_local_dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:io';
 
 import 'package:analyzer/file_system/file_system.dart' as file_system;

--- a/web/component1/index.dart
+++ b/web/component1/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component1/src/demos/button/index.dart
+++ b/web/component1/src/demos/button/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component1/src/demos/list-group/index.dart
+++ b/web/component1/src/demos/list-group/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component1/src/demos/progress/index.dart
+++ b/web/component1/src/demos/progress/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component1/src/demos/tag/index.dart
+++ b/web/component1/src/demos/tag/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component2/index.dart
+++ b/web/component2/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component2/src/demos/button/index.dart
+++ b/web/component2/src/demos/button/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component2/src/demos/list-group/index.dart
+++ b/web/component2/src/demos/list-group/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component2/src/demos/progress/index.dart
+++ b/web/component2/src/demos/progress/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/component2/src/demos/tag/index.dart
+++ b/web/component2/src/demos/tag/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/advanced/examples/flux_implementation/index.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/advanced/examples/influx_implementation/index.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/advanced/examples/redux_implementation/index.dart
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/simple/examples/flux_implementation/index.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/simple/examples/influx_implementation/index.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/flux_to_redux/simple/examples/redux_implementation/index.dart
+++ b/web/flux_to_redux/simple/examples/redux_implementation/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/over_react_redux/examples/dev_tools/index.dart
+++ b/web/over_react_redux/examples/dev_tools/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/over_react_redux/examples/multiple_stores/index.dart
+++ b/web/over_react_redux/examples/multiple_stores/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/web/over_react_redux/examples/simple/index.dart
+++ b/web/over_react_redux/examples/simple/index.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)