### PR TITLE
Update 3rd party dependencies

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   meta: ^1.6.0
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0
-  redux: ">=3.0.0 <5.0.0"
-  redux_dev_tools: ">=0.4.0 <0.6.0"
+  redux: '>=3.0.0 <6.0.0'
+  redux_dev_tools: '>=0.4.0 <0.8.0'
   uuid: '>=1.0.3 <4.0.0'
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,14 @@ dependencies:
   meta: ^1.6.0
   path: ^1.5.1
   react: ^6.2.0
-  redux: ">=3.0.0 <5.0.0"
+  redux: '>=3.0.0 <6.0.0'
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: '>=2.0.0 <4.0.0'
   w_flux: ^2.10.21
   platform_detect: '>=1.3.4 <3.0.0'
   quiver: ">=0.25.0 <4.0.0"
-  redux_dev_tools: ">=0.4.0 <0.6.0"
+  redux_dev_tools: '>=0.4.0 <0.8.0'
 
 dev_dependencies:
   build_resolvers: '>=1.0.5 <3.0.0'

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/compact_hoc_syntax_integration_test.dart
@@ -31,7 +31,7 @@ main() {
         TestJacket<FooComponent> jacket;
         expect(() {
           jacket = mount(
-            (ReduxProvider()..store = Store((_, __) => null))(
+            (ReduxProvider()..store = Store((_, __) => null, initialState: null))(
               (Foo()..foo = 'bar')(),
             ),
           );
@@ -50,7 +50,7 @@ main() {
         TestJacket<FooComponent290> jacket;
         expect(() {
           jacket = mount(
-            (ReduxProvider()..store = Store((_, __) => null))(
+            (ReduxProvider()..store = Store((_, __) => null, initialState: null))(
               (Foo290()..foo = 'bar')(),
             ),
           );


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies.

This batch raises maximum versions for a set of 3rd party dependencies
in order to get the latest (nullsafe) versions of these packages.

```
pubspec_codemod raise-max codemirror 0.8.0 --recursive
pubspec_codemod raise-max csv 6.0.0 --recursive
pubspec_codemod raise-max diff_match_patch 0.5.0 --recursive
pubspec_codemod raise-max faker 3.0.0 --recursive
pubspec_codemod raise-max get_it 7.0.0 --recursive
pubspec_codemod raise-max redux 6.0.0 --recursive
pubspec_codemod raise-max redux_dev_tools 0.8.0 --recursive
pubspec_codemod raise-max redux_saga 4.0.0 --recursive
pubspec_codemod raise-max redux_thunk 0.5.0 --recursive
pubspec_codemod raise-max synchronized 4.0.0 --recursive
```

A test batch was done prior to verify that these new versions were statically safe.
CI tests passed on this test batch as well.

A second followup batch will raise the minimum versions once the newer versions
have been consumed everywhere.

Post questions or concerns in #support-frontend-dx

[_Created by Sourcegraph batch change `Workiva/raise_3rd_party_deps`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/raise_3rd_party_deps)