### PR TITLE
RM-179762 RM-179761 Release over_react 4.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## [4.8.3](https://github.com/Workiva/over_react/compare/4.8.2...4.8.3)
+
+- [#807] Allow analyzer 2.x, fix analyzer plugin not starting in newer SDKs
+- 
 ## [4.8.2](https://github.com/Workiva/over_react/compare/4.8.1...4.8.2)
 
 - [#804] Dependencies: raise analyzer to ^1.7.2, unpin meta

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.8.2
+version: 4.8.3
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.8.2
+  over_react: 4.8.3
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-756 Allow analyzer 2.x, fix analyzer plugin in newer SDKs](https://github.com/Workiva/over_react/pull/807)
	* [Allow newer build dependencies](https://github.com/Workiva/over_react/pull/808)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.8.2...Workiva:release_over_react_4.8.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.8.2...4.8.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=810)