### PR TITLE
SafeRenderManager retention workaround

### DIFF
--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -52,11 +52,13 @@ class SafeRenderManager extends Disposable {
   /// If not specified, a new div will be used.
   final Element mountNode;
 
+  final _contentRefObject = createRef<dynamic>();
+
   /// The ref to the component rendered by [render].
   ///
   /// Due to react_dom.render calls not being guaranteed to be synchronous.
   /// this may not be populated until later than expected.
-  dynamic contentRef;
+  dynamic get contentRef => _contentRefObject.current;
 
   _RenderState _state = _RenderState.unmounted;
 
@@ -105,7 +107,7 @@ class SafeRenderManager extends Disposable {
           content = null;
           return value;
         }
-        ..contentRef = _contentCallbackRef
+        ..contentRef = _contentRefObject
       )(), mountNode);
     } catch (_) {
       _state = _RenderState.unmounted;
@@ -201,10 +203,6 @@ class SafeRenderManager extends Disposable {
       _renderQueue.forEach(_helper.renderContent);
       _renderQueue = [];
     }
-  }
-
-  void _contentCallbackRef(ref) {
-    contentRef = ref;
   }
 
   @override

--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -60,6 +60,10 @@ class SafeRenderManager extends Disposable {
   /// this may not be populated until later than expected.
   dynamic get contentRef => _contentRefObject.current;
 
+  // This setter only exists for backwards compatibility purposes.
+  @Deprecated('This ref should only be read, since it gets set by the rendered content')
+  set contentRef(dynamic value) => _contentRefObject.current = value;
+
   _RenderState _state = _RenderState.unmounted;
 
   /// A list of [render] calls queued up while the component is in the process

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
@@ -18,21 +18,18 @@ part 'safe_render_manager_helper.over_react.g.dart';
 
 /// A component that allows for safe unmounting of its single child by waiting for state changes
 /// sometimes queued by ReactJS to be applied.
-@Factory()
 UiFactory<SafeRenderManagerHelperProps> SafeRenderManagerHelper =
     // ignore: undefined_identifier
-    _$SafeRenderManagerHelper;
+    castUiFactory(_$SafeRenderManagerHelper);
 
-@Props()
-class _$SafeRenderManagerHelperProps extends UiProps {
+mixin SafeRenderManagerHelperProps on UiProps {
   @requiredProp
   ReactElement Function() getInitialContent;
 
-  CallbackRef contentRef;
+  dynamic contentRef;
 }
 
-@State()
-class _$SafeRenderManagerHelperState extends UiState {
+mixin SafeRenderManagerHelperState on UiState {
   ReactElement content;
 }
 
@@ -57,24 +54,6 @@ class SafeRenderManagerHelperComponent extends UiStatefulComponent2<SafeRenderMa
   render() {
     if (state.content == null) return null;
 
-    return cloneElement(state.content, domProps()..ref = chainRef(state.content, _contentRef));
+    return cloneElement(state.content, domProps()..ref = chainRefs(state.content.ref, props.contentRef));
   }
-
-  void _contentRef(ref) {
-    props.contentRef?.call(ref);
-  }
-}
-
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class SafeRenderManagerHelperProps extends _$SafeRenderManagerHelperProps with _$SafeRenderManagerHelperPropsAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForSafeRenderManagerHelperProps;
-}
-
-// AF-3369 This will be removed once the transition to Dart 2 is complete.
-// ignore: mixin_of_non_class, undefined_class
-class SafeRenderManagerHelperState extends _$SafeRenderManagerHelperState with _$SafeRenderManagerHelperStateAccessorsMixin {
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = _$metaForSafeRenderManagerHelperState;
 }

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -10,6 +10,8 @@ part of 'safe_render_manager_helper.dart';
 // React component factory implementation.
 //
 // Registers component implementation and links type meta to builder factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 final $SafeRenderManagerHelperComponentFactory = registerComponent2(
   () => _$SafeRenderManagerHelperComponent(),
   builderFactory: _$SafeRenderManagerHelper,
@@ -17,62 +19,6 @@ final $SafeRenderManagerHelperComponentFactory = registerComponent2(
   isWrapper: false,
   parentType: null,
   displayName: 'SafeRenderManagerHelper',
-);
-
-abstract class _$SafeRenderManagerHelperPropsAccessorsMixin
-    implements _$SafeRenderManagerHelperProps {
-  @override
-  Map get props;
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperProps.getInitialContent] -->
-  @override
-  @requiredProp
-  ReactElement Function() get getInitialContent =>
-      (props[_$key__getInitialContent___$SafeRenderManagerHelperProps] ?? null)
-          as ReactElement Function();
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperProps.getInitialContent] -->
-  @override
-  @requiredProp
-  set getInitialContent(ReactElement Function() value) =>
-      props[_$key__getInitialContent___$SafeRenderManagerHelperProps] = value;
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperProps.contentRef] -->
-  @override
-  CallbackRef get contentRef =>
-      (props[_$key__contentRef___$SafeRenderManagerHelperProps] ?? null)
-          as CallbackRef;
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperProps.contentRef] -->
-  @override
-  set contentRef(CallbackRef value) =>
-      props[_$key__contentRef___$SafeRenderManagerHelperProps] = value;
-  /* GENERATED CONSTANTS */
-  static const PropDescriptor
-      _$prop__getInitialContent___$SafeRenderManagerHelperProps =
-      PropDescriptor(_$key__getInitialContent___$SafeRenderManagerHelperProps,
-          isRequired: true);
-  static const PropDescriptor
-      _$prop__contentRef___$SafeRenderManagerHelperProps =
-      PropDescriptor(_$key__contentRef___$SafeRenderManagerHelperProps);
-  static const String _$key__getInitialContent___$SafeRenderManagerHelperProps =
-      'SafeRenderManagerHelperProps.getInitialContent';
-  static const String _$key__contentRef___$SafeRenderManagerHelperProps =
-      'SafeRenderManagerHelperProps.contentRef';
-
-  static const List<PropDescriptor> $props = [
-    _$prop__getInitialContent___$SafeRenderManagerHelperProps,
-    _$prop__contentRef___$SafeRenderManagerHelperProps
-  ];
-  static const List<String> $propKeys = [
-    _$key__getInitialContent___$SafeRenderManagerHelperProps,
-    _$key__contentRef___$SafeRenderManagerHelperProps
-  ];
-}
-
-const PropsMeta _$metaForSafeRenderManagerHelperProps = PropsMeta(
-  fields: _$SafeRenderManagerHelperPropsAccessorsMixin.$props,
-  keys: _$SafeRenderManagerHelperPropsAccessorsMixin.$propKeys,
 );
 
 _$$SafeRenderManagerHelperProps _$SafeRenderManagerHelper([Map backingProps]) =>
