### PR TITLE
Allow react 7 and w_flux 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,12 +16,12 @@ dependencies:
   logging: ^1.0.0
   meta: ^1.6.0
   path: ^1.5.1
-  react: ^6.3.0
+  react: '>=6.3.0 <8.0.0'
   redux: '>=3.0.0 <6.0.0'
   source_span: ^1.4.1
   transformer_utils: ^0.2.6
   w_common: ^3.0.0
-  w_flux: ^2.10.21
+  w_flux: '>=2.10.21 <4.0.0'
   platform_detect: '>=1.3.4 <3.0.0'
   quiver: ">=0.25.0 <4.0.0"
   redux_dev_tools: '>=0.4.0 <0.8.0'


### PR DESCRIPTION
This PR raises the max allowed versions for react and w_flux. A second batch will follow to raise the minimums of these later.
These versions have been tested across the frontend ecosystem in a test batch prior to releasing these versions.
Feel free to review, approve and merge if CI passes. Otherwise someone on FEDX will come around and get it merged.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_flux_majors`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/react_flux_majors)