### PR TITLE
Upgrade to platform_detect 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   transformer_utils: ^0.2.6
   w_common: '^2.0.0'
   w_flux: ^2.10.21
-  platform_detect: ^1.3.4
+  platform_detect: '>=1.3.4 <3.0.0'
   quiver: ">=0.25.0 <4.0.0"
   redux_dev_tools: ">=0.4.0 <0.6.0"
 


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will raise the max allowed version of platform_detect to allow v2.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/platform_detect_2_raise_max`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/platform_detect_2_raise_max)