### PR TITLE
Enable resolution of build_web_compilers 1.12.0, fix Dart stable build

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -53,7 +53,12 @@ jobs:
         name: Build generated files / precompile DDC assets
         run: |
           pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
-          git diff --exit-code
+          if [ ${{ matrix.sdk }} = '2.7.2' ]; then
+            git diff --exit-code
+          else
+            # Exclude built_redux generated files since they get generated differently in Dart 2.7 vs other versions
+            git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
+          fi
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,13 @@ environment:
 
 dependencies:
   collection: ^1.14.11
-  analyzer: '>=0.35.0 <0.40.0'
+  analyzer: '>=0.40.0 <0.42.0'
   build: ^1.0.0
-  built_redux: ^7.4.2
-  built_value: '>=5.4.4 <8.0.0'
+  built_redux:
+    git:
+      url: https://github.com/aaronlademann-wf/built_redux.git
+      ref: widen-analyzer-range
+  built_value: '>=6.8.2 <9.0.0'
   dart_style: ^1.2.5
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
@@ -20,7 +23,7 @@ dependencies:
   react: ^6.0.0
   redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
-  transformer_utils: ^0.2.0
+  transformer_utils: ^0.2.6
   w_common: ^1.13.0
   w_flux: ^2.10.4
   platform_detect: ^1.3.4
@@ -32,16 +35,16 @@ dev_dependencies:
   build_runner: ^1.7.1
   build_test: ^0.10.9
   build_web_compilers: ^2.5.1
-  built_value_generator: '>=6.0.0 <8.0.0'
+  built_value_generator: '>=7.0.0 <9.0.0'
   dart2_constant: ^1.0.0
-  dart_dev: ^3.0.0
+  dart_dev: ^3.6.4
   dependency_validator: ^1.4.0
   glob: ^1.2.0
   io: ^0.3.2+1
   mockito: ^4.1.1
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
-  test: ^1.9.1
+  test: ^1.15.7
   yaml: ^2.2.1
 
 workiva:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,7 @@ dependencies:
   # to enable proper opting out of null-safety.
   analyzer: '>=0.39.0 <0.42.0'
   build: ^1.0.0
-  built_redux:
-    git:
-      url: https://github.com/aaronlademann-wf/built_redux.git
-      ref: widen-analyzer-range
+  built_redux: ^7.4.2
   built_value: '>=6.8.2 <9.0.0'
   dart_style: ^1.2.5
   js: ^0.6.1+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,10 @@ environment:
 
 dependencies:
   collection: ^1.14.11
-  analyzer: '>=0.40.0 <0.42.0'
+  # Dart 2.7 needs 0.39.x to resolve,
+  # and Dart 2.12+ needs 0.42.x to resolve to build_web_compilers 2.12.0, etc.
+  # to enable proper opting out of null-safety.
+  analyzer: '>=0.39.0 <0.42.0'
   build: ^1.0.0
   built_redux:
     git:

--- a/test/over_react_redux/hooks/use_selector_test.dart
+++ b/test/over_react_redux/hooks/use_selector_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:developer';
-
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react_redux.dart';
 import 'package:redux/redux.dart';


### PR DESCRIPTION
## Motivation
The Dart stable build was failing due to:
- (Mainly) not being able to resolve to build_web_compilers, `^1.12.0`, which contains fixes for null-safety being opted into when it shouldn't
- Differences in some generated files compared to those generated in 2.7.2

## Changes
- Update version bounds (credit to @aaronlademann-wf for almost all of these changes)
    - Increase analyzer upper bound so that build_web_compilers `1.12.0` can be resolved to in Dart 2.12+, and keep lower bound low enough so that we can still resolve in Dart 2.7
    - Widen other bounds as needed
- Update build to ignore changes in generated files

#### Release Notes
Update dependencies to allow resolution of build_web_compilers `^1.12.0` in Dart 2.12+, which contains fixes for null-safety being opted into when it shouldn't.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Main CI passes in Dart 2.7.2 and stable 
            - Ignore dev for now; not sure what's going on there
        - [ ] Analyzer CI passes in Dart 2.7.2
            - Ignore stable, it has more issues we'll address later
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
