### PR TITLE
Consume react-dart 6.1.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: '>=0.11.3+2 <2.0.0'
   meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
-  react: ^6.1.6
+  react: ^6.1.8
   redux: ">=3.0.0 <5.0.0"
   source_span: ^1.4.1
   transformer_utils: ^0.2.6


### PR DESCRIPTION
Consume [react-dart 6.1.8](https://github.com/Workiva/react-dart/releases/tag/6.1.8)

Pull Requests included in release:
* Patch changes:
	* [FED-202 Return `jsUndefined` instead of `null` when children prop is empty](https://github.com/Workiva/react-dart/pull/350)
	* [RM-156571 Release react-dart 6.1.8](https://github.com/Workiva/react-dart/pull/351)


Requested by: @rmconsole3-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?repo_name=Workiva%2Fover_react&pull_number=793)