### PR TITLE
RM-133131 RM-133130 Release over_react 4.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.2.9](https://github.com/Workiva/over_react/compare/4.2.8...4.2.9)
+
+- [#733] Update SafeRenderManager to not be retained by the React tree it renders, to aid in memory leak testing. Outside of that context, this change has negligible effects.
+
 ## [4.2.8](https://github.com/Workiva/over_react/compare/4.2.7...4.2.8)
 
 - [#729] Raise built_value lower bound to `^8.0.0`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.2.8
+version: 4.2.9
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.2.8
+  over_react: 4.2.9
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [SafeRenderManager retention workaround](https://github.com/Workiva/over_react/pull/733)


Requested by: @lukeanderson-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.2.8...Workiva:release_over_react_4.2.9
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.2.8...4.2.9

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=734&repo_name=Workiva%2Fover_react)