### PR TITLE
Consume react-dart 6.1.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   memoize: ^2.0.0
   meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
-  react: ^6.0.0
-  redux: ">=3.0.0 <5.0.0"
+  react: ^6.1.3  redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: ^1.13.0


### PR DESCRIPTION
Consume [react-dart 6.1.3](https://github.com/Workiva/react-dart/releases/tag/6.1.3)

Pull Requests included in release:
* Patch changes:
	* [Bump elliptic from 6.5.3 to 6.5.4](https://github.com/Workiva/react-dart/pull/308)
	* [Update README.md](https://github.com/Workiva/react-dart/pull/309)
	* [Bump ssri from 6.0.1 to 6.0.2](https://github.com/Workiva/react-dart/pull/311)
	* [Bump lodash from 4.17.20 to 4.17.21](https://github.com/Workiva/react-dart/pull/312)
	* [Bump browserslist from 4.16.1 to 4.16.6](https://github.com/Workiva/react-dart/pull/313)
	* [Upgrade to Dart 2.13](https://github.com/Workiva/react-dart/pull/315)
	* [Bump path-parse from 1.0.6 to 1.0.7](https://github.com/Workiva/react-dart/pull/318)
	* [Raise the Dart SDK minimum to at least 2.11.0](https://github.com/Workiva/react-dart/pull/323)
	* [Upgrade dependency_validator](https://github.com/Workiva/react-dart/pull/325)
	* [RM-113709 Release react-dart 6.1.3](https://github.com/Workiva/react-dart/pull/326)


Requested by: @rmconsole2-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?pull_number=713&repo_name=Workiva%2Fover_react)