### PR TITLE
Don't silently fail when there are Dart analysis errors, disable null safety in test contex

### DIFF
--- a/tools/analyzer_plugin/dart_test.yaml
+++ b/tools/analyzer_plugin/dart_test.yaml
@@ -1,0 +1,2 @@
+# Better async stack traces
+chain_stack_traces: true

--- a/tools/analyzer_plugin/lib/src/diagnostic/bad_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/bad_key.dart
@@ -154,7 +154,8 @@ class BadKeyDiagnostic extends ComponentUsageDiagnosticContributor {
 
     for (final type in keyTypesToProcess) {
       // Provide context if this type was derived from a Map/Iterable type argument.
-      getTypeContextString() => type == topLevelKeyType ? '' : ' (from $topLevelKeyType)';
+      getTypeContextString() =>
+          type == topLevelKeyType ? '' : ' (from ${topLevelKeyType.getDisplayString(withNullability: false)})';
 
       if (type.isDartCoreInt || type.isDartCoreDouble || type.isDartCoreString || type.isDartCoreSymbol) {
         // Ignore core types that have good `Object.toString` implementations values.

--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -232,9 +232,6 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
         errorType == PartDirectiveErrorType.missing ? memberMissingPartErrorMsg : memberInvalidPartErrorMsg;
     final memberPartDirectiveFixKind =
         errorType == PartDirectiveErrorType.missing ? missingGeneratedPartFixKind : invalidGeneratedPartFixKind;
-    final fixFn = errorType == PartDirectiveErrorType.missing
-        ? addOverReactGeneratedPartDirective as void Function(DartFileEditBuilder, CompilationUnit?, Uri)
-        : fixOverReactGeneratedPartDirective as void Function(DartFileEditBuilder, CompilationUnit?, Uri);
 
     return collector.addErrorWithFix(
       errorCode,
@@ -242,7 +239,11 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
       errorMessageArgs: ['$memberPartDirectiveErrorMsg to use OverReact component boilerplate.'],
       fixKind: memberPartDirectiveFixKind,
       computeFix: () => buildFileEdit(result, (builder) {
-        fixFn(builder, result.unit, result.uri);
+        if (errorType == PartDirectiveErrorType.missing) {
+          addOverReactGeneratedPartDirective(builder, result.unit!, result.lineInfo, result.uri);
+        } else {
+          fixOverReactGeneratedPartDirective(builder, result.unit!, result.uri);
+        }
       }),
     );
   }

--- a/tools/analyzer_plugin/test/integration/diagnostics/bad_key_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/bad_key_test.dart
@@ -2,11 +2,13 @@
 // ignore_for_file: camel_case_types
 import 'dart:async';
 
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/bad_key.dart';
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import '../test_bases/diagnostic_test_base.dart';
+import '../matchers.dart';
 
 void main() {
   defineReflectiveSuite(() {
@@ -64,7 +66,7 @@ class BadKeyDiagnosticTest_NoErrors extends BadKeyDiagnosticTest {
       ];
     ''');
 
-    expect(await getAllErrors(source, includeOtherCodes: true), isEmpty);
+    expect((await getAllErrors(source, includeOtherCodes: true)).allErrors, isEmpty);
   }
 
   Future<void> test_noErrorsEvenWithEdgeCases() async {
@@ -83,7 +85,14 @@ class BadKeyDiagnosticTest_NoErrors extends BadKeyDiagnosticTest {
       ];
     ''');
 
-    expect(await getAllErrors(source, includeOtherCodes: true), isEmpty);
+    expect(
+        (await getAllErrors(source, includeOtherCodes: true)).allErrors,
+        unorderedEquals(<dynamic>[
+          isA<AnalysisError>().havingCode('missing_identifier'),
+          isA<AnalysisError>().havingCode('missing_identifier'),
+          isA<AnalysisError>().havingCode('use_of_void_result'),
+        ]),
+        reason: 'should only have the Dart analysis errors we expect');
   }
 }
 

--- a/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
@@ -25,6 +25,9 @@ class DuplicatePropCascadeDiagnosticTest extends DiagnosticTestBase {
 
   Future<void> test_noError() async {
     final source = newSource('test.dart', /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
 part 'test.over_react.g.dart';
 
 mixin CustomProps on UiProps {
@@ -47,11 +50,13 @@ final customUsage = (Custom()
   ..hidden = false
 )();
 ''');
-    expect(await getAllErrors(source), isEmpty);
+    expect((await getAllErrors(source)).allErrors, isEmpty);
   }
 
   Future<void> test_error() async {
     final source = newSource('test.dart', /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
 final foo = (Dom.div()
   ..id = '1'
   ..dom.id = 'foo'
@@ -59,7 +64,7 @@ final foo = (Dom.div()
   ..aria.hidden = false
 )();
 ''');
-    final allErrors = await getAllErrors(source);
+    final allErrors = (await getAllErrors(source)).allErrors;
     expect(allErrors, hasLength(2));
 
     for (final selection in [createSelection(source, "#..id# = '1'"), createSelection(source, "#..dom.id# = 'foo'")]) {

--- a/tools/analyzer_plugin/test/integration/matchers.dart
+++ b/tools/analyzer_plugin/test/integration/matchers.dart
@@ -47,17 +47,19 @@ TypeMatcher<AnalysisError> isDiagnostic(DiagnosticCode diagnosticCode, {bool? ha
 /// Convenience methods that leverage [TypeMatcher.having] to make it easy to
 /// add expectations for properties specific to [AnalysisError].
 extension AnalysisErrorHavingUtils on TypeMatcher<AnalysisError> {
-  TypeMatcher<AnalysisError> havingCode(String code) => having((e) => e.code, 'code', code);
+  TypeMatcher<AnalysisError> havingCode(/*String|Matcher*/ dynamic code) => having((e) => e.code, 'code', code);
 
-  TypeMatcher<AnalysisError> havingCorrection(String? correction) =>
+  TypeMatcher<AnalysisError> havingCorrection(/*String?|Matcher*/ dynamic correction) =>
       having((e) => e.correction, 'correction', correction);
 
-  TypeMatcher<AnalysisError> havingLocation(Matcher matcher) => having((e) => e.location, 'location', matcher);
+  TypeMatcher<AnalysisError> havingLocation(/*Matcher|Matcher*/ dynamic matcher) =>
+      having((e) => e.location, 'location', matcher);
 
-  TypeMatcher<AnalysisError> havingSeverity(AnalysisErrorSeverity severity) =>
+  TypeMatcher<AnalysisError> havingSeverity(/*AnalysisErrorSeverity|Matcher*/ dynamic severity) =>
       having((e) => e.severity, 'severity', severity);
 
-  TypeMatcher<AnalysisError> havingType(AnalysisErrorType type) => having((e) => e.type, 'type', type);
+  TypeMatcher<AnalysisError> havingType(/*AnalysisErrorType|Matcher*/ dynamic type) =>
+      having((e) => e.type, 'type', type);
 
   TypeMatcher<AnalysisError> thatHasFix() => having((e) => e.hasFix, 'hasFix', isTrue);
 

--- a/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
@@ -129,6 +129,12 @@ abstract class ServerPluginContributorTestBase extends AnalysisDriverTestBase {
   /// Will fail the test if any unexpected plugin errors were sent on the plugin
   /// communication channel.
   void expectNoPluginErrors() {
+    if (_channel == null) {
+      throw ArgumentError(
+          '_channel was unexpectedly null, meaning setUp may have thrown an error that wasn\'t handled yet. '
+          'Try returning early from this function instead of throwing this error to show the real error.');
+    }
+
     final pluginErrors = _channel!.sentNotifications.where((n) => n.event == 'plugin.error');
     expect(pluginErrors, isEmpty,
         reason: 'Unexpected plugin error(s):\n${pluginErrors.map((e) => e.toJson()).join('\n')}');


### PR DESCRIPTION
## Motivation
Analysis errors originating from the analysis server and not the plugin were being silently ignored in tests.

This meant that it was easy to unknowingly create a bad test setup that didn't properly exercise diagnostics.

After fixing that, I also discovered that the test analysis context was opted into null safety, which we don't want since over_react is not yet null safe.

## Changes
- By default, throw if there are analysis errors not coming from the plugin
- Return a new object that separates errors from the plugin from other errors
- Disable null safety in the test analysis context
- Fix tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
