### PR TITLE
RM-164256 RM-164255 Release over_react 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # OverReact Changelog
 
+## [4.6.0](https://github.com/Workiva/over_react/compare/4.5.0...4.6.0)
+#### Analyzer Plugin
+- [#788] Add new `over_react_hooks_exhaustive_deps` diagnostic that validates the dependency lists of React hooks such as `useEffect`, `useMemo`, and `useCallback`. 
+  
+  Ported/forked from the JS eslint-plugin-react-hooks `react-hooks/exhaustive-deps` rule 
+([info from the React docs](https://reactjs.org/docs/hooks-effect.html#:~:text=If%20you%20use%20this%20optimization%2C%20make%20sure%20the%20array%20includes),
+ [package](https://www.npmjs.com/package/eslint-plugin-react-hooks),
+ [source](https://github.com/facebook/react/blob/main@%7B2020-10-16%7D/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js)),
+this Dart diagnostic aims to provide parity with the dev experience of the JS lint rule, with some tweaks to work better with Dart and over_react's flavor of React APIs.
+
 ## [4.5.0](https://github.com/Workiva/over_react/compare/4.4.4...4.5.0)
 - [#785] Add utilities for jsifying/unsifying context props
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.5.0
+version: 4.6.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.5.0
+  over_react: 4.6.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-194 Fully implement hooks exhaustive dependencies diagnostic, add tests](https://github.com/Workiva/over_react/pull/788)
* Patch changes:
	* [FED-513 Fix PlainJavaScriptObject test failure in master](https://github.com/Workiva/over_react/pull/791)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.5.0...Workiva:release_over_react_4.6.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.5.0...4.6.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=792)