### PR TITLE
CPLAT-15063 Conditionally unconvert style and children props

### DIFF
--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -49,7 +49,25 @@ abstract class _$ReactPropsMixin {
   dynamic _raw$ReactProps$children;
 
   /// The children that were passed in to this component when it was built.
-  List<dynamic> get children => _conditionallyUnconvertChildren(_raw$ReactProps$children);
+  List<dynamic> get children {
+    final value = _raw$ReactProps$children;
+
+    // Most common case; Dart components should all have List children
+    // when rendered by Dart code.
+    if (value is List) return value;
+
+    if (value == null) {
+      // Normalize explicit null values to an empty list, but still return null
+      // when children aren't specified so that we don't break existing usages
+      // where checking for null is equivalent to checking to see if the value was specified.
+      // E.g., `builder..children ??= ['foo']`.
+      return props.containsKey('children') ? const [] : null;
+    }
+
+    // Wrap single children in a list.
+    return [value];
+  }
+
   set children(List<dynamic> value) => _raw$ReactProps$children = value;
 
   /// A String that differentiates a component from its siblings.
@@ -83,14 +101,6 @@ abstract class $DomPropsMixin {
   @Deprecated('This API is for use only within generated code.'
       ' Do not reference it in your code, as it may change at any time.')
   static const PropsMeta meta = _$metaForDomPropsMixin;
-}
-
-List<dynamic> _conditionallyUnconvertChildren(dynamic children) {
-  // Most common case; Dart components should all have List children
-  // when rendered by Dart code.
-  if (children is List) return children;
-  if (children == null) return const [];
-  return [children];
 }
 
 Map<String, dynamic> _conditionallyUnconvertStyle(dynamic style) {

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -13,8 +13,15 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
 
   static const PropsMeta meta = _$metaForReactPropsMixin;
   @override
-  List<dynamic> get children =>
-      _conditionallyUnconvertChildren(_raw$ReactProps$children);
+  List<dynamic> get children {
+    final value = _raw$ReactProps$children;
+    if (value is List) return value;
+    if (value == null) {
+      return props.containsKey('children') ? const [] : null;
+    }
+    return [value];
+  }
+
   @override
   set children(List<dynamic> value) => _raw$ReactProps$children = value;
   @override

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -13,23 +13,28 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
 
   static const PropsMeta meta = _$metaForReactPropsMixin;
   @override
+  List<dynamic> get children =>
+      _conditionallyUnconvertChildren(_raw$ReactProps$children);
+  @override
+  set children(List<dynamic> value) => _raw$ReactProps$children = value;
+  @override
   String get key => props['key'] as String;
   @override
   set key(Object value) =>
       props['key'] = value == null ? null : value.toString();
 
-  /// The children that were passed in to this component when it was built.
-  ///
-  /// <!-- Generated from [_$ReactPropsMixin.children] -->
+  /// <!-- Generated from [_$ReactPropsMixin._raw$ReactProps$children] -->
   @override
-  List get children =>
-      (props[_$key__children___$ReactPropsMixin] ?? null) as List;
+  @Accessor(key: 'children')
+  dynamic get _raw$ReactProps$children =>
+      (props[_$key___raw$ReactProps$children___$ReactPropsMixin] ?? null)
+          as dynamic;
 
-  /// The children that were passed in to this component when it was built.
-  ///
-  /// <!-- Generated from [_$ReactPropsMixin.children] -->
+  /// <!-- Generated from [_$ReactPropsMixin._raw$ReactProps$children] -->
   @override
-  set children(List value) => props[_$key__children___$ReactPropsMixin] = value;
+  @Accessor(key: 'children')
+  set _raw$ReactProps$children(dynamic value) =>
+      props[_$key___raw$ReactProps$children___$ReactPropsMixin] = value;
 
   /// Either a String used to retrieve the element at a later time via [react.Component.ref],
   /// or a Function that gets called with the element when it is mounted.
@@ -49,19 +54,21 @@ abstract class ReactPropsMixin implements _$ReactPropsMixin {
   @override
   set ref(dynamic value) => props[_$key__ref___$ReactPropsMixin] = value;
   /* GENERATED CONSTANTS */
-  static const PropDescriptor _$prop__children___$ReactPropsMixin =
-      PropDescriptor(_$key__children___$ReactPropsMixin);
+  static const PropDescriptor
+      _$prop___raw$ReactProps$children___$ReactPropsMixin =
+      PropDescriptor(_$key___raw$ReactProps$children___$ReactPropsMixin);
   static const PropDescriptor _$prop__ref___$ReactPropsMixin =
       PropDescriptor(_$key__ref___$ReactPropsMixin);
-  static const String _$key__children___$ReactPropsMixin = 'children';
+  static const String _$key___raw$ReactProps$children___$ReactPropsMixin =
+      'children';
   static const String _$key__ref___$ReactPropsMixin = 'ref';
 
   static const List<PropDescriptor> $props = [
-    _$prop__children___$ReactPropsMixin,
+    _$prop___raw$ReactProps$children___$ReactPropsMixin,
     _$prop__ref___$ReactPropsMixin
   ];
   static const List<String> $propKeys = [
-    _$key__children___$ReactPropsMixin,
+    _$key___raw$ReactProps$children___$ReactPropsMixin,
     _$key__ref___$ReactPropsMixin
   ];
 }
@@ -76,6 +83,11 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   Map get props;
 
   static const PropsMeta meta = _$metaForDomPropsMixin;
+  @override
+  Map<String, dynamic> get style =>
+      _conditionallyUnconvertStyle(_raw$DomProps$style);
+  @override
+  set style(Map<String, dynamic> value) => _raw$DomProps$style = value;
 
   /// <!-- Generated from [_$DomPropsMixin.cols] -->
   @override
@@ -368,15 +380,17 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   @override
   set selected(bool value) => props[_$key__selected___$DomPropsMixin] = value;
 
-  /// <!-- Generated from [_$DomPropsMixin.style] -->
+  /// <!-- Generated from [_$DomPropsMixin._raw$DomProps$style] -->
   @override
-  Map<String, dynamic> get style =>
-      (props[_$key__style___$DomPropsMixin] ?? null) as Map<String, dynamic>;
+  @Accessor(key: 'style')
+  dynamic get _raw$DomProps$style =>
+      (props[_$key___raw$DomProps$style___$DomPropsMixin] ?? null) as dynamic;
 
-  /// <!-- Generated from [_$DomPropsMixin.style] -->
+  /// <!-- Generated from [_$DomPropsMixin._raw$DomProps$style] -->
   @override
-  set style(Map<String, dynamic> value) =>
-      props[_$key__style___$DomPropsMixin] = value;
+  @Accessor(key: 'style')
+  set _raw$DomProps$style(dynamic value) =>
+      props[_$key___raw$DomProps$style___$DomPropsMixin] = value;
 
   /// <!-- Generated from [_$DomPropsMixin.challenge] -->
   @override
@@ -2208,8 +2222,8 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
       PropDescriptor(_$key__seamless___$DomPropsMixin);
   static const PropDescriptor _$prop__selected___$DomPropsMixin =
       PropDescriptor(_$key__selected___$DomPropsMixin);
-  static const PropDescriptor _$prop__style___$DomPropsMixin =
-      PropDescriptor(_$key__style___$DomPropsMixin);
+  static const PropDescriptor _$prop___raw$DomProps$style___$DomPropsMixin =
+      PropDescriptor(_$key___raw$DomProps$style___$DomPropsMixin);
   static const PropDescriptor _$prop__challenge___$DomPropsMixin =
       PropDescriptor(_$key__challenge___$DomPropsMixin);
   static const PropDescriptor _$prop__cite___$DomPropsMixin =
@@ -2598,7 +2612,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
   static const String _$key__scoped___$DomPropsMixin = 'scoped';
   static const String _$key__seamless___$DomPropsMixin = 'seamless';
   static const String _$key__selected___$DomPropsMixin = 'selected';
-  static const String _$key__style___$DomPropsMixin = 'style';
+  static const String _$key___raw$DomProps$style___$DomPropsMixin = 'style';
   static const String _$key__challenge___$DomPropsMixin = 'challenge';
   static const String _$key__cite___$DomPropsMixin = 'cite';
   static const String _$key__className___$DomPropsMixin = 'className';
@@ -2843,7 +2857,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$prop__scoped___$DomPropsMixin,
     _$prop__seamless___$DomPropsMixin,
     _$prop__selected___$DomPropsMixin,
-    _$prop__style___$DomPropsMixin,
+    _$prop___raw$DomProps$style___$DomPropsMixin,
     _$prop__challenge___$DomPropsMixin,
     _$prop__cite___$DomPropsMixin,
     _$prop__className___$DomPropsMixin,
@@ -3056,7 +3070,7 @@ abstract class DomPropsMixin implements _$DomPropsMixin {
     _$key__scoped___$DomPropsMixin,
     _$key__seamless___$DomPropsMixin,
     _$key__selected___$DomPropsMixin,
-    _$key__style___$DomPropsMixin,
+    _$key___raw$DomProps$style___$DomPropsMixin,
     _$key__challenge___$DomPropsMixin,
     _$key__cite___$DomPropsMixin,
     _$key__className___$DomPropsMixin,
@@ -6773,6 +6787,13 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     return _dom ??= DomProps(null, props);
   }
 
+  @override
+  Map<String, dynamic> get style =>
+      _conditionallyUnconvertStyle(_raw$UbiquitousDomProps$style);
+  @override
+  set style(Map<String, dynamic> value) =>
+      _raw$UbiquitousDomProps$style = value;
+
   /// Whether the element if focusable.
   /// Must be a valid integer or String of valid integer.
   ///
@@ -6818,34 +6839,19 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   set title(String value) =>
       props[_$key__title___$UbiquitousDomPropsMixin] = value;
 
-  /// An inline CSS style for the element.
-  ///
-  ///     ..style = {
-  ///       'width': '${state.progress * 100}%',
-  ///       'display': state.isHidden ? 'none' : '',
-  ///     }
-  ///
-  /// See: <https://facebook.github.io/react/tips/inline-styles.html>
-  ///
-  /// <!-- Generated from [_$UbiquitousDomPropsMixin.style] -->
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin._raw$UbiquitousDomProps$style] -->
   @override
-  Map<String, dynamic> get style =>
-      (props[_$key__style___$UbiquitousDomPropsMixin] ?? null)
-          as Map<String, dynamic>;
+  @Accessor(key: 'style')
+  dynamic get _raw$UbiquitousDomProps$style =>
+      (props[_$key___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin] ??
+          null) as dynamic;
 
-  /// An inline CSS style for the element.
-  ///
-  ///     ..style = {
-  ///       'width': '${state.progress * 100}%',
-  ///       'display': state.isHidden ? 'none' : '',
-  ///     }
-  ///
-  /// See: <https://facebook.github.io/react/tips/inline-styles.html>
-  ///
-  /// <!-- Generated from [_$UbiquitousDomPropsMixin.style] -->
+  /// <!-- Generated from [_$UbiquitousDomPropsMixin._raw$UbiquitousDomProps$style] -->
   @override
-  set style(Map<String, dynamic> value) =>
-      props[_$key__style___$UbiquitousDomPropsMixin] = value;
+  @Accessor(key: 'style')
+  set _raw$UbiquitousDomProps$style(dynamic value) =>
+      props[_$key___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin] =
+          value;
 
   /// Callback for when a CSS Animation has completed.
   ///
@@ -7591,8 +7597,10 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
       PropDescriptor(_$key__id___$UbiquitousDomPropsMixin);
   static const PropDescriptor _$prop__title___$UbiquitousDomPropsMixin =
       PropDescriptor(_$key__title___$UbiquitousDomPropsMixin);
-  static const PropDescriptor _$prop__style___$UbiquitousDomPropsMixin =
-      PropDescriptor(_$key__style___$UbiquitousDomPropsMixin);
+  static const PropDescriptor
+      _$prop___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin =
+      PropDescriptor(
+          _$key___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin);
   static const PropDescriptor
       _$prop__onAnimationEnd___$UbiquitousDomPropsMixin =
       PropDescriptor(_$key__onAnimationEnd___$UbiquitousDomPropsMixin);
@@ -7699,7 +7707,8 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
   static const String _$key__tabIndex___$UbiquitousDomPropsMixin = 'tabIndex';
   static const String _$key__id___$UbiquitousDomPropsMixin = 'id';
   static const String _$key__title___$UbiquitousDomPropsMixin = 'title';
-  static const String _$key__style___$UbiquitousDomPropsMixin = 'style';
+  static const String
+      _$key___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin = 'style';
   static const String _$key__onAnimationEnd___$UbiquitousDomPropsMixin =
       'onAnimationEnd';
   static const String _$key__onAnimationIteration___$UbiquitousDomPropsMixin =
@@ -7783,7 +7792,7 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     _$prop__tabIndex___$UbiquitousDomPropsMixin,
     _$prop__id___$UbiquitousDomPropsMixin,
     _$prop__title___$UbiquitousDomPropsMixin,
-    _$prop__style___$UbiquitousDomPropsMixin,
+    _$prop___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin,
     _$prop__onAnimationEnd___$UbiquitousDomPropsMixin,
     _$prop__onAnimationIteration___$UbiquitousDomPropsMixin,
     _$prop__onAnimationStart___$UbiquitousDomPropsMixin,
@@ -7837,7 +7846,7 @@ abstract class UbiquitousDomPropsMixin implements _$UbiquitousDomPropsMixin {
     _$key__tabIndex___$UbiquitousDomPropsMixin,
     _$key__id___$UbiquitousDomPropsMixin,
     _$key__title___$UbiquitousDomPropsMixin,
-    _$key__style___$UbiquitousDomPropsMixin,
+    _$key___raw$UbiquitousDomProps$style___$UbiquitousDomPropsMixin,
     _$key__onAnimationEnd___$UbiquitousDomPropsMixin,
     _$key__onAnimationIteration___$UbiquitousDomPropsMixin,
     _$key__onAnimationStart___$UbiquitousDomPropsMixin,

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -19,7 +19,8 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart' show Dom, DummyComponent, DummyComponent2, JsBackedMap, UiComponent2, UiStatefulComponent2, ValidationUtil, registerComponent2;
+import 'package:js/js_util.dart';
+import 'package:over_react/over_react.dart' show Dom, DummyComponent, DummyComponent2, JsBackedMap, UiComponent2, UiStatefulComponent2, ValidationUtil, domProps, registerComponent2;
 import 'package:over_react/over_react.dart' as over_react;
 import 'package:over_react_test/over_react_test.dart';
 import 'package:over_react/src/component_declaration/component_base.dart';
@@ -135,6 +136,9 @@ main() {
         expect(getJsChildren(instance), equals(expectedChildren));
       });
     });
