### PR TITLE
Allow test_html_builder 3

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -132,9 +132,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Can't run in 2.13.4 since dependencies can no longer resolve in that version.
-        # Can't run on `dev` (Dart 3) until we're fully null-safe.
-        sdk: [ 2.18.7, stable ]
+        # Can't run on `stable` (Dart 3) until we're fully null-safe.
+        sdk: [ 2.18.7, 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
   test: ^1.15.7
-  test_html_builder: ^2.2.2
+  test_html_builder: '>=2.2.2 <4.0.0'
   time: ^1.2.0
   w_common: '>=2.0.0 <4.0.0'
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!

This update will allow the nullsafe/analyzer2 versions of test_html_builder.
We've made the v3 version safe to use a range for so that once the json_serializable 4
PRs land, everything can upgrade to analyzer 2.

Feel free to approve and merge this if CI passes.
Otherwise, someone from FEF will come by to approve and merge it.
Consumer tests and release notes are not needed.

For more info, visit `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/test_html_builder_3`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_html_builder_3)