### PR TITLE
Prepare for dart_dev v4.0.0

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_web_compilers: '>=2.5.1 <4.0.0'
   build_test: '>=0.10.9 <3.0.0'
-  dart_dev: ^3.0.0
+  dart_dev: '>=3.0.0 <5.0.0'
   glob: ^1.2.0
   json_serializable: ^3.2.2
   over_react_test: ^2.10.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: '>=2.12.0 <4.0.0'
   built_value_generator: ^8.0.0
-  dart_dev: ^3.6.4
+  dart_dev: '>=3.6.4 <5.0.0'
   dependency_validator: '>=2.0.0 <4.0.0'
   glob: '>=1.2.0<3.0.0'
   io: '>=0.3.2+1 <2.0.0'

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   build_test: ^2.0.0
   convert: ^3.0.0
   crypto: ^3.0.0
-  dart_dev: ^3.8.5
+  dart_dev: '>=3.8.5 <5.0.0'
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
This PR widens the allowable version ranges of dart_dev so that all repos at Workiva can consume dart_dev 4.0.0 without updating all repositories in lock step.
For more info, reach out to Timothy Steward or `#link23-state-of-the-dart-jam` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dev_widen_ranges_v4`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dev_widen_ranges_v4)