### PR TITLE
RM-156570 RM-156569 Release over_react 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # OverReact Changelog
 
 ## [4.4.3](https://github.com/Workiva/over_react/compare/4.4.2...4.4.3)
-	* [#774] Make error message when component failed to initialize more helpful
-	* [#778] Allow w_common 2
+- [#774] Make error message when component failed to initialize more helpful
+- [#778] Allow w_common 2
 
 ## [4.4.2](https://github.com/Workiva/over_react/compare/4.4.1...4.4.2)
 - [#770] Fix component names not showing in Error Boundary stacks for class-based components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## [4.4.3](https://github.com/Workiva/over_react/compare/4.4.2...4.4.3)
+	* [#774] Make error message when component failed to initialize more helpful
+	* [#778] Allow wcommon 2
+	* [#779] Remove duplicate import
+
 ## [4.4.2](https://github.com/Workiva/over_react/compare/4.4.1...4.4.2)
 - [#770] Fix component names not showing in Error Boundary stacks for class-based components
 - [#769] Add [documentation for wrapping JS components](https://github.com/Workiva/over_react/blob/master/doc/wrapping_js_components.md) using `uiJsComponent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## [4.4.3](https://github.com/Workiva/over_react/compare/4.4.2...4.4.3)
 	* [#774] Make error message when component failed to initialize more helpful
-	* [#778] Allow wcommon 2
-	* [#779] Remove duplicate import
+	* [#778] Allow w_common 2
 
 ## [4.4.2](https://github.com/Workiva/over_react/compare/4.4.1...4.4.2)
 - [#770] Fix component names not showing in Error Boundary stacks for class-based components

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.4.2
+version: 4.4.3
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.4.2
+  over_react: 4.4.3
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Update references to the previous team name](https://github.com/Workiva/over_react/pull/773)
	* [Make error message when component failed to initialize more helpful](https://github.com/Workiva/over_react/pull/774)
	* [Allow wcommon 2](https://github.com/Workiva/over_react/pull/778)
	* [Remove duplicate import](https://github.com/Workiva/over_react/pull/779)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.4.2...Workiva:release_over_react_4.4.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.4.2...4.4.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=780)