### PR TITLE
RM-94745 RM-94744 Release over_react 4.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   memoize: ^2.0.0
-  meta: ^1.1.6
+  meta: '>=1.1.6 <1.7.0'
   path: ^1.5.1
   react: ^6.0.0
   redux: ">=3.0.0 <5.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.1.0
+version: 4.1.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.1.0
+  over_react: 4.1.1
   meta: ^1.1.6
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/over_react/pull/685)
	* [DE-657: Delete docs.yml file created for Dev Portal.](https://github.com/Workiva/over_react/pull/686)
	* [Enable resolution of build_web_compilers 2.12.0, fix Dart stable build](https://github.com/Workiva/over_react/pull/691)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.1.0...Workiva:release_over_react_4.1.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.1.0...4.1.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=692&repo_name=Workiva%2Fover_react)