### PR TITLE
[Analyzer Plugin] Add function component support + tests for add ref assist / callback ref diagnostic

### DIFF
--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -173,11 +173,10 @@ VariableElement? _getRefCallbackAssignedField(Expression refPropRhs) {
     if (parent is AssignmentExpression && parent.rightHandSide == reference) {
       final lhs = parent.leftHandSide;
       if (lhs is Identifier) {
-        if (lhs.staticElement is VariableElement) {
-          return lhs.staticElement as VariableElement;
-        }
-
-        return lhs.staticElement.tryCast<PropertyAccessorElement>()?.variable;
+        final varInFnComponent = lhs.staticElement?.tryCast<VariableElement>();
+        final varInClassComponent =
+            lhs.parent?.tryCast<AssignmentExpression>()?.writeElement?.tryCast<PropertyAccessorElement>()?.variable;
+        return varInFnComponent ?? varInClassComponent;
       }
     }
   }

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -48,9 +48,6 @@ void addUseOrCreateRef(
   RefTypeToReplace? refTypeToReplace;
   Expression? callbackRefPropRhs;
 
-  // final enclosingClassOrMixin = usage.node.thisOrAncestorOfType<ClassOrMixinDeclaration>();
-  // final enclosingFnExpression = usage.node.thisOrAncestorOfType<FunctionExp
-
   final refTypeName = usage.isDom
       ? 'Element'
       : 'dynamic';

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -27,6 +27,8 @@ typedef CreateRefLinkedEditFn = void Function(
 
 /// Utility function shared between diagnostics and assists to add a field to a
 /// component assigned to the return value of a `createRef()` call.
+///
+/// > Note: This currently cannot handle callback refs that are tear-offs.
 void addUseOrCreateRef(
   DartFileEditBuilder builder,
   FluentComponentUsage usage,
@@ -47,9 +49,7 @@ void addUseOrCreateRef(
   RefTypeToReplace? refTypeToReplace;
   Expression? callbackRefPropRhs;
 
-  final refTypeName = usage.isDom
-      ? 'Element'
-      : 'dynamic';
+  final refTypeName = usage.isDom ? 'Element' : 'dynamic';
 
   final refProp = usage.cascadedProps.firstWhereOrNull((prop) => prop.name.name == 'ref');
   if (refProp != null) {

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -37,7 +37,7 @@ void addUseOrCreateRef(
   const nameGroup = 'refName';
   const typeGroup = 'refType';
 
-  final isFnComponentUsage = getClosestFunctionComponent(usage.node) != null;
+  final isUsageInFnComponent = getClosestFunctionComponent(usage.node) != null;
   final lineInfo = result.lineInfo;
   String? oldStringRefSource;
   final componentName = usage.domNodeName ?? usage.componentName;
@@ -82,7 +82,7 @@ void addUseOrCreateRef(
   void _addCreateRefFieldDeclaration(DartEditBuilder _builder) {
     _builder.write('final ');
     _builder.addSimpleLinkedEdit(nameGroup, createRefFieldName);
-    _builder.write(isFnComponentUsage ? ' = useRef<' : ' = createRef<');
+    _builder.write(isUsageInFnComponent ? ' = useRef<' : ' = createRef<');
     _builder.addSimpleLinkedEdit(typeGroup, refTypeName);
     _builder.write('>()');
     if (fromAssist) {

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -31,7 +31,6 @@ void addUseOrCreateRef(
   DartFileEditBuilder builder,
   FluentComponentUsage usage,
   ResolvedUnitResult result, {
-  bool fromAssist = false,
   AnalyzerDebugHelper? debug,
 }) {
   const nameGroup = 'refName';

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref_assist.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref_assist.dart
@@ -45,7 +45,7 @@ class AddUseOrCreateRefAssistContributor extends AssistContributorBase {
 
     final changeBuilder = ChangeBuilder(session: request.result.session);
     await changeBuilder.addDartFileEdit(request.result.path!, (builder) {
-      return ref_util.addUseOrCreateRef(builder, usage, request.result, fromAssist: true);
+      return ref_util.addUseOrCreateRef(builder, usage, request.result);
     });
 
     final sourceChange = changeBuilder.sourceChange

--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref_assist.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref_assist.dart
@@ -4,24 +4,25 @@ import 'package:analyzer_plugin/utilities/change_builder/change_builder_core.dar
 import 'package:over_react_analyzer_plugin/src/assist/contributor_base.dart';
 import 'package:over_react_analyzer_plugin/src/component_usage.dart';
 
-import 'add_create_ref.dart' as create_ref_util;
+import 'add_create_ref.dart' as ref_util;
 
 const _desc = r'Add a React ref to the currently selected component builder.';
 // <editor-fold desc="Documentation Details">
 const _details = r'''
 
 When an over_react component builder is selected by the user, the assist adds a `ref` prop value
-on the builder, set equal to a field that is added within the class instance, assigned to the return
-value of a call to `createRef()`. 
+on the builder, set equal to a variable that is added within the component definition, assigned to the return
+value of a call to `createRef()` for class-based components, or the return value of a call to `useRef()` for function components. 
 
 ''';
 // </editor-fold>
 
-/// An assist that adds a `ref` prop value to a component builder and assigns it to a field that is
-/// added to a component class that gets assigned to the return value of a `createRef()` call.
+/// An assist that adds a `ref` prop value to a component builder and assigns it to a variable that is
+/// added to a component class or function component body that gets assigned to the return value
+/// of a `useRef()` / `createRef()` call.
 ///
-/// > See: [create_ref_util.addCreateRef]
-class AddCreateRefAssistContributor extends AssistContributorBase {
+/// > See: [ref_util.addUseOrCreateRef]
+class AddUseOrCreateRefAssistContributor extends AssistContributorBase {
   @DocsMeta(_desc, details: _details)
   static const addRef = AssistKind('addRef', 32, 'Add ref');
 
@@ -30,10 +31,10 @@ class AddCreateRefAssistContributor extends AssistContributorBase {
     await super.computeAssists(request, collector);
     if (!setupCompute()) return;
 
-    await _addCreateRef();
+    await _addUseOrCreateRef();
   }
 
-  Future<void> _addCreateRef() async {
+  Future<void> _addUseOrCreateRef() async {
     final usage = identifyUsage(node);
 
     if (usage == null) return;
@@ -44,7 +45,7 @@ class AddCreateRefAssistContributor extends AssistContributorBase {
 
     final changeBuilder = ChangeBuilder(session: request.result.session);
     await changeBuilder.addDartFileEdit(request.result.path!, (builder) {
-      return create_ref_util.addCreateRef(builder, usage, request.result);
+      return ref_util.addUseOrCreateRef(builder, usage, request.result, fromAssist: true);
     });
 
     final sourceChange = changeBuilder.sourceChange

--- a/tools/analyzer_plugin/lib/src/diagnostic/callback_ref.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/callback_ref.dart
@@ -1,6 +1,6 @@
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 
-import 'package:over_react_analyzer_plugin/src/assist/refs/add_create_ref.dart' show addCreateRef;
+import 'package:over_react_analyzer_plugin/src/assist/refs/add_create_ref.dart' show addUseOrCreateRef;
 import 'string_ref.dart';
 
 const _desc = r'Avoid using callback refs to assign ref field values.';
@@ -50,18 +50,18 @@ class NavItemWrapperComponent extends UiComponent<NavItemWrapperProps> {
 
 /// A diagnostic that warns the user about callback ref usage.
 ///
-/// > See: [addCreateRef], [StringRefDiagnostic]
+/// > See: [addUseOrCreateRef], [StringRefDiagnostic]
 class CallbackRefDiagnostic extends ComponentUsageDiagnosticContributor {
   @DocsMeta(_desc, details: _details)
   static const code = DiagnosticCode(
-    'over_react_prefer_create_ref',
+    'over_react_prefer_use_or_create_ref',
     _desc,
     AnalysisErrorSeverity.INFO,
     AnalysisErrorType.HINT,
-    correction: 'Use the return value of createRef() as the ref field value instead.',
+    correction: 'Use the return value of useRef() / createRef() as the ref field value instead.',
   );
 
-  static final fixKind = FixKind(code.name, 200, 'Convert to createRef()');
+  static final fixKind = FixKind(code.name, 200, 'Convert to useRef() / createRef()');
 
   @override
   computeErrorsForUsage(result, collector, usage) async {
@@ -74,7 +74,7 @@ class CallbackRefDiagnostic extends ComponentUsageDiagnosticContributor {
             result.locationFor(prop.rightHandSide),
             fixKind: fixKind,
             computeFix: () => buildFileEdit(result, (builder) {
-              addCreateRef(builder, usage, result);
+              addUseOrCreateRef(builder, usage, result);
             }),
           );
         }

--- a/tools/analyzer_plugin/lib/src/diagnostic/hooks_exhaustive_deps.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/hooks_exhaustive_deps.dart
@@ -146,17 +146,6 @@ class _RefInEffectCleanup {
       });
 }
 
-VariableDeclaration lookUpVariable(Element element, AstNode root) {
-  // if (element is ExecutableElement) return null;
-
-  final node = NodeLocator2(element.nameOffset).searchWithin(root);
-  if (node is Identifier && node.staticElement == element) {
-    return node.parent.tryCast<VariableDeclaration>();
-  }
-
-  return null;
-}
-
 FunctionExpression lookUpFunction(Element element, AstNode root) {
   final node = NodeLocator2(element.nameOffset).searchWithin(root);
   if (node is Identifier && node.staticElement == element) {

--- a/tools/analyzer_plugin/lib/src/diagnostic/string_ref.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/string_ref.dart
@@ -1,6 +1,6 @@
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 
-import 'package:over_react_analyzer_plugin/src/assist/refs/add_create_ref.dart' show addCreateRef;
+import 'package:over_react_analyzer_plugin/src/assist/refs/add_create_ref.dart' show addUseOrCreateRef;
 import 'callback_ref.dart';
 
 const _desc = r'Avoid using deprecated string refs.';
@@ -69,7 +69,7 @@ class NavItemWrapperComponent extends UiComponent<NavItemWrapperProps> {
 
 /// A diagnostic that warns the user about String ref usage.
 ///
-/// > See: [addCreateRef], [CallbackRefDiagnostic]
+/// > See: [addUseOrCreateRef], [CallbackRefDiagnostic]
 class StringRefDiagnostic extends ComponentUsageDiagnosticContributor {
   @DocsMeta(_desc, details: _details)
   static const code = DiagnosticCode(
@@ -91,7 +91,7 @@ class StringRefDiagnostic extends ComponentUsageDiagnosticContributor {
           result.locationFor(prop.rightHandSide),
           fixKind: fixKind,
           computeFix: () => buildFileEdit(result, (builder) {
-            addCreateRef(builder, usage, result);
+            addUseOrCreateRef(builder, usage, result);
           }),
         );
       }

--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -94,7 +94,7 @@ abstract class OverReactAnalyzerPluginBase extends ServerPlugin
   @override
   List<AsyncAssistContributor> getAssistContributors(String path) => [
         AddPropsAssistContributor(),
-        AddCreateRefAssistContributor(),
+        AddUseOrCreateRefAssistContributor(),
         ExtractComponentAssistContributor(),
         ExtractStatefulComponentAssistContributor(),
         ToggleComponentStatefulness(),

--- a/tools/analyzer_plugin/lib/src/util/ast_util.dart
+++ b/tools/analyzer_plugin/lib/src/util/ast_util.dart
@@ -7,11 +7,26 @@ import 'dart:mirrors';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:analyzer/source/line_info.dart';
 
+import 'analyzer_util.dart';
 import 'constant_evaluator.dart';
 import 'util.dart';
+
+/// Returns an AST associated with the [element] by searching within [root],
+/// or null is returned if the [element] is not found.
+VariableDeclaration? lookUpVariable(Element? element, AstNode? root) {
+  if (element == null || root == null) return null;
+
+  final node = NodeLocator2(element.nameOffset).searchWithin(root);
+  if (node is Identifier && node.staticElement == element) {
+    return node.parent.tryCast<VariableDeclaration>();
+  }
+
+  return null;
+}
 
 /// Returns a String value when a literal or constant var/identifier is found within [expr].
 String? getConstOrLiteralStringValueFrom(Expression expr) {

--- a/tools/analyzer_plugin/playground/web/refs_fn_components.dart
+++ b/tools/analyzer_plugin/playground/web/refs_fn_components.dart
@@ -13,6 +13,11 @@ final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
     ChildComponent _someCustomRefName;
     ChildComponent _anotherCustomRefName;
+    ChildComponent _customRefAssignedInTearoff;
+
+    void _tearOffRefAssignment(ChildComponent ref) {
+      _customRefAssignedInTearoff = ref;
+    }
 
     void foo() {
       _someCustomRefName.someMethodName();
@@ -22,15 +27,25 @@ final UsesCallbackRef = uiFunction<UiProps>(
       _anotherCustomRefName.someMethodName();
       _anotherCustomRefName?.anotherMethodName();
       final baz = _anotherCustomRefName.someGetter;
+
+      _customRefAssignedInTearoff.someMethodName();
+      _customRefAssignedInTearoff?.anotherMethodName();
+      final biz = _customRefAssignedInTearoff.someGetter;
     }
 
     return Fragment()(
       (Child()
-        ..ref = _someCustomRefName)(props.children),
+        ..ref = (ref) {
+          _someCustomRefName = ref;
+        })(props.children),
       (Child()
         ..id = 'bar'
         ..ref = ((ref) => _anotherCustomRefName = ref)
       )('hi'),
+      (Child()
+        ..id = 'biz'
+        ..ref = _tearOffRefAssignment
+      )('yo'),
       (Child())('there'),
     );
   },

--- a/tools/analyzer_plugin/playground/web/refs_fn_components.dart
+++ b/tools/analyzer_plugin/playground/web/refs_fn_components.dart
@@ -1,0 +1,38 @@
+import 'package:over_react/over_react.dart';
+
+import 'refs.dart';
+
+final HasNoRefs = uiFunction<UiProps>(
+  (props) {
+    return Child()(props.children);
+  },
+  UiFactoryConfig(displayName: 'HasNoRefs'),
+);
+
+final UsesCallbackRef = uiFunction<UiProps>(
+  (props) {
+    ChildComponent _someCustomRefName;
+    ChildComponent _anotherCustomRefName;
+
+    void foo() {
+      _someCustomRefName.someMethodName();
+      _someCustomRefName?.anotherMethodName();
+      final bar = _someCustomRefName.someGetter;
+
+      _anotherCustomRefName.someMethodName();
+      _anotherCustomRefName?.anotherMethodName();
+      final baz = _anotherCustomRefName.someGetter;
+    }
+
+    return Fragment()(
+      (Child()
+        ..ref = _someCustomRefName)(props.children),
+      (Child()
+        ..id = 'bar'
+        ..ref = ((ref) => _anotherCustomRefName = ref)
+      )('hi'),
+      (Child())('there'),
+    );
+  },
+  UiFactoryConfig(displayName: 'UsesCallbackRef'),
+);

--- a/tools/analyzer_plugin/test/integration/assists/add_create_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/add_create_ref_test.dart
@@ -1,0 +1,76 @@
+// Disable null-safety in the plugin entrypoint until all dependencies are null-safe,
+// otherwise tests won't be able to run. See: https://github.com/dart-lang/test#compiler-flags
+// @dart=2.9
+import 'dart:async';
+
+import 'package:analyzer_plugin/utilities/assist/assist.dart';
+import 'package:meta/meta.dart';
+import 'package:over_react_analyzer_plugin/src/assist/refs/add_create_ref_assist.dart';
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../test_bases/assist_test_base.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AddUseOrCreateRefAssistTest);
+  });
+}
+
+@reflectiveTest
+class AddUseOrCreateRefAssistTest extends AssistTestBase {
+  @override
+  AssistKind get assistKindUnderTest => AddUseOrCreateRefAssistContributor.addRef;
+
+  String usageSourceWithinClassComponent({@required bool fixed}) => '''
+import 'package:over_react/over_react.dart';
+
+part 'refs.over_react.g.dart';
+
+UiFactory<HasNoRefsProps> HasNoRefs = castUiFactory(_\$HasNoRefs); // ignore: undefined_identifier
+
+mixin HasNoRefsProps on UiProps {}
+
+class HasNoRefsComponent extends UiComponent2<HasNoRefsProps> {
+  ${fixed ? 'final _childRef = createRef<dynamic>();\n\n  ' : ''}
+  @override
+  render() {
+    return ${fixed ? '(Child()..ref = _childRef)' : 'Child()'}(props.children);
+  }
+}
+''';
+
+  String usageSourceWithinFnComponent({@required bool fixed}) => '''
+import 'package:over_react/over_react.dart';
+
+final HasNoRefs = uiFunction<UiProps>(
+  (props) {
+    ${fixed ? 'final _childRef = useRef<dynamic>();\n\n    ' : ''}
+    return ${fixed ? '(Child()..ref = _childRef)' : 'Child()'}(props.children);
+  },
+  UiFactoryConfig(displayName: 'HasNoRefs'),
+);
+''';
+
+  Future<void> test_noAssist() async {
+    final source = newSource('test.dart', 'var foo = true;');
+    final selection = createSelection(source, '#var foo = true;#');
+    await expectNoAssist(selection);
+  }
+
+  Future<void> test_classComponentAssist() async {
+    var source = newSource('test.dart', usageSourceWithinClassComponent(fixed: false));
+    var selection = createSelection(source, 'return #Child#()');
+    final change = await expectAndGetSingleAssist(selection);
+    source = applySourceChange(change, source);
+    expect(source.contents.data, usageSourceWithinClassComponent(fixed: true));
+  }
+
+  Future<void> test_fnComponentAssist() async {
+    var source = newSource('test.dart', usageSourceWithinFnComponent(fixed: false));
+    var selection = createSelection(source, 'return #Child#()');
+    final change = await expectAndGetSingleAssist(selection);
+    source = applySourceChange(change, source);
+    expect(source.contents.data, usageSourceWithinFnComponent(fixed: true));
+  }
+}

--- a/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
@@ -1,0 +1,281 @@
+// Disable null-safety in the plugin entrypoint until all dependencies are null-safe,
+// otherwise tests won't be able to run. See: https://github.com/dart-lang/test#compiler-flags
+// @dart=2.9
+import 'dart:async';
+
+import 'package:over_react_analyzer_plugin/src/diagnostic/callback_ref.dart';
+import 'package:test/test.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../test_bases/diagnostic_test_base.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(CallbackRefDiagnosticFnComponentTest);
+  });
+}
+
+abstract class CallbackRefDiagnosticTest extends DiagnosticTestBase {
+  @override
+  get errorUnderTest => CallbackRefDiagnostic.code;
+
+  @override
+  get fixKindUnderTest => CallbackRefDiagnostic.fixKind;
+
+  static const refVarDeclarations = '''
+    ChildComponent _someCustomRefName;
+    ChildComponent _anotherCustomRefName;''';
+
+  static const refVarDeclarationsFixedSome = '''
+    final _someCustomRefName = useRef<dynamic>();
+    ChildComponent _anotherCustomRefName;''';
+
+  static const refVarDeclarationsFixedTheRest = '''
+    final _someCustomRefName = useRef<dynamic>();
+    final _anotherCustomRefName = useRef<dynamic>();''';
+
+  static const refUsage = '''
+    void foo() {
+      _someCustomRefName.someMethodName();
+      _someCustomRefName?.anotherMethodName();
+      final bar = _someCustomRefName.someGetter;
+
+      _anotherCustomRefName.someMethodName();
+      _anotherCustomRefName?.anotherMethodName();
+      final baz = _anotherCustomRefName.someGetter;
+    }''';
+
+  static const refUsageFixedSome = '''
+    void foo() {
+      _someCustomRefName.current.someMethodName();
+      _someCustomRefName.current?.anotherMethodName();
+      final bar = _someCustomRefName.current.someGetter;
+
+      _anotherCustomRefName.someMethodName();
+      _anotherCustomRefName?.anotherMethodName();
+      final baz = _anotherCustomRefName.someGetter;
+    }''';
+
+  static const refUsageFixedTheRest = '''
+    void foo() {
+      _someCustomRefName.current.someMethodName();
+      _someCustomRefName.current?.anotherMethodName();
+      final bar = _someCustomRefName.current.someGetter;
+
+      _anotherCustomRefName.current.someMethodName();
+      _anotherCustomRefName.current?.anotherMethodName();
+      final baz = _anotherCustomRefName.current.someGetter;
+    }''';
+
+  static const renderReturn = '''
+    return Fragment()(
+      (Child()
+        ..ref = (ref) {
+          _someCustomRefName = ref;
+        })(props.children),
+      (Child()
+        ..id = 'bar'
+        ..ref = ((ref) => _anotherCustomRefName = ref)
+      )('hi'),
+      (Child())('there'),
+    );
+  ''';
+
+  static const renderReturnFixedSome = '''
+    return Fragment()(
+      (Child()
+        ..ref = _someCustomRefName)(props.children),
+      (Child()
+        ..id = 'bar'
+        ..ref = ((ref) => _anotherCustomRefName = ref)
+      )('hi'),
+      (Child())('there'),
+    );
+  ''';
+
+  static const renderReturnFixedTheRest = '''
+    return Fragment()(
+      (Child()
+        ..ref = _someCustomRefName)(props.children),
+      (Child()
+        ..id = 'bar'
+        ..ref = _anotherCustomRefName
+      )('hi'),
+      (Child())('there'),
+    );
+  ''';
+
+  static const selectionToFixSome = '''#(ref) {
+          _someCustomRefName = ref;
+        }#''';
+
+  static const selectionToFixAnother = '''#((ref) => _anotherCustomRefName = ref)#''';
+}
+
+@reflectiveTest
+class CallbackRefDiagnosticFnComponentTest extends CallbackRefDiagnosticTest {
+  static const usageSourceWithinFnComponent = '''
+import 'package:over_react/over_react.dart';
+
+final UsesCallbackRef = uiFunction<UiProps>(
+  (props) {
+    ${CallbackRefDiagnosticTest.refVarDeclarations}
+
+    ${CallbackRefDiagnosticTest.refUsage}
+
+    ${CallbackRefDiagnosticTest.renderReturn}
+  },
+  UiFactoryConfig(displayName: 'UsesCallbackRef'),
+);
+''';
+
+  static const usageSourceWithinFnComponentFixedSome = '''
+import 'package:over_react/over_react.dart';
+
+final UsesCallbackRef = uiFunction<UiProps>(
+  (props) {
+    ${CallbackRefDiagnosticTest.refVarDeclarationsFixedSome}
+
+    ${CallbackRefDiagnosticTest.refUsageFixedSome}
+
+    ${CallbackRefDiagnosticTest.renderReturnFixedSome}
+  },
+  UiFactoryConfig(displayName: 'UsesCallbackRef'),
+);
+''';
+
+  static const usageSourceWithinFnComponentFixedTheRest = '''
+import 'package:over_react/over_react.dart';
+
+final UsesCallbackRef = uiFunction<UiProps>(
+  (props) {
+    ${CallbackRefDiagnosticTest.refVarDeclarationsFixedTheRest}
+
+    ${CallbackRefDiagnosticTest.refUsageFixedTheRest}
+
+    ${CallbackRefDiagnosticTest.renderReturnFixedTheRest}
+  },
+  UiFactoryConfig(displayName: 'UsesCallbackRef'),
+);
+''';
+
+  Future<void> test_someCustomRefError() async {
+    final source = newSource('test.dart', usageSourceWithinFnComponent);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+  }
+
+  Future<void> test_someCustomRefErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinFnComponent);
+    final errorFix = await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, usageSourceWithinFnComponentFixedSome);
+  }
+
+  Future<void> test_anotherCustomRefError() async {
+    final source = newSource('test.dart', usageSourceWithinFnComponentFixedSome);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  }
+
+  Future<void> test_anotherCustomRefErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinFnComponentFixedSome);
+    final errorFix =
+        await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, usageSourceWithinFnComponentFixedTheRest);
+  }
+}
+
+@reflectiveTest
+class CallbackRefDiagnosticClassComponentTest extends CallbackRefDiagnosticTest {
+  static const usageSourceWithinClassComponent = '''
+import 'package:over_react/over_react.dart';
+
+part 'test.over_react.g.dart';
+
+UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
+
+mixin UsesCallbackRefProps on UiProps {}
+
+class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
+  ${CallbackRefDiagnosticTest.refVarDeclarations}
+
+  @override
+  render() {
+    ${CallbackRefDiagnosticTest.renderReturn}
+  }
+
+  ${CallbackRefDiagnosticTest.refUsage}
+}
+''';
+
+  static const usageSourceWithinClassComponentFixedSome = '''
+import 'package:over_react/over_react.dart';
+
+part 'test.over_react.g.dart';
+
+UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
+
+mixin UsesCallbackRefProps on UiProps {}
+
+class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
+  ${CallbackRefDiagnosticTest.refVarDeclarationsFixedSome}
+
+  @override
+  render() {
+    ${CallbackRefDiagnosticTest.renderReturnFixedSome}
+  }
+
+  ${CallbackRefDiagnosticTest.refUsageFixedSome}
+}
+''';
+
+  static const usageSourceWithinClassComponentFixedTheRest = '''
+import 'package:over_react/over_react.dart';
+
+part 'test.over_react.g.dart';
+
+UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
+
+mixin UsesCallbackRefProps on UiProps {}
+
+class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
+  ${CallbackRefDiagnosticTest.refVarDeclarationsFixedTheRest}
+
+  @override
+  render() {
+    ${CallbackRefDiagnosticTest.renderReturnFixedTheRest}
+  }
+
+  ${CallbackRefDiagnosticTest.refUsageFixedTheRest}
+}
+''';
+
+  Future<void> test_someCustomRefError() async {
+    final source = newSource('test.dart', usageSourceWithinClassComponent);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+  }
+
+  Future<void> test_someCustomRefErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinClassComponent);
+    final errorFix = await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, usageSourceWithinClassComponentFixedSome);
+  }
+
+  Future<void> test_anotherCustomRefError() async {
+    final source = newSource('test.dart', usageSourceWithinClassComponentFixedSome);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  }
+
+  Future<void> test_anotherCustomRefErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinClassComponentFixedSome);
+    final errorFix =
+        await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+    expect(errorFix.fixes.single.change.selection, isNull);
+    source = applyErrorFixes(errorFix, source);
+    expect(source.contents.data, usageSourceWithinClassComponentFixedTheRest);
+  }
+}

--- a/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
@@ -22,18 +22,6 @@ abstract class CallbackRefDiagnosticTest extends DiagnosticTestBase {
   @override
   get fixKindUnderTest => CallbackRefDiagnostic.fixKind;
 
-  static const refVarDeclarations = '''
-    ChildComponent _someCustomRefName;
-    ChildComponent _anotherCustomRefName;''';
-
-  static const refVarDeclarationsFixedSome = '''
-    final _someCustomRefName = useRef<dynamic>();
-    ChildComponent _anotherCustomRefName;''';
-
-  static const refVarDeclarationsFixedTheRest = '''
-    final _someCustomRefName = useRef<dynamic>();
-    final _anotherCustomRefName = useRef<dynamic>();''';
-
   static const refUsage = '''
     void foo() {
       _someCustomRefName.someMethodName();
@@ -119,7 +107,8 @@ import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    ${CallbackRefDiagnosticTest.refVarDeclarations}
+    ChildComponent _someCustomRefName;
+    ChildComponent _anotherCustomRefName;
 
     ${CallbackRefDiagnosticTest.refUsage}
 
@@ -134,7 +123,8 @@ import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    ${CallbackRefDiagnosticTest.refVarDeclarationsFixedSome}
+    final _someCustomRefName = useRef<dynamic>();
+    ChildComponent _anotherCustomRefName;
 
     ${CallbackRefDiagnosticTest.refUsageFixedSome}
 
@@ -149,7 +139,8 @@ import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    ${CallbackRefDiagnosticTest.refVarDeclarationsFixedTheRest}
+    final _someCustomRefName = useRef<dynamic>();
+    final _anotherCustomRefName = useRef<dynamic>();
 
     ${CallbackRefDiagnosticTest.refUsageFixedTheRest}
 
@@ -199,7 +190,8 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  ${CallbackRefDiagnosticTest.refVarDeclarations}
+  ChildComponent _someCustomRefName;
+  ChildComponent _anotherCustomRefName;
 
   @override
   render() {
@@ -220,7 +212,8 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  ${CallbackRefDiagnosticTest.refVarDeclarationsFixedSome}
+  final _someCustomRefName = createRef<dynamic>();
+  ChildComponent _anotherCustomRefName;
 
   @override
   render() {
@@ -241,7 +234,8 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  ${CallbackRefDiagnosticTest.refVarDeclarationsFixedTheRest}
+  final _someCustomRefName = createRef<dynamic>();
+  final _anotherCustomRefName = createRef<dynamic>();
 
   @override
   render() {

--- a/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
@@ -12,6 +12,7 @@ import '../test_bases/diagnostic_test_base.dart';
 void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(CallbackRefDiagnosticFnComponentTest);
+    defineReflectiveTests(CallbackRefDiagnosticClassComponentTest);
   });
 }
 

--- a/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
@@ -13,6 +13,8 @@ void main() {
   defineReflectiveSuite(() {
     defineReflectiveTests(CallbackRefDiagnosticFnComponentTest);
     defineReflectiveTests(CallbackRefDiagnosticClassComponentTest);
+    defineReflectiveTests(CallbackRefDiagnosticFnComponentTestNoFix);
+    defineReflectiveTests(CallbackRefDiagnosticClassComponentTestNoFix);
   });
 }
 
@@ -21,95 +23,139 @@ abstract class CallbackRefDiagnosticTest extends DiagnosticTestBase {
   get errorUnderTest => CallbackRefDiagnostic.code;
 
   @override
-  get fixKindUnderTest => CallbackRefDiagnostic.fixKind;
+  get fixKindUnderTest => null;
 
   static const refUsage = '''
-    void foo() {
-      _someCustomRefName.someMethodName();
-      _someCustomRefName?.anotherMethodName();
-      final bar = _someCustomRefName.someGetter;
+    void _tearOffRefAssignment(ChildComponent ref) {
+      _customRefAssignedInTearoff = ref;
+    }
 
-      _anotherCustomRefName.someMethodName();
-      _anotherCustomRefName?.anotherMethodName();
-      final baz = _anotherCustomRefName.someGetter;
+    void foo() {
+      _customRefAssignedInBlockFnBody.someMethodName();
+      _customRefAssignedInBlockFnBody?.anotherMethodName();
+      final bar = _customRefAssignedInBlockFnBody.someGetter;
+
+      _customRefAssignedInArrowFn.someMethodName();
+      _customRefAssignedInArrowFn?.anotherMethodName();
+      final baz = _customRefAssignedInArrowFn.someGetter;
+      
+      _customRefAssignedInTearoff.someMethodName();
+      _customRefAssignedInTearoff?.anotherMethodName();
+      final biz = _customRefAssignedInTearoff.someGetter;
     }''';
 
-  static const refUsageFixedSome = '''
-    void foo() {
-      _someCustomRefName.current.someMethodName();
-      _someCustomRefName.current?.anotherMethodName();
-      final bar = _someCustomRefName.current.someGetter;
+  static const refUsageFixedBlockFnBodyRefAssignment = '''
+    void _tearOffRefAssignment(ChildComponent ref) {
+      _customRefAssignedInTearoff = ref;
+    }
 
-      _anotherCustomRefName.someMethodName();
-      _anotherCustomRefName?.anotherMethodName();
-      final baz = _anotherCustomRefName.someGetter;
+    void foo() {
+      _customRefAssignedInBlockFnBody.current.someMethodName();
+      _customRefAssignedInBlockFnBody.current?.anotherMethodName();
+      final bar = _customRefAssignedInBlockFnBody.current.someGetter;
+
+      _customRefAssignedInArrowFn.someMethodName();
+      _customRefAssignedInArrowFn?.anotherMethodName();
+      final baz = _customRefAssignedInArrowFn.someGetter;
+      
+      _customRefAssignedInTearoff.someMethodName();
+      _customRefAssignedInTearoff?.anotherMethodName();
+      final biz = _customRefAssignedInTearoff.someGetter;
     }''';
 
-  static const refUsageFixedTheRest = '''
-    void foo() {
-      _someCustomRefName.current.someMethodName();
-      _someCustomRefName.current?.anotherMethodName();
-      final bar = _someCustomRefName.current.someGetter;
+  static const refUsageFixedArrowFnRefAssignment = '''
+    void _tearOffRefAssignment(ChildComponent ref) {
+      _customRefAssignedInTearoff = ref;
+    }
 
-      _anotherCustomRefName.current.someMethodName();
-      _anotherCustomRefName.current?.anotherMethodName();
-      final baz = _anotherCustomRefName.current.someGetter;
+    void foo() {
+      _customRefAssignedInBlockFnBody.current.someMethodName();
+      _customRefAssignedInBlockFnBody.current?.anotherMethodName();
+      final bar = _customRefAssignedInBlockFnBody.current.someGetter;
+
+      _customRefAssignedInArrowFn.current.someMethodName();
+      _customRefAssignedInArrowFn.current?.anotherMethodName();
+      final baz = _customRefAssignedInArrowFn.current.someGetter;
+      
+      _customRefAssignedInTearoff.someMethodName();
+      _customRefAssignedInTearoff?.anotherMethodName();
+      final biz = _customRefAssignedInTearoff.someGetter;
     }''';
 
   static const renderReturn = '''
     return Fragment()(
       (Child()
         ..ref = (ref) {
-          _someCustomRefName = ref;
+          _customRefAssignedInBlockFnBody = ref;
         })(props.children),
       (Child()
         ..id = 'bar'
-        ..ref = ((ref) => _anotherCustomRefName = ref)
+        ..ref = ((ref) => _customRefAssignedInArrowFn = ref)
       )('hi'),
+      (Child()
+        ..id = 'biz'
+        ..ref = _tearOffRefAssignment
+      )('yo'),
       (Child())('there'),
     );
   ''';
 
-  static const renderReturnFixedSome = '''
+  static const renderReturnFixedBlockFnBodyRefAssignment = '''
     return Fragment()(
       (Child()
-        ..ref = _someCustomRefName)(props.children),
+        ..ref = _customRefAssignedInBlockFnBody)(props.children),
       (Child()
         ..id = 'bar'
-        ..ref = ((ref) => _anotherCustomRefName = ref)
+        ..ref = ((ref) => _customRefAssignedInArrowFn = ref)
       )('hi'),
+      (Child()
+        ..id = 'biz'
+        ..ref = _tearOffRefAssignment
+      )('yo'),
       (Child())('there'),
     );
   ''';
 
-  static const renderReturnFixedTheRest = '''
+  static const renderReturnFixedArrowFnRefAssignment = '''
     return Fragment()(
       (Child()
-        ..ref = _someCustomRefName)(props.children),
+        ..ref = _customRefAssignedInBlockFnBody)(props.children),
       (Child()
         ..id = 'bar'
-        ..ref = _anotherCustomRefName
+        ..ref = _customRefAssignedInArrowFn
       )('hi'),
+      (Child()
+        ..id = 'biz'
+        ..ref = _tearOffRefAssignment
+      )('yo'),
       (Child())('there'),
     );
   ''';
 
-  static const selectionToFixSome = '''#(ref) {
-          _someCustomRefName = ref;
+  static const selectionToFixBlockFnBodyRefAssignment = '''#(ref) {
+          _customRefAssignedInBlockFnBody = ref;
         }#''';
 
-  static const selectionToFixAnother = '''#((ref) => _anotherCustomRefName = ref)#''';
+  static const selectionToFixArrowFnRefAssignment = '''#((ref) => _customRefAssignedInArrowFn = ref)#''';
+
+  static const selectionForTearoffRefAssignmentError = '''..ref = #_tearOffRefAssignment#''';
+}
+
+abstract class CallbackRefDiagnosticWithFixTest extends CallbackRefDiagnosticTest {
+  @override
+  get fixKindUnderTest => CallbackRefDiagnostic.fixKind;
 }
 
 @reflectiveTest
-class CallbackRefDiagnosticFnComponentTest extends CallbackRefDiagnosticTest {
+class CallbackRefDiagnosticFnComponentTest extends CallbackRefDiagnosticWithFixTest {
   static const usageSourceWithinFnComponent = '''
 import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    ChildComponent _someCustomRefName;
-    ChildComponent _anotherCustomRefName;
+    ChildComponent _customRefAssignedInBlockFnBody;
+    ChildComponent _customRefAssignedInArrowFn;
+    ChildComponent _customRefAssignedInTearoff;
 
     ${CallbackRefDiagnosticTest.refUsage}
 
@@ -119,68 +165,87 @@ final UsesCallbackRef = uiFunction<UiProps>(
 );
 ''';
 
-  static const usageSourceWithinFnComponentFixedSome = '''
+  static const usageSourceWithinFnComponentFixedBlockFnBodyRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    final _someCustomRefName = useRef<dynamic>();
-    ChildComponent _anotherCustomRefName;
+    final _customRefAssignedInBlockFnBody = useRef<dynamic>();
+    ChildComponent _customRefAssignedInArrowFn;
+    ChildComponent _customRefAssignedInTearoff;
 
-    ${CallbackRefDiagnosticTest.refUsageFixedSome}
+    ${CallbackRefDiagnosticTest.refUsageFixedBlockFnBodyRefAssignment}
 
-    ${CallbackRefDiagnosticTest.renderReturnFixedSome}
+    ${CallbackRefDiagnosticTest.renderReturnFixedBlockFnBodyRefAssignment}
   },
   UiFactoryConfig(displayName: 'UsesCallbackRef'),
 );
 ''';
 
-  static const usageSourceWithinFnComponentFixedTheRest = '''
+  static const usageSourceWithinFnComponentFixedArrowFnRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
 final UsesCallbackRef = uiFunction<UiProps>(
   (props) {
-    final _someCustomRefName = useRef<dynamic>();
-    final _anotherCustomRefName = useRef<dynamic>();
+    final _customRefAssignedInBlockFnBody = useRef<dynamic>();
+    final _customRefAssignedInArrowFn = useRef<dynamic>();
+    ChildComponent _customRefAssignedInTearoff;
 
-    ${CallbackRefDiagnosticTest.refUsageFixedTheRest}
+    ${CallbackRefDiagnosticTest.refUsageFixedArrowFnRefAssignment}
 
-    ${CallbackRefDiagnosticTest.renderReturnFixedTheRest}
+    ${CallbackRefDiagnosticTest.renderReturnFixedArrowFnRefAssignment}
   },
   UiFactoryConfig(displayName: 'UsesCallbackRef'),
 );
 ''';
 
-  Future<void> test_someCustomRefError() async {
+  Future<void> test_blockFnBodyRefAssignment() async {
     final source = newSource('test.dart', usageSourceWithinFnComponent);
-    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    await expectSingleErrorAt(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixBlockFnBodyRefAssignment));
   }
 
-  Future<void> test_someCustomRefErrorFix() async {
+  Future<void> test_blockFnBodyRefAssignmentFix() async {
     var source = newSource('test.dart', usageSourceWithinFnComponent);
-    final errorFix = await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    final errorFix = await expectSingleErrorFix(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixBlockFnBodyRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinFnComponentFixedSome);
+    expect(source.contents.data, usageSourceWithinFnComponentFixedBlockFnBodyRefAssignment);
   }
 
-  Future<void> test_anotherCustomRefError() async {
-    final source = newSource('test.dart', usageSourceWithinFnComponentFixedSome);
-    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  Future<void> test_arrowFnRefAssignmentError() async {
+    final source = newSource('test.dart', usageSourceWithinFnComponentFixedBlockFnBodyRefAssignment);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixArrowFnRefAssignment));
   }
 
-  Future<void> test_anotherCustomRefErrorFix() async {
-    var source = newSource('test.dart', usageSourceWithinFnComponentFixedSome);
-    final errorFix =
-        await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  Future<void> test_arrowFnRefAssignmentErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinFnComponentFixedBlockFnBodyRefAssignment);
+    final errorFix = await expectSingleErrorFix(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixArrowFnRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinFnComponentFixedTheRest);
+    expect(source.contents.data, usageSourceWithinFnComponentFixedArrowFnRefAssignment);
   }
 }
 
 @reflectiveTest
-class CallbackRefDiagnosticClassComponentTest extends CallbackRefDiagnosticTest {
+class CallbackRefDiagnosticFnComponentTestNoFix extends CallbackRefDiagnosticTest {
+  @override
+  get fixKindUnderTest => null;
+
+  Future<void> test_tearoffFnRefAssignment() async {
+    final source = newSource('test.dart', CallbackRefDiagnosticFnComponentTest.usageSourceWithinFnComponent);
+    final selection = createSelection(source, CallbackRefDiagnosticTest.selectionForTearoffRefAssignmentError);
+    await expectSingleErrorAt(selection);
+    // We intentionally do not want the diagnostic to suggest a fix since
+    // the `addUseOrCreateRef` utility that builds the fix currently can't handle that use case.
+    await expectNoErrorFix(selection);
+  }
+}
+
+@reflectiveTest
+class CallbackRefDiagnosticClassComponentTest extends CallbackRefDiagnosticWithFixTest {
   static const usageSourceWithinClassComponent = '''
 import 'package:over_react/over_react.dart';
 
@@ -191,8 +256,9 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  ChildComponent _someCustomRefName;
-  ChildComponent _anotherCustomRefName;
+  ChildComponent _customRefAssignedInBlockFnBody;
+  ChildComponent _customRefAssignedInArrowFn;
+  ChildComponent _customRefAssignedInTearoff;
 
   @override
   render() {
@@ -203,7 +269,7 @@ class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
 }
 ''';
 
-  static const usageSourceWithinClassComponentFixedSome = '''
+  static const usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
 part 'test.over_react.g.dart';
@@ -213,19 +279,20 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  final _someCustomRefName = createRef<dynamic>();
-  ChildComponent _anotherCustomRefName;
+  final _customRefAssignedInBlockFnBody = createRef<dynamic>();
+  ChildComponent _customRefAssignedInArrowFn;
+  ChildComponent _customRefAssignedInTearoff;
 
   @override
   render() {
-    ${CallbackRefDiagnosticTest.renderReturnFixedSome}
+    ${CallbackRefDiagnosticTest.renderReturnFixedBlockFnBodyRefAssignment}
   }
 
-  ${CallbackRefDiagnosticTest.refUsageFixedSome}
+  ${CallbackRefDiagnosticTest.refUsageFixedBlockFnBodyRefAssignment}
 }
 ''';
 
-  static const usageSourceWithinClassComponentFixedTheRest = '''
+  static const usageSourceWithinClassComponentFixedArrowFnRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
 part 'test.over_react.g.dart';
@@ -235,42 +302,60 @@ UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackR
 mixin UsesCallbackRefProps on UiProps {}
 
 class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
-  final _someCustomRefName = createRef<dynamic>();
-  final _anotherCustomRefName = createRef<dynamic>();
+  final _customRefAssignedInBlockFnBody = createRef<dynamic>();
+  final _customRefAssignedInArrowFn = createRef<dynamic>();
+  ChildComponent _customRefAssignedInTearoff;
 
   @override
   render() {
-    ${CallbackRefDiagnosticTest.renderReturnFixedTheRest}
+    ${CallbackRefDiagnosticTest.renderReturnFixedArrowFnRefAssignment}
   }
 
-  ${CallbackRefDiagnosticTest.refUsageFixedTheRest}
+  ${CallbackRefDiagnosticTest.refUsageFixedArrowFnRefAssignment}
 }
 ''';
 
-  Future<void> test_someCustomRefError() async {
+  Future<void> test_blockFnBodyRefAssignment() async {
     final source = newSource('test.dart', usageSourceWithinClassComponent);
-    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    await expectSingleErrorAt(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixBlockFnBodyRefAssignment));
   }
 
-  Future<void> test_someCustomRefErrorFix() async {
+  Future<void> test_blockFnBodyRefAssignmentFix() async {
     var source = newSource('test.dart', usageSourceWithinClassComponent);
-    final errorFix = await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixSome));
+    final errorFix = await expectSingleErrorFix(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixBlockFnBodyRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinClassComponentFixedSome);
+    expect(source.contents.data, usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment);
   }
 
-  Future<void> test_anotherCustomRefError() async {
-    final source = newSource('test.dart', usageSourceWithinClassComponentFixedSome);
-    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  Future<void> test_arrowFnRefAssignmentError() async {
+    final source = newSource('test.dart', usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment);
+    await expectSingleErrorAt(createSelection(source, CallbackRefDiagnosticTest.selectionToFixArrowFnRefAssignment));
   }
 
-  Future<void> test_anotherCustomRefErrorFix() async {
-    var source = newSource('test.dart', usageSourceWithinClassComponentFixedSome);
-    final errorFix =
-        await expectSingleErrorFix(createSelection(source, CallbackRefDiagnosticTest.selectionToFixAnother));
+  Future<void> test_arrowFnRefAssignmentErrorFix() async {
+    var source = newSource('test.dart', usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment);
+    final errorFix = await expectSingleErrorFix(
+        createSelection(source, CallbackRefDiagnosticTest.selectionToFixArrowFnRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinClassComponentFixedTheRest);
+    expect(source.contents.data, usageSourceWithinClassComponentFixedArrowFnRefAssignment);
+  }
+}
+
+@reflectiveTest
+class CallbackRefDiagnosticClassComponentTestNoFix extends CallbackRefDiagnosticTest {
+  @override
+  get fixKindUnderTest => null;
+
+  Future<void> test_tearoffFnRefAssignment() async {
+    final source = newSource('test.dart', CallbackRefDiagnosticClassComponentTest.usageSourceWithinClassComponent);
+    final selection = createSelection(source, CallbackRefDiagnosticTest.selectionForTearoffRefAssignmentError);
+    await expectSingleErrorAt(selection);
+    // We intentionally do not want the diagnostic to suggest a fix since
+    // the `addUseOrCreateRef` utility that builds the fix currently can't handle that use case.
+    await expectNoErrorFix(selection);
   }
 }

--- a/tools/analyzer_plugin/test/integration/test_bases/diagnostic_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/diagnostic_test_base.dart
@@ -190,7 +190,7 @@ abstract class DiagnosticTestBase extends ServerPluginContributorTestBase {
     return DartAndPluginErrorsIterable(dartErrors: dartErrors, pluginErrors: pluginErrors);
   }
 
-  /// Returns all error fixes prroduced at [selection].
+  /// Returns all error fixes produced at [selection].
   Future<List<AnalysisErrorFixes>> _getAllErrorFixesAtSelection(SourceSelection selection) async {
     final parameters = EditGetFixesParams(sourcePath(selection.source), selection.offset);
     return (await testPlugin.handleEditGetFixes(parameters)).fixes;


### PR DESCRIPTION
Our "add_ref" assist, and the `CallbackRefDiagnostic` that uses it did not support function components. Now it does, it replaces callback refs with `useRef` instead of `createRef`, and there are tests.