### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -31,14 +31,14 @@ jobs:
 
       - id: install
         name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Validate dependencies
         run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
       - name: Verify formatting
-        run: pub run dart_dev format --check
+        run: dart run dart_dev format --check
         if: always() && matrix.sdk == '2.7.2' && steps.install.outcome == 'success'
 
       # Analyze before generated files are created to verify that component boilerplate analysis is "clean" without the need for building
@@ -48,14 +48,14 @@ jobs:
           # which could cause analysis issues for consumers who haven't run a build yet.
           dartanalyzer lib
           cd example/boilerplate_versions
-          if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
+          dart analyze
         if: always() && steps.install.outcome == 'success'
 
       - id: build
         timeout-minutes: 6
         name: Build generated files / precompile DDC assets
         run: |
-          pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
+          dart pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
           if [ ${{ matrix.sdk }} = '2.7.2' ]; then
             git diff --exit-code
           else
@@ -66,19 +66,19 @@ jobs:
 
       # Analyze again after generated files are created to verify that those generated classes don't cause analysis errors
       - name: Analyze project source (post-build)
-        run: if [ ${{ matrix.sdk }} = '2.7.2' ]; then pub global activate tuneup && tuneup check; else dart analyze; fi
+        run: dart analyze
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (VM)
-        run: pub run dart_dev test -P vm
+        run: dart pub run dart_dev test -P vm
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (DDC)
-        run: pub run test --precompiled ddc_precompiled -P dartdevc
+        run: dart test --precompiled ddc_precompiled -P dartdevc
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (dart2js)
-        run: pub run dart_dev test --build-args="-r" -P dart2js
+        run: dart pub run dart_dev test --build-args="-r" -P dart2js
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
   analyzer_plugin:
@@ -101,11 +101,11 @@ jobs:
 
       - id: link
         name: Override over_react dependency with local path
-        run: cd ../.. && pub get && dart tool/travis_link_plugin_deps.dart
+        run: cd ../.. && dart pub get && dart tool/travis_link_plugin_deps.dart
 
       - id: install
         name: Install dependencies
-        run: pub get
+        run: dart pub get
         if: always() && steps.link.outcome == 'success'
 
       - name: Validate dependencies
@@ -113,9 +113,9 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - name: Verify formatting
-        run: pub run dart_dev format --check
+        run: dart pub run dart_dev format --check
         if: always() && matrix.sdk == '2.7.2' && steps.install.outcome == 'success'
 
       - name: Run tests
-        run: pub run dart_dev test
+        run: dart pub run dart_dev test
         if: always() && steps.install.outcome == 'success'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN eval "$(ssh-agent -s)" && \
 
 WORKDIR /build/
 ADD pubspec.yaml /build
-RUN pub get
+RUN dart pub get
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
 FROM scratch


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)