### PR TITLE
Release over_react 4.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.9.1
+version: 4.10.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.9.1
+  over_react: 4.10.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Update json_annotation & serializable in example app](https://github.com/Workiva/over_react/pull/809)
	* [Allow test_html_builder 3](https://github.com/Workiva/over_react/pull/826)
	* [Raise minimums](https://github.com/Workiva/over_react/pull/827)
	* [FED-279: Add improved prop forwarding method](https://github.com/Workiva/over_react/pull/829)


Requested by: @kealjones-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/4.9.1...Workiva:release_over_react_4.10.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/4.9.1...4.10.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)