### PR TITLE
[Analyzer Plugin] Fix existing / add more duplicate prop cascade diagnostic tests

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
@@ -34,6 +34,11 @@ class DuplicatePropCascadeDiagnostic extends ComponentUsageDiagnosticContributor
 
       // Prefix with the class the prop was declared in so that things like `.dom.type` don't conflict with an unrelated `type` prop.
       final enclosingElementName = prop.staticElement?.enclosingElement?.name ?? '';
+      // If it comes from DomPropsMixin / UbiquitousDomPropsMixin, the key is considered non-namespaced.
+      if (['DomPropsMixin', 'UbiquitousDomPropsMixin'].contains(enclosingElementName)) {
+        return prop.name.name;
+      }
+
       return '$enclosingElementName.${prop.name.name}';
     });
     final propUsagesWithDuplicates = propUsagesByName.values.where((usages) => usages.length > 1);

--- a/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/playground/web/duplicate_prop_cascade.dart
@@ -9,10 +9,14 @@ duplicatePropCascade() {
     ..dom.hidden = false
     ..aria.hidden = false
     ..hidden = false // None of these "hidden" props should be linted as dupes
+    ..id = '1'
+    ..dom.id = 'foo' // Should lint as dupe of `id`
+    ..dom.id = 'bar' // Should lint as dupe of `id`
   )();
   (Dom.div()
     ..id = '1'
     ..dom.id = 'foo' // Should lint as dupe of `id`
+    ..dom.id = 'bar' // Should lint as dupe of `id`
     ..id = '2'
     ..hidden = false
     ..aria.hidden = false // Should not lint as dupe of `hidden`

--- a/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
@@ -60,10 +60,11 @@ final foo = (Dom.div()
 )();
 ''');
     final allErrors = await getAllErrors(source);
-    expect(allErrors, hasLength(2));
-
-    for (final selection in [createSelection(source, "#..id# = '1'"), createSelection(source, "#..dom.id# = 'foo'")]) {
-      expect(allErrors, contains(isAnErrorUnderTest(locatedAt: selection, hasFix: true)));
-    }
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = '1'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'foo'"), hasFix: true),
+        ]));
   }
 }

--- a/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
@@ -23,8 +23,9 @@ class DuplicatePropCascadeDiagnosticTest extends DiagnosticTestBase {
   @override
   get fixKindUnderTest => DuplicatePropCascadeDiagnostic.fixKind;
 
-  Future<void> test_noError() async {
-    final source = newSource('test.dart', /*language=dart*/ r'''
+  static const customComponentDefinition = /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
 part 'test.over_react.g.dart';
 
 mixin CustomProps on UiProps {
@@ -38,24 +39,247 @@ final Custom = uiFunction<CustomProps>(
   },
   _$CustomConfig, // ignore: undefined_identifier
 );
+''';
 
-final customUsage = (Custom()
+  Future<void> test_noFalsePositives() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final customComponentUsage = (Custom()
+  // CustomProps.size / DomProps.size should not be flagged as duplicate 
+  // because of a different `enclosingElement` name.
   ..size = 2
   ..dom.size = 2
+  // CustomProps.hidden / DomProps.hidden / AriaProps.hidden should not be flagged as duplicate 
+  // because of a different prefix and/or differing `enclosingElement` names. 
   ..dom.hidden = false
   ..aria.hidden = false
   ..hidden = false
+)();
+
+final domComponentUsage = (Dom.div()
+  // DomProps.hidden / AriaProps.hidden should not be flagged as duplicate 
+  // because of a different prefix. 
+  ..dom.hidden = false
+  ..aria.hidden = false
 )();
 ''');
     expect(await getAllErrors(source), isEmpty);
   }
 