+
+    // Equivalent tests from the react-dart version of this shared test function (sharedChildrenTests)
+    // are located below instead of in this function.
   }
 
   group('component base:', () {
@@ -231,11 +235,11 @@ main() {
 
       group('renders a composite Dart component with the correct children when', () {
         test('no children are passed in', () {
-
           var renderedInstance = render(TestComponent()());
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), isEmpty);
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), isEmpty);
+          expect(getTypedDartChildren(renderedInstance), same(getTypedDartChildren(renderedInstance)));
 
           expect(getJsChildren(renderedInstance), isNull);
         });
@@ -243,8 +247,9 @@ main() {
         test('children is null', () {
           var renderedInstance = render(TestComponent()(null));
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), isEmpty);
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), isEmpty);
+          expect(getTypedDartChildren(renderedInstance), same(getTypedDartChildren(renderedInstance)));
 
           expect(getJsChildren(renderedInstance), isNull);
         });
@@ -253,8 +258,9 @@ main() {
           var child = 'Only child';
           var renderedInstance = render(TestComponent()(child));
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), equals([child]));
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), equals([child]));
+          expect(getTypedDartChildren(renderedInstance), same(getTypedDartChildren(renderedInstance)));
 
           expect(getJsChildren(renderedInstance), equals(child));
         });
