### PR TITLE
RM-132104 RM-132103 Release over_react 4.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.2.8](https://github.com/Workiva/over_react/compare/4.2.7...4.2.8)
+
+- [#729] Raise built_value lower bound to `^8.0.0`
+
 ## [4.2.7](https://github.com/Workiva/over_react/compare/4.2.7...4.2.6)
 
 - [#730] Fix bug where components using the React Redux `useSelector` and `createSelectorHook` hook APIs would rerender on every store update, even when there were no changes to selected values

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.2.7
+version: 4.2.8
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.2.7
+  over_react: 4.2.8
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Upgrade built_value_generator to v8](https://github.com/Workiva/over_react/pull/729)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.2.7...Workiva:release_over_react_4.2.8
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.2.7...4.2.8

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=732&repo_name=Workiva%2Fover_react)