### PR TITLE
Add ability to get activeElement within "open" shadowroot to dom util

### DIFF
--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -49,9 +49,14 @@ Element closest(Element lowerBound, String selector, {Element upperBound}) {
 }
 
 /// Returns the currently focused element ([Document.activeElement]),
+/// or the focused element within a ShadowDOM ([ShadowRoot.activeElement]),
 /// or `null` if nothing is focused (e.g. [Document.activeElement] is [BodyElement]).
 Element getActiveElement() {
   var activeElement = document.activeElement;
+
+  while (activeElement.shadowRoot != null) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
 
   if (activeElement is! Element || activeElement == document.body) return null;
 

--- a/lib/src/util/dom_util.dart
+++ b/lib/src/util/dom_util.dart
@@ -51,12 +51,15 @@ Element closest(Element lowerBound, String selector, {Element upperBound}) {
 /// Returns the currently focused element ([Document.activeElement]),
 /// or the focused element within a ShadowDOM ([ShadowRoot.activeElement]),
 /// or `null` if nothing is focused (e.g. [Document.activeElement] is [BodyElement]).
-Element getActiveElement() {
+Element getActiveElement({bool getWithinShadowRoots = true}) {
   var activeElement = document.activeElement;
 
-  while (activeElement.shadowRoot != null) {
-    activeElement = activeElement.shadowRoot.activeElement;
+  if (getWithinShadowRoots) {
+    while (activeElement.shadowRoot != null) {
+      activeElement = activeElement.shadowRoot.activeElement;
+    }
   }
+
 
   if (activeElement is! Element || activeElement == document.body) return null;
 

--- a/test/over_react/util/dom_util_test.dart
+++ b/test/over_react/util/dom_util_test.dart
@@ -146,6 +146,18 @@ main() {
 
       await triggerFocus(activeElement);
 
+      expect(getActiveElement(getWithinShadowRoots: false), isNull);
+      expect(getActiveElement(), activeElement);
+      activeElement.remove();
+    });
+
+    test('a valid element within a ShadowRoot', () async {
+      var divWithShadowRoot = DivElement()..attachShadow({'mode':'open'});
+      var activeElement = DivElement()..tabIndex = 1;
+      divWithShadowRoot.shadowRoot.append(activeElement);
+
+      await triggerFocus(activeElement);
+
       expect(getActiveElement(), activeElement);
       activeElement.remove();
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
ShadowRoots are becoming quite popular and with them, comes the issue of `document.activeElement` only returning the "host" element instead of the actual element within an element.

## Changes
  <!-- What this PR changes to fix the problem. -->

- Added a while loop to check for the activeElement within returned elements that have shadowRoots.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
