### PR TITLE
Allow newer build dependencies

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
-  build_web_compilers: ^2.5.1
-  build_test: ">=0.10.9 <2.0.0"
+  build_web_compilers: '>=2.5.1 <4.0.0'
+  build_test: '>=0.10.9 <3.0.0'
   dart_dev: ^3.0.0
   glob: ^1.2.0
   json_serializable: ^3.2.2


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This PR gets us closer to unblocking analyzer 2+ by allowing these new versions
once we upgrade built_redux, over_react, and handle json_serializable.

It raises the maximum for these packages:
- build_web_compilers
- build_test
- build_runner

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/newer_build_dev_deps`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/newer_build_dev_deps)