@@ -263,8 +269,8 @@ main() {
           var children = ['First Child', 'Second Child'];
           var renderedInstance = render(TestComponent()(children));
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), equals(children));
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), equals(children));
 
           expect(getJsChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
           expect(getJsChildren(renderedInstance), equals(children));
@@ -277,8 +283,9 @@ main() {
           })();
           var renderedInstance = render(TestComponent()(children));
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), orderedEquals(children));
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), orderedEquals(children));
+          expect(getTypedDartChildren(renderedInstance), same(getTypedDartChildren(renderedInstance)));
 
           expect(getJsChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
           expect(getJsChildren(renderedInstance), orderedEquals(children));
@@ -289,8 +296,9 @@ main() {
           var secondChild = 'Second Child';
           var renderedInstance = render(TestComponent()(firstChild, secondChild));
 
-          expect(getDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
-          expect(getDartChildren(renderedInstance), equals([firstChild, secondChild]));
+          expect(getRawDartChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
+          expect(getRawDartChildren(renderedInstance), equals([firstChild, secondChild]));
+          expect(getTypedDartChildren(renderedInstance), same(getTypedDartChildren(renderedInstance)));
 
           expect(getJsChildren(renderedInstance), isA<List>(), reason: 'Should be a list because lists will be JSified');
           expect(getJsChildren(renderedInstance), equals([firstChild, secondChild]));
@@ -458,6 +466,120 @@ main() {
           props.addTestId(null);
 
           expect(props, equals({}));
+        });
+      });
+
+      group('custom prop getters/setters', () {
+        void sharedNormalizationTests(UiProps Function(Map props) getTypedView) {
+          group('children', () {
+            const childrenKey = 'children';
+
+            test('setter works normally, passing through the value', () {
+              final children = ['foo', 'bar'];
+              expect(getTypedView({})..children = children, {childrenKey: same(children)});
+              expect(getTypedView({})..children = null, {childrenKey: isNull});
+            });
+
+            group('getter normalizes the children prop to a List'
+                ' (to accommodate children passed in from JS components,'
+                ' since only components rendered from Dart are guaranteed to have List children)'
+                ' when the children are', () {
+
+              test('a List: returns the same list', () {
+                final list = ['foo', 'bar'];
+                expect(getTypedView({childrenKey: list}).children, same(list));
+              });
+
+              test('null: returns an empty list', () {
+                expect(getTypedView({childrenKey: null}).children, same(const []));
+              });
+
+              test('a single child: wraps in a list', () {
+                expect(getTypedView({childrenKey: 'foo'}).children, ['foo']);
+              });
+
+              // See source for explanation on why we return null here.
+              test('not present in the map: returns null', () {
+                expect(getTypedView({}).children, isNull);
+              });
+            });
+          });
+
+          group('style', () {
+            const styleKey = 'style';
+
+            test('setter works normally, passing through the value', () {
+              final style = <String, dynamic>{};
+              expect(getTypedView({})..style = style, {styleKey: same(style)});
+              expect(getTypedView({})..style = null, {styleKey: isNull});
+            });
+
+            group('getter normalizes the style prop to a Map'
+                ' (to accommodate styles passed in from JS components)'
+                ' when the style is', () {
+
+              test('a Map: returns the same map', () {
+                final style = <String, dynamic>{'color': 'blue'};
+                expect(getTypedView({styleKey: style}).style, same(style));
+              });
+
+              // This test verifies we're not .cast()-ing maps of the wrong type when we shouldn't
+              test('a Map of the wrong type throws a type error', () {
+                final style = <dynamic, dynamic>{'color': 'blue'};
+                expect(() => getTypedView({styleKey: style}).style,
+                    // ignore: deprecated_member_use
+                    throwsA(anyOf(isA<TypeError>(), isA<CastError>())));
+              });
+
+              test('null: returns null', () {
+                expect(getTypedView({styleKey: null}).style, isNull);
+              });
+
+              test('a JS object: unconverts into a Dart object', () {
+                final jsStyle = jsify({
+                  'color': 'blue',
+                  'someNestedMapThatWillProbablyNeverHappen': {
+                    'color': 'red'
+                  },
+                  'someNestedListThatWillProbablyNeverHappen': [
+                    {
+                      'color': 'green'
+                    },
+                  ]
+                });
+
+                final style = getTypedView({styleKey: jsStyle}).style;
+                expect(
+                    style,
+                    allOf(
+                      isA<Map<String, dynamic>>(),
+                      equals({
+                        'color': 'blue',
+                        'someNestedMapThatWillProbablyNeverHappen': {
+                          'color': 'red'
+                        },
+                        'someNestedListThatWillProbablyNeverHappen': [
+                          {'color': 'green'},
+                        ]
+                      }),
+                    ));
+              });
+
+              test('not present in the map: returns null', () {
+                expect(getTypedView({}).style, isNull);
+              });
+            });
+          });
+        }
+
+        // Test both of these since the `style` implementation is
+        // duplicated across both mixins.
+        group('(UbiquitousDomPropsMixin)', () {
+          sharedNormalizationTests(TestComponent);
+        });
+
+        group('(DomProps)', () {
+          sharedNormalizationTests(domProps);
         });
       });
     });

