### PR TITLE
w_common v2 rollout - 1 of 2 raise max

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   test: ^1.15.7
   test_html_builder: ^2.2.2
   time: ^1.2.0
-  w_common: ^1.20.0
+  w_common: '>=1.20.0 <3.0.0'
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: '>=1.13.0 <3.0.0'
-  w_flux: ^2.10.4
+  w_flux: ^2.10.21
   platform_detect: ^1.3.4
   quiver: ">=0.25.0 <4.0.0"
   redux_dev_tools: ">=0.4.0 <0.6.0"


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This update will allow w_common 2x by raising the max to < 3.0.0
It also raises the minimum of a few packages that addressed w_common
v2 breaking changes. In order to be compatible with w_common v2, we
need at least these versions.
  dart_dev_workiva 1.5.9
  wdesk_sdk 3.7.8
  w_router 1.1.15
  w_flux 2.10.21
  w_module 2.0.30
  bigsky_rest_files 1.33.10

In addition, sass compilation was moved out of w_common into a 
w_common_tools package, so if it detects that the repo might need it, 
it might add a dependency on w_common_tools.

Lastly, app/pubspec.lock files may have needed to be updated to get 
those minimum versions of packages

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v2)