### PR TITLE
Upgrade built_value_generator to v8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer: '>=0.39.0 <0.42.0'
   build: '>=1.0.0 <3.0.0'
   built_redux: ^7.4.2
-  built_value: '>=6.8.2 <9.0.0'
+  built_value: ^8.0.0
   dart_style: ^1.2.5
   js: ^0.6.1+1
   logging: '>=0.11.3+2 <2.0.0'
@@ -35,7 +35,7 @@ dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: ^2.5.1
-  built_value_generator: '>=7.0.0 <9.0.0'
+  built_value_generator: ^8.0.0
   dart_dev: ^3.6.4
   dependency_validator: ^2.0.0
   glob: ^1.2.0


### PR DESCRIPTION
## Summary

Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This PR is the last step in the process to upgrade to built_value_generator
v8. At this point, all packages at Workiva are compatible with built_value
v8 and built_collection v5, so this PR upgrades the generator from v7 to v8
and commits the updated assets from it.

Note that because code generated by built_value_generator v8 uses APIs that
are only available in built_value v8 and built_collection v5, this PR also
raises the minimums of those dependencies accordingly.

## TODO

- [x] Run `dart build_runner build` and commit updated generated assets.

## Testing

For most consumers, static analysis along with existing unit and functional
tests should provide adequate coverage of these changes. We are already
using built_value v8 and built_collection v5 in Wdesk; this PR just upgrades
the generated code that uses those libraries to the same version.

---

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/built_value_generator_v8`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/built_value_generator_v8)