### PR TITLE
Vanilla Dart images Need Updateing

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, dev ]
+        sdk: [ stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -35,7 +35,6 @@ jobs:
 
       - name: Verify formatting
         run: pub run dart_dev format --check
-        if: always() && ${{ matrix.sdk }} == '2.7.2' && steps.install.outcome == 'success'
 
       # Analyze before generated files are created to verify that component boilerplate analysis is "clean" without the need for building
       - name: Analyze example source (pre-build)
@@ -44,7 +43,6 @@ jobs:
           # which could cause analysis issues for consumers who haven't run a build yet.
           dartanalyzer lib
           cd example/boilerplate_versions
-          if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; fi
           if [ ${{ matrix.sdk }} = 'stable' ]; then echo 'Skip pre-build analysis for Dart versions >=2.9 and <2.12 because there will be analysis errors.'; fi
           if [ ${{ matrix.sdk }} = 'dev' ]; then cd mixin_based/dart_2_9_compatible && dart analyze; fi
         if: always() && steps.install.outcome == 'success'
@@ -54,17 +52,13 @@ jobs:
         name: Build generated files / precompile DDC assets
         run: |
           pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
-          if [ ${{ matrix.sdk }} = '2.7.2' ]; then
-            git diff --exit-code
-          else
-            # Exclude built_redux generated files since they get generated differently in Dart 2.7 vs other versions
-            git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
-          fi
+          # Exclude built_redux generated files since they get generated differently in Dart 2.7 vs other versions
+          git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors
       - name: Analyze project source (post-build)
-        run: if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
+        run: dart analyze; 
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (VM)
@@ -84,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, dev ]
+        sdk: [ stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -48,16 +48,17 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - id: build
-        timeout-minutes: 6
+        timeout-minutes: 15
         name: Build generated files / precompile DDC assets
         run: |
           pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
-          if [ ${{ matrix.sdk }} = '2.13.4' ]; then
-            git diff --exit-code
-          else
-            # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
-            git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
-          fi
+          # TODO: This can be uncommented out once the PR has merged.
+          # if [ ${{ matrix.sdk }} = '2.13.4' ]; then
+          #   git diff --exit-code
+          # else
+          #   # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
+          #   git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
+          # fi
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, dev ]
+        sdk: [ 2.13.4, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -35,6 +35,7 @@ jobs:
 
       - name: Verify formatting
         run: pub run dart_dev format --check
+        if: always() && ${{ matrix.sdk }} == '2.13.4' && steps.install.outcome == 'success'
 
       # Analyze before generated files are created to verify that component boilerplate analysis is "clean" without the need for building
       - name: Analyze example source (pre-build)
@@ -43,6 +44,7 @@ jobs:
           # which could cause analysis issues for consumers who haven't run a build yet.
           dartanalyzer lib
           cd example/boilerplate_versions
+          if [ ${{ matrix.sdk }} = '2.13.4' ]; then pub global activate tuneup && tuneup check; fi
           if [ ${{ matrix.sdk }} = 'stable' ]; then echo 'Skip pre-build analysis for Dart versions >=2.9 and <2.12 because there will be analysis errors.'; fi
           if [ ${{ matrix.sdk }} = 'dev' ]; then cd mixin_based/dart_2_9_compatible && dart analyze; fi
         if: always() && steps.install.outcome == 'success'
@@ -51,14 +53,18 @@ jobs:
         timeout-minutes: 6
         name: Build generated files / precompile DDC assets
         run: |
-          pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
-          # Exclude built_redux generated files since they get generated differently in Dart 2.7 vs other versions
+        if [ ${{ matrix.sdk }} = '2.13.4' ]; then
+          git diff --exit-code
+        else
+          # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
+          git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
+        fi
           git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors
       - name: Analyze project source (post-build)
-        run: dart analyze; 
+        run: if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (VM)
@@ -78,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ stable, dev ]
+        sdk: [ 2.13.4, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -59,12 +59,11 @@ jobs:
           # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
           git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
         fi
-          git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors
       - name: Analyze project source (post-build)
-        run: if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
+        run: if [ ${{ matrix.sdk }} = '2.13.4' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (VM)

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Verify formatting
         run: pub run dart_dev format --check
-        if: always() && ${{ matrix.sdk }} == '2.13.4' && steps.install.outcome == 'success'
+        if: always() && matrix.sdk == '2.13.4' && steps.install.outcome == 'success'
 
       # Analyze before generated files are created to verify that component boilerplate analysis is "clean" without the need for building
       - name: Analyze example source (pre-build)
@@ -44,9 +44,7 @@ jobs:
           # which could cause analysis issues for consumers who haven't run a build yet.
           dartanalyzer lib
           cd example/boilerplate_versions
-          if [ ${{ matrix.sdk }} = '2.13.4' ]; then pub global activate tuneup && tuneup check; fi
-          if [ ${{ matrix.sdk }} = 'stable' ]; then echo 'Skip pre-build analysis for Dart versions >=2.9 and <2.12 because there will be analysis errors.'; fi
-          if [ ${{ matrix.sdk }} = 'dev' ]; then cd mixin_based/dart_2_9_compatible && dart analyze; fi
+          dart analyze
         if: always() && steps.install.outcome == 'success'
 
       - id: build
@@ -63,7 +61,7 @@ jobs:
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors
       - name: Analyze project source (post-build)
-        run: if [ ${{ matrix.sdk }} = '2.13.4' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
+        run: dart analyze
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (VM)

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -51,12 +51,13 @@ jobs:
         timeout-minutes: 6
         name: Build generated files / precompile DDC assets
         run: |
-        if [ ${{ matrix.sdk }} = '2.13.4' ]; then
-          git diff --exit-code
-        else
-          # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
-          git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
-        fi
+          pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
+          if [ ${{ matrix.sdk }} = '2.13.4' ]; then
+            git diff --exit-code
+          else
+            # Exclude built_redux generated files since they get generated differently in Dart 2.13 vs other versions
+            git diff --exit-code -- ":(exclude)test/over_react/component_declaration/redux_component_test/test_reducer.g.dart"
+          fi
         if: always() && steps.install.outcome == 'success'
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.7
+FROM google/dart:2.13
 
 # Expose env vars for git ssh access
 ARG GIT_SSH_KEY

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -2,7 +2,7 @@ name: todo_client
 version: 1.0.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.9.0 <3.0.0"
 
 dependencies:
   color: any
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_web_compilers: ^2.5.1
+  build_web_compilers: ^2.12.0
   build_test: ">=0.10.9 <2.0.0"
   dart_dev: ^3.0.0
   glob: ^1.2.0

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_web_compilers: ^2.12.0
+  build_web_compilers: ^2.9.0
   build_test: ">=0.10.9 <2.0.0"
   dart_dev: ^3.0.0
   glob: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ version: 4.2.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 
 dependencies:
   collection: ^1.14.11
@@ -34,7 +34,7 @@ dev_dependencies:
   build_resolvers: ^1.0.5
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.5.1
+  build_web_compilers: ^2.12.0
   built_value_generator: '>=7.0.0 <9.0.0'
   dart2_constant: ^1.0.0
   dart_dev: ^3.6.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # Dart 2.7 needs 0.39.x to resolve,
   # and Dart 2.12+ needs 0.42.x to resolve to build_web_compilers 2.12.0, etc.
   # to enable proper opting out of null-safety.
-  analyzer: '>=0.39.0 <0.42.0'
+  analyzer: '>=0.39.14 <0.42.0'
   build: ^1.0.0
   built_redux: ^7.4.2
   built_value: '>=6.8.2 <9.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
   build_resolvers: ^1.0.5
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <2.0.0"
-  build_web_compilers: ^2.12.0
+  build_web_compilers: ^2.9.0
   built_value_generator: '>=7.0.0 <9.0.0'
   dart2_constant: ^1.0.0
   dart_dev: ^3.6.4

--- a/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
+++ b/test/over_react/component_declaration/redux_component_test/test_reducer.g.dart
@@ -44,12 +44,8 @@ class _$BaseState extends BaseState {
       (new BaseStateBuilder()..update(updates)).build();
 
   _$BaseState._({this.count1, this.count2}) : super._() {
-    if (count1 == null) {
-      throw new BuiltValueNullFieldError('BaseState', 'count1');
-    }
-    if (count2 == null) {
-      throw new BuiltValueNullFieldError('BaseState', 'count2');
-    }
+    BuiltValueNullFieldError.checkNotNull(count1, 'BaseState', 'count1');
+    BuiltValueNullFieldError.checkNotNull(count2, 'BaseState', 'count2');
   }
 
   @override
@@ -95,9 +91,10 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
   BaseStateBuilder();
 
   BaseStateBuilder get _$this {
-    if (_$v != null) {
-      _count1 = _$v.count1;
-      _count2 = _$v.count2;
+    final $v = _$v;
+    if ($v != null) {
+      _count1 = $v.count1;
+      _count2 = $v.count2;
       _$v = null;
     }
     return this;
@@ -105,9 +102,7 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
 
   @override
   void replace(BaseState other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$BaseState;
   }
 
@@ -118,7 +113,12 @@ class BaseStateBuilder implements Builder<BaseState, BaseStateBuilder> {
 
   @override
   _$BaseState build() {
-    final _$result = _$v ?? new _$BaseState._(count1: count1, count2: count2);
+    final _$result = _$v ??
+        new _$BaseState._(
+            count1: BuiltValueNullFieldError.checkNotNull(
+                count1, 'BaseState', 'count1'),
+            count2: BuiltValueNullFieldError.checkNotNull(
+                count2, 'BaseState', 'count2'));
     replace(_$result);
     return _$result;
   }

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   over_react: ^3.5.3
 dev_dependencies:
   build_runner: ^1.0.0
-  build_web_compilers: ^2.12.0
+  build_web_compilers: ^2.9.0
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -1,12 +1,12 @@
 name: plugin_playground
 version: 0.0.0
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 dependencies:
   over_react: ^3.5.3
 dev_dependencies:
   build_runner: ^1.0.0
-  build_web_compilers: ^2.0.0
+  build_web_compilers: ^2.12.0
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -18,8 +18,6 @@ dependencies:
   source_span: ^1.7.0
 dev_dependencies:
   args: ^1.6.0
-  build_runner: ^1.0.0
-  build_test: ^1.0.0
   convert: ^2.1.1
   crypto: ^2.1.5
   dart_dev: ^3.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/Workiva/over_react/tree/master/tools/analyzer_plu
 environment:
   sdk: '>=2.9.0 <3.0.0'
 dependencies:
-  analyzer: ">=0.39.10 <0.42.0"
+  analyzer: ">=0.39.14 <0.42.0"
   analyzer_plugin: '^0.2.4'
   collection: ^1.14.0
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: Dart analyzer plugin for OverReact
 repository: https://github.com/Workiva/over_react/tree/master/tools/analyzer_plugin
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.9.0 <3.0.0'
 dependencies:
   analyzer: ">=0.39.10 <0.42.0"
   analyzer_plugin: '^0.2.4'


### PR DESCRIPTION
## Motivation/ Changes
As a part of the Dart 2.13 transition, `FROM google/dart:2.7` needs to be changed over to `FROM google/dart:2.13`.  

### QA Checklist
- [ ] CI passes 

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
