### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pub get
 
       - name: Validate dependencies
-        run: pub run dependency_validator --no-fatal-pins -i analyzer,build_runner,build_web_compilers,built_value_generator
+        run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
       - name: Verify formatting
@@ -105,7 +105,7 @@ jobs:
         if: always() && steps.link.outcome == 'success'
 
       - name: Validate dependencies
-        run: pub run dependency_validator --no-fatal-pins -i analyzer,build_runner,build_web_compilers,built_value_generator
+        run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
       - name: Verify formatting

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   built_value_generator: '>=7.0.0 <9.0.0'
   dart2_constant: ^1.0.0
   dart_dev: ^3.6.4
-  dependency_validator: ^1.4.0
+  dependency_validator: ^2.0.0
   glob: ^1.2.0
   io: ^0.3.2+1
   mockito: ^4.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,3 +51,10 @@ workiva:
   core_checks:
     version: 1
     react_boilerplate: disabled
+
+dependency_validator:
+  exclude:
+    - app/**
+    - tools/**
+  ignore:
+    - meta

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -34,6 +34,11 @@ dev_dependencies:
   workiva_analysis_options: ^1.1.0
   yaml: ^2.2.1
 
+dependency_validator:
+  ignore:
+    - meta
+    - over_react
+
 # If you're developing on changes in over_react that the analyzer plugin needs to consume,
 # point to the local copy of over_react. This must be an absolute path.
 #

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   convert: ^2.1.1
   crypto: ^2.1.5
   dart_dev: ^3.0.0
-  dependency_validator: ^1.4.0
+  dependency_validator: ^2.0.0
   glob: ^1.2.0
   io: ^0.3.2+1
   logging: ^0.11.3+2


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)