### PR TITLE
Consume react-dart 6.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   memoize: ^2.0.0
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
-  react: ^6.0.0
-  redux: ">=3.0.0 <5.0.0"
+  react: ^6.1.0  redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: ^1.13.0


### PR DESCRIPTION
Consume [react-dart 6.1.0](https://github.com/Workiva/react-dart/releases/tag/6.1.0)

Pull Requests included in release:
* Minor changes:
	* [CPLAT-15062 Export generateJsProps](https://github.com/Workiva/react-dart/pull/316)
	* [RM-95981 Release react-dart 6.1.0](https://github.com/Workiva/react-dart/pull/317)
* Patch changes:
	* [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/react-dart/pull/310)


Requested by: @rmconsole7-wk
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?pull_number=699&repo_name=Workiva%2Fover_react)