### PR TITLE
Raise Max Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.2.6](https://github.com/Workiva/over_react/compare/4.2.5...4.2.6)
+
+- [#722] Dependency upgrades
+
 ## [4.2.5](https://github.com/Workiva/over_react/compare/4.2.4...4.2.5)
 - [#720] Auto-tear-down ConnectFluxAdapterStores when backing Flux stores dispose
 - Bump react lower bound to 6.1.4
@@ -48,7 +52,7 @@ Internal Tech Debt:
 
   This introduced a new component factory syntax that future proofs the boilerplate syntax through Dart 2.12! For more information and migration instructions, refer to the [PR description](https://github.com/Workiva/over_react/pull/679).
 
-- [#674] Add Redux hooks. 
+- [#674] Add Redux hooks.
 
   Introducing new Redux hook APIs! OverReact consumers also using OverReact Redux can now use the `useDispatch`, `useSelector`, and `useStore` hooks. For more information, refer to the [documenation](https://github.com/Workiva/over_react/blob/master/doc/over_react_redux_documentation.md#hooks).
 
@@ -67,11 +71,11 @@ The underlying `.js` files provided by this package are now ReactJS version `17.
 > __[Full List of Breaking Changes](https://github.com/Workiva/over_react/pull/647)__
 
 ## [3.12.1](https://github.com/Workiva/over_react/compare/3.12.0...3.12.1)
-- [#643] Use `propsOrStateMapsEqual` in `memo` so that function tearoffs don't cause unnecessary rerenders. 
+- [#643] Use `propsOrStateMapsEqual` in `memo` so that function tearoffs don't cause unnecessary rerenders.
 
 ## [3.12.0](https://github.com/Workiva/over_react/compare/3.11.0...3.12.0)
-- [#641] Expose new event helper APIs. In react-dart, using the `SyntheticEvent` class constructors were deprecated. 
-New event helpers were added as a replacement, and to make their usage convenient, these helpers have been exposed directly via OverReact. 
+- [#641] Expose new event helper APIs. In react-dart, using the `SyntheticEvent` class constructors were deprecated.
+New event helpers were added as a replacement, and to make their usage convenient, these helpers have been exposed directly via OverReact.
 
 ## [3.11.0](https://github.com/Workiva/over_react/compare/3.10.1...3.11.0)
 
@@ -109,8 +113,8 @@ __New Features__
 
 - 🎉 🎉 🎉 __Support for function components, memo and hooks!!!__ 🎉 🎉 🎉
 
-    Sooooo much work from so many amazing people made this possible, but to summarize: 
-    
+    Sooooo much work from so many amazing people made this possible, but to summarize:
+
     - [#606] Add support for function components
     - [#613] Add support for `memo` higher order component
     - [#611] Hooks, hooks, and more hooks!
@@ -126,39 +130,39 @@ __New Features__
         - useDebugValue
 
     <p><br>It works like this...</p>
-    
+
     Define the component
     ```dart
     mixin FancyBorderProps on UiProps {
       String color;
     }
-    
+
     UiFactory<FancyBorderProps> FancyBorder = uiFunction(
       (props) {
         // props is typed as a `FancyBorderProps`
         // whatever you return here will be rendered
-        return (Dom.div()..className = 'fancy-border border-${props.color}')( 
+        return (Dom.div()..className = 'fancy-border border-${props.color}')(
           props.children,
         );
-      }, 
+      },
       $FancyBorderConfig, // ignore: undefined_identifier
     );
     ```
-    
+
     Render the component _(exact same consumer API as a class-based component)_:
     ```dart
     import 'package:over_react/over_react.dart';
     import 'fancy_border.dart'; // Where your component is defined
-    
+
     main() {
       final renderedWidget = (FancyBorder()..color = /* some color value */)(
         // put some children here!
       );
-    
+
       react_dom.render(renderedWidget, querySelector('#idOfSomeNodeInTheDom'));
     }
     ```
-  
+
 __Other Changes__
 
 - [#612] Deprecate `forwardRef` / add `uiForwardRef` as its replacement
@@ -180,7 +184,7 @@ __Analyzer Plugin Changes:__
 
 - Add [OverReact Analyzer Plugin (beta)](https://github.com/Workiva/over_react/tree/master/tools/analyzer_plugin) ⚡️
     > A Dart analyzer plugin for OverReact, bringing analysis-time checks and behavior to IDEs using the Dart Analysis Server (including JetBrains IDEs and VS Code).
-    > 
+    >
     > Functionality includes checking for issues that cause React warnings/errors at runtime, linting for best practices, adding "assists" for common edits to component syntax and boilerplate, and more!
 
 - [#498] Fix missing `allowInterop` call in `OverReactReduxDevToolsMiddleware.handleEventFromRemote`
@@ -200,14 +204,14 @@ __Analyzer Plugin Changes:__
 
 ## [3.5.0](https://github.com/Workiva/over_react/compare/3.4.1...3.5.0)
 - Introduce new and improved component boilerplate syntax 🎉
-    
+
     ![side-by-side comparison of old and new boilerplate for a simple component](doc/new-boilerplate-side-by-side.png)
-    
+
     See our [migration guide](https://github.com/Workiva/over_react/blob/master/doc/new_boilerplate_migration.md) for more information around these changes, including why we made them and how to convert existing components to use thew new syntax.
-    
-    The existing boilerplate syntax will be deprecated in a future release. 
-    
-- [#469] Throw helpful error when `connect`, `connectFlux`, and `forwardRef` are passed an invalid component. 
+
+    The existing boilerplate syntax will be deprecated in a future release.
+
+- [#469] Throw helpful error when `connect`, `connectFlux`, and `forwardRef` are passed an invalid component.
 
 ## [3.4.1](https://github.com/Workiva/over_react/compare/3.4.0...3.4.1)
 - [#468] Allow redux.dart version 4
@@ -2390,4 +2394,3 @@ Initial public release of the library.
 [#997]: https://github.com/Workiva/over_react/pull/997
 [#998]: https://github.com/Workiva/over_react/pull/998
 [#999]: https://github.com/Workiva/over_react/pull/999
-

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   uuid: ^1.0.3
 
 dev_dependencies:
-  build_runner: ^1.7.1
+  build_runner: '>=1.7.1 <3.0.0'
   build_web_compilers: ^2.5.1
   build_test: ">=0.10.9 <2.0.0"
   dart_dev: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   # and Dart 2.12+ needs 0.42.x to resolve to build_web_compilers 2.12.0, etc.
   # to enable proper opting out of null-safety.
   analyzer: '>=0.39.0 <0.42.0'
-  build: ^1.0.0
+  build: '>=1.0.0 <3.0.0'
   built_redux: ^7.4.2
   built_value: '>=6.8.2 <9.0.0'
   dart_style: ^1.2.5
   js: ^0.6.1+1
-  logging: ">=0.11.3+2 <1.0.0"
+  logging: '>=0.11.3+2 <2.0.0'
   memoize: ^2.0.0
   meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
@@ -32,7 +32,7 @@ dependencies:
 
 dev_dependencies:
   build_resolvers: ^1.0.5
-  build_runner: ^1.7.1
+  build_runner: '>=1.7.1 <3.0.0'
   build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.5.1
   built_value_generator: '>=7.0.0 <9.0.0'

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
 dependencies:
   over_react: ^3.5.3
 dev_dependencies:
-  build_runner: ^1.0.0
+  build_runner: '>=1.0.0 <3.0.0'
   build_web_compilers: ^2.0.0
   workiva_analysis_options: ^1.1.0
 

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   path: ^1.5.1
   source_span: ^1.7.0
 dev_dependencies:
-  args: ^1.6.0
-  build_runner: ^1.0.0
+  args: '>=1.6.0 <3.0.0'
+  build_runner: '>=1.0.0 <3.0.0'
   build_test: ^1.0.0
   convert: ^2.1.1
   crypto: ^2.1.5
@@ -26,7 +26,7 @@ dev_dependencies:
   dependency_validator: ^2.0.0
   glob: ^1.2.0
   io: ^0.3.2+1
-  logging: ^0.11.3+2
+  logging: '>=0.11.3+2 <2.0.0'
   markdown: ^2.1.5
   package_config: ^1.9.3
   test: ^1.15.7


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)