--- a/test/test_util/test_util.dart
+++ b/test/test_util/test_util.dart
@@ -22,9 +22,14 @@ export 'package:over_react_test/over_react_test.dart';
 
 dynamic getJsChildren(instance) => getProperty(instance.props, 'children');
 
-dynamic getDartChildren(var renderedInstance) {
+dynamic getRawDartChildren(var renderedInstance) {
   assert(isDartComponent(renderedInstance));
   return getProps(renderedInstance)['children'];
+}
+
+List<dynamic> getTypedDartChildren(var renderedInstance) {
+  assert(isDartComponent(renderedInstance));
+  return domProps(getProps(renderedInstance)).children;
 }
 
 bool isDDC() {


### PR DESCRIPTION
## Motivation
Sometimes, Dart code can read props that originate from JS code (e.g., a JS component rendering/cloning a Dart component), and in cases where the JS prop value doesn't match the typings on the OverReact prop getter, you get a runtime type error.

Two common cases of this are the `style` and `children` props.

`style` props set by JS code are JS objects, which can't be casted to Dart `Map`s in the `DomPropsMixin.style` and `UbiquitousDomPropsMixin.style` getters.

`children` props are always `List`s for Dart components rendered by Dart code, but can be nullish or a singular value when rendered by JS components, and can cause cast errors in the typed `children` prop getter.

## Changes
- Normalize the value of the `children` prop getter (`ReactPropsMixin.children`, mixed into `UiProps`) to always be a `List`
- Normalize the value of the `style` prop getters (`UbiquitousDomPropsMixin.style`, mixed into `UiProps`, and `DomPropsMixin.style`) to convert JS object values to Dart `Map`s
- Add tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] All existing tests pass
        - [ ] Consumer tests pass ([link to Rosie Evaluation](https://w-rmconsole.appspot.com/pulls/Workiva/over_react/698/evaluation/), which is hidden on OSS repos)
        - [ ] JS component test cases in RMUI branch pass
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
