### PR TITLE
RM-108356 RM-108355 Release over_react 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # OverReact Changelog
 
+## [4.1.2](https://github.com/Workiva/over_react/compare/4.1.1...4.1.2)
+
+- [#689] Copy language version comments to generated part files
+- [#695] Widen Dependency Ranges Blocking Dart 2.13
+
+## [4.1.1](https://github.com/Workiva/over_react/compare/4.1.0...4.1.1)
+
+- [#685] Remove deprecated authors field from pubspec.yaml
+- [#691] Enable resolution of build_web_compilers 2.12.0, fix Dart stable build
+
 ## [4.1.0](https://github.com/Workiva/over_react/compare/4.0.0...4.1.0)
 
 - [#679] Update boilerplate to be compatible with Dart >=2.9.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.1.1
+version: 4.1.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.1.1
+  over_react: 4.1.2
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Copy language version comments to generated part files](https://github.com/Workiva/over_react/pull/689)
	* [Widen Dependency Ranges Blocking Dart 2.13](https://github.com/Workiva/over_react/pull/695)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.1.1...Workiva:release_over_react_4.1.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.1.1...4.1.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=697&repo_name=Workiva%2Fover_react)