### PR TITLE
RM-213359 RM-213358 Release over_react 4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OverReact Changelog
 
-## [4.10.1](https://github.com/Workiva/over_react/compare/4.10.0...4.10.1)
+## [4.10.2](https://github.com/Workiva/over_react/compare/4.10.0...4.10.2)
 - [#835] Upgrade dependencies, notably jumping to analyzer 5.x
      - analyzer: `^5.1.0` (was `>=1.7.2 <3.0.0`)
      - dart_style: `^2.0.0` (was `>=1.2.5 <3.0.0`)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 4.10.1
+version: 4.10.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/.pubignore
+++ b/tools/analyzer_plugin/.pubignore
@@ -5,3 +5,4 @@
 #
 #     Bad state: Unable to find the context to …/tools/analyzer_plugin/playground/web/bad_keys.dart
 playground/
+test/test_fixtures/

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 4.10.1
+  over_react: 4.10.2
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION
There was a problem publishing 4.10.1 because of a nested test_fixture directory. Adding it to the .pubignore works around this issue.

```
Bad state: Unable to find the context to /Users/greglittlefield/workspaces/over_react2/tools/analyzer_plugin/test/test_fixtures/over_react_project/lib/analysis_warmup.dart
package:pub/src/dart.dart 119:5                           AnalysisContextManager._getExistingSession
package:pub/src/dart.dart 83:23                           AnalysisContextManager.parse
package:pub/src/dart.dart 102:16                          AnalysisContextManager.parseImportsAndExports
package:pub/src/validator/strict_dependencies.dart 35:45  StrictDependenciesValidator._findPackages
dart:async                                                _SyncStarIterator.moveNext
package:pub/src/validator/strict_dependencies.dart 95:23  StrictDependenciesValidator._validateBenchmarkTestTool
package:pub/src/validator/strict_dependencies.dart 71:5   StrictDependenciesValidator.validate
package:pub/src/validator.dart 166:23                     Validator.runAll.<fn>
dart:async                                                Future.wait
package:pub/src/validator.dart 164:25                     Validator.runAll
===== asynchronous gap ===========================
package:pub/src/command/lish.dart 263:5                   LishCommand._validate
===== asynchronous gap ===========================
package:pub/src/command/lish.dart 236:19                  LishCommand.runProtected
This is an unexpected error. The full log and other details are collected in:
```