### PR TITLE
Raise minimums

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -5,8 +5,8 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  color: <4.0.0
-  memoize: '>=2.0.0 <4.0.0'
+  color: ^3.0.0
+  memoize: ^3.0.0
   meta: ^1.6.0
   over_react: ">=3.1.5 <5.0.0"
   json_annotation: ^3.0.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

```
  # Raise minimums for package versions that we already resolve to
  pubspec_codemod raise-min w_intl 2.0.0 --recursive
  pubspec_codemod raise-min json_schema 5.0.0 --recursive
  pubspec_codemod raise-min intl 0.18.0 --recursive
  pubspec_codemod raise-min color 3.0.0 --recursive
  pubspec_codemod raise-min memoize 3.0.0 --recursive
```

A passing CI is sufficient QA (means dependencies resolve and tests run and pass).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/raise_mins_5_31`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/raise_mins_5_31)