### PR TITLE
[Analyzer Plugin] Don't compute disabled diagnostics

### DIFF
--- a/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
+++ b/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
@@ -204,6 +204,14 @@ class _DiagnosticGenerator {
     List<FluentComponentUsage> getUsages() => _usages ??= getAllComponentUsages(unitResult.unit!);
 
     for (final contributor in contributors) {
+      final isEveryCodeDisabled = contributor.codes.every(
+        (e) => _errorSeverityProvider.isCodeDisabled(e.name),
+      );
+      if (isEveryCodeDisabled) {
+        // Don't compute errors if all of the codes provided by the contributor are disabled
+        continue;
+      }
+
       try {
         if (contributor is ComponentUsageDiagnosticContributor) {
           await contributor.computeErrorsForUsages(unitResult, collector, getUsages());

--- a/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/arrow_function_prop.dart
@@ -45,6 +45,9 @@ class ArrowFunctionPropCascadeDiagnostic extends ComponentUsageDiagnosticContrib
     correction: 'Try wrapping the arrow functions in parentheses or using a block function.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Wrap arrow function in parentheses');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/bad_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/bad_key.dart
@@ -104,6 +104,9 @@ class BadKeyDiagnostic extends ComponentUsageDiagnosticContributor {
   );
 
   @override
+  List<DiagnosticCode> get codes => [hashCodeCode, toStringCode, dynamicOrObjectCode, lowQualityCode];
+
+  @override
   computeErrorsForUsage(result, collector, usage) async {
     for (final prop in usage.cascadedProps) {
       if (prop.name.name != 'key') continue;

--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -52,6 +52,9 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
   static const debugCode =
       DiagnosticCode('over_react_boilerplate_debug', '{0}', AnalysisErrorSeverity.INFO, AnalysisErrorType.HINT);
 
+  @override
+  List<DiagnosticCode> get codes => [errorCode, warningCode, debugCode];
+
   static final missingGeneratedPartFixKind = FixKind(errorCode.name, 200, 'Add generated part directive');
   static final invalidGeneratedPartFixKind = FixKind(errorCode.name, 200, 'Fix generated part directive');
   static final unnecessaryGeneratedPartFixKind = FixKind(errorCode.name, 200, 'Remove generated part directive');

--- a/tools/analyzer_plugin/lib/src/diagnostic/bool_prop_name_readability.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/bool_prop_name_readability.dart
@@ -39,6 +39,9 @@ class BoolPropNameReadabilityDiagnostic extends DiagnosticContributor {
   );
 
   @override
+  List<DiagnosticCode> get codes => [code];
+
+  @override
   computeErrors(result, collector) async {
     final typeProvider = result.libraryElement.typeProvider;
     final visitor = PropsVisitor();

--- a/tools/analyzer_plugin/lib/src/diagnostic/callback_ref.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/callback_ref.dart
@@ -61,6 +61,9 @@ class CallbackRefDiagnostic extends ComponentUsageDiagnosticContributor {
     correction: 'Use the return value of createRef() as the ref field value instead.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Convert to createRef()');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/consumed_props_return_value.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/consumed_props_return_value.dart
@@ -56,6 +56,9 @@ class ConsumedPropsReturnValueDiagnostic extends DiagnosticContributor {
     correction: 'Use propsMeta.forMixins(...) instead.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(
     code.name,
     200,

--- a/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/dom_prop_types.dart
@@ -35,6 +35,9 @@ class InvalidDomAttributeDiagnostic extends ComponentUsageDiagnosticContributor 
   );
 
   @override
+  List<DiagnosticCode> get codes => [code];
+
+  @override
   computeErrorsForUsage(result, collector, usage) async {
     // todo support SVG icons
     // Don't support SVG icons since we only have HTML element metadata.

--- a/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/duplicate_prop_cascade.dart
@@ -22,6 +22,9 @@ class DuplicatePropCascadeDiagnostic extends ComponentUsageDiagnosticContributor
       AnalysisErrorSeverity.WARNING,
       AnalysisErrorType.STATIC_TYPE_WARNING);
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Remove duplicate prop keys / values');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/forward_only_dom_props_to_dom_builders.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/forward_only_dom_props_to_dom_builders.dart
@@ -48,6 +48,9 @@ class ForwardOnlyDomPropsToDomBuildersDiagnostic extends ComponentUsageDiagnosti
     correction: 'Use addUnconsumedDomProps instead of addUnconsumedProps.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Use addUnconsumedDomProps');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/hooks_exhaustive_deps.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/hooks_exhaustive_deps.dart
@@ -44,6 +44,9 @@ class HooksExhaustiveDeps extends DiagnosticContributor {
     url: 'https://reactjs.org/docs/hooks-rules.html',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, "{0}");
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/incorrect_doc_comment_location.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/incorrect_doc_comment_location.dart
@@ -93,6 +93,9 @@ class IncorrectDocCommentLocationDiagnostic extends DiagnosticContributor {
         'Place documentation comments above the UiFactory instead so that consumers can see them when consuming them.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(
     code.name,
     200,

--- a/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
@@ -62,6 +62,9 @@ class InvalidChildDiagnostic extends ComponentUsageDiagnosticContributor {
   );
 
   @override
+  List<DiagnosticCode> get codes => [code];
+
+  @override
   computeErrorsForUsage(result, collector, usage) async {
     for (final argument in usage.node.argumentList.arguments) {
       await validateReactChildType(argument.staticType, result.typeSystem, result.typeProvider,

--- a/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/iterator_key.dart
@@ -74,6 +74,9 @@ class IteratorKey extends ComponentUsageDiagnosticContributor {
         " or passing children as arguments as opposed to wrapping them in a list literal.",
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final listLiteralFixKind = convertUsageListLiteralToVariadicChildrenFixKind(code);
   static final mappedIterableFixKind = FixKind(code.name, 200, 'Add a key');
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/link_target_without_rel.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/link_target_without_rel.dart
@@ -53,6 +53,9 @@ class LinkTargetUsageWithoutRelDiagnostic extends ComponentUsageDiagnosticContri
     correction: 'Always add rel="noopener noreferrer" when using a target for a link.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Add rel="noopener noreferrer"');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_cascade_parens.dart
@@ -52,6 +52,9 @@ class MissingCascadeParensDiagnostic extends DiagnosticContributor {
     correction: "Try adding parentheses around the cascaded props",
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   // Make smaller (higher priority) than
   // REMOVE_PARENTHESIS_IN_GETTER_INVOCATION
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
@@ -57,6 +57,9 @@ class MissingRequiredPropDiagnostic extends ComponentUsageDiagnosticContributor 
     AnalysisErrorType.STATIC_WARNING,
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Add required prop \'{0}\'');
 
   ClassElement? _cachedAccessorClass;

--- a/tools/analyzer_plugin/lib/src/diagnostic/non_defaulted_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/non_defaulted_prop.dart
@@ -68,6 +68,9 @@ class NonDefaultedPropDiagnostic extends DiagnosticContributor {
     AnalysisErrorType.STATIC_WARNING,
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 400, "Use local variable '{0}' with default value");
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/proptypes_return_value.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/proptypes_return_value.dart
@@ -65,6 +65,9 @@ class PropTypesReturnValueDiagnostic extends DiagnosticContributor {
     correction: 'Return the error instead of throwing it.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Return the error');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/pseudo_static_lifecycle.dart
@@ -53,6 +53,9 @@ class PseudoStaticLifecycleDiagnostic extends DiagnosticContributor {
   );
 
   @override
+  List<DiagnosticCode> get codes => [code];
+
+  @override
   computeErrors(result, collector) async {
     // This is the return type even if it's not explicitly declared.
     final visitor = LifecycleMethodVisitor();

--- a/tools/analyzer_plugin/lib/src/diagnostic/render_return_value.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/render_return_value.dart
@@ -111,6 +111,9 @@ class RenderReturnValueDiagnostic extends DiagnosticContributor {
     correction: 'Return null instead.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [invalidTypeErrorCode, preferNullOverFalseErrorCode];
+
   static final falseToNull = FixKind(preferNullOverFalseErrorCode.name, 200, 'Return null instead');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/rules_of_hooks.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/rules_of_hooks.dart
@@ -24,6 +24,9 @@ class RulesOfHooks extends DiagnosticContributor {
   );
 
   @override
+  List<DiagnosticCode> get codes => [code];
+
+  @override
   Future<void> computeErrors(result, collector) async {
     for (final hook in getAllHookUsages(result.unit!)) {
       const sameOrderMessage = "React Hooks must be called in the exact same order in every component render.";

--- a/tools/analyzer_plugin/lib/src/diagnostic/string_ref.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/string_ref.dart
@@ -80,6 +80,9 @@ class StringRefDiagnostic extends ComponentUsageDiagnosticContributor {
     correction: 'Try using createRef() or a callback ref instead.',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Convert to createRef()');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/style_value_diagnostic.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/style_value_diagnostic.dart
@@ -64,6 +64,9 @@ class StyleValueDiagnostic extends ComponentUsageDiagnosticContributor {
   static final propertyFixKind = FixKind(propertyCode.name, 200, "Use camelCase property name: '{0}'");
 
   @override
+  List<DiagnosticCode> get codes => [code, propertyCode];
+
+  @override
   computeErrorsForUsage(result, collector, usage) async {
     // Collect these then iterate later to make keeping things async simpler
     final styleEntries = <MapLiteralEntry>[];

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children.dart
@@ -44,6 +44,9 @@ class VariadicChildrenDiagnostic extends ComponentUsageDiagnosticContributor {
     AnalysisErrorType.LINT,
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = convertUsageListLiteralToVariadicChildrenFixKind(code);
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic/variadic_children_with_keys.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/variadic_children_with_keys.dart
@@ -65,6 +65,9 @@ class VariadicChildrenWithKeys extends ComponentUsageDiagnosticContributor {
     url: 'https://reactjs.org/docs/lists-and-keys.html',
   );
 
+  @override
+  List<DiagnosticCode> get codes => [code];
+
   static final fixKind = FixKind(code.name, 200, 'Remove unnecessary key');
 
   @override

--- a/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic_contributor.dart
@@ -97,6 +97,9 @@ class DiagnosticCode {
 ///
 /// Clients may implement this class when implementing plugins.
 abstract class DiagnosticContributor {
+  /// List of all possible [DiagnosticCode]s that this contributor could compute as errors.
+  List<DiagnosticCode> get codes;
+
   /// Contribute errors for the location in the file specified by the given
   /// [result] into the given [collector].
   Future<void> computeErrors(ResolvedUnitResult result, DiagnosticCollector collector);

--- a/tools/analyzer_plugin/test/integration/diagnostics/analysis_options_configuration_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/analysis_options_configuration_test.dart
@@ -72,6 +72,20 @@ void main() {
       expect(errors, hasLength(1));
       expect(errors.first.code, equals('over_react_hash_code_as_key'));
     });
+
+    test('configured with fully disabled diagnostic contributor', () async {
+      await setUp(yamlContents: yamlFullyDisabledContributor);
+      final errors = await computeErrors(sourceCode: badKeysSourceCode);
+      expect(errors, isEmpty);
+    });
+
+    test('configured with fully enabled diagnostic contributor', () async {
+      await setUp(yamlContents: yamlFullyEnabledContributor);
+      final errors = await computeErrors(sourceCode: badKeysSourceCode);
+      expect(errors, hasLength(2));
+      expect(errors, contains(predicate<AnalysisError>((e) => e.code == 'over_react_hash_code_as_key')));
+      expect(errors, contains(predicate<AnalysisError>((e) => e.code == 'over_react_low_quality_key')));
+    });
   });
 }
 
@@ -150,3 +164,24 @@ over_react:
   errors:
     over_react_hash_code_as_key: error
     over_react_low_quality_key: ignore''';
+
+const yamlFullyEnabledContributor = /*language=yaml*/ '''analyzer:
+  plugins:
+    over_react
+
+over_react:
+  errors:
+    over_react_hash_code_as_key: error
+    over_react_low_quality_key: error''';
+
+
+const yamlFullyDisabledContributor = /*language=yaml*/ '''analyzer:
+  plugins:
+    over_react
+
+over_react:
+  errors:
+    over_react_hash_code_as_key: ignore
+    over_react_low_quality_key: ignore
+    over_react_object_to_string_as_key: ignore
+    over_react_unknown_key_type: ignore''';

--- a/tools/analyzer_plugin/test/integration/diagnostics/analysis_options_configuration_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/analysis_options_configuration_test.dart
@@ -79,7 +79,7 @@ const sourceCode = /*language=dart*/ '''
 part 'test.over_react.g.dart';
 ''';
 
-const yamlError = '''analyzer:
+const yamlError = /*language=yaml*/ '''analyzer:
   plugins:
     over_react
 
@@ -87,7 +87,7 @@ over_react:
   errors:
     over_react_boilerplate_error: error''';
 
-const yamlWarn = '''analyzer:
+const yamlWarn = /*language=yaml*/ '''analyzer:
   plugins:
     over_react
 
@@ -95,7 +95,7 @@ over_react:
   errors:
     over_react_boilerplate_error: warning''';
 
-const yamlInfo = '''analyzer:
+const yamlInfo = /*language=yaml*/ '''analyzer:
   plugins:
     over_react
 
@@ -103,7 +103,7 @@ over_react:
   errors:
     over_react_boilerplate_error: info''';
 
-const yamlIgnore = '''analyzer:
+const yamlIgnore = /*language=yaml*/ '''analyzer:
   plugins:
     over_react
 
@@ -111,7 +111,7 @@ over_react:
   errors:
     over_react_boilerplate_error: ignore''';
 
-const yamlNotConfigured = '''analyzer:
+const yamlNotConfigured = /*language=yaml*/ '''analyzer:
   plugins:
     over_react
 

--- a/tools/analyzer_plugin/test/unit/analysis_options/parse_test.dart
+++ b/tools/analyzer_plugin/test/unit/analysis_options/parse_test.dart
@@ -60,7 +60,7 @@ over_react:
     over_react_unnecessary_key: info
     over_react_pseudo_static_lifecycle: ignore''';
 
-const pluginNotConfiguredYaml = '''include: package:workiva_analysis_options/v1.recommended.yaml
+const pluginNotConfiguredYaml = /*language=yaml*/ '''include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
   plugins:
@@ -68,7 +68,7 @@ analyzer:
   errors:
     missing_required_param: warning''';
 
-const noErrorSectionYaml = '''include: package:workiva_analysis_options/v1.recommended.yaml
+const noErrorSectionYaml = /*language=yaml*/ '''include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
   plugins:
@@ -81,7 +81,7 @@ over_react:
     over_react_boilerplate_error: error
     over_react_pseudo_static_lifecycle: ignore''';
 
-const invalidSeverityLevelYaml = '''include: package:workiva_analysis_options/v1.recommended.yaml
+const invalidSeverityLevelYaml = /*language=yaml*/ '''include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
   plugins:
@@ -95,7 +95,7 @@ over_react:
     over_react_incorrect_doc_comment_location: critical
     over_react_pseudo_static_lifecycle: ignore''';
 
-const emptyErrorListYaml = '''include: package:workiva_analysis_options/v1.recommended.yaml
+const emptyErrorListYaml = /*language=yaml*/ '''include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
   plugins:


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

Right now when you disable a diagnostic, we still compute the errors for that diagnostic even though the will eventually get filtered out.

## Changes
  <!-- What this PR changes to fix the problem. -->
Make it so that when all the diagnostics for a diagnostic contributor have been turned off, skip computing errors for that diagnostic.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
         - [ ] Turn some diagnostics off and others on. Make sure only the diagnostics that are turned off are ignored.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
