### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   color: ^3.0.0
   memoize: ^3.0.0
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   over_react: ^4.8.4
   json_annotation: ^4.6.0
   redux: '>=3.0.0 <6.0.0'
@@ -32,3 +32,6 @@ dev_dependencies:
 dependency_overrides:
   over_react:
     path: '../../../'
+dependency_validator:
+  ignore:
+    - meta

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dart_style: '>=1.2.5 <3.0.0'
   js: ^0.6.1+1
   logging: ^1.0.0
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   path: ^1.5.1
   react: ^6.2.0
   redux: '>=3.0.0 <6.0.0'
@@ -55,4 +55,5 @@ dependency_validator:
     - app/**
     - tools/**
   ignore:
+    - meta
     - mockito

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   # Can't be 0.7.0 since its results in errors around JenkinsSmiHash not existing
   analyzer_plugin: ^0.8.0
   collection: ^1.15.0-nullsafety.4
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)