### PR TITLE
RM-111110 Release over_react 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.2.0](https://github.com/Workiva/over_react/compare/4.1.3...4.2.0)
+
+- [#701] Add `elementType` convenience getter to `UiFactory`, Change `meta` dependency lower-bound to `1.1.6` to prevent dependency gridlock (missed in [#695]).
+
 ## [4.1.3](https://github.com/Workiva/over_react/compare/4.1.2...4.1.3)
 
 - [#698] Conditionally unconvert style and children props

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -99,6 +99,13 @@ extension UiFactoryHelpers<TProps extends bh.UiProps> on UiFactory<TProps> {
   ///
   /// See `uiForwardRef` for examples and context.
   UiFactoryConfig<TProps> asForwardRefConfig({String displayName}) => UiFactoryConfig(propsFactory: PropsFactory.fromUiFactory(this), displayName: displayName);
+
+  /// The type of the element created by this factory.
+  ///
+  /// For DOM components, this will be a [String] tagName (e.g., `'div'`, `'a'`).
+  ///
+  /// For composite components (react-dart or pure JS), this will be a [ReactClass].
+  dynamic get elementType => this().componentFactory.type;
 }
 
 /// A utility variation on [UiFactory], __without__ a `backingProps` parameter.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.1.3
+version: 4.2.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   js: ^0.6.1+1
   logging: ">=0.11.3+2 <1.0.0"
   memoize: ^2.0.0
-  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   react: ^6.0.0
   redux: ">=3.0.0 <5.0.0"

--- a/test/over_react/component/element_type_test.dart
+++ b/test/over_react/component/element_type_test.dart
@@ -14,17 +14,9 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 library element_type_test;
 
-import 'dart:html';
-import 'dart:js_util';
-
-import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component/dom_components.dart';
-
-import '../../test_util/test_util.dart';
-import '../component/fixtures/basic_child_component.dart';
-import 'fixtures/basic_ui_component.dart';
 
 part 'element_type_test.over_react.g.dart'; // ignore: uri_has_not_been_generated
 

--- a/test/over_react/component/element_type_test.dart
+++ b/test/over_react/component/element_type_test.dart
@@ -1,0 +1,74 @@
+// Copyright 2021 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ignore_for_file: deprecated_member_use_from_same_package
+library element_type_test;
+
+import 'dart:html';
+import 'dart:js_util';
+
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+import 'package:over_react/over_react.dart';
+import 'package:over_react/src/component/dom_components.dart';
+
+import '../../test_util/test_util.dart';
+import '../component/fixtures/basic_child_component.dart';
+import 'fixtures/basic_ui_component.dart';
+
+part 'element_type_test.over_react.g.dart'; // ignore: uri_has_not_been_generated
+
+void main() {
+  group('UiFactory.elementType', () {
+    group('returns the expected value when used on a', () {
+      test('Dom component', () {
+        const factory = Dom.div;
+        expect(factory.elementType, same(factory().componentFactory.type));
+        expect(factory.elementType, 'div');
+      });
+
+      test('custom composite component', () {
+        final factory = CustomTest;
+        expect(factory.elementType, same(factory().componentFactory.type));
+      });
+
+      test('custom function component', () {
+        final factory = CustomFnTest;
+        expect(factory.elementType, same(factory().componentFactory.type));
+      });
+    });
+  });
+}
+
+UiFactory<CustomTestProps> CustomTest =
+    // ignore: undefined_identifier
+    castUiFactory(_$CustomTest);
+
+mixin CustomTestProps on UiProps {}
+
+class CustomTestComponent extends UiComponent2<CustomTestProps> {
+  @override
+  render() {
+    return null;
+  }
+}
+
+final CustomFnTest = uiFunction<CustomFnTestProps>(
+  (props) {
+    return null;
+  },
+  _$CustomFnTestConfig, // ignore: undefined_identifier
+);
+
+mixin CustomFnTestProps on UiProps {}
+

--- a/test/over_react/component/element_type_test.over_react.g.dart
+++ b/test/over_react/component/element_type_test.over_react.g.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'element_type_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $CustomTestComponentFactory = registerComponent2(
+  () => _$CustomTestComponent(),
+  builderFactory: _$CustomTest,
+  componentClass: CustomTestComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'CustomTest',
+);
+
+_$$CustomTestProps _$CustomTest([Map backingProps]) => backingProps == null
+    ? _$$CustomTestProps$JsMap(JsBackedMap())
+    : _$$CustomTestProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$CustomTestProps extends UiProps
+    with
+        CustomTestProps,
+        $CustomTestProps // If this generated mixin is undefined, it's likely because CustomTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CustomTestProps, and check that $CustomTestProps is exported/imported properly.
+{
+  _$$CustomTestProps._();
+
+  factory _$$CustomTestProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$CustomTestProps$JsMap(backingMap as JsBackedMap);
+    } else {
+      return _$$CustomTestProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $CustomTestComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because CustomTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CustomTestProps, and check that $CustomTestProps is exported/imported properly.
+        CustomTestProps: $CustomTestProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$CustomTestProps$PlainMap extends _$$CustomTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$CustomTestProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$CustomTestProps$JsMap extends _$$CustomTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$CustomTestProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$CustomTestComponent extends CustomTestComponent {
+  _$$CustomTestProps$JsMap _cachedTypedProps;
+
+  @override
+  _$$CustomTestProps$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps =
+        typedPropsFactoryJs(getBackingMap(value) as JsBackedMap);
+  }
+
+  @override
+  _$$CustomTestProps$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$CustomTestProps$JsMap(backingMap);
+
+  @override
+  _$$CustomTestProps typedPropsFactory(Map backingMap) =>
+      _$$CustomTestProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by CustomTestProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because CustomTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CustomTestProps, and check that $CustomTestProps is exported/imported properly.
+        CustomTestProps: $CustomTestProps.meta,
+      });
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $CustomTestProps on CustomTestProps {
+  static const PropsMeta meta = _$metaForCustomTestProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForCustomTestProps = PropsMeta(
+  fields: $CustomTestProps.$props,
+  keys: $CustomTestProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $CustomFnTestProps on CustomFnTestProps {
+  static const PropsMeta meta = _$metaForCustomFnTestProps;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForCustomFnTestProps = PropsMeta(
+  fields: $CustomFnTestProps.$props,
+  keys: $CustomFnTestProps.$propKeys,
+);
+
+final UiFactoryConfig<_$$CustomFnTestProps> _$CustomFnTestConfig =
+    UiFactoryConfig(
+        propsFactory: PropsFactory(
+          map: (map) => _$$CustomFnTestProps(map),
+          jsMap: (map) => _$$CustomFnTestProps$JsMap(map),
+        ),
+        displayName: 'CustomFnTest');
+
+@Deprecated(r'Use the private variable, _$CustomFnTestConfig, instead '
+    'and update the `over_react` lower bound to version 4.1.0. '
+    'For information on why this is deprecated, see https://github.com/Workiva/over_react/pull/650')
+final UiFactoryConfig<_$$CustomFnTestProps> $CustomFnTestConfig =
+    _$CustomFnTestConfig;
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$CustomFnTestProps extends UiProps
+    with
+        CustomFnTestProps,
+        $CustomFnTestProps // If this generated mixin is undefined, it's likely because CustomFnTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CustomFnTestProps, and check that $CustomFnTestProps is exported/imported properly.
+{
+  _$$CustomFnTestProps._();
+
+  factory _$$CustomFnTestProps(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$CustomFnTestProps$JsMap(backingMap as JsBackedMap);
+    } else {
+      return _$$CustomFnTestProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because CustomFnTestProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of CustomFnTestProps, and check that $CustomFnTestProps is exported/imported properly.
+        CustomFnTestProps: $CustomFnTestProps.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$CustomFnTestProps$PlainMap extends _$$CustomFnTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$CustomFnTestProps$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$CustomFnTestProps$JsMap extends _$$CustomFnTestProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$CustomFnTestProps$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}

--- a/test/over_react_component_test.dart
+++ b/test/over_react_component_test.dart
@@ -35,6 +35,7 @@ import 'over_react/component/_deprecated/error_boundary_mixin_test.dart'
 import 'over_react/component/_deprecated/error_boundary_test.dart'
     as deprecated_error_boundary_test;
 import 'over_react/component/ref_util_test.dart' as ref_test;
+import 'over_react/component/element_type_test.dart' as element_type_test;
 import 'over_react/component/memo_test.dart' as memo_test;
 import 'over_react/component/prop_mixins_test.dart' as prop_mixins_test;
 import 'over_react/component/prop_typedefs_test.dart' as prop_typedefs_test;
@@ -61,6 +62,7 @@ void main() {
   deprecated_error_boundary_mixin_test.main();
   deprecated_error_boundary_test.main();
   ref_test.main();
+  element_type_test.main();
   memo_test.main();
   dom_components_test.main();
   prop_mixins_test.main();

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.1.3
+  over_react: 4.2.0
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
__The latest version of over_react contains:__

* Add `UiFactory.elementType` convenience getter
* Fix lower bound of the `meta` dependency that was mistakenly set too high in #695