### PR TITLE
w_common v2 rollout - 2 of 2 raise min

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   test: ^1.15.7
   test_html_builder: ^2.2.2
   time: ^1.2.0
-  w_common: '>=1.20.0 <3.0.0'
+  w_common: '^2.0.0'
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
-  w_common: '>=1.13.0 <3.0.0'
+  w_common: '^2.0.0'
   w_flux: ^2.10.21
   platform_detect: ^1.3.4
   quiver: ">=0.25.0 <4.0.0"


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This update will require w_common 2x by raising the min to ^2.0.0
All consumers have already been updated to allow w_common 2 in the
step 1 batch, so this PR should be a no-op.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v2_raise_min`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v2_raise_min)