### PR TITLE
FEA-1258: Named redux devtools instances

### DIFF
--- a/app/over_react_redux/todo_client/lib/src/store.dart
+++ b/app/over_react_redux/todo_client/lib/src/store.dart
@@ -22,7 +22,7 @@ DevToolsStore<AppState> getStore() => DevToolsStore<AppState>(
   appStateReducer,
   initialState: initializeState(),
   middleware: [
-    overReactReduxDevToolsMiddleware,
+    overReactReduxDevToolsMiddlewareFactory(name: 'Example Store'),
     localStorageMiddleware(),
   ],
 );

--- a/doc/over_react_redux_documentation.md
+++ b/doc/over_react_redux_documentation.md
@@ -648,3 +648,13 @@ Redux DevTools can be set up easily by adding only a few lines of code.
    - Firefox: https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/
 
 You can run your code and open the devtools in your browser!
+
+`overReactReduxDevToolsMiddlewareFactory` is also available to pass [options](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md) into the initialization of the redux dev tools.
+
+```dart
+var store = new DevToolsStore<AppState>(
+  /*ReducerName*/,
+  initialState: /*Default App State Object*/,
+  middleware: [overReactReduxDevToolsMiddlewareFactory(name: 'Some Custom Instance Name')],
+)
+```

--- a/lib/over_react_redux.dart
+++ b/lib/over_react_redux.dart
@@ -18,4 +18,5 @@ export 'src/over_react_redux/over_react_redux.dart';
 export 'src/over_react_redux/hooks/use_dispatch.dart' show createDispatchHook, useDispatch;
 export 'src/over_react_redux/hooks/use_selector.dart' show createSelectorHook, useSelector;
 export 'src/over_react_redux/hooks/use_store.dart' show createStoreHook, useStore;
-export 'src/over_react_redux/devtools/middleware.dart' show overReactReduxDevToolsMiddleware;
+export 'src/over_react_redux/devtools/middleware.dart' 
+  show overReactReduxDevToolsMiddleware, overReactReduxDevToolsMiddlewareFactory, ReduxDevToolsExtensionOptions;

--- a/lib/over_react_redux.dart
+++ b/lib/over_react_redux.dart
@@ -19,4 +19,4 @@ export 'src/over_react_redux/hooks/use_dispatch.dart' show createDispatchHook, u
 export 'src/over_react_redux/hooks/use_selector.dart' show createSelectorHook, useSelector;
 export 'src/over_react_redux/hooks/use_store.dart' show createStoreHook, useStore;
 export 'src/over_react_redux/devtools/middleware.dart' 
-  show overReactReduxDevToolsMiddleware, overReactReduxDevToolsMiddlewareFactory, ReduxDevToolsExtensionOptions;
+  show overReactReduxDevToolsMiddleware, overReactReduxDevToolsMiddlewareFactory;

--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -41,7 +41,7 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
   _ReduxDevToolsExtensionConnection devToolsExt;
   final Logger log = Logger('OverReactReduxDevToolsMiddleware');
 
-  _OverReactReduxDevToolsMiddleware([Map<String, dynamic> options]) {
+  _OverReactReduxDevToolsMiddleware([Map<String, dynamic> options = const {}]) {
     var windowConsole = getProperty(window, 'console');
     log.onRecord.listen((rec) {
       // This return is to safeguard against this listener acting like
@@ -196,6 +196,11 @@ final MiddlewareClass overReactReduxDevToolsMiddleware = _OverReactReduxDevTools
 
 /// A Middleware that can be added to a [DevToolsStore] in order to utilize the Redux DevTools browser extension.
 /// Similar to [overReactReduxDevToolsMiddleware], but allows passing of options to initialize dev tools with.
+/// 
+/// Arguments:
+/// - [name] - the instance name to be shown on the monitor page. Default value is `document.title`. 
+///   If not specified and there's no document title, it will consist of tabId and instanceId. 
+///   Use this if your page has multiple stores.
 ///
 /// Example:
 /// ```
@@ -208,5 +213,5 @@ final MiddlewareClass overReactReduxDevToolsMiddleware = _OverReactReduxDevTools
 MiddlewareClass overReactReduxDevToolsMiddlewareFactory({
   String name,
 }) => _OverReactReduxDevToolsMiddleware({
-  'name': name,
+  if (name != null) 'name': name,
 });

--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -41,7 +41,7 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
   _ReduxDevToolsExtensionConnection devToolsExt;
   final Logger log = Logger('OverReactReduxDevToolsMiddleware');
 
-  _OverReactReduxDevToolsMiddleware() {
+  _OverReactReduxDevToolsMiddleware([Map<String, dynamic> options]) {
     var windowConsole = getProperty(window, 'console');
     log.onRecord.listen((rec) {
       // This return is to safeguard against this listener acting like
@@ -54,7 +54,7 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
       }
     });
     try {
-      devToolsExt = reduxExtConnect();
+      devToolsExt = reduxExtConnect(jsify(options));
       devToolsExt.subscribe(allowInterop(handleEventFromRemote));
     } catch (e) {
       log.warning(e);
@@ -193,3 +193,20 @@ class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
 /// );
 /// ```
 final MiddlewareClass overReactReduxDevToolsMiddleware = _OverReactReduxDevToolsMiddleware();
+
+/// A Middleware that can be added to a [DevToolsStore] in order to utilize the Redux DevTools browser extension.
+/// Similar to [overReactReduxDevToolsMiddleware], but allows passing of options to initialize dev tools with.
+///
+/// Example:
+/// ```
+/// var store = new DevToolsStore<AppState>(
+///   /*YourReducer*/,
+///   initialState: /*YourInitialState*/,
+///   middleware: [overReactReduxDevToolsMiddlewareFactory(name: 'My Store')],
+/// );
+/// ```
+MiddlewareClass overReactReduxDevToolsMiddlewareFactory({
+  String name,
+}) => _OverReactReduxDevToolsMiddleware({
+  'name': name,
+});


### PR DESCRIPTION
## Motivation

As its currently implemented, we have no way to provide options to the initialization of the `overReactReduxDevToolsMiddleware`. This pr adds an additional `overReactReduxDevToolsMiddlewareFactory` which currently only accepts a `name` parameter (more can be added as needed)

This directly proxies the list of available options which the redux-devtools api [provides](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md)

![Screenshot 2023-01-18 at 11 49 21 AM](https://user-images.githubusercontent.com/39171685/213273002-6686cf99-e44b-4a3c-a9e2-c7b8b5e0f92e.png)


## Changes

- exposes new `overReactReduxDevToolsMiddlewareFactory` to allow constructing a dev tools middleware with a name parameter

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Add `overReactReduxDevToolsMiddlewareFactory` which allows constructing redux dev tools with options

## Review

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