-  Future<void> test_error() async {
-    final source = newSource('test.dart', /*language=dart*/ r'''
-final foo = (Dom.div()
-  ..id = '1'
-  ..dom.id = 'foo'
+  Future<void> test_dupeDomPropFix() async {
+    var source = newSource('test.dart', /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
+final domComponentUsage = (Dom.div()
+  ..id = 'def'
+  ..dom.id = 'bar'
+  ..dom.id = 'baz'
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(allErrors, isNotEmpty);
+
+    final selection = createSelection(source, "#..id# = 'def'");
+    final errorFix = await expectSingleErrorFix(selection);
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
+final domComponentUsage = (Dom.div()
+  ..dom.id = 'baz'
+)();
+''');
+  }
+
+  Future<void> test_dupeCustomPropFix() async {
+    var source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final componentUsage = (Custom()
   ..hidden = false
+  ..hidden = true
+  ..dom.hidden = false
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(allErrors, isNotEmpty);
+
+    final selection = createSelection(source, "#..hidden# = false");
+    final errorFix = await expectSingleErrorFix(selection);
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, /*language=dart*/ '''
+$customComponentDefinition
+
+final componentUsage = (Custom()
+  ..hidden = true
+  ..dom.hidden = false
+)();
+''');
+  }
+
+  // ********************************************************
+  //  DomProps
+  // ********************************************************
+
+  Future<void> test_dupeDomPropWithOnePrefixedKey() async {
+    var source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final customComponentUsage = (Custom()
+  ..id = 'abc'
+  ..dom.id = 'foo'
+)();
+
+final domComponentUsage = (Dom.div()
+  ..id = 'def'
+  ..dom.id = 'bar'
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'abc'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'foo'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'def'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'bar'"), hasFix: true),
+        ]));
+  }
+
+  Future<void> test_dupeDomPropWithMultiplePrefixedKeys() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..id = 'abc'
+  ..dom.id = 'foo'
+  ..dom.id = 'bar'
+)();
+
+final customComponentUsage = (Custom()
+  ..id = 'def'
+  ..dom.id = 'baz'
+  ..dom.id = 'biz'
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'abc'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'foo'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'bar'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'def'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'baz'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'biz'"), hasFix: true),
+        ]));
+  }
+
+  Future<void> test_dupeDomPropWithAllPrefixedKeys() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..dom.id = 'abc'
+  ..dom.id = 'foo'
+  ..dom.id = 'bar'
+)();
+
+final customComponentUsage = (Custom()
+  ..dom.id = 'def'
+  ..dom.id = 'baz'
+  ..dom.id = 'biz'
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'abc'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'foo'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'bar'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'def'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'baz'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'biz'"), hasFix: true),
+        ]));
+  }
+
+  Future<void> test_dupeDomPropWithNoPrefixedKeys() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..id = 'abc'
+  ..id = 'foo'
+  ..id = 'bar'
+)();
+
+final customComponentUsage = (Custom()
+  ..id = 'def'
+  ..id = 'baz'
+  ..id = 'biz'
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'abc'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'foo'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'bar'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'def'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'baz'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = 'biz'"), hasFix: true),
+        ]));
+  }
+
+  // We currently don't support flagging dupes when a key is added using `..addProps(domProps()..key)`, but
+  // we run a test here to verify that no lint is shown, and that the plugin doesn't crash.
+  Future<void> test_noDupeAndNoPluginCrashWhenUsingAddPropsDomPropsAndPrefixedKey() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..id = 'def'
+  ..addProps(domProps()..id = 'abc')
+)();
+
+final domComponentUsagePrefixed = (Dom.div()
+  ..dom.id = 'def'
+  ..addProps(domProps()..id = 'abc')
+)();
+
+final customComponentUsage = (Custom()
+  ..id = 'abc'
+  ..addProps(domProps()..id = 'def')
+)();
+
+final customComponentUsagePrefixed = (Custom()
+  ..dom.id = 'abc'
+  ..addProps(domProps()..id = 'def')
+)();
+''');
+    expect(await getAllErrors(source), isEmpty);
+  }
+
+  // ********************************************************
+  //  AriaProps
+  // ********************************************************
+
+  Future<void> test_dupeAriaPropWithAllPrefixedKeys() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..aria.label = 'oh'
+  ..aria.label = 'hai'
+)();
+
+final customComponentUsage = (Custom()
+  ..aria.hidden = true
   ..aria.hidden = false
 )();
 ''');
@@ -63,8 +287,58 @@ final foo = (Dom.div()
     expect(
         allErrors,
         unorderedEquals(<Matcher>[
-          isAnErrorUnderTest(locatedAt: createSelection(source, "#..id# = '1'"), hasFix: true),
-          isAnErrorUnderTest(locatedAt: createSelection(source, "#..dom.id# = 'foo'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..aria.label# = 'oh'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..aria.label# = 'hai'"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..aria.hidden# = true"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..aria.hidden# = false"), hasFix: true),
+        ]));
+  }
+
+  // We currently don't support flagging dupes when a key is added using `..addProps(ariaProps()..key)`, but
+  // we run a test here to verify that no lint is shown, and that the plugin doesn't crash.
+  Future<void> test_noDupeAndNoPluginCrashWhenUsingAddPropsAriaProps() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final domComponentUsage = (Dom.div()
+  ..aria.hidden = false
+  ..addProps(ariaProps()..hidden = true)
+)();
+
+final customComponentUsage = (Custom()
+  ..aria.hidden = true
+  ..addProps(ariaProps()..hidden = false)
+)();
+''');
+    expect(await getAllErrors(source), isEmpty);
+  }
+
+  // ********************************************************
+  //  CustomProps
+  // ********************************************************
+
+  Future<void> test_dupeCustomProp() async {
+    final source = newSource('test.dart', /*language=dart*/ '''
+$customComponentDefinition
+
+final usage = (Custom()
+  ..dom.size = 0
+  ..size = 1
+  ..size = 2
+  ..size = 3
+  ..hidden = true
+  ..hidden = false
+)();
+''');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<Matcher>[
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..size# = 1"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..size# = 2"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..size# = 3"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..hidden# = true"), hasFix: true),
+          isAnErrorUnderTest(locatedAt: createSelection(source, "#..hidden# = false"), hasFix: true),
         ]));
   }
 }


### PR DESCRIPTION
This is a follow-up for feedback on #607.