### PR TITLE
Update test_html_builder to v2

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
   test: ^1.15.7
-  test_html_builder: ^1.0.0
+  test_html_builder: ^2.2.2
   time: ^1.2.0
   w_common: ^1.20.0
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch is to find and open PRs to upgrade test_html_builder to v2.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_test_html_builder_to_v2`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_test_html_builder_to_v2)