### PR TITLE
RM-176692 RM-176691 Release over_react 4.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## [4.8.1](https://github.com/Workiva/over_react/compare/4.8.0...4.8.1)
+
+- [#802] Raise platform_detect upperbound to allow 2.x
+- [#800] (Docs) Add Redux DevTools integration documentation
+
 ## [4.8.0](https://github.com/Workiva/over_react/compare/4.7.0...4.8.0)
 - [#797] Add `overReactReduxDevToolsMiddlewareFactory` for constructing middleware with a `name`, allowing store instances to be separated in the Redux Dev Tools
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.8.0
+version: 4.8.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.8.0
+  over_react: 4.8.1
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-681: Add integration docs](https://github.com/Workiva/over_react/pull/800)
	* [Upgrade to platform_detect 2](https://github.com/Workiva/over_react/pull/802)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.8.0...Workiva:release_over_react_4.8.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.8.0...4.8.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=803)