### PR TITLE
RM-184155 RM-184154 Release over_react 4.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## [4.8.5](https://github.com/Workiva/over_react/compare/4.8.4...4.8.5)
+Dependency updates: `dart_dev: '>=3.0.0 <5.0.0'` and `w_common: '>=2.0.0 <4.0.0'`
+
 ## [4.8.4](https://github.com/Workiva/over_react/compare/4.8.3...4.8.4)
 4.8.3 was missing the analyzer plugin in the published package for some reason, and this release should hopefully include it again.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.8.4
+version: 4.8.5
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.8.4
+  over_react: 4.8.5
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Prepare for dart_dev v4.0.0](https://github.com/Workiva/over_react/pull/815)
	* [w_common v3 rollout - 1 of 2 raise max](https://github.com/Workiva/over_react/pull/816)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.8.4...Workiva:release_over_react_4.8.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.8.4...4.8.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=817)