### PR TITLE
Rollout Analyzer 5

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   json_serializable: ^6.0.0
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
-  test: ^1.15.7
+  test: ^1.21.1
   test_html_builder: ^3.0.0
   time: ^1.2.0
   w_common: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: ^5.1.0
   build: '>=1.0.0 <3.0.0'
   built_redux: ^8.0.6
-  built_value: ^8.0.0
+  built_value: ^8.5.0
   dart_style: ^2.0.0
   js: ^0.6.1+1
   logging: ^1.0.0
@@ -31,16 +31,16 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
   build_web_compilers: ^3.0.0
-  built_value_generator: ^8.0.0
+  built_value_generator: ^8.5.0
   dart_dev: ^4.0.0
   dependency_validator: ^3.0.0
   glob: ^2.0.0
   io: '>=0.3.2+1 <2.0.0'
-  mockito: ^5.3.1
+  mockito: ^5.3.2
   react_testing_library: ^2.1.0
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
-  test: ^1.15.7
+  test: ^1.21.1
   yaml: ^3.0.0
 
 workiva:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   io: ^1.0.0
   logging: ^1.0.1
   markdown: ^4.0.0
-  test: ^1.14.0
+  test: ^1.21.1
   test_reflective_loader: ^0.2.0
   uuid: '>3.0.0 <5.0.0'
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
# Rollout Analyzer 5

This batch will raise the minimum of workiva_dependency_constrainer
to one that requires analyzer 5, thus ensuring that a repo resolves
to analyzer 5. It also raises the minimums of other packages that
are needed, like built_value.

## Things that may need fixing manually

1. Probably the most common thing is that built_value generated code
will need to be regenerated. There should be no breaking changes in
this new generated code. Some repos have a make target called `gen`,
`gen-built` or similar, or just run a full `dart run build_runner build`

2. The temporary fix for Dart coverage needs to be removed. The fix
is to simply remove lines like these below from Github Actions. This PR
will have raised the minimum of the test package to 1.21.1 which is
the first version needed that removes the need to backpatched test
versions.
```
  - uses: Workiva/gha-dart/temp-coverage-setup@v0.2.28
    with:
      test-package-version: 1.20.1
```

3. As part of moving to analyzer 5, the sort_pub_dependencies lint 
seems to act as a warning now, causing analyze to fail CI.
To fix: either sort the dependencies in alphabetical order or
alter the analysis_options.yaml to lower the severity to a hint



For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer_5`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer_5)