### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -50,6 +50,7 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - id: build
+        timeout-minutes: 6
         name: Build generated files / precompile DDC assets
         run: |
           pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   color: any
   memoize: ^2.0.0
-  meta: ^1.2.2
+  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0
   redux: ">=3.0.0 <5.0.0"

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   color: any
   memoize: ^2.0.0
-  meta: ^1.0.0
+  meta: ^1.2.2
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0
   redux: ">=3.0.0 <5.0.0"
@@ -17,13 +17,13 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.7.1
   build_web_compilers: ^2.5.1
-  build_test: ^0.10.9
+  build_test: ">=0.10.9 <2.0.0"
   dart_dev: ^3.0.0
   glob: ^1.2.0
   json_serializable: ^3.2.2
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
-  test: ^1.9.1
+  test: ^1.15.7
   test_html_builder: ^1.0.0
   time: ^1.2.0
   w_common: ^1.20.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   memoize: ^2.0.0
-  meta: ^1.2.2
+  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   react: ^6.0.0
   redux: ">=3.0.0 <5.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   memoize: ^2.0.0
-  meta: '>=1.1.6 <1.7.0'
+  meta: ^1.2.2
   path: ^1.5.1
   react: ^6.0.0
   redux: ">=3.0.0 <5.0.0"
@@ -33,7 +33,7 @@ dependencies:
 dev_dependencies:
   build_resolvers: ^1.0.5
   build_runner: ^1.7.1
-  build_test: ^0.10.9
+  build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.5.1
   built_value_generator: '>=7.0.0 <9.0.0'
   dart2_constant: ^1.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -6,21 +6,20 @@ repository: https://github.com/Workiva/over_react/tree/master/tools/analyzer_plu
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  analyzer: '^0.39.10'
+  analyzer: ">=0.39.0 <0.42.0"
   analyzer_plugin: '^0.2.4'
   collection: ^1.14.0
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
   over_react: 4.1.1
-  meta: ^1.1.6
+  meta: ^1.2.2
   path: ^1.5.1
   source_span: ^1.7.0
 dev_dependencies:
   args: ^1.6.0
   build_runner: ^1.0.0
-  build_test: ^1.0.0
-  build_vm_compilers: ^1.0.0
+  build_test: ">=0.10.9 <2.0.0"
   convert: ^2.1.1
   crypto: ^2.1.5
   dart_dev: ^3.0.0
@@ -31,7 +30,7 @@ dev_dependencies:
   markdown: ^2.1.5
   mockito: ^4.1.1
   package_config: ^1.9.3
-  test: ^1.14.0
+  test: ^1.15.7
   test_reflective_loader: ^0.1.9
   workiva_analysis_options: ^1.1.0
   yaml: ^2.2.1

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -6,20 +6,20 @@ repository: https://github.com/Workiva/over_react/tree/master/tools/analyzer_plu
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  analyzer: ">=0.39.0 <0.42.0"
+  analyzer: ">=0.39.10 <0.42.0"
   analyzer_plugin: '^0.2.4'
   collection: ^1.14.0
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
   over_react: 4.1.1
-  meta: ^1.2.2
+  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0
 dev_dependencies:
   args: ^1.6.0
   build_runner: ^1.0.0
-  build_test: ">=0.10.9 <2.0.0"
+  build_test: ^1.0.0
   convert: ^2.1.1
   crypto: ^2.1.5
   dart_dev: ^3.0.0


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)