### PR TITLE
RM-150529 RM-150528 Release over_react 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Changelog
 
+## [4.4.2](https://github.com/Workiva/over_react/compare/4.4.1...4.4.2)
+- [#770] Fix component names not showing in Error Boundary stacks for class-based components
+- [#769] Add [documentation for wrapping JS components](https://github.com/Workiva/over_react/blob/master/doc/wrapping_js_components.md) using `uiJsComponent`
+
+## [4.4.1](https://github.com/Workiva/over_react/compare/4.4.0...4.4.1)
+- [#764] (Example app) Widen uuid dependency
+
 ## [4.4.0](https://github.com/Workiva/over_react/compare/4.3.1...4.4.0)
 
 - [#743] Add `js_component.dart` entrypoint with utilities for wrapping JS React components. More in-depth documentation around how to use these APIs and best practices is coming soon.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.4.1
+version: 4.4.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.4.1
+  over_react: 4.4.2
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [fw-149 Change skynet to verify that github workflow is successful](https://github.com/Workiva/over_react/pull/765)
	* [Update to latest image of github ci verifier](https://github.com/Workiva/over_react/pull/768)
	* [FED-178 Add Documentation for `uiJsComponent`](https://github.com/Workiva/over_react/pull/769)
	* [FED-193 Show Component Name in ErrorBoundary Stack](https://github.com/Workiva/over_react/pull/770)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.4.1...Workiva:release_over_react_4.4.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.4.1...4.4.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?pull_number=771&repo_name=Workiva%2Fover_react)