### PR TITLE
Update dev dependencies for analyzer 2

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   test: ^1.15.7
   test_html_builder: ^3.0.0
   time: ^1.2.0
-  w_common: '>=2.0.0 <4.0.0'
+  w_common: ^3.0.0
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -363,7 +363,9 @@ class _TypedMapMixinAccessorsGenerator extends TypedMapAccessorsGenerator {
 
   @override
   void generate() {
-    outputContentsBuffer..write(_generateAccessorsMixin())..write(_generateMetaConstImpl());
+    outputContentsBuffer
+      ..write(_generateAccessorsMixin())
+      ..write(_generateMetaConstImpl());
   }
 }
 

--- a/lib/src/builder/codegen/component_factory_generator.dart
+++ b/lib/src/builder/codegen/component_factory_generator.dart
@@ -100,6 +100,8 @@ class ComponentFactoryProxyGenerator extends BoilerplateDeclarationGenerator {
       outputContentsBuffer.writeln('    skipMethods: const [],');
     }
 
-    outputContentsBuffer..writeln(');')..writeln();
+    outputContentsBuffer
+      ..writeln(');')
+      ..writeln();
   }
 }

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -153,7 +153,9 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
       classDeclaration.write('abstract ');
     }
 
-    classDeclaration..write(_generateImplClassHeader())..write(' {');
+    classDeclaration
+      ..write(_generateImplClassHeader())
+      ..write(' {');
 
     final propsOrState = isProps ? 'props' : 'state';
 
@@ -235,7 +237,9 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
     // Component2-specific classes
     if (isComponent2) {
       // TODO need to remove this workaround once https://github.com/dart-lang/sdk/issues/36217 is fixed get nice dart2js output
-      buffer..writeln()..writeln('''
+      buffer
+        ..writeln()
+        ..writeln('''
 // Concrete $propsOrState implementation that can be backed by any [Map].
 ${internalGeneratedMemberDeprecationLine()}class ${names.plainMapImplName}$typeParamsOnClass extends ${names.implName}$typeParamsOnSuper {
   // This initializer of `_$propsOrState` to an empty map, as well as the reassignment

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
 
 dependencies:
   collection: ^1.14.11
-  analyzer: '>=1.7.2 <3.0.0'
+  analyzer: ^2.0.0
   build: '>=1.0.0 <3.0.0'
   built_redux: ^8.0.0
   built_value: ^8.0.0
-  dart_style: '>=1.2.5 <3.0.0'
+  dart_style: ^2.0.0
   js: ^0.6.1+1
   logging: ^1.0.0
   meta: ^1.6.0
@@ -20,7 +20,7 @@ dependencies:
   redux: '>=3.0.0 <6.0.0'
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
-  w_common: '>=2.0.0 <4.0.0'
+  w_common: ^3.0.0
   w_flux: ^2.10.21
   platform_detect: '>=1.3.4 <3.0.0'
   quiver: ">=0.25.0 <4.0.0"
@@ -28,12 +28,12 @@ dependencies:
 
 dev_dependencies:
   build_resolvers: '>=1.0.5 <3.0.0'
-  build_runner: '>=1.7.1 <3.0.0'
-  build_test: ">=0.10.9 <3.0.0"
-  build_web_compilers: '>=2.12.0 <4.0.0'
+  build_runner: ^2.0.0
+  build_test: ^2.0.0
+  build_web_compilers: ^3.0.0
   built_value_generator: ^8.0.0
-  dart_dev: '>=3.6.4 <5.0.0'
-  dependency_validator: '>=2.0.0 <4.0.0'
+  dart_dev: ^4.0.0
+  dependency_validator: ^3.0.0
   glob: ^2.0.0
   io: '>=0.3.2+1 <2.0.0'
   # Pin mockito to work around https://github.com/dart-lang/mockito/issues/552

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -5,8 +5,8 @@ environment:
 dependencies:
   over_react: ^3.5.3
 dev_dependencies:
-  build_runner: '>=1.0.0 <3.0.0'
-  build_web_compilers: '>=2.0.0 <4.0.0'
+  build_runner: ^2.0.0
+  build_web_compilers: ^3.0.0
   workiva_analysis_options: ^1.1.0
 
 dependency_overrides:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   build_test: ^2.0.0
   convert: ^3.0.0
   crypto: ^3.0.0
-  dart_dev: '>=3.8.5 <5.0.0'
+  dart_dev: ^4.0.0
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
   glob: ^2.0.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! Now that we can resolve to analyzer 2
we can raise the minimums of many dependencies were ranged to support both 
analyzer 1 and 2.

```
  pubspec_codemod raise-min analyzer 2.0.0 --recursive
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  pubspec_codemod raise-min test_html_builder 3.0.0 --recursive
  pubspec_codemod raise-min dart_style 2.0.0 --recursive
  pubspec_codemod raise-min build_web_compilers 3.0.0 --recursive
  pubspec_codemod raise-min build_test 2.0.0 --recursive
  pubspec_codemod raise-min build_runner 2.0.0 --recursive
  pubspec_codemod raise-min w_common 3.0.0 --recursive
  pubspec_codemod raise-min w_common_tools 3.0.0 --recursive
  pubspec_codemod raise-min uuid 3.0.0 --recursive
  pubspec_codemod raise-min fluri 2.0.0 --recursive
  pubspec_codemod raise-min get_it 6.0.0 --recursive
  pubspec_codemod raise-min dart_dev 4.0.0 --recursive
```

A passing CI is sufficient QA (that means dependencies resolve and tests run and pass).

For question or concerns visit `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_dev_deps_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_dev_deps_analyzer2)