### PR TITLE
Raise analyzer minimum & unpin meta

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   color: any
   memoize: ^2.0.0
-  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ^1.6.0 # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0
   redux: ">=3.0.0 <5.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
 
 dependencies:
   collection: ^1.14.11
-  analyzer: '>=0.40.0 <2.0.0'
+  analyzer: ^1.7.2
   build: '>=1.0.0 <3.0.0'
   built_redux: ">=7.4.2 <9.0.0"
   built_value: ^8.0.0
   dart_style: '>=1.2.5 <3.0.0'
   js: ^0.6.1+1
   logging: '>=0.11.3+2 <2.0.0'
-  meta: ">=1.1.6 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ^1.6.0 # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   path: ^1.5.1
   react: ^6.1.8
   redux: ">=3.0.0 <5.0.0"

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   analyzer: ^1.7.2
   analyzer_plugin: ^0.6.0
   collection: ^1.15.0-nullsafety.4
-  meta: ^1.1.6
+  meta: ^1.6.0
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will require analyzer 1.7.2+ and now that we're past analyzer 1.7.1
we can unpin the meta dependency. (We had restricted it to <1.7.0 in many places)

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer1_unpin_meta`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer1_unpin_meta)