### PR TITLE
Improve FluxUiComponent disposed store logging

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react/component_base.dart' as component_base;
+import 'package:over_react/src/util/component_debug_name.dart';
 import 'package:w_flux/w_flux.dart';
 
 import 'annotations.dart' as annotations;
@@ -235,10 +236,12 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
 
   void _validateStoreDisposalState(Store store) {
     if (store.isOrWillBeDisposed) {
+      final componentName = getDebugNameForDartComponent(this);
+
       // Include the component name in the logger so that
       // 1. it's included in the log somewhere
       // 2. logs from the same component can be easily grouped together
-      final logger = Logger('over_react._FluxComponentMixin.$displayName');
+      final logger = Logger('over_react._FluxComponentMixin.$componentName');
 
       var storeNameOrType = store.disposableTypeName;
       // Detect if they don't override disposableTypeName and use the default name.

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -238,13 +238,13 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
     if (store.isOrWillBeDisposed) {
       final componentName = getDebugNameForDartComponent(this);
 
-      // Include the component name in the logger so that
+      // Include the component name in the logger name so that:
       // 1. it's included in the log somewhere
       // 2. logs from the same component can be easily grouped together
       final logger = Logger('over_react._FluxComponentMixin.$componentName');
 
       var storeNameOrType = store.disposableTypeName;
-      // Detect if they don't override disposableTypeName and use the default name.
+      // Detect if they don't override disposableTypeName by checking for the default name.
       if (storeNameOrType == 'Store') {
         storeNameOrType = store.runtimeType.toString();
       }

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -10,6 +10,8 @@ import 'package:over_react/component_base.dart';
 ///
 /// __For use in debugging contexts only; not suitable for other use.__
 ///
+// Need to ignore this just for Dart 2.7.2
+// ignore: comment_references
 /// This is preferable to [UiComponent.displayName] since that doesn't include
 /// the generated displayName passed to [registerComponent]/
 String getDebugNameForDartComponent(UiComponent component) {

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+@JS()
+library over_react.src.component_debug_name;
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+import 'package:over_react/component_base.dart';
+
+/// Returns the displayName of the given [component].
+///
+/// __For use in debugging contexts only; not suitable for other use.__
+///
+/// This is preferable to [UiComponent.displayName] since that doesn't include
+/// the generated displayName passed to [registerComponent]/
+String getDebugNameForDartComponent(UiComponent component) {
+  // We don't have a great way of looking up the display name the component was
+  // registered with, so we'll resort to pulling it off the JS component.
+
+  // Don't assume the component is mounted.
+  final jsThis = component.jsThis;
+  if (jsThis != null) {
+    final jsPrototype = _getPrototypeOf(jsThis);
+    final jsComponentType =
+        jsPrototype == null ? null : getProperty(jsPrototype, 'constructor');
+    if (jsComponentType != null) {
+      return (getProperty(jsComponentType, 'displayName') as String) ??
+          (getProperty(jsComponentType, 'name') as String);
+    }
+  }
+
+  // Fall back to displayName, which only uses the runtimeType, but only when asserts are enabled in Component2.
+  return component.displayName;
+}
+
+@JS('Object.getPrototypeOf')
+external dynamic _getPrototypeOf(dynamic object);

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -6,9 +6,11 @@ import 'package:js/js.dart';
 import 'package:js/js_util.dart';
 import 'package:over_react/component_base.dart';
 
-/// Returns the displayName of the given [component].
-///
 /// __For use in debugging contexts only; not suitable for other use.__
+/// If there's another use-case for getting a component name from its mounted
+/// instance, we should reevaluate approach here.
+///
+/// Returns the displayName of the given [component].
 ///
 // Need to ignore this just for Dart 2.7.2
 // ignore: comment_references

--- a/test/over_react/util/component_debug_name_test.dart
+++ b/test/over_react/util/component_debug_name_test.dart
@@ -1,0 +1,80 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:over_react/over_react.dart';
+import 'package:over_react/src/util/component_debug_name.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/test_util.dart';
+
+part 'component_debug_name_test.over_react.g.dart';
+
+void main() {
+  group('getDebugNameForDartComponent', () {
+    group('returns the displayName it was registered with for a mounted', () {
+      test('UiComponent component declared with standard boilerplate', () {
+        final component = mount(TestComponent()()).getDartInstance() as UiComponent;
+        expect(getDebugNameForDartComponent(component), 'TestComponent');
+      });
+
+      test('UiComponent2 component declared with standard boilerplate', () {
+        final component = mount(TestComponent2()()).getDartInstance() as UiComponent2;
+        expect(getDebugNameForDartComponent(component), 'TestComponent2');
+      });
+    });
+
+    group('returns the .displayName getter for a non-mounted component', () {
+      test('UiComponent component declared with standard boilerplate', () {
+        final component = TestNonMountedComponentComponent();
+        expect(getDebugNameForDartComponent(component), component.displayName);
+      });
+
+      test('UiComponent2 component declared with standard boilerplate', () {
+        final component = TestNonMountedComponent2Component();
+        expect(getDebugNameForDartComponent(component), component.displayName);
+      });
+    });
+  });
+}
+
+@Factory()
+UiFactory<TestComponentProps> TestComponent = castUiFactory(_$TestComponent); // ignore: undefined_identifier
+
+@Props()
+class _$TestComponentProps extends UiProps {}
+
+@Component()
+class TestComponentComponent extends UiComponent<TestComponentProps> {
+  @override
+  render() {}
+}
+
+// ignore: mixin_of_non_class, undefined_class
+abstract class TestComponentProps extends _$TestComponentProps with _$TestComponentPropsAccessorsMixin {
+  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value, invalid_assignment
+  static const PropsMeta meta = _$metaForTestComponentProps;
+}
+
+UiFactory<TestComponent2Props> TestComponent2 = castUiFactory(_$TestComponent2); // ignore: undefined_identifier
+
+mixin TestComponent2Props on UiProps {}
+
+class TestComponent2Component extends UiComponent2<TestComponent2Props> {
+  @override
+  render() {}
+}
+
+class TestNonMountedComponentComponent extends UiComponent {
+  @override
+  render() {}
+
+  @override
+  bool get $isClassGenerated => true;
+}
+
+class TestNonMountedComponent2Component extends UiComponent2 {
+  @override
+  render() {}
+
+  @override
+  bool get $isClassGenerated => true;
+}

--- a/test/over_react/util/component_debug_name_test.over_react.g.dart
+++ b/test/over_react/util/component_debug_name_test.over_react.g.dart
@@ -1,0 +1,256 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'component_debug_name_test.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+final $TestComponent2ComponentFactory = registerComponent2(
+  () => _$TestComponent2Component(),
+  builderFactory: _$TestComponent2,
+  componentClass: TestComponent2Component,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestComponent2',
+);
+
+_$$TestComponent2Props _$TestComponent2([Map backingProps]) =>
+    backingProps == null
+        ? _$$TestComponent2Props$JsMap(JsBackedMap())
+        : _$$TestComponent2Props(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$TestComponent2Props extends UiProps
+    with
+        TestComponent2Props,
+        $TestComponent2Props // If this generated mixin is undefined, it's likely because TestComponent2Props is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestComponent2Props, and check that $TestComponent2Props is exported/imported properly.
+{
+  _$$TestComponent2Props._();
+
+  factory _$$TestComponent2Props(Map backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$TestComponent2Props$JsMap(backingMap as JsBackedMap);
+    } else {
+      return _$$TestComponent2Props$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $TestComponent2ComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestComponent2Props is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestComponent2Props, and check that $TestComponent2Props is exported/imported properly.
+        TestComponent2Props: $TestComponent2Props.meta,
+      });
+}
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestComponent2Props$PlainMap extends _$$TestComponent2Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestComponent2Props$PlainMap(Map backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$TestComponent2Props$JsMap extends _$$TestComponent2Props {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestComponent2Props$JsMap(JsBackedMap backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$TestComponent2Component extends TestComponent2Component {
+  _$$TestComponent2Props$JsMap _cachedTypedProps;
+
+  @override
+  _$$TestComponent2Props$JsMap get props => _cachedTypedProps;
+
+  @override
+  set props(Map value) {
+    assert(
+        getBackingMap(value) is JsBackedMap,
+        'Component2.props should never be set directly in '
+        'production. If this is required for testing, the '
+        'component should be rendered within the test. If '
+        'that does not have the necessary result, the last '
+        'resort is to use typedPropsFactoryJs.');
+    super.props = value;
+    _cachedTypedProps =
+        typedPropsFactoryJs(getBackingMap(value) as JsBackedMap);
+  }
+
+  @override
+  _$$TestComponent2Props$JsMap typedPropsFactoryJs(JsBackedMap backingMap) =>
+      _$$TestComponent2Props$JsMap(backingMap);
+
+  @override
+  _$$TestComponent2Props typedPropsFactory(Map backingMap) =>
+      _$$TestComponent2Props(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, comprising all props mixins used by TestComponent2Props.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because TestComponent2Props is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of TestComponent2Props, and check that $TestComponent2Props is exported/imported properly.
+        TestComponent2Props: $TestComponent2Props.meta,
+      });
+}
+
+// React component factory implementation.
+//
+// Registers component implementation and links type meta to builder factory.
+final $TestComponentComponentFactory = registerComponent(
+  () => _$TestComponentComponent(),
+  builderFactory: _$TestComponent,
+  componentClass: TestComponentComponent,
+  isWrapper: false,
+  parentType: null,
+  displayName: 'TestComponent',
+);
+
+abstract class _$TestComponentPropsAccessorsMixin
+    implements _$TestComponentProps {
+  @override
+  Map get props;
+
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+const PropsMeta _$metaForTestComponentProps = PropsMeta(
+  fields: _$TestComponentPropsAccessorsMixin.$props,
+  keys: _$TestComponentPropsAccessorsMixin.$propKeys,
+);
+
+_$$TestComponentProps _$TestComponent([Map backingProps]) =>
+    _$$TestComponentProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+class _$$TestComponentProps extends _$TestComponentProps
+    with _$TestComponentPropsAccessorsMixin
+    implements TestComponentProps {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$TestComponentProps(Map backingMap) : this._props = {} {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The `ReactComponentFactory` associated with the component built by this class.
+  @override
+  ReactComponentFactoryProxy get componentFactory =>
+      super.componentFactory ?? $TestComponentComponentFactory;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => 'TestComponentProps.';
+}
+
+// Concrete component implementation mixin.
+//
+// Implements typed props/state factories, defaults `consumedPropKeys` to the keys
+// generated for the associated props class.
+class _$TestComponentComponent extends TestComponentComponent {
+  @override
+  _$$TestComponentProps typedPropsFactory(Map backingMap) =>
+      _$$TestComponentProps(backingMap);
+
+  /// Let `UiComponent` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default consumed props, taken from _$TestComponentProps.
+  /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
+  @override
+  final List<ConsumedProps> $defaultConsumedProps = const [
+    _$metaForTestComponentProps
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $TestComponent2Props on TestComponent2Props {
+  static const PropsMeta meta = _$metaForTestComponent2Props;
+  /* GENERATED CONSTANTS */
+
+  static const List<PropDescriptor> $props = [];
+  static const List<String> $propKeys = [];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForTestComponent2Props = PropsMeta(
+  fields: $TestComponent2Props.$props,
+  keys: $TestComponent2Props.$propKeys,
+);

--- a/test/over_react_util_test.dart
+++ b/test/over_react_util_test.dart
@@ -24,6 +24,7 @@ import 'package:test/test.dart';
 
 import 'over_react/util/cast_ui_factory_test.dart' as cast_ui_factory_test;
 import 'over_react/util/class_names_test.dart' as class_names_test;
+import 'over_react/util/component_debug_name_test.dart' as component_debug_name_test;
 import 'over_react/util/constants_base_test.dart' as constants_base_test;
 import 'over_react/util/css_value_util_test.dart' as css_value_util_test;
 import 'over_react/util/dom_util_test.dart' as dom_util_test;
@@ -47,6 +48,7 @@ void main() {
 
   cast_ui_factory_test.main();
   class_names_test.main();
+  component_debug_name_test.main();
   constants_base_test.main();
   css_value_util_test.main();
   dom_util_test.main();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We have some warning logs in place for before FluxUiComponent(2) components attempt to subscribe to disposed stores.

These logs weren't very helpful, though, since they didn't contain a stack trace, component name, or store name.

## Changes
- Add more information to logs
    - Add a utility to get a Dart component name from its Dart instance
- Add basic unit tests for this logging

#### Release Notes

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
