### PR TITLE
Consume react-dart 6.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   memoize: ^2.0.0
   meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
-  react: ^6.0.0
-  redux: ">=3.0.0 <5.0.0"
+  react: ^6.1.1  redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: ^1.13.0


### PR DESCRIPTION
Consume [react-dart 6.1.1](https://github.com/Workiva/react-dart/releases/tag/6.1.1)

Pull Requests included in release:
* Patch changes:
	* [Add `baseURI` polyfill for IE 11 compatibility on Dart 2.13](https://github.com/Workiva/react-dart/pull/319)
	* [RM-110959 Release react-dart 6.1.1](https://github.com/Workiva/react-dart/pull/320)


Requested by: @rmconsole4-wk
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?pull_number=702&repo_name=Workiva%2Fover_react)