### PR TITLE
Update dart dependencies

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -5,8 +5,8 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  color: any
-  memoize: ^2.0.0
+  color: <4.0.0
+  memoize: '>=2.0.0 <4.0.0'
   meta: ^1.6.0
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0
@@ -19,7 +19,7 @@ dev_dependencies:
   build_web_compilers: '>=2.5.1 <4.0.0'
   build_test: '>=0.10.9 <3.0.0'
   dart_dev: '>=3.0.0 <5.0.0'
-  glob: ^1.2.0
+  glob: ^2.0.0
   json_serializable: ^3.2.2
   over_react_test: ^2.10.2
   pedantic: ^1.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,11 @@ dependencies:
   collection: ^1.14.11
   analyzer: '>=1.7.2 <3.0.0'
   build: '>=1.0.0 <3.0.0'
-  built_redux: ">=7.4.2 <9.0.0"
+  built_redux: ^8.0.0
   built_value: ^8.0.0
   dart_style: '>=1.2.5 <3.0.0'
   js: ^0.6.1+1
-  logging: '>=0.11.3+2 <2.0.0'
+  logging: ^1.0.0
   meta: ^1.6.0
   path: ^1.5.1
   react: ^6.1.8
@@ -34,7 +34,7 @@ dev_dependencies:
   built_value_generator: ^8.0.0
   dart_dev: '>=3.6.4 <5.0.0'
   dependency_validator: '>=2.0.0 <4.0.0'
-  glob: '>=1.2.0<3.0.0'
+  glob: ^2.0.0
   io: '>=0.3.2+1 <2.0.0'
   # Pin mockito to work around https://github.com/dart-lang/mockito/issues/552
   # until we can get to 5.3.1, which requires a newer analyzer.
@@ -43,7 +43,7 @@ dev_dependencies:
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
   test: ^1.15.7
-  yaml: '>=2.2.1 <4.0.0'
+  yaml: ^3.0.0
 
 workiva:
   core_checks:


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

```
  # Raise minimums for package versions that we already resolve to
  pubspec_codemod raise-min built_redux 8.0.0 --recursive
  pubspec_codemod raise-min logging 1.0.0 --recursive
  pubspec_codemod raise-min glob 2.0.0 --recursive
  pubspec_codemod raise-min yaml 3.0.0 --recursive
  pubspec_codemod raise-min archive 3.0.0 --recursive
  pubspec_codemod raise-min xml 5.0.0 --recursive

  # allow next versions (io 1 and memoize 3)
  pubspec_codemod raise-max io 2.0.0 --recursive
  pubspec_codemod raise-max memoize 4.0.0 --recursive
   
  # Allow the nullsafe version of intl and color
  pubspec_codemod raise-min intl 0.17.0 --recursive
  pubspec_codemod raise-max intl 0.19.0 --recursive
  pubspec_codemod raise-max color 4.0.0 --recursive
```

A passing CI is sufficient QA (means dependencies resolve and tests run and pass).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_deps_april_23`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_deps_april_23)