@@ -83,10 +29,13 @@ _$$SafeRenderManagerHelperProps _$SafeRenderManagerHelper([Map backingProps]) =>
 // Concrete props implementation.
 //
 // Implements constructor and backing map, and links up to generated component factory.
-abstract class _$$SafeRenderManagerHelperProps
-    extends _$SafeRenderManagerHelperProps
-    with _$SafeRenderManagerHelperPropsAccessorsMixin
-    implements SafeRenderManagerHelperProps {
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SafeRenderManagerHelperProps extends UiProps
+    with
+        SafeRenderManagerHelperProps,
+        $SafeRenderManagerHelperProps // If this generated mixin is undefined, it's likely because SafeRenderManagerHelperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SafeRenderManagerHelperProps, and check that $SafeRenderManagerHelperProps is exported/imported properly.
+{
   _$$SafeRenderManagerHelperProps._();
 
   factory _$$SafeRenderManagerHelperProps(Map backingMap) {
@@ -108,10 +57,18 @@ abstract class _$$SafeRenderManagerHelperProps
 
   /// The default namespace for the prop getters/setters generated for this class.
   @override
-  String get propKeyNamespace => 'SafeRenderManagerHelperProps.';
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SafeRenderManagerHelperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SafeRenderManagerHelperProps, and check that $SafeRenderManagerHelperProps is exported/imported properly.
+        SafeRenderManagerHelperProps: $SafeRenderManagerHelperProps.meta,
+      });
 }
 
 // Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 class _$$SafeRenderManagerHelperProps$PlainMap
     extends _$$SafeRenderManagerHelperProps {
   // This initializer of `_props` to an empty map, as well as the reassignment
@@ -130,6 +87,8 @@ class _$$SafeRenderManagerHelperProps$PlainMap
 
 // Concrete props implementation that can only be backed by [JsMap],
 // allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 class _$$SafeRenderManagerHelperProps$JsMap
     extends _$$SafeRenderManagerHelperProps {
   // This initializer of `_props` to an empty map, as well as the reassignment
@@ -146,47 +105,16 @@ class _$$SafeRenderManagerHelperProps$JsMap
   JsBackedMap _props;
 }
 
-abstract class _$SafeRenderManagerHelperStateAccessorsMixin
-    implements _$SafeRenderManagerHelperState {
-  @override
-  Map get state;
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperState.content] -->
-  @override
-  ReactElement get content =>
-      (state[_$key__content___$SafeRenderManagerHelperState] ?? null)
-          as ReactElement;
-
-  /// <!-- Generated from [_$SafeRenderManagerHelperState.content] -->
-  @override
-  set content(ReactElement value) =>
-      state[_$key__content___$SafeRenderManagerHelperState] = value;
-  /* GENERATED CONSTANTS */
-  static const StateDescriptor _$prop__content___$SafeRenderManagerHelperState =
-      StateDescriptor(_$key__content___$SafeRenderManagerHelperState);
-  static const String _$key__content___$SafeRenderManagerHelperState =
-      'SafeRenderManagerHelperState.content';
-
-  static const List<StateDescriptor> $state = [
-    _$prop__content___$SafeRenderManagerHelperState
-  ];
-  static const List<String> $stateKeys = [
-    _$key__content___$SafeRenderManagerHelperState
-  ];
-}
-
-const StateMeta _$metaForSafeRenderManagerHelperState = StateMeta(
-  fields: _$SafeRenderManagerHelperStateAccessorsMixin.$state,
-  keys: _$SafeRenderManagerHelperStateAccessorsMixin.$stateKeys,
-);
-
 // Concrete state implementation.
 //
 // Implements constructor and backing map.
-abstract class _$$SafeRenderManagerHelperState
-    extends _$SafeRenderManagerHelperState
-    with _$SafeRenderManagerHelperStateAccessorsMixin
-    implements SafeRenderManagerHelperState {
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$SafeRenderManagerHelperState extends UiState
+    with
+        SafeRenderManagerHelperState,
+        $SafeRenderManagerHelperState // If this generated mixin is undefined, it's likely because SafeRenderManagerHelperState is not a valid `mixin`-based state mixin, or because it is but the generated mixin was not imported. Check the declaration of SafeRenderManagerHelperState, and check that $SafeRenderManagerHelperState is exported/imported properly.
+{
   _$$SafeRenderManagerHelperState._();
 
   factory _$$SafeRenderManagerHelperState(Map backingMap) {
@@ -203,6 +131,8 @@ abstract class _$$SafeRenderManagerHelperState
 }
 
 // Concrete state implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 class _$$SafeRenderManagerHelperState$PlainMap
     extends _$$SafeRenderManagerHelperState {
   // This initializer of `_state` to an empty map, as well as the reassignment
@@ -221,6 +151,8 @@ class _$$SafeRenderManagerHelperState$PlainMap
 
 // Concrete state implementation that can only be backed by [JsMap],
 // allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 class _$$SafeRenderManagerHelperState$JsMap
     extends _$$SafeRenderManagerHelperState {
   // This initializer of `_state` to an empty map, as well as the reassignment
@@ -241,6 +173,8 @@ class _$$SafeRenderManagerHelperState$JsMap
 //
 // Implements typed props/state factories, defaults `consumedPropKeys` to the keys
 // generated for the associated props class.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
 class _$SafeRenderManagerHelperComponent
     extends SafeRenderManagerHelperComponent {
   _$$SafeRenderManagerHelperProps$JsMap _cachedTypedProps;
@@ -298,10 +232,99 @@ class _$SafeRenderManagerHelperComponent
   @override
   bool get $isClassGenerated => true;
 
-  /// The default consumed props, taken from _$SafeRenderManagerHelperProps.
+  /// The default consumed props, comprising all props mixins used by SafeRenderManagerHelperProps.
   /// Used in `*ConsumedProps` methods if [consumedProps] is not overridden.
   @override
-  final List<ConsumedProps> $defaultConsumedProps = const [
-    _$metaForSafeRenderManagerHelperProps
+  get $defaultConsumedProps => propsMeta.all;
+
+  @override
+  PropsMetaCollection get propsMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because SafeRenderManagerHelperProps is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of SafeRenderManagerHelperProps, and check that $SafeRenderManagerHelperProps is exported/imported properly.
+        SafeRenderManagerHelperProps: $SafeRenderManagerHelperProps.meta,
+      });
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $SafeRenderManagerHelperProps on SafeRenderManagerHelperProps {
+  static const PropsMeta meta = _$metaForSafeRenderManagerHelperProps;
+  @override
+  @requiredProp
+  ReactElement Function() get getInitialContent =>
+      (props[_$key__getInitialContent__SafeRenderManagerHelperProps] ?? null)
+          as ReactElement Function();
+  @override
+  @requiredProp
+  set getInitialContent(ReactElement Function() value) =>
+      props[_$key__getInitialContent__SafeRenderManagerHelperProps] = value;
+  @override
+  dynamic get contentRef =>
+      (props[_$key__contentRef__SafeRenderManagerHelperProps] ?? null)
+          as dynamic;
+  @override
+  set contentRef(dynamic value) =>
+      props[_$key__contentRef__SafeRenderManagerHelperProps] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__getInitialContent__SafeRenderManagerHelperProps = PropDescriptor(
+          _$key__getInitialContent__SafeRenderManagerHelperProps,
+          isRequired: true);
+  static const PropDescriptor _$prop__contentRef__SafeRenderManagerHelperProps =
+      PropDescriptor(_$key__contentRef__SafeRenderManagerHelperProps);
+  static const String _$key__getInitialContent__SafeRenderManagerHelperProps =
+      'SafeRenderManagerHelperProps.getInitialContent';
+  static const String _$key__contentRef__SafeRenderManagerHelperProps =
+      'SafeRenderManagerHelperProps.contentRef';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__getInitialContent__SafeRenderManagerHelperProps,
+    _$prop__contentRef__SafeRenderManagerHelperProps
+  ];
+  static const List<String> $propKeys = [
+    _$key__getInitialContent__SafeRenderManagerHelperProps,
+    _$key__contentRef__SafeRenderManagerHelperProps
   ];
 }
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaForSafeRenderManagerHelperProps = PropsMeta(
+  fields: $SafeRenderManagerHelperProps.$props,
+  keys: $SafeRenderManagerHelperProps.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $SafeRenderManagerHelperState on SafeRenderManagerHelperState {
+  static const StateMeta meta = _$metaForSafeRenderManagerHelperState;
+  @override
+  ReactElement get content =>
+      (state[_$key__content__SafeRenderManagerHelperState] ?? null)
+          as ReactElement;
+  @override
+  set content(ReactElement value) =>
+      state[_$key__content__SafeRenderManagerHelperState] = value;
+  /* GENERATED CONSTANTS */
+  static const StateDescriptor _$prop__content__SafeRenderManagerHelperState =
+      StateDescriptor(_$key__content__SafeRenderManagerHelperState);
+  static const String _$key__content__SafeRenderManagerHelperState =
+      'SafeRenderManagerHelperState.content';
+
+  static const List<StateDescriptor> $state = [
+    _$prop__content__SafeRenderManagerHelperState
+  ];
+  static const List<String> $stateKeys = [
+    _$key__content__SafeRenderManagerHelperState
+  ];
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const StateMeta _$metaForSafeRenderManagerHelperState = StateMeta(
+  fields: $SafeRenderManagerHelperState.$state,
+  keys: $SafeRenderManagerHelperState.$stateKeys,
+);

--- a/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
@@ -62,20 +62,58 @@ main() {
       });
 
       group('renders a component and exposes a ref to it via `contentRef`', () {
-        test('when there is no existing ref', () {
-          renderManager.render(Wrapper()());
+        group('when the content is a Dart component', () {
+          test('when there is no existing ref', () {
+            renderManager.render(Wrapper()());
 
-          expect(renderManager.contentRef, isNotNull);
-          expect(renderManager.contentRef, isA<WrapperComponent>());
+            expect(renderManager.contentRef, isNotNull);
+            expect(renderManager.contentRef, isA<WrapperComponent>());
+          });
+
+          test('by chaining any existing callback ref', () {
+            WrapperComponent existingWrapperRef;
+
+            renderManager.render((Wrapper()..ref = ((ref) => existingWrapperRef = ref as WrapperComponent))());
+
+            expect(renderManager.contentRef, isNotNull);
+            expect(existingWrapperRef, same(renderManager.contentRef));
+          });
+
+          test('by chaining any existing ref object re', () {
+            final existingWrapperRef = createRef<WrapperComponent>();
+
+            renderManager.render((Wrapper()..ref = existingWrapperRef)());
+
+            expect(renderManager.contentRef, isNotNull);
+            expect(existingWrapperRef.current, same(renderManager.contentRef));
+          });
         });
 
-        test('by chaining any existing callback ref', () {
-          WrapperComponent existingWrapperRef;
+        group('when the content is a DOM component', () {
+          test('when there is no existing ref', () {
+            renderManager.render(Dom.p()());
 
-          renderManager.render((Wrapper()..ref = ((ref) => existingWrapperRef = ref as WrapperComponent))());
+            expect(renderManager.contentRef, isNotNull);
+            expect(renderManager.contentRef, isA<ParagraphElement>());
+          });
 
-          expect(renderManager.contentRef, isNotNull);
-          expect(existingWrapperRef, same(renderManager.contentRef));
+          test('by chaining any existing callback ref', () {
+            ParagraphElement existingWrapperRef;
+
+            renderManager.render((Wrapper()..ref = ((ref) => existingWrapperRef = ref as ParagraphElement))());
+
+            expect(renderManager.contentRef, isNotNull);
+            expect(existingWrapperRef, same(renderManager.contentRef));
+          });
+
+          test('by chaining any existing callback ref', () {
+            final existingWrapperRef = createRef<ParagraphElement>();
+
+            renderManager.render((Wrapper()..ref = existingWrapperRef)());
+
+            expect(renderManager.contentRef, isNotNull);
+            expect(existingWrapperRef.current, same(renderManager.contentRef));
+          });
         });
       });
     });

--- a/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
+++ b/test/over_react/util/safe_render_manager/safe_render_manager_test.dart
@@ -100,7 +100,7 @@ main() {
           test('by chaining any existing callback ref', () {
             ParagraphElement existingWrapperRef;
 
-            renderManager.render((Wrapper()..ref = ((ref) => existingWrapperRef = ref as ParagraphElement))());
+            renderManager.render((Dom.p()..ref = ((ref) => existingWrapperRef = ref as ParagraphElement))());
 
             expect(renderManager.contentRef, isNotNull);
             expect(existingWrapperRef, same(renderManager.contentRef));
@@ -109,7 +109,7 @@ main() {
           test('by chaining any existing callback ref', () {
             final existingWrapperRef = createRef<ParagraphElement>();
 
-            renderManager.render((Wrapper()..ref = existingWrapperRef)());
+            renderManager.render((Dom.p()..ref = existingWrapperRef)());
 
             expect(renderManager.contentRef, isNotNull);
             expect(existingWrapperRef.current, same(renderManager.contentRef));


### PR DESCRIPTION
## Motivation
SafeRenderManager gets retained by the rendered SafeRenderManagerHelper, which in some cases was being retained by React, seemingly because of the following behavior:

_From https://github.com/facebook/react/issues/16087:_
> Props/child trees retained by alternate children. Similarly, children that was just removed can sometimes between retained by the alternate copy of that. That is until that node gets another update on it which clears out the old children. These cases are fairly unusual and fix themselves eventually as the app lives on.

These retentions eventually resolve themselves, so they're not true leaks, but they can show up as leaks in memory leak tests that look for disposed-but-retained objects (via Disposable's LeakFlag mechanism).

There are cases where it's very difficult to avoid these kinds of React retention paths. However, this case happens to be easier to avoid, and doing so would reduce noise and some false positives in these memory leak tests, so we want to update SafeRenderManager to not be retained by the tree it renders.

This won't prevent React from retaining the React tree it renders, which may retain other Disposable instances and still be flagged as leaks; only the SafeRenderManager object itself will no longer be retained. However, it's possible that the way content is "safely" unmounted (by rerendering SafeRenderManagerHelper with empty children before unmounting) helps prevent consumer-provided content being retained, but we're not sure at this time. 

## Changes
- Prevent SafeRenderManager from being retained by the React tree it renders. The retainers were two callback refs that directly retained SafeRenderManager due to being tearoffs:
    - `_contentCallbackRef` - fixed by using a ref object instead
    - `_helperRef` - fixed by instead retaining a `_selfRef` ref object which holds a SafeRenderManager, and gets cleared out on disposal
- Add additional test coverage to ensure callback chaining works as intended with different component types

Note that callback refs aren't inherently problematic, nor was how SafeRenderManager was being retained by the tree it rendered. The root issue here is React retaining things longer than we'd like/expect it to, and this issue helps work around that to reduce noise in tests. 

#### Release Notes
- Update `SafeRenderManager` to not be retained by the React tree it renders, to aid in memory leak testing. Outside of that context, this change has negligible effects.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
