### PR TITLE
FED-513 Fix PlainJavaScriptObject test failure in master

### DIFF
--- a/test/over_react/util/prop_conversion_test.dart
+++ b/test/over_react/util/prop_conversion_test.dart
@@ -726,7 +726,7 @@ main() {
                   r"Expected a value of type 'Map[^']*', but got one of type 'NativeJavaScriptObject'")),
               // dart2js error message
               matches(RegExp(
-                  r"type 'UnknownJavaScriptObject' is not a subtype of type 'Map[^']*'")),
+                  r"type '(Unknown|Plain)JavaScriptObject' is not a subtype of type 'Map[^']*'")),
             )),
           ]);
 


### PR DESCRIPTION
## Motivation
There's a test in master that just started failing, without any changes: https://github.com/Workiva/over_react/actions/runs/3245189553/jobs/5649287921
```
00:11 +1142 -1: [Chrome] test/over_react_util_test.dart: prop conversion works as expected in advanced cases: Dart component used as `component` prop expecting a custom Dart Map prop [E]             
  Expected: [
              <<Instance of 'Object'> with `toString() value`: (match 'Expected a value of type 'Map[^']*', but got one of type 'NativeJavaScriptObject'' or match 'type 'UnknownJavaScriptObject' is not a subtype of type 'Map[^']*'')>
            ]
    Actual: [
              _TypeError:TypeError: Instance of 'PlainJavaScriptObject': type 'PlainJavaScriptObject' is not a subtype of type 'Map<dynamic, dynamic>'
            ]
     Which: at location [0] is _TypeError:<TypeError: Instance of 'PlainJavaScriptObject': type 'PlainJavaScriptObject' is not a subtype of type 'Map<dynamic, dynamic>'> which has `toString() value` with value 'TypeError: Instance of \'PlainJavaScriptObject\': type \'PlainJavaScriptObject\' is not a subtype of type \'Map<dynamic, dynamic>\''
```

For some reason the error is now `PlainJavaScriptObject` instead of `UnknownJavaScriptObject`.

Since this started failing in CI with the same Dart SDK, I'm guessing  this is related to changes in Chrome, causing dart2js to use slightly different interceptors under the hood for JS Objects. For reference, here are those classes: https://github.com/dart-lang/sdk/blob/2.13.4/sdk/lib/_internal/js_runtime/lib/interceptors.dart#L423-L435

The test is really asserting that there's a type mismatch between a Map and a JS object type, and the details of the JS object's interceptor type doesn't really matter to us.

## Changes
- Update the test to accept either `PlainJavaScriptObject` or `UnknownJavaScriptObject`

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
