### PR TITLE
Include class methods when converting to a function component

### DIFF
--- a/tools/analyzer_plugin/lib/src/assist/convert_class_or_function_component.dart
+++ b/tools/analyzer_plugin/lib/src/assist/convert_class_or_function_component.dart
@@ -63,8 +63,7 @@ class ConvertClassOrFunctionComponentAssistContributor extends AssistContributor
     final factoryInitializer = factory.initializer;
     if (factoryInitializer == null) return;
 
-    // todo check for other methods
-    // todo migrate defaults
+    // todo migrate defaults?
 
     final render = closestClass.members.whereType<MethodDeclaration>().firstWhereOrNull((m) => m.name.name == 'render');
     if (render == null) return;


### PR DESCRIPTION
## Motivation
Previously, methods in class components were discarded when converting to a function component.

This meant any render helper methods get removed as part of the assist, and also also lifecycle methods that need to be converted get lost.

## Changes
Add any methods in the class inside the function component body.

![convert-to-function](https://user-images.githubusercontent.com/1713967/170137906-c1ee8e5e-ec9b-4f9f-80ad-edd86afb705e.gif)


#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
