### PR TITLE
RM-114209 RM-114208 Release over_react 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.2.2](https://github.com/Workiva/over_react/compare/4.2.1...4.2.2)
+
+- Reinstate null-aware isDisposedOrDisposing (removed in [#703]/4.2.1) to support tests with mocked stores
+
 ## [4.2.1](https://github.com/Workiva/over_react/compare/4.2.0...4.2.1)
 
 - [#703] Improve FluxUiComponent logging when attempting to subscribe to a disposed store

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -235,7 +235,9 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
   List<StreamSubscription> _subscriptions = [];
 
   void _validateStoreDisposalState(Store store) {
-    if (store.isOrWillBeDisposed) {
+    // We need a null-aware here since there are many mocked store classes
+    // in the wild that return null for isOrWillBeDisposed.
+    if (store.isOrWillBeDisposed ?? false) {
       final componentName = getDebugNameForDartComponent(this);
 
       // Include the component name in the logger name so that:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.2.1
+version: 4.2.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.2.0
+  over_react: 4.2.2
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION
Reinstates [a recently-removed null-coalescing operator](https://github.com/Workiva/over_react/commit/dcbbea46dd0230c7915624388b3233ea1ccad8cf#diff-47691740357c7cfe159ca805f455f4b9e27d5df1ed49fc5c4bca5a0c21ce95a5L241) that consumers were depending on due to the use of mocked stores.