### PR TITLE
TEST: override built_collection to v5 and built_value to v8

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -32,3 +32,5 @@ dev_dependencies:
 dependency_overrides:
   over_react:
     path: '../../../'
+  built_collection: ^5.0.0
+  built_value: ^8.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,3 +57,7 @@ dependency_validator:
     - tools/**
   ignore:
     - meta
+
+dependency_overrides:
+  built_collection: ^5.0.0
+  built_value: ^8.0.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -13,3 +13,5 @@ dependency_overrides:
   # Pull in the local copy of over_react so it pulls in the local copy of the plugin
   over_react:
       path: ../../..
+  built_collection: ^5.0.0
+  built_value: ^8.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -47,3 +47,7 @@ dependency_validator:
 # dependency_overrides:
 #   over_react:
 #     path: /Users/me/workspaces/over_react
+
+dependency_overrides:
+  built_collection: ^5.0.0
+  built_value: ^8.0.0


### PR DESCRIPTION
Summary
---

Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This PR tests for compatibility with the next major versions of
built_collection and built_value prior to upgrading to them.

Note that we are intentionally _not_ changing the built_value_generator
version in this test because we want to test that the code being generated
by built_value_generator v7 is compatible with the next major versions of
the APIs it uses (built_collection and built_value).

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/built_value_v8_test`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/built_value_v8_test)