### PR TITLE
Dependency updates March 2023

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  color: any
+  color: <4.0.0
   memoize: ^2.0.0
   meta: ^1.6.0
   over_react: ">=3.1.5 <5.0.0"
@@ -18,7 +18,7 @@ dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_web_compilers: '>=2.5.1 <4.0.0'
   build_test: '>=0.10.9 <3.0.0'
-  dart_dev: ^3.0.0
+  dart_dev: ^3.9.2
   glob: ^1.2.0
   json_serializable: ^3.2.2
   over_react_test: ^2.10.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   collection: ^1.14.11
   analyzer: '>=1.7.2 <3.0.0'
   build: '>=1.0.0 <3.0.0'
-  built_redux: ">=7.4.2 <9.0.0"
+  built_redux: ^8.0.0
   built_value: ^8.0.0
   dart_style: '>=1.2.5 <3.0.0'
   js: ^0.6.1+1
@@ -32,8 +32,8 @@ dev_dependencies:
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: '>=2.12.0 <4.0.0'
   built_value_generator: ^8.0.0
-  dart_dev: ^3.6.4
-  dependency_validator: '>=2.0.0 <4.0.0'
+  dart_dev: ^3.9.2
+  dependency_validator: ^3.0.0
   glob: '>=1.2.0<3.0.0'
   io: '>=0.3.2+1 <2.0.0'
   # Pin mockito to work around https://github.com/dart-lang/mockito/issues/552

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   build_test: ^2.0.0
   convert: ^3.0.0
   crypto: ^3.0.0
-  dart_dev: ^3.8.5
+  dart_dev: ^3.9.2
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades
(This is part of Milestone 12)

  # partially unblocks analyzer 2
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  
  # We already resolve to built_redux 8, step 2 raise minimum
  pubspec_codemod raise-min built_redux 8.0.0 --recursive
  
  # Allow the nullsafe version of intl
  pubspec_codemod raise-min intl 0.17.0 --recursive
  pubspec_codemod raise-max intl 0.19.0 --recursive
  pubspec_codemod raise-max color 4.0.0 --recursive
  
  # Shorten pub get times
  pubspec_codemod raise-min dart_dev 3.9.2 --recursive
  pubspec_codemod raise-min dart_dev_workiva 2.0.4 --recursive

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dep_updates_mar23`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dep_updates_mar23)