### PR TITLE
RM-114239 RM-114238 Release over_react 4.2.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.2.2
+version: 4.2.3
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.2.2
+  over_react: 4.2.3
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Add 2.13.4 to matrix](https://github.com/Workiva/over_react/pull/708)
	* [Raise the Dart SDK minimum to at least 2.11.0](https://github.com/Workiva/over_react/pull/709)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.2.2...Workiva:release_over_react_4.2.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.2.2...4.2.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=711&repo_name=Workiva%2Fover_react)