### PR TITLE
RM-171589 RM-171588 Release over_react 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## [4.8.0](https://github.com/Workiva/over_react/compare/4.7.0...4.8.0)
+- [#797] Add `overReactReduxDevToolsMiddlewareFactory` for constructing middleware with a `name`, allowing store instances to be separated in the Redux Dev Tools
+
 ## [4.7.0](https://github.com/Workiva/over_react/compare/4.6.0...4.7.0)
 - [#795] Add `jsifyMapListProp` and `unjsifyMapListProp` conversion utils
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.7.0
+version: 4.8.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.7.0
+  over_react: 4.8.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FEA-1258: Named redux devtools instances](https://github.com/Workiva/over_react/pull/797)
* Patch changes:
	* [FED-675 Stop running plugin build on Dart 3 to fix CI](https://github.com/Workiva/over_react/pull/798)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.7.0...Workiva:release_over_react_4.8.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.7.0...4.8.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=799)