### PR TITLE
Dart 2.19

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -51,7 +51,7 @@ jobs:
         timeout-minutes: 6
         name: Build generated files / precompile DDC assets
         run: |
-          dart pub run build_runner build --delete-conflicting-outputs -o ddc_precompiled
+          dart run build_runner build --delete-conflicting-outputs -o ddc_precompiled
           if [ ${{ matrix.sdk }} = '2.18.7' ]; then
             git diff --exit-code
           else
@@ -77,7 +77,7 @@ jobs:
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
       - name: Run tests (dart2js)
-        run: dart pub run dart_dev test --build-args="-r" -P dart2js
+        run: dart run dart_dev test --build-args="-r" -P dart2js
         if: always() && steps.install.outcome == 'success' && steps.build.outcome == 'success'
 
   validate_analyzer:
@@ -100,7 +100,7 @@ jobs:
       - name: Print Dart SDK version
         run: dart --version
 
-      - name: Update analyzer constraint to ${{ matrix.analyzer }} and validate `pub get` can resolve
+      - name: Update analyzer constraint to ${{ matrix.analyzer }} and validate `dart pub get` can resolve
         id: resolve
         run: |
           dart tool/set_analyzer_constraint.dart "${{ matrix.analyzer }}"
@@ -115,7 +115,7 @@ jobs:
         run: dart run build_runner build --build-filter='**.dart' --delete-conflicting-outputs
 
       - name: Run builder tests
-        run: dart run test -p vm -- test/vm_tests/builder
+        run: dart test -p vm -- test/vm_tests/builder
 
   analyzer_plugin:
     runs-on: ubuntu-latest
@@ -150,9 +150,9 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 
       - name: Verify formatting
-        run: dart pub run dart_dev format --check
+        run: dart run dart_dev format --check
         if: always() && matrix.sdk == '2.7.2' && steps.install.outcome == 'success'
 
       - name: Run tests
-        run: dart pub run dart_dev test
+        run: dart run dart_dev test
         if: always() && steps.install.outcome == 'success'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.18
+FROM dart:2.19.6
 
 # Expose env vars for git ssh access
 ARG GIT_SSH_KEY


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_219`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_219)