### PR TITLE
Remove dart2_constant

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,6 @@ dev_dependencies:
   build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.5.1
   built_value_generator: '>=7.0.0 <9.0.0'
-  dart2_constant: ^1.0.0
   dart_dev: ^3.6.4
   dependency_validator: ^2.0.0
   glob: ^1.2.0

--- a/test/over_react/component/_deprecated/abstract_transition_test.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.dart
@@ -19,7 +19,6 @@ library deprecated_abstract_transition_test;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart2_constant/core.dart' as d2c;
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react_test/over_react_test.dart';
@@ -64,7 +63,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
               reason: 'should still be waiting for a transition event');
 
@@ -96,7 +95,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -131,7 +130,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
               reason: 'should still be waiting for a transition event');
 
@@ -143,7 +142,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -183,7 +182,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -228,7 +227,7 @@ main() {
             expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
             for (var i = 0; i < expectedTransitionInCount; i++) {
-              await Future.delayed(d2c.Duration.zero);
+              await Future.delayed(Duration.zero);
               expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
                   reason: 'should still be waiting for a transition event');
 
@@ -244,7 +243,7 @@ main() {
             expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
             for (var i = 0; i < expectedTransitionOutCount; i++) {
-              await Future.delayed(d2c.Duration.zero);
+              await Future.delayed(Duration.zero);
               expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
                   reason: 'should still be waiting for a transition event');
 
@@ -510,7 +509,7 @@ main() {
 
         expect(transitioner.state.transitionPhase, TransitionPhase.HIDING);
 
-        await Future.delayed(d2c.Duration.zero);
+        await Future.delayed(Duration.zero);
 
         expect(transitioner.state.transitionPhase, TransitionPhase.HIDDEN);
 

--- a/test/over_react/component/abstract_transition_test.dart
+++ b/test/over_react/component/abstract_transition_test.dart
@@ -17,7 +17,6 @@ library abstract_transition_test;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart2_constant/core.dart' as d2c;
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart' hide TransitionPropsMixin, $TransitionPropsMixin, AbstractTransitionProps, AbstractTransitionState, AbstractTransitionComponent;
 import 'package:over_react/components.dart';
@@ -63,7 +62,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
               reason: 'should still be waiting for a transition event');
 
@@ -95,7 +94,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -130,7 +129,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
               reason: 'should still be waiting for a transition event');
 
@@ -142,7 +141,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -182,7 +181,7 @@ main() {
 
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
-          await Future.delayed(d2c.Duration.zero);
+          await Future.delayed(Duration.zero);
           expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
               reason: 'should still be waiting for a transition event');
 
@@ -227,7 +226,7 @@ main() {
             expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING));
 
             for (var i = 0; i < expectedTransitionInCount; i++) {
-              await Future.delayed(d2c.Duration.zero);
+              await Future.delayed(Duration.zero);
               expect(transitioner.state.transitionPhase, equals(TransitionPhase.SHOWING),
                   reason: 'should still be waiting for a transition event');
 
@@ -243,7 +242,7 @@ main() {
             expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING));
 
             for (var i = 0; i < expectedTransitionOutCount; i++) {
-              await Future.delayed(d2c.Duration.zero);
+              await Future.delayed(Duration.zero);
               expect(transitioner.state.transitionPhase, equals(TransitionPhase.HIDING),
                   reason: 'should still be waiting for a transition event');
 
@@ -509,7 +508,7 @@ main() {
 
         expect(transitioner.state.transitionPhase, TransitionPhase.HIDING);
 
-        await Future.delayed(d2c.Duration.zero);
+        await Future.delayed(Duration.zero);
 
         expect(transitioner.state.transitionPhase, TransitionPhase.HIDDEN);
 

--- a/test/over_react/component_declaration/redux_component_test.dart
+++ b/test/over_react/component_declaration/redux_component_test.dart
@@ -16,7 +16,6 @@ library over_react.component_declaration.redux_component_test;
 
 import 'dart:async';
 
-import 'package:dart2_constant/core.dart' as d2c;
 import 'package:test/test.dart';
 import 'package:built_redux/built_redux.dart';
 import 'package:over_react/over_react.dart';
@@ -80,14 +79,14 @@ void main() {
       TestDefaultComponent component = getDartComponent(renderedInstance);
 
       store.actions.trigger1();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
 
       expect(component.numberOfRedraws, 1);
 
       unmount(renderedInstance);
 
       store.actions.trigger1();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
 
       expect(component.numberOfRedraws, 1,
           reason: 'component should no longer be listening after unmount');
@@ -103,11 +102,11 @@ void main() {
       TestConnectComponent component = getDartComponent(renderedInstance);
 
       stores.actions.trigger1();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
       expect(component.numberOfRedraws, 1);
 
       stores.actions.trigger2();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
       expect(component.numberOfRedraws, 1);
     });
 
@@ -122,7 +121,7 @@ void main() {
         TestPureComponent component = jacket.getDartInstance();
 
         store.actions.trigger1();
-        await Future.delayed(d2c.Duration.zero);
+        await Future.delayed(Duration.zero);
         expect(component.numberOfRedraws, 1);
       });
 
@@ -198,7 +197,7 @@ void main() {
       TestDefaultComponent component = jacket.getDartInstance();
 
       store.actions.trigger1();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
       expect(component.numberOfRedraws, 1);
 
       jacket.rerender((TestDefault()..store = updatedStore)());
@@ -206,7 +205,7 @@ void main() {
       expect(component.numberOfRedraws, 2);
 
       updatedStore.actions.trigger1();
-      await Future.delayed(d2c.Duration.zero);
+      await Future.delayed(Duration.zero);
       expect(component.numberOfRedraws, 3);
     });
   });

--- a/test/over_react/util/css_value_util_test.dart
+++ b/test/over_react/util/css_value_util_test.dart
@@ -15,7 +15,6 @@
 @TestOn('browser')
 library css_value_util_test;
 
-import 'package:dart2_constant/core.dart' as d2c;
 import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
 
@@ -73,18 +72,18 @@ main() {
             }
 
             test('infinity', () {
-              testValue(d2c.double.infinity);
-              testValue(d2c.double.infinity.toString());
+              testValue(double.infinity);
+              testValue(double.infinity.toString());
             });
 
             test('negative infinity', () {
-              testValue(d2c.double.negativeInfinity);
-              testValue(d2c.double.negativeInfinity.toString());
+              testValue(double.negativeInfinity);
+              testValue(double.negativeInfinity.toString());
             });
 
             test('NaN', () {
-              testValue(d2c.double.nan);
-              testValue(d2c.double.nan.toString());
+              testValue(double.nan);
+              testValue(double.nan.toString());
             });
           });
 


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch is to remove uses of dart2_constant which is a remnant from the dart 2 upgrade.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/remove_dart2_constant`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_dart2_constant)