### PR TITLE
CPLAT-16343 Auto-tear-down ConnectFluxAdapterStores when backing Flux stores dispose

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,7 @@ analyzer:
     - tools/analyzer_plugin/**
     - ddc_precompiled/**
   errors:
+    invalid_export_of_internal_element: warning
     unused_import: warning
     duplicate_import: warning
     missing_required_param: error

--- a/lib/over_react_flux.dart
+++ b/lib/over_react_flux.dart
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export 'src/over_react_redux/over_react_flux.dart';
+export 'src/over_react_redux/over_react_flux.dart' hide ConnectFluxAdapterStoreTestingHelper;
 export 'src/over_react_redux/redux_multi_provider.dart';
 export 'src/over_react_redux/over_react_redux.dart' show ReduxProvider;

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -138,7 +138,9 @@ class ConnectFluxAdapterStore<S extends flux.Store> extends redux.Store<S> {
     // In most cases, though, from a memory management standpoint, tearing this
     // store down shouldn't be necessary, since any components subscribed to it
     // should have also been unmounted, leaving nothing to retain it.
-    store.didDispose.whenComplete(teardown);
+    //
+    // Use a null-aware to accommodate mock stores in unit tests that return null for `didDispose`.
+    store.didDispose?.whenComplete(teardown);
   }
 
   bool _teardownCalled = false;

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -131,13 +131,33 @@ class ConnectFluxAdapterStore<S extends flux.Store> extends redux.Store<S> {
     });
 
     actionsForStore[store] = actions;
+
+    // This store is useless once the flux store is disposed, so for convenience,
+    // we'll tear it down for consumers.
+    //
+    // In most cases, though, from a memory management standpoint, tearing this
+    // store down shouldn't be necessary, since any components subscribed to it
+    // should have also been unmounted, leaving nothing to retain it.
+    store.didDispose.whenComplete(teardown);
   }
+
+  bool _teardownCalled = false;
 
   @override
   Future teardown() async {
+    _teardownCalled = true;
+
     await _storeListener.cancel();
     await super.teardown();
   }
+}
+
+/// Not to be exported; only used to expose private fields for testing.
+@internal
+@visibleForTesting
+extension ConnectFluxAdapterStoreTestingHelper on ConnectFluxAdapterStore {
+  @visibleForTesting
+  bool get teardownCalled => _teardownCalled;
 }
 
 /// Adapts a Flux store to the interface of a Redux store.

--- a/test/over_react_redux/connect_flux_adapter_store_test.dart
+++ b/test/over_react_redux/connect_flux_adapter_store_test.dart
@@ -1,0 +1,130 @@
+// Copyright 2021 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:over_react/src/over_react_redux/over_react_flux.dart';
+import 'package:test/test.dart';
+import 'package:w_flux/w_flux.dart' as flux;
+
+main() {
+  // See connect_flux_integration_test.dart for more test coverage of this class
+  group('ConnectFluxAdapterStore', () {
+    group('teardown', () {
+      test('calls super, closing change subscriptions', () async {
+        final adapterStore = SimpleStore().asConnectFluxStore(null);
+        expect(() => adapterStore.onChange.listen((_) {}), returnsNormally,
+            reason: 'test setup check: the stream should be open');
+
+        await adapterStore.teardown();
+      });
+
+      test('stops listening to the flux store', () async {
+        final store = SpyStore();
+        final adapterStore = store.asConnectFluxStore(null);
+
+        expect(store.spiedSubscriptions, hasLength(1));
+        // ignore: cancel_subscriptions
+        final sub = store.spiedSubscriptions.single;
+
+        final subCalls = [];
+        sub.onData(subCalls.add);
+
+        store.trigger();
+        await pumpEventQueue();
+        expect(subCalls, hasLength(1),
+            reason: 'test setup check; subscription should have gotten event');
+
+        await adapterStore.teardown();
+        store.trigger();
+        await pumpEventQueue();
+        expect(subCalls, hasLength(1), reason: 'subscription should have been cancelled');
+      });
+
+      group('can be called multiple times without throwing', () {
+        ConnectFluxAdapterStore adapterStore;
+
+        setUp(() {
+          adapterStore = SimpleStore().asConnectFluxStore(null);
+        });
+
+        test('synchronously', () async {
+          await Future.wait([
+            adapterStore.teardown(),
+            adapterStore.teardown(),
+          ]);
+        });
+
+        test('synchronously', () async {
+          await adapterStore.teardown();
+          await adapterStore.teardown();
+        });
+      });
+    });
+
+    group('calls teardown when the flux store is disposed', () {
+      flux.Store store;
+      ConnectFluxAdapterStore adapterStore;
+
+      setUp(() {
+        store = SimpleStore();
+        adapterStore = store.asConnectFluxStore(null);
+      });
+
+      test('', () async {
+        expect(adapterStore.teardownCalled, isFalse);
+
+        await store.dispose();
+        await pumpEventQueue();
+        expect(adapterStore.teardownCalled, isTrue);
+      });
+
+      group('and doesn\'t break if teardown', () {
+        test('has already been called', () async {
+          expect(adapterStore.teardownCalled, isFalse);
+
+          await adapterStore.teardown();
+          expect(adapterStore.teardownCalled, isTrue);
+
+          await store.dispose();
+          await pumpEventQueue();
+        });
+
+        test('is called after', () async {
+          expect(adapterStore.teardownCalled, isFalse);
+
+          await store.dispose();
+          await pumpEventQueue();
+          expect(adapterStore.teardownCalled, isTrue);
+
+          await adapterStore.teardown();
+        });
+      });
+    });
+  });
+}
+
+class SimpleStore extends flux.Store {}
+
+class SpyStore extends flux.Store {
+  final spiedSubscriptions = <StreamSubscription>[];
+
+  @override
+  listen(onData, {onError, onDone, cancelOnError}) {
+    final sub =
+        super.listen(onData, onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+    spiedSubscriptions.add(sub);
+    return sub;
+  }
+}

--- a/test/over_react_redux_test.dart
+++ b/test/over_react_redux_test.dart
@@ -27,6 +27,7 @@ import 'over_react_redux/hooks/use_selector_test.dart' as use_selector_hook_test
 import 'over_react_redux/hooks/use_store_test.dart' as use_store_hook_test;
 import './over_react_redux/connect_test.dart' as connect_test;
 import './over_react_redux/connect_flux_test.dart' as connect_flux_test;
+import './over_react_redux/connect_flux_adapter_store_test.dart' as connect_flux_adapter_store_test;
 import './over_react_redux/connect_flux_integration_test.dart' as connect_flux_integration_test;
 import './over_react_redux/redux_multi_provider_test.dart' as multi_provider_test;
 import './over_react_redux/value_mutation_checker_test.dart' as value_mutation_checker_test;
@@ -39,6 +40,7 @@ void main() {
   use_store_hook_test.main();
   connect_test.main();
   connect_flux_test.main();
+  connect_flux_adapter_store_test.main();
   connect_flux_integration_test.main();
   multi_provider_test.main();
   value_mutation_checker_test.main();


### PR DESCRIPTION
## Motivation
It's inconvenient to store references to `ConnectFluxAdapterStore`s to call `teardown` on them later, especially when using the extension method `asConnectFluxStore` after passing through the Flux store through several layers of constructors/functions.

## Changes
Automatically call `teardown` on the created store when the backing Flux store disposes, since the Redux store won't be used to dispatch any events anyways after the Flux store has been disposed.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Consumer tests pass
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
