### PR TITLE
Release over_react 4.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.2.9
+version: 4.3.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.2.9
+  over_react: 4.3.0
   meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   source_span: ^1.7.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [CPLAT-17301 Update AriaPropsMixin](https://github.com/Workiva/over_react/pull/742)
* Patch changes:
	* [Temporarily disable the mockito builder for better build perf](https://github.com/Workiva/over_react/pull/737)
	* [Replace deprecated commands with new dart commands](https://github.com/Workiva/over_react/pull/741)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.2.9...Workiva:release_over_react_4.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.2.9...4.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)