### PR TITLE
RM-188184 RM-188183 Release over_react 4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,24 @@
 # OverReact Changelog
 
+## [4.9.0](https://github.com/Workiva/over_react/compare/4.8.5...4.9.0)
+- [#820] Add Suspense Component
+- [#819] More dependency updates
+
 ## [4.8.5](https://github.com/Workiva/over_react/compare/4.8.4...4.8.5)
-Dependency updates: `dart_dev: '>=3.0.0 <5.0.0'` and `w_common: '>=2.0.0 <4.0.0'`
+- [#815] Dependency updates: `dart_dev: '>=3.0.0 <5.0.0'`
+- [#816] Dependency updates: `w_common: '>=2.0.0 <4.0.0'`
 
 ## [4.8.4](https://github.com/Workiva/over_react/compare/4.8.3...4.8.4)
-4.8.3 was missing the analyzer plugin in the published package for some reason, and this release should hopefully include it again.
+- 4.8.3 was missing the analyzer plugin in the published package for some reason, and this release should hopefully include it again.
 
 ## [4.8.3](https://github.com/Workiva/over_react/compare/4.8.2...4.8.3)
-
 - [#807] Allow analyzer 2.x, fix analyzer plugin not starting in newer SDKs
-- 
-## [4.8.2](https://github.com/Workiva/over_react/compare/4.8.1...4.8.2)
 
+## [4.8.2](https://github.com/Workiva/over_react/compare/4.8.1...4.8.2)
 - [#804] Dependencies: raise analyzer to ^1.7.2, unpin meta
 - [#805] Internal CI and dev_dependencies updates
 
 ## [4.8.1](https://github.com/Workiva/over_react/compare/4.8.0...4.8.1)
-
 - [#802] Raise platform_detect upperbound to allow 2.x
 - [#800] (Docs) Add Redux DevTools integration documentation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.8.5
+version: 4.9.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.8.5
+  over_react: 4.9.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-1255 Add [Suspense] Component](https://github.com/Workiva/over_react/pull/820)
* Patch changes:
	* [Update dart dependencies](https://github.com/Workiva/over_react/pull/819)


Requested by: @kealjones-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.8.5...Workiva:release_over_react_4.9.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.8.5...4.9.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=822)