### PR TITLE
FED-1946 Null safety update lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.8.0.yaml
+include: package:workiva_analysis_options/v2.recommended.yaml
 
 analyzer:
   strong-mode:
@@ -10,102 +10,39 @@ analyzer:
     - tools/analyzer_plugin/**
     - ddc_precompiled/**
   errors:
-    invalid_export_of_internal_element: warning
-    unused_import: warning
-    duplicate_import: warning
-    missing_required_param: error
-    must_call_super: error
-    uri_has_not_been_generated: ignore
-    # Workaround for https://github.com/dart-lang/sdk/issues/51087
-    # TODO remove once we can run on Dart 2.19 (blocked by https://github.com/dart-lang/sdk/issues/51128 or working around it by upgrading to analyzer ^5.1.0)
-    part_of_different_library: ignore
-    cast_nullable_to_non_nullable: warning
-linter:
-  rules:
-    cast_nullable_to_non_nullable: true
-    # -------------------
-    # Pedantic
-    # -------------------
-    avoid_empty_else: true
-    avoid_init_to_null: true
-    avoid_relative_lib_imports: true
-    avoid_return_types_on_setters: true
-    avoid_shadowing_type_parameters: true
-    avoid_types_as_parameter_names: true
-    curly_braces_in_flow_control_structures: true
-    empty_catches: true
-    empty_constructor_bodies: true
-    empty_statements: true
-    library_names: true
-    library_prefixes: true
-    no_duplicate_case_values: true
-    null_closures: true
-    prefer_contains: true
-    prefer_equal_for_default_values: true
-    prefer_is_empty: true
-    prefer_is_not_empty: true
-    prefer_iterable_whereType: true
-    recursive_getters: true
-    slash_for_doc_comments: true
-    type_init_formals: true
-    unawaited_futures: true
-    unnecessary_const: true
-    unnecessary_new: true
-    unnecessary_null_in_if_null_operators: true
-    unrelated_type_equality_checks: true
-    use_rethrow_when_possible: true
-    valid_regexps: true
+    # Too noisy for over_react code / boilerplate
+    always_declare_return_types: ignore
+    avoid_types_on_closure_parameters: ignore
+    prefer_mixin: ignore
+    type_annotate_public_apis: ignore
 
-    # -------------------
-    # Other
-    # -------------------
-    annotate_overrides: true
-    avoid_bool_literals_in_conditional_expressions: true
-    avoid_classes_with_only_static_members: true
-    avoid_double_and_int_checks: true
-    avoid_null_checks_in_equality_operators: true
-    avoid_returning_null_for_void: true
-    avoid_returning_this: true
-    avoid_setters_without_getters: true
-    avoid_single_cascade_in_expression_statements: true
-    avoid_slow_async_io: true
-    avoid_types_on_closure_parameters: true
-    avoid_unused_constructor_parameters: true
-    avoid_void_async: true
-    await_only_futures: true
-    camel_case_types: true
-    cancel_subscriptions: true
-    close_sinks: true
-    comment_references: true
-    hash_and_equals: true
-    implementation_imports: true
-    iterable_contains_unrelated_type: true
-    list_remove_unrelated_type: true
-    literal_only_boolean_expressions: true
-    no_adjacent_strings_in_list: true
-    package_names: true
-    prefer_collection_literals: true
-    prefer_conditional_assignment: true
-    prefer_const_declarations: true
-    prefer_constructors_over_static_methods: true
-    prefer_function_declarations_over_variables: true
-    prefer_generic_function_type_aliases: true
-    prefer_if_null_operators: true
-    prefer_initializing_formals: true
-    prefer_null_aware_operators: true
-    prefer_single_quotes: true
-    prefer_spread_collections: true
-    prefer_typing_uninitialized_variables: true
-    provide_deprecation_message: true
-    test_types_in_equals: true
-    unnecessary_await_in_return: true
-    unnecessary_brace_in_string_interps: true
-    unnecessary_getters_setters: true
-    unnecessary_lambdas: true
-    unnecessary_null_aware_assignments: true
-    unnecessary_overrides: true
-    unnecessary_statements: true
-    unsafe_html: true
-    use_function_type_syntax_for_parameters: true
-    use_to_and_as_if_applicable: true
-    void_checks: true
+    # Affects generated code
+    unnecessary_this: ignore
+
+    # Lints that have too many exceptions and provide limited value
+    avoid_private_typedef_functions: ignore
+    join_return_with_assignment: ignore
+
+    # Fixing these would cause a lot of changes, and these lints don't provide too much value
+    prefer_interpolation_to_compose_strings: ignore
+    sort_unnamed_constructors_first: ignore
+    unnecessary_lambdas: ignore
+
+    # Fixing these would cause a lot of changes; clean up after null safety branch
+    always_put_required_named_parameters_first: ignore
+    avoid_function_literals_in_foreach_calls: ignore
+    avoid_positional_boolean_parameters: ignore
+    avoid_renaming_method_parameters: ignore
+    directives_ordering: ignore
+    file_names: ignore
+    omit_local_variable_types: ignore
+    overridden_fields: ignore
+    prefer_asserts_in_initializer_lists: ignore
+    prefer_final_in_for_each: ignore
+    prefer_final_locals: ignore
+    unnecessary_parenthesis: ignore
+    unnecessary_string_interpolations: ignore
+
+    # Maybe fix within null safety branch in follow-up PR?
+    prefer_final_fields: ignore
+    prefer_void_to_null: ignore

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,6 +18,7 @@ analyzer:
 
     # Affects generated code
     unnecessary_this: ignore
+    unused_field: ignore
 
     # Lints that have too many exceptions and provide limited value
     avoid_private_typedef_functions: ignore

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,10 @@ analyzer:
     - tools/analyzer_plugin/**
     - ddc_precompiled/**
   errors:
+    # Workaround for https://github.com/dart-lang/sdk/issues/51087
+    # TODO remove once we're no longer running CI on Dart 2.18
+    part_of_different_library: ignore
+
     # Too noisy for over_react code / boilerplate
     always_declare_return_types: ignore
     avoid_types_on_closure_parameters: ignore

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -82,8 +82,8 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
       final implementsClause = 'implements ${names.consumerName}$typeParamsOnSuper';
       generatedClass
         ..write(generatedCodeUseOnlyDeprecation)
-        ..writeln('abstract class $accessorsMixinName$typeParamsOnClass $implementsClause {\n' +
-            '  @override' +
+        ..writeln('abstract class $accessorsMixinName$typeParamsOnClass $implementsClause {\n'
+            '  @override'
             '  Map get ${type.isProps ? 'props' : 'state'};\n');
       if (type.isMixin) {
         generatedClass.writeln(_generateStaticMetaDecl(names.publicName, type.isProps));

--- a/lib/src/component/dom_components.dart
+++ b/lib/src/component/dom_components.dart
@@ -85,826 +85,826 @@ abstract class Dom {
   /// Returns a new builder that renders an `<a>` tag with getters/setters for all DOM-related React props,
 
   /// optionally backed by a specified map.
-  static DomProps a([Map? backingMap]) => DomProps(react.a as ReactComponentFactoryProxy, backingMap);
+  static DomProps a([Map? backingMap]) => DomProps(react.a, backingMap);
 
   /// Returns a new builder that renders an `<abbr>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps abbr([Map? backingMap]) => DomProps(react.abbr as ReactComponentFactoryProxy, backingMap);
+  static DomProps abbr([Map? backingMap]) => DomProps(react.abbr, backingMap);
 
   /// Returns a new builder that renders an `<address>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps address([Map? backingMap]) => DomProps(react.address as ReactComponentFactoryProxy, backingMap);
+  static DomProps address([Map? backingMap]) => DomProps(react.address, backingMap);
 
   /// Returns a new builder that renders an `<area>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps area([Map? backingMap]) => DomProps(react.area as ReactComponentFactoryProxy, backingMap);
+  static DomProps area([Map? backingMap]) => DomProps(react.area, backingMap);
 
   /// Returns a new builder that renders an `<article>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps article([Map? backingMap]) => DomProps(react.article as ReactComponentFactoryProxy, backingMap);
+  static DomProps article([Map? backingMap]) => DomProps(react.article, backingMap);
 
   /// Returns a new builder that renders an `<aside>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps aside([Map? backingMap]) => DomProps(react.aside as ReactComponentFactoryProxy, backingMap);
+  static DomProps aside([Map? backingMap]) => DomProps(react.aside, backingMap);
 
   /// Returns a new builder that renders an `<audio>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps audio([Map? backingMap]) => DomProps(react.audio as ReactComponentFactoryProxy, backingMap);
+  static DomProps audio([Map? backingMap]) => DomProps(react.audio, backingMap);
 
   /// Returns a new builder that renders a `<b>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps b([Map? backingMap]) => DomProps(react.b as ReactComponentFactoryProxy, backingMap);
+  static DomProps b([Map? backingMap]) => DomProps(react.b, backingMap);
 
   /// Returns a new builder that renders a `<base>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps base([Map? backingMap]) => DomProps(react.base as ReactComponentFactoryProxy, backingMap);
+  static DomProps base([Map? backingMap]) => DomProps(react.base, backingMap);
 
   /// Returns a new builder that renders a `<bdi>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps bdi([Map? backingMap]) => DomProps(react.bdi as ReactComponentFactoryProxy, backingMap);
+  static DomProps bdi([Map? backingMap]) => DomProps(react.bdi, backingMap);
 
   /// Returns a new builder that renders a `<bdo>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps bdo([Map? backingMap]) => DomProps(react.bdo as ReactComponentFactoryProxy, backingMap);
+  static DomProps bdo([Map? backingMap]) => DomProps(react.bdo, backingMap);
 
   /// Returns a new builder that renders a `<big>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps big([Map? backingMap]) => DomProps(react.big as ReactComponentFactoryProxy, backingMap);
+  static DomProps big([Map? backingMap]) => DomProps(react.big, backingMap);
 
   /// Returns a new builder that renders a `<blockquote>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps blockquote([Map? backingMap]) => DomProps(react.blockquote as ReactComponentFactoryProxy, backingMap);
+  static DomProps blockquote([Map? backingMap]) => DomProps(react.blockquote, backingMap);
 
   /// Returns a new builder that renders a `<body>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps body([Map? backingMap]) => DomProps(react.body as ReactComponentFactoryProxy, backingMap);
+  static DomProps body([Map? backingMap]) => DomProps(react.body, backingMap);
 
   /// Returns a new builder that renders a `<br>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps br([Map? backingMap]) => DomProps(react.br as ReactComponentFactoryProxy, backingMap);
+  static DomProps br([Map? backingMap]) => DomProps(react.br, backingMap);
 
   /// Returns a new builder that renders a `<button>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps button([Map? backingMap]) => DomProps(react.button as ReactComponentFactoryProxy, backingMap);
+  static DomProps button([Map? backingMap]) => DomProps(react.button, backingMap);
 
   /// Returns a new builder that renders a `<canvas>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps canvas([Map? backingMap]) => DomProps(react.canvas as ReactComponentFactoryProxy, backingMap);
+  static DomProps canvas([Map? backingMap]) => DomProps(react.canvas, backingMap);
 
   /// Returns a new builder that renders a `<caption>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps caption([Map? backingMap]) => DomProps(react.caption as ReactComponentFactoryProxy, backingMap);
+  static DomProps caption([Map? backingMap]) => DomProps(react.caption, backingMap);
 
   /// Returns a new builder that renders a `<cite>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps cite([Map? backingMap]) => DomProps(react.cite as ReactComponentFactoryProxy, backingMap);
+  static DomProps cite([Map? backingMap]) => DomProps(react.cite, backingMap);
 
   /// Returns a new builder that renders a `<code>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps code([Map? backingMap]) => DomProps(react.code as ReactComponentFactoryProxy, backingMap);
+  static DomProps code([Map? backingMap]) => DomProps(react.code, backingMap);
 
   /// Returns a new builder that renders a `<col>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps col([Map? backingMap]) => DomProps(react.col as ReactComponentFactoryProxy, backingMap);
+  static DomProps col([Map? backingMap]) => DomProps(react.col, backingMap);
 
   /// Returns a new builder that renders a `<colgroup>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps colgroup([Map? backingMap]) => DomProps(react.colgroup as ReactComponentFactoryProxy, backingMap);
+  static DomProps colgroup([Map? backingMap]) => DomProps(react.colgroup, backingMap);
 
   /// Returns a new builder that renders a `<data>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps data([Map? backingMap]) => DomProps(react.data as ReactComponentFactoryProxy, backingMap);
+  static DomProps data([Map? backingMap]) => DomProps(react.data, backingMap);
 
   /// Returns a new builder that renders a `<datalist>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps datalist([Map? backingMap]) => DomProps(react.datalist as ReactComponentFactoryProxy, backingMap);
+  static DomProps datalist([Map? backingMap]) => DomProps(react.datalist, backingMap);
 
   /// Returns a new builder that renders a `<dd>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps dd([Map? backingMap]) => DomProps(react.dd as ReactComponentFactoryProxy, backingMap);
+  static DomProps dd([Map? backingMap]) => DomProps(react.dd, backingMap);
 
   /// Returns a new builder that renders a `<del>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps del([Map? backingMap]) => DomProps(react.del as ReactComponentFactoryProxy, backingMap);
+  static DomProps del([Map? backingMap]) => DomProps(react.del, backingMap);
 
   /// Returns a new builder that renders a `<details>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps details([Map? backingMap]) => DomProps(react.details as ReactComponentFactoryProxy, backingMap);
+  static DomProps details([Map? backingMap]) => DomProps(react.details, backingMap);
 
   /// Returns a new builder that renders a `<dfn>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps dfn([Map? backingMap]) => DomProps(react.dfn as ReactComponentFactoryProxy, backingMap);
+  static DomProps dfn([Map? backingMap]) => DomProps(react.dfn, backingMap);
 
   /// Returns a new builder that renders a `<dialog>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps dialog([Map? backingMap]) => DomProps(react.dialog as ReactComponentFactoryProxy, backingMap);
+  static DomProps dialog([Map? backingMap]) => DomProps(react.dialog, backingMap);
 
   /// Returns a new builder that renders a `<div>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps div([Map? backingMap]) => DomProps(react.div as ReactComponentFactoryProxy, backingMap);
+  static DomProps div([Map? backingMap]) => DomProps(react.div, backingMap);
 
   /// Returns a new builder that renders a `<dl>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps dl([Map? backingMap]) => DomProps(react.dl as ReactComponentFactoryProxy, backingMap);
+  static DomProps dl([Map? backingMap]) => DomProps(react.dl, backingMap);
 
   /// Returns a new builder that renders a `<dt>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps dt([Map? backingMap]) => DomProps(react.dt as ReactComponentFactoryProxy, backingMap);
+  static DomProps dt([Map? backingMap]) => DomProps(react.dt, backingMap);
 
   /// Returns a new builder that renders an `<em>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps em([Map? backingMap]) => DomProps(react.em as ReactComponentFactoryProxy, backingMap);
+  static DomProps em([Map? backingMap]) => DomProps(react.em, backingMap);
 
   /// Returns a new builder that renders an `<embed>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps embed([Map? backingMap]) => DomProps(react.embed as ReactComponentFactoryProxy, backingMap);
+  static DomProps embed([Map? backingMap]) => DomProps(react.embed, backingMap);
 
   /// Returns a new builder that renders a `<fieldset>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps fieldset([Map? backingMap]) => DomProps(react.fieldset as ReactComponentFactoryProxy, backingMap);
+  static DomProps fieldset([Map? backingMap]) => DomProps(react.fieldset, backingMap);
 
   /// Returns a new builder that renders a `<figcaption>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps figcaption([Map? backingMap]) => DomProps(react.figcaption as ReactComponentFactoryProxy, backingMap);
+  static DomProps figcaption([Map? backingMap]) => DomProps(react.figcaption, backingMap);
 
   /// Returns a new builder that renders a `<figure>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps figure([Map? backingMap]) => DomProps(react.figure as ReactComponentFactoryProxy, backingMap);
+  static DomProps figure([Map? backingMap]) => DomProps(react.figure, backingMap);
 
   /// Returns a new builder that renders a `<footer>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps footer([Map? backingMap]) => DomProps(react.footer as ReactComponentFactoryProxy, backingMap);
+  static DomProps footer([Map? backingMap]) => DomProps(react.footer, backingMap);
 
   /// Returns a new builder that renders a `<form>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps form([Map? backingMap]) => DomProps(react.form as ReactComponentFactoryProxy, backingMap);
+  static DomProps form([Map? backingMap]) => DomProps(react.form, backingMap);
 
   /// Returns a new builder that renders a `<h1>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h1([Map? backingMap]) => DomProps(react.h1 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h1([Map? backingMap]) => DomProps(react.h1, backingMap);
 
   /// Returns a new builder that renders a `<h2>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h2([Map? backingMap]) => DomProps(react.h2 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h2([Map? backingMap]) => DomProps(react.h2, backingMap);
 
   /// Returns a new builder that renders a `<h3>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h3([Map? backingMap]) => DomProps(react.h3 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h3([Map? backingMap]) => DomProps(react.h3, backingMap);
 
   /// Returns a new builder that renders a `<h4>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h4([Map? backingMap]) => DomProps(react.h4 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h4([Map? backingMap]) => DomProps(react.h4, backingMap);
 
   /// Returns a new builder that renders a `<h5>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h5([Map? backingMap]) => DomProps(react.h5 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h5([Map? backingMap]) => DomProps(react.h5, backingMap);
 
   /// Returns a new builder that renders a `<h6>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps h6([Map? backingMap]) => DomProps(react.h6 as ReactComponentFactoryProxy, backingMap);
+  static DomProps h6([Map? backingMap]) => DomProps(react.h6, backingMap);
 
   /// Returns a new builder that renders a `<head>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps head([Map? backingMap]) => DomProps(react.head as ReactComponentFactoryProxy, backingMap);
+  static DomProps head([Map? backingMap]) => DomProps(react.head, backingMap);
 
   /// Returns a new builder that renders a `<header>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps header([Map? backingMap]) => DomProps(react.header as ReactComponentFactoryProxy, backingMap);
+  static DomProps header([Map? backingMap]) => DomProps(react.header, backingMap);
 
   /// Returns a new builder that renders a `<hr>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps hr([Map? backingMap]) => DomProps(react.hr as ReactComponentFactoryProxy, backingMap);
+  static DomProps hr([Map? backingMap]) => DomProps(react.hr, backingMap);
 
   /// Returns a new builder that renders a `<html>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps html([Map? backingMap]) => DomProps(react.html as ReactComponentFactoryProxy, backingMap);
+  static DomProps html([Map? backingMap]) => DomProps(react.html, backingMap);
 
   /// Returns a new builder that renders an `<i>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps i([Map? backingMap]) => DomProps(react.i as ReactComponentFactoryProxy, backingMap);
+  static DomProps i([Map? backingMap]) => DomProps(react.i, backingMap);
 
   /// Returns a new builder that renders an `<iframe>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps iframe([Map? backingMap]) => DomProps(react.iframe as ReactComponentFactoryProxy, backingMap);
+  static DomProps iframe([Map? backingMap]) => DomProps(react.iframe, backingMap);
 
   /// Returns a new builder that renders an `<img>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps img([Map? backingMap]) => DomProps(react.img as ReactComponentFactoryProxy, backingMap);
+  static DomProps img([Map? backingMap]) => DomProps(react.img, backingMap);
 
   /// Returns a new builder that renders an `<input>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps input([Map? backingMap]) => DomProps(react.input as ReactComponentFactoryProxy, backingMap);
+  static DomProps input([Map? backingMap]) => DomProps(react.input, backingMap);
 
   /// Returns a new builder that renders an `<ins>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps ins([Map? backingMap]) => DomProps(react.ins as ReactComponentFactoryProxy, backingMap);
+  static DomProps ins([Map? backingMap]) => DomProps(react.ins, backingMap);
 
   /// Returns a new builder that renders a `<kbd>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps kbd([Map? backingMap]) => DomProps(react.kbd as ReactComponentFactoryProxy, backingMap);
+  static DomProps kbd([Map? backingMap]) => DomProps(react.kbd, backingMap);
 
   /// Returns a new builder that renders a `<keygen>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps keygen([Map? backingMap]) => DomProps(react.keygen as ReactComponentFactoryProxy, backingMap);
+  static DomProps keygen([Map? backingMap]) => DomProps(react.keygen, backingMap);
 
   /// Returns a new builder that renders a `<label>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps label([Map? backingMap]) => DomProps(react.label as ReactComponentFactoryProxy, backingMap);
+  static DomProps label([Map? backingMap]) => DomProps(react.label, backingMap);
 
   /// Returns a new builder that renders a `<legend>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps legend([Map? backingMap]) => DomProps(react.legend as ReactComponentFactoryProxy, backingMap);
+  static DomProps legend([Map? backingMap]) => DomProps(react.legend, backingMap);
 
   /// Returns a new builder that renders a `<li>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps li([Map? backingMap]) => DomProps(react.li as ReactComponentFactoryProxy, backingMap);
+  static DomProps li([Map? backingMap]) => DomProps(react.li, backingMap);
 
   /// Returns a new builder that renders a `<link>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps link([Map? backingMap]) => DomProps(react.link as ReactComponentFactoryProxy, backingMap);
+  static DomProps link([Map? backingMap]) => DomProps(react.link, backingMap);
 
   /// Returns a new builder that renders a `<main>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps main([Map? backingMap]) => DomProps(react.htmlMain as ReactComponentFactoryProxy, backingMap);
+  static DomProps main([Map? backingMap]) => DomProps(react.htmlMain, backingMap);
 
   /// Returns a new builder that renders a `<backingMap>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps map([Map? backingMap]) => DomProps(react.map as ReactComponentFactoryProxy, backingMap);
+  static DomProps map([Map? backingMap]) => DomProps(react.map, backingMap);
 
   /// Returns a new builder that renders a `<mark>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps mark([Map? backingMap]) => DomProps(react.mark as ReactComponentFactoryProxy, backingMap);
+  static DomProps mark([Map? backingMap]) => DomProps(react.mark, backingMap);
 
   /// Returns a new builder that renders a `<menu>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps menu([Map? backingMap]) => DomProps(react.menu as ReactComponentFactoryProxy, backingMap);
+  static DomProps menu([Map? backingMap]) => DomProps(react.menu, backingMap);
 
   /// Returns a new builder that renders a `<menuitem>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps menuitem([Map? backingMap]) => DomProps(react.menuitem as ReactComponentFactoryProxy, backingMap);
+  static DomProps menuitem([Map? backingMap]) => DomProps(react.menuitem, backingMap);
 
   /// Returns a new builder that renders a `<meta>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps meta([Map? backingMap]) => DomProps(react.meta as ReactComponentFactoryProxy, backingMap);
+  static DomProps meta([Map? backingMap]) => DomProps(react.meta, backingMap);
 
   /// Returns a new builder that renders a `<meter>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps meter([Map? backingMap]) => DomProps(react.meter as ReactComponentFactoryProxy, backingMap);
+  static DomProps meter([Map? backingMap]) => DomProps(react.meter, backingMap);
 
   /// Returns a new builder that renders a `<nav>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps nav([Map? backingMap]) => DomProps(react.nav as ReactComponentFactoryProxy, backingMap);
+  static DomProps nav([Map? backingMap]) => DomProps(react.nav, backingMap);
 
   /// Returns a new builder that renders a `<noscript>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps noscript([Map? backingMap]) => DomProps(react.noscript as ReactComponentFactoryProxy, backingMap);
+  static DomProps noscript([Map? backingMap]) => DomProps(react.noscript, backingMap);
 
   /// Returns a new builder that renders an `<object>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps object([Map? backingMap]) => DomProps(react.object as ReactComponentFactoryProxy, backingMap);
+  static DomProps object([Map? backingMap]) => DomProps(react.object, backingMap);
 
   /// Returns a new builder that renders an `<ol>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps ol([Map? backingMap]) => DomProps(react.ol as ReactComponentFactoryProxy, backingMap);
+  static DomProps ol([Map? backingMap]) => DomProps(react.ol, backingMap);
 
   /// Returns a new builder that renders an `<optgroup>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps optgroup([Map? backingMap]) => DomProps(react.optgroup as ReactComponentFactoryProxy, backingMap);
+  static DomProps optgroup([Map? backingMap]) => DomProps(react.optgroup, backingMap);
 
   /// Returns a new builder that renders an `<option>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps option([Map? backingMap]) => DomProps(react.option as ReactComponentFactoryProxy, backingMap);
+  static DomProps option([Map? backingMap]) => DomProps(react.option, backingMap);
 
   /// Returns a new builder that renders an `<output>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps output([Map? backingMap]) => DomProps(react.output as ReactComponentFactoryProxy, backingMap);
+  static DomProps output([Map? backingMap]) => DomProps(react.output, backingMap);
 
   /// Returns a new builder that renders a `<p>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps p([Map? backingMap]) => DomProps(react.p as ReactComponentFactoryProxy, backingMap);
+  static DomProps p([Map? backingMap]) => DomProps(react.p, backingMap);
 
   /// Returns a new builder that renders a `<param>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps param([Map? backingMap]) => DomProps(react.param as ReactComponentFactoryProxy, backingMap);
+  static DomProps param([Map? backingMap]) => DomProps(react.param, backingMap);
 
   /// Returns a new builder that renders a `<picture>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps picture([Map? backingMap]) => DomProps(react.picture as ReactComponentFactoryProxy, backingMap);
+  static DomProps picture([Map? backingMap]) => DomProps(react.picture, backingMap);
 
   /// Returns a new builder that renders a `<pre>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps pre([Map? backingMap]) => DomProps(react.pre as ReactComponentFactoryProxy, backingMap);
+  static DomProps pre([Map? backingMap]) => DomProps(react.pre, backingMap);
 
   /// Returns a new builder that renders a `<progress>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps progress([Map? backingMap]) => DomProps(react.progress as ReactComponentFactoryProxy, backingMap);
+  static DomProps progress([Map? backingMap]) => DomProps(react.progress, backingMap);
 
   /// Returns a new builder that renders a `<q>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps q([Map? backingMap]) => DomProps(react.q as ReactComponentFactoryProxy, backingMap);
+  static DomProps q([Map? backingMap]) => DomProps(react.q, backingMap);
 
   /// Returns a new builder that renders a `<rp>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps rp([Map? backingMap]) => DomProps(react.rp as ReactComponentFactoryProxy, backingMap);
+  static DomProps rp([Map? backingMap]) => DomProps(react.rp, backingMap);
 
   /// Returns a new builder that renders a `<rt>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps rt([Map? backingMap]) => DomProps(react.rt as ReactComponentFactoryProxy, backingMap);
+  static DomProps rt([Map? backingMap]) => DomProps(react.rt, backingMap);
 
   /// Returns a new builder that renders a `<ruby>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps ruby([Map? backingMap]) => DomProps(react.ruby as ReactComponentFactoryProxy, backingMap);
+  static DomProps ruby([Map? backingMap]) => DomProps(react.ruby, backingMap);
 
   /// Returns a new builder that renders a `<s>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps s([Map? backingMap]) => DomProps(react.s as ReactComponentFactoryProxy, backingMap);
+  static DomProps s([Map? backingMap]) => DomProps(react.s, backingMap);
 
   /// Returns a new builder that renders a `<samp>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps samp([Map? backingMap]) => DomProps(react.samp as ReactComponentFactoryProxy, backingMap);
+  static DomProps samp([Map? backingMap]) => DomProps(react.samp, backingMap);
 
   /// Returns a new builder that renders a `<script>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps script([Map? backingMap]) => DomProps(react.script as ReactComponentFactoryProxy, backingMap);
+  static DomProps script([Map? backingMap]) => DomProps(react.script, backingMap);
 
   /// Returns a new builder that renders a `<section>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps section([Map? backingMap]) => DomProps(react.section as ReactComponentFactoryProxy, backingMap);
+  static DomProps section([Map? backingMap]) => DomProps(react.section, backingMap);
 
   /// Returns a new builder that renders a `<select>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps select([Map? backingMap]) => DomProps(react.select as ReactComponentFactoryProxy, backingMap);
+  static DomProps select([Map? backingMap]) => DomProps(react.select, backingMap);
 
   /// Returns a new builder that renders a `<small>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps small([Map? backingMap]) => DomProps(react.small as ReactComponentFactoryProxy, backingMap);
+  static DomProps small([Map? backingMap]) => DomProps(react.small, backingMap);
 
   /// Returns a new builder that renders a `<source>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps source([Map? backingMap]) => DomProps(react.source as ReactComponentFactoryProxy, backingMap);
+  static DomProps source([Map? backingMap]) => DomProps(react.source, backingMap);
 
   /// Returns a new builder that renders a `<span>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps span([Map? backingMap]) => DomProps(react.span as ReactComponentFactoryProxy, backingMap);
+  static DomProps span([Map? backingMap]) => DomProps(react.span, backingMap);
 
   /// Returns a new builder that renders a `<strong>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps strong([Map? backingMap]) => DomProps(react.strong as ReactComponentFactoryProxy, backingMap);
+  static DomProps strong([Map? backingMap]) => DomProps(react.strong, backingMap);
 
   /// Returns a new builder that renders a `<style>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps style([Map? backingMap]) => DomProps(react.style as ReactComponentFactoryProxy, backingMap);
+  static DomProps style([Map? backingMap]) => DomProps(react.style, backingMap);
 
   /// Returns a new builder that renders a `<sub>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps sub([Map? backingMap]) => DomProps(react.sub as ReactComponentFactoryProxy, backingMap);
+  static DomProps sub([Map? backingMap]) => DomProps(react.sub, backingMap);
 
   /// Returns a new builder that renders a `<summary>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps summary([Map? backingMap]) => DomProps(react.summary as ReactComponentFactoryProxy, backingMap);
+  static DomProps summary([Map? backingMap]) => DomProps(react.summary, backingMap);
 
   /// Returns a new builder that renders a `<sup>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps sup([Map? backingMap]) => DomProps(react.sup as ReactComponentFactoryProxy, backingMap);
+  static DomProps sup([Map? backingMap]) => DomProps(react.sup, backingMap);
 
   /// Returns a new builder that renders a `<table>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps table([Map? backingMap]) => DomProps(react.table as ReactComponentFactoryProxy, backingMap);
+  static DomProps table([Map? backingMap]) => DomProps(react.table, backingMap);
 
   /// Returns a new builder that renders a `<tbody>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps tbody([Map? backingMap]) => DomProps(react.tbody as ReactComponentFactoryProxy, backingMap);
+  static DomProps tbody([Map? backingMap]) => DomProps(react.tbody, backingMap);
 
   /// Returns a new builder that renders a `<td>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps td([Map? backingMap]) => DomProps(react.td as ReactComponentFactoryProxy, backingMap);
+  static DomProps td([Map? backingMap]) => DomProps(react.td, backingMap);
 
   /// Returns a new builder that renders a `<textarea>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps textarea([Map? backingMap]) => DomProps(react.textarea as ReactComponentFactoryProxy, backingMap);
+  static DomProps textarea([Map? backingMap]) => DomProps(react.textarea, backingMap);
 
   /// Returns a new builder that renders a `<tfoot>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps tfoot([Map? backingMap]) => DomProps(react.tfoot as ReactComponentFactoryProxy, backingMap);
+  static DomProps tfoot([Map? backingMap]) => DomProps(react.tfoot, backingMap);
 
   /// Returns a new builder that renders a `<th>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps th([Map? backingMap]) => DomProps(react.th as ReactComponentFactoryProxy, backingMap);
+  static DomProps th([Map? backingMap]) => DomProps(react.th, backingMap);
 
   /// Returns a new builder that renders a `<thead>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps thead([Map? backingMap]) => DomProps(react.thead as ReactComponentFactoryProxy, backingMap);
+  static DomProps thead([Map? backingMap]) => DomProps(react.thead, backingMap);
 
   /// Returns a new builder that renders a `<time>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps time([Map? backingMap]) => DomProps(react.time as ReactComponentFactoryProxy, backingMap);
+  static DomProps time([Map? backingMap]) => DomProps(react.time, backingMap);
 
   /// Returns a new builder that renders a `<title>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps title([Map? backingMap]) => DomProps(react.title as ReactComponentFactoryProxy, backingMap);
+  static DomProps title([Map? backingMap]) => DomProps(react.title, backingMap);
 
   /// Returns a new builder that renders a `<tr>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps tr([Map? backingMap]) => DomProps(react.tr as ReactComponentFactoryProxy, backingMap);
+  static DomProps tr([Map? backingMap]) => DomProps(react.tr, backingMap);
 
   /// Returns a new builder that renders a `<track>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps track([Map? backingMap]) => DomProps(react.track as ReactComponentFactoryProxy, backingMap);
+  static DomProps track([Map? backingMap]) => DomProps(react.track, backingMap);
 
   /// Returns a new builder that renders an `<u>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps u([Map? backingMap]) => DomProps(react.u as ReactComponentFactoryProxy, backingMap);
+  static DomProps u([Map? backingMap]) => DomProps(react.u, backingMap);
 
   /// Returns a new builder that renders an `<ul>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps ul([Map? backingMap]) => DomProps(react.ul as ReactComponentFactoryProxy, backingMap);
+  static DomProps ul([Map? backingMap]) => DomProps(react.ul, backingMap);
 
   /// Returns a new builder that renders a `<var>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps variable([Map? backingMap]) => DomProps(react.variable as ReactComponentFactoryProxy, backingMap);
+  static DomProps variable([Map? backingMap]) => DomProps(react.variable, backingMap);
 
   /// Returns a new builder that renders a `<video>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps video([Map? backingMap]) => DomProps(react.video as ReactComponentFactoryProxy, backingMap);
+  static DomProps video([Map? backingMap]) => DomProps(react.video, backingMap);
 
   /// Returns a new builder that renders a `<wbr>` tag with getters/setters for all DOM-related React props,
   /// optionally backed by a specified map.
-  static DomProps wbr([Map? backingMap]) => DomProps(react.wbr as ReactComponentFactoryProxy, backingMap);
+  static DomProps wbr([Map? backingMap]) => DomProps(react.wbr, backingMap);
 
   // SVG Elements
   /// Returns a new builder that renders an `<a>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgA([Map? backingMap]) => SvgProps(react.a as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgA([Map? backingMap]) => SvgProps(react.a, backingMap);
 
   /// Returns a new builder that renders an `<altGlyph>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps altGlyph([Map? backingMap]) => SvgProps(react.altGlyph as ReactComponentFactoryProxy, backingMap);
+  static SvgProps altGlyph([Map? backingMap]) => SvgProps(react.altGlyph, backingMap);
 
   /// Returns a new builder that renders an `<altGlyphDef>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps altGlyphDef([Map? backingMap]) => SvgProps(react.altGlyphDef as ReactComponentFactoryProxy, backingMap);
+  static SvgProps altGlyphDef([Map? backingMap]) => SvgProps(react.altGlyphDef, backingMap);
 
   /// Returns a new builder that renders an `<altGlyphItem>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps altGlyphItem([Map? backingMap]) => SvgProps(react.altGlyphItem as ReactComponentFactoryProxy, backingMap);
+  static SvgProps altGlyphItem([Map? backingMap]) => SvgProps(react.altGlyphItem, backingMap);
 
   /// Returns a new builder that renders an `<animate>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps animate([Map? backingMap]) => SvgProps(react.animate as ReactComponentFactoryProxy, backingMap);
+  static SvgProps animate([Map? backingMap]) => SvgProps(react.animate, backingMap);
 
   /// Returns a new builder that renders an `<animateColor>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps animateColor([Map? backingMap]) => SvgProps(react.animateColor as ReactComponentFactoryProxy, backingMap);
+  static SvgProps animateColor([Map? backingMap]) => SvgProps(react.animateColor, backingMap);
 
   /// Returns a new builder that renders an `<animateMotion>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps animateMotion([Map? backingMap]) => SvgProps(react.animateMotion as ReactComponentFactoryProxy, backingMap);
+  static SvgProps animateMotion([Map? backingMap]) => SvgProps(react.animateMotion, backingMap);
 
   /// Returns a new builder that renders an `<animateTransform>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps animateTransform([Map? backingMap]) => SvgProps(react.animateTransform as ReactComponentFactoryProxy, backingMap);
+  static SvgProps animateTransform([Map? backingMap]) => SvgProps(react.animateTransform, backingMap);
 
   /// Returns a new builder that renders an `<audio>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgAudio([Map? backingMap]) => SvgProps(react.audio as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgAudio([Map? backingMap]) => SvgProps(react.audio, backingMap);
 
   /// Returns a new builder that renders a `<canvas>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgCanvas([Map? backingMap]) => SvgProps(react.canvas as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgCanvas([Map? backingMap]) => SvgProps(react.canvas, backingMap);
 
   /// Returns a new builder that renders a `<circle>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps circle([Map? backingMap]) => SvgProps(react.circle as ReactComponentFactoryProxy, backingMap);
+  static SvgProps circle([Map? backingMap]) => SvgProps(react.circle, backingMap);
 
   /// Returns a new builder that renders a `<clipPath>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps clipPath([Map? backingMap]) => SvgProps(react.clipPath as ReactComponentFactoryProxy, backingMap);
+  static SvgProps clipPath([Map? backingMap]) => SvgProps(react.clipPath, backingMap);
 
   /// Returns a new builder that renders a `<color-profile>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps colorProfile([Map? backingMap]) => SvgProps(react.colorProfile as ReactComponentFactoryProxy, backingMap);
+  static SvgProps colorProfile([Map? backingMap]) => SvgProps(react.colorProfile, backingMap);
 
   /// Returns a new builder that renders a `<cursor>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps cursor([Map? backingMap]) => SvgProps(react.cursor as ReactComponentFactoryProxy, backingMap);
+  static SvgProps cursor([Map? backingMap]) => SvgProps(react.cursor, backingMap);
 
   /// Returns a new builder that renders a `<defs>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps defs([Map? backingMap]) => SvgProps(react.defs as ReactComponentFactoryProxy, backingMap);
+  static SvgProps defs([Map? backingMap]) => SvgProps(react.defs, backingMap);
 
   /// Returns a new builder that renders a `<desc>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps desc([Map? backingMap]) => SvgProps(react.desc as ReactComponentFactoryProxy, backingMap);
+  static SvgProps desc([Map? backingMap]) => SvgProps(react.desc, backingMap);
 
   /// Returns a new builder that renders a `<discard>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps discard([Map? backingMap]) => SvgProps(react.discard as ReactComponentFactoryProxy, backingMap);
+  static SvgProps discard([Map? backingMap]) => SvgProps(react.discard, backingMap);
 
   /// Returns a new builder that renders an `<ellipse>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps ellipse([Map? backingMap]) => SvgProps(react.ellipse as ReactComponentFactoryProxy, backingMap);
+  static SvgProps ellipse([Map? backingMap]) => SvgProps(react.ellipse, backingMap);
 
   /// Returns a new builder that renders a `<feBlend>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feBlend([Map? backingMap]) => SvgProps(react.feBlend as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feBlend([Map? backingMap]) => SvgProps(react.feBlend, backingMap);
 
   /// Returns a new builder that renders a `<feColorMatrix>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feColorMatrix([Map? backingMap]) => SvgProps(react.feColorMatrix as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feColorMatrix([Map? backingMap]) => SvgProps(react.feColorMatrix, backingMap);
 
   /// Returns a new builder that renders a `<feComponentTransfer>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feComponentTransfer([Map? backingMap]) => SvgProps(react.feComponentTransfer as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feComponentTransfer([Map? backingMap]) => SvgProps(react.feComponentTransfer, backingMap);
 
   /// Returns a new builder that renders a `<feComposite>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feComposite([Map? backingMap]) => SvgProps(react.feComposite as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feComposite([Map? backingMap]) => SvgProps(react.feComposite, backingMap);
 
   /// Returns a new builder that renders a `<feConvolveMatrix>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feConvolveMatrix([Map? backingMap]) => SvgProps(react.feConvolveMatrix as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feConvolveMatrix([Map? backingMap]) => SvgProps(react.feConvolveMatrix, backingMap);
 
   /// Returns a new builder that renders a `<feDiffuseLighting>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feDiffuseLighting([Map? backingMap]) => SvgProps(react.feDiffuseLighting as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feDiffuseLighting([Map? backingMap]) => SvgProps(react.feDiffuseLighting, backingMap);
 
   /// Returns a new builder that renders a `<feDisplacementMap>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feDisplacementMap([Map? backingMap]) => SvgProps(react.feDisplacementMap as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feDisplacementMap([Map? backingMap]) => SvgProps(react.feDisplacementMap, backingMap);
 
   /// Returns a new builder that renders a `<feDistantLight>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feDistantLight([Map? backingMap]) => SvgProps(react.feDistantLight as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feDistantLight([Map? backingMap]) => SvgProps(react.feDistantLight, backingMap);
 
   /// Returns a new builder that renders a `<feDropShadow>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feDropShadow([Map? backingMap]) => SvgProps(react.feDropShadow as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feDropShadow([Map? backingMap]) => SvgProps(react.feDropShadow, backingMap);
 
   /// Returns a new builder that renders a `<feFlood>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feFlood([Map? backingMap]) => SvgProps(react.feFlood as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feFlood([Map? backingMap]) => SvgProps(react.feFlood, backingMap);
 
   /// Returns a new builder that renders a `<feFuncA>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feFuncA([Map? backingMap]) => SvgProps(react.feFuncA as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feFuncA([Map? backingMap]) => SvgProps(react.feFuncA, backingMap);
 
   /// Returns a new builder that renders a `<feFuncB>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feFuncB([Map? backingMap]) => SvgProps(react.feFuncB as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feFuncB([Map? backingMap]) => SvgProps(react.feFuncB, backingMap);
 
   /// Returns a new builder that renders a `<feFuncG>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feFuncG([Map? backingMap]) => SvgProps(react.feFuncG as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feFuncG([Map? backingMap]) => SvgProps(react.feFuncG, backingMap);
 
   /// Returns a new builder that renders a `<feFuncR>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feFuncR([Map? backingMap]) => SvgProps(react.feFuncR as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feFuncR([Map? backingMap]) => SvgProps(react.feFuncR, backingMap);
 
   /// Returns a new builder that renders a `<feGaussianBlur>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feGaussianBlur([Map? backingMap]) => SvgProps(react.feGaussianBlur as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feGaussianBlur([Map? backingMap]) => SvgProps(react.feGaussianBlur, backingMap);
 
   /// Returns a new builder that renders a `<feImage>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feImage([Map? backingMap]) => SvgProps(react.feImage as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feImage([Map? backingMap]) => SvgProps(react.feImage, backingMap);
 
   /// Returns a new builder that renders a `<feMerge>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feMerge([Map? backingMap]) => SvgProps(react.feMerge as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feMerge([Map? backingMap]) => SvgProps(react.feMerge, backingMap);
 
   /// Returns a new builder that renders a `<feMergeNode>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feMergeNode([Map? backingMap]) => SvgProps(react.feMergeNode as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feMergeNode([Map? backingMap]) => SvgProps(react.feMergeNode, backingMap);
 
   /// Returns a new builder that renders a `<feMorphology>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feMorphology([Map? backingMap]) => SvgProps(react.feMorphology as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feMorphology([Map? backingMap]) => SvgProps(react.feMorphology, backingMap);
 
   /// Returns a new builder that renders a `<feOffset>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feOffset([Map? backingMap]) => SvgProps(react.feOffset as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feOffset([Map? backingMap]) => SvgProps(react.feOffset, backingMap);
 
   /// Returns a new builder that renders a `<fePointLight>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fePointLight([Map? backingMap]) => SvgProps(react.fePointLight as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fePointLight([Map? backingMap]) => SvgProps(react.fePointLight, backingMap);
 
   /// Returns a new builder that renders a `<feSpecularLighting>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feSpecularLighting([Map? backingMap]) => SvgProps(react.feSpecularLighting as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feSpecularLighting([Map? backingMap]) => SvgProps(react.feSpecularLighting, backingMap);
 
   /// Returns a new builder that renders a `<feSpotLight>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feSpotLight([Map? backingMap]) => SvgProps(react.feSpotLight as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feSpotLight([Map? backingMap]) => SvgProps(react.feSpotLight, backingMap);
 
   /// Returns a new builder that renders a `<feTile>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feTile([Map? backingMap]) => SvgProps(react.feTile as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feTile([Map? backingMap]) => SvgProps(react.feTile, backingMap);
 
   /// Returns a new builder that renders a `<feTurbulence>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps feTurbulence([Map? backingMap]) => SvgProps(react.feTurbulence as ReactComponentFactoryProxy, backingMap);
+  static SvgProps feTurbulence([Map? backingMap]) => SvgProps(react.feTurbulence, backingMap);
 
   /// Returns a new builder that renders a `<filter>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps filter([Map? backingMap]) => SvgProps(react.filter as ReactComponentFactoryProxy, backingMap);
+  static SvgProps filter([Map? backingMap]) => SvgProps(react.filter, backingMap);
 
   /// Returns a new builder that renders a `<font>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps font([Map? backingMap]) => SvgProps(react.font as ReactComponentFactoryProxy, backingMap);
+  static SvgProps font([Map? backingMap]) => SvgProps(react.font, backingMap);
 
   /// Returns a new builder that renders a `<font-face>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fontFace([Map? backingMap]) => SvgProps(react.fontFace as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fontFace([Map? backingMap]) => SvgProps(react.fontFace, backingMap);
 
   /// Returns a new builder that renders a `<font-face-format>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fontFaceFormat([Map? backingMap]) => SvgProps(react.fontFaceFormat as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fontFaceFormat([Map? backingMap]) => SvgProps(react.fontFaceFormat, backingMap);
 
   /// Returns a new builder that renders a `<font-face-name>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fontFaceName([Map? backingMap]) => SvgProps(react.fontFaceName as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fontFaceName([Map? backingMap]) => SvgProps(react.fontFaceName, backingMap);
 
   /// Returns a new builder that renders a `<font-face-src>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fontFaceSrc([Map? backingMap]) => SvgProps(react.fontFaceSrc as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fontFaceSrc([Map? backingMap]) => SvgProps(react.fontFaceSrc, backingMap);
 
   /// Returns a new builder that renders a `<font-face-uri>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps fontFaceUri([Map? backingMap]) => SvgProps(react.fontFaceUri as ReactComponentFactoryProxy, backingMap);
+  static SvgProps fontFaceUri([Map? backingMap]) => SvgProps(react.fontFaceUri, backingMap);
 
   /// Returns a new builder that renders a `<foreignObject>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps foreignObject([Map? backingMap]) => SvgProps(react.foreignObject as ReactComponentFactoryProxy, backingMap);
+  static SvgProps foreignObject([Map? backingMap]) => SvgProps(react.foreignObject, backingMap);
 
   /// Returns a new builder that renders a `<g>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps g([Map? backingMap]) => SvgProps(react.g as ReactComponentFactoryProxy, backingMap);
+  static SvgProps g([Map? backingMap]) => SvgProps(react.g, backingMap);
 
   /// Returns a new builder that renders a `<glyph>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps glyph([Map? backingMap]) => SvgProps(react.glyph as ReactComponentFactoryProxy, backingMap);
+  static SvgProps glyph([Map? backingMap]) => SvgProps(react.glyph, backingMap);
 
   /// Returns a new builder that renders a `<glyphRef>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps glyphRef([Map? backingMap]) => SvgProps(react.glyphRef as ReactComponentFactoryProxy, backingMap);
+  static SvgProps glyphRef([Map? backingMap]) => SvgProps(react.glyphRef, backingMap);
 
   /// Returns a new builder that renders a `<hatch>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps hatch([Map? backingMap]) => SvgProps(react.hatch as ReactComponentFactoryProxy, backingMap);
+  static SvgProps hatch([Map? backingMap]) => SvgProps(react.hatch, backingMap);
 
   /// Returns a new builder that renders a `<hatchpath>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps hatchpath([Map? backingMap]) => SvgProps(react.hatchpath as ReactComponentFactoryProxy, backingMap);
+  static SvgProps hatchpath([Map? backingMap]) => SvgProps(react.hatchpath, backingMap);
 
   /// Returns a new builder that renders a `<hkern>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps hkern([Map? backingMap]) => SvgProps(react.hkern as ReactComponentFactoryProxy, backingMap);
+  static SvgProps hkern([Map? backingMap]) => SvgProps(react.hkern, backingMap);
 
   /// Returns a new builder that renders an `<iframe>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgIframe([Map? backingMap]) => SvgProps(react.iframe as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgIframe([Map? backingMap]) => SvgProps(react.iframe, backingMap);
 
   /// Returns a new builder that renders an `<image>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps image([Map? backingMap]) => SvgProps(react.image as ReactComponentFactoryProxy, backingMap);
+  static SvgProps image([Map? backingMap]) => SvgProps(react.image, backingMap);
 
   /// Returns a new builder that renders a `<line>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps line([Map? backingMap]) => SvgProps(react.line as ReactComponentFactoryProxy, backingMap);
+  static SvgProps line([Map? backingMap]) => SvgProps(react.line, backingMap);
 
   /// Returns a new builder that renders a `<linearGradient>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps linearGradient([Map? backingMap]) => SvgProps(react.linearGradient as ReactComponentFactoryProxy, backingMap);
+  static SvgProps linearGradient([Map? backingMap]) => SvgProps(react.linearGradient, backingMap);
 
   /// Returns a new builder that renders a `<marker>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps marker([Map? backingMap]) => SvgProps(react.marker as ReactComponentFactoryProxy, backingMap);
+  static SvgProps marker([Map? backingMap]) => SvgProps(react.marker, backingMap);
 
   /// Returns a new builder that renders a `<mask>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps mask([Map? backingMap]) => SvgProps(react.mask as ReactComponentFactoryProxy, backingMap);
+  static SvgProps mask([Map? backingMap]) => SvgProps(react.mask, backingMap);
 
   /// Returns a new builder that renders a `<mesh>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps mesh([Map? backingMap]) => SvgProps(react.mesh as ReactComponentFactoryProxy, backingMap);
+  static SvgProps mesh([Map? backingMap]) => SvgProps(react.mesh, backingMap);
 
   /// Returns a new builder that renders a `<meshgradient>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps meshgradient([Map? backingMap]) => SvgProps(react.meshgradient as ReactComponentFactoryProxy, backingMap);
+  static SvgProps meshgradient([Map? backingMap]) => SvgProps(react.meshgradient, backingMap);
 
   /// Returns a new builder that renders a `<meshpatch>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps meshpatch([Map? backingMap]) => SvgProps(react.meshpatch as ReactComponentFactoryProxy, backingMap);
+  static SvgProps meshpatch([Map? backingMap]) => SvgProps(react.meshpatch, backingMap);
 
   /// Returns a new builder that renders a `<meshrow>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps meshrow([Map? backingMap]) => SvgProps(react.meshrow as ReactComponentFactoryProxy, backingMap);
+  static SvgProps meshrow([Map? backingMap]) => SvgProps(react.meshrow, backingMap);
 
   /// Returns a new builder that renders a `<metadata>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps metadata([Map? backingMap]) => SvgProps(react.metadata as ReactComponentFactoryProxy, backingMap);
+  static SvgProps metadata([Map? backingMap]) => SvgProps(react.metadata, backingMap);
 
   /// Returns a new builder that renders a `<missing-glyph>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps missingGlyph([Map? backingMap]) => SvgProps(react.missingGlyph as ReactComponentFactoryProxy, backingMap);
+  static SvgProps missingGlyph([Map? backingMap]) => SvgProps(react.missingGlyph, backingMap);
 
   /// Returns a new builder that renders a `<mpath>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps mpath([Map? backingMap]) => SvgProps(react.mpath as ReactComponentFactoryProxy, backingMap);
+  static SvgProps mpath([Map? backingMap]) => SvgProps(react.mpath, backingMap);
 
   /// Returns a new builder that renders a `<path>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps path([Map? backingMap]) => SvgProps(react.path as ReactComponentFactoryProxy, backingMap);
+  static SvgProps path([Map? backingMap]) => SvgProps(react.path, backingMap);
 
   /// Returns a new builder that renders a `<pattern>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps pattern([Map? backingMap]) => SvgProps(react.pattern as ReactComponentFactoryProxy, backingMap);
+  static SvgProps pattern([Map? backingMap]) => SvgProps(react.pattern, backingMap);
 
   /// Returns a new builder that renders a `<polygon>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps polygon([Map? backingMap]) => SvgProps(react.polygon as ReactComponentFactoryProxy, backingMap);
+  static SvgProps polygon([Map? backingMap]) => SvgProps(react.polygon, backingMap);
 
   /// Returns a new builder that renders a `<polyline>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps polyline([Map? backingMap]) => SvgProps(react.polyline as ReactComponentFactoryProxy, backingMap);
+  static SvgProps polyline([Map? backingMap]) => SvgProps(react.polyline, backingMap);
 
   /// Returns a new builder that renders a `<radialGradient>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps radialGradient([Map? backingMap]) => SvgProps(react.radialGradient as ReactComponentFactoryProxy, backingMap);
+  static SvgProps radialGradient([Map? backingMap]) => SvgProps(react.radialGradient, backingMap);
 
   /// Returns a new builder that renders a `<rect>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps rect([Map? backingMap]) => SvgProps(react.rect as ReactComponentFactoryProxy, backingMap);
+  static SvgProps rect([Map? backingMap]) => SvgProps(react.rect, backingMap);
 
   /// Returns a new builder that renders a `<script>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgScript([Map? backingMap]) => SvgProps(react.script as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgScript([Map? backingMap]) => SvgProps(react.script, backingMap);
 
   /// Returns a new builder that renders a `<set>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgSet([Map? backingMap]) => SvgProps(react.svgSet as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgSet([Map? backingMap]) => SvgProps(react.svgSet, backingMap);
 
   /// Returns a new builder that renders a `<solidcolor>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps solidcolor([Map? backingMap]) => SvgProps(react.solidcolor as ReactComponentFactoryProxy, backingMap);
+  static SvgProps solidcolor([Map? backingMap]) => SvgProps(react.solidcolor, backingMap);
 
   /// Returns a new builder that renders a `<stop>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps stop([Map? backingMap]) => SvgProps(react.stop as ReactComponentFactoryProxy, backingMap);
+  static SvgProps stop([Map? backingMap]) => SvgProps(react.stop, backingMap);
 
   /// Returns a new builder that renders a `<style>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgStyle([Map? backingMap]) => SvgProps(react.style as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgStyle([Map? backingMap]) => SvgProps(react.style, backingMap);
 
   /// Returns a new builder that renders a `<svg>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svg([Map? backingMap]) => SvgProps(react.svg as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svg([Map? backingMap]) => SvgProps(react.svg, backingMap);
 
   /// Returns a new builder that renders a `<switch>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgSwitch([Map? backingMap]) => SvgProps(react.svgSwitch as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgSwitch([Map? backingMap]) => SvgProps(react.svgSwitch, backingMap);
 
   /// Returns a new builder that renders a `<symbol>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps symbol([Map? backingMap]) => SvgProps(react.symbol as ReactComponentFactoryProxy, backingMap);
+  static SvgProps symbol([Map? backingMap]) => SvgProps(react.symbol, backingMap);
 
   /// Returns a new builder that renders a `<text>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps text([Map? backingMap]) => SvgProps(react.text as ReactComponentFactoryProxy, backingMap);
+  static SvgProps text([Map? backingMap]) => SvgProps(react.text, backingMap);
 
   /// Returns a new builder that renders a `<textPath>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps textPath([Map? backingMap]) => SvgProps(react.textPath as ReactComponentFactoryProxy, backingMap);
+  static SvgProps textPath([Map? backingMap]) => SvgProps(react.textPath, backingMap);
 
   /// Returns a new builder that renders a `<title>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgTitle([Map? backingMap]) => SvgProps(react.title as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgTitle([Map? backingMap]) => SvgProps(react.title, backingMap);
 
   /// Returns a new builder that renders a `<tref>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps tref([Map? backingMap]) => SvgProps(react.tref as ReactComponentFactoryProxy, backingMap);
+  static SvgProps tref([Map? backingMap]) => SvgProps(react.tref, backingMap);
 
   /// Returns a new builder that renders a `<tspan>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps tspan([Map? backingMap]) => SvgProps(react.tspan as ReactComponentFactoryProxy, backingMap);
+  static SvgProps tspan([Map? backingMap]) => SvgProps(react.tspan, backingMap);
 
   /// Returns a new builder that renders an `<unknown>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps unknown([Map? backingMap]) => SvgProps(react.unknown as ReactComponentFactoryProxy, backingMap);
+  static SvgProps unknown([Map? backingMap]) => SvgProps(react.unknown, backingMap);
 
   /// Returns a new builder that renders an `<use>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps use([Map? backingMap]) => SvgProps(react.use as ReactComponentFactoryProxy, backingMap);
+  static SvgProps use([Map? backingMap]) => SvgProps(react.use, backingMap);
 
   /// Returns a new builder that renders a `<video>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps svgVideo([Map? backingMap]) => SvgProps(react.video as ReactComponentFactoryProxy, backingMap);
+  static SvgProps svgVideo([Map? backingMap]) => SvgProps(react.video, backingMap);
 
   /// Returns a new builder that renders a `<view>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps view([Map? backingMap]) => SvgProps(react.view as ReactComponentFactoryProxy, backingMap);
+  static SvgProps view([Map? backingMap]) => SvgProps(react.view, backingMap);
 
   /// Returns a new builder that renders a `<vkern>` tag with getters/setters for all SVG-related React props,
   /// optionally backed by a specified map.
-  static SvgProps vkern([Map? backingMap]) => SvgProps(react.vkern as ReactComponentFactoryProxy, backingMap);
+  static SvgProps vkern([Map? backingMap]) => SvgProps(react.vkern, backingMap);
 }

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -313,10 +313,11 @@ bool isPotentiallyValidComponentType(dynamic type) {
 /// Returns an [Iterable] of all component types that are ancestors of [type].
 ///
 /// For example, given components A, B, and C, where B subtypes A and C subtypes B:
-///
-///     getParentTypes(getComponentTypeFromAlias(A)); // []
-///     getParentTypes(getComponentTypeFromAlias(B)); // [A].map(getTypeFromAlias)
-///     getParentTypes(getComponentTypeFromAlias(C)); // [B, A].map(getTypeFromAlias)
+/// ```dart
+/// getParentTypes(getComponentTypeFromAlias(A)); // []
+/// getParentTypes(getComponentTypeFromAlias(B)); // [A].map(getTypeFromAlias)
+/// getParentTypes(getComponentTypeFromAlias(C)); // [B, A].map(getTypeFromAlias)
+/// ```
 Iterable<Object> getParentTypes(Object type) sync* {
   assert(isPotentiallyValidComponentType(type),
       '`type` should be a valid component type (and not null or a type alias).');

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -436,8 +436,8 @@ mixin ReduxProviderPropsMixin on UiProps {
 /// [ReduxProviderProps] is a typed props class for [ReduxProvider].
 ///
 /// Props:
-/// [store] (Redux Store) The single Redux store in your application.
-/// [context] You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
+/// - [ReduxProviderProps.store] (Redux Store) The single Redux store in your application.
+/// - [ReduxProviderProps.context] You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
 ///
 /// See: <https://react-redux.js.org/api/provider>
 class ReduxProviderProps = builder_helpers.UiProps with ReduxProviderPropsMixin;

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -436,8 +436,8 @@ mixin ReduxProviderPropsMixin on UiProps {
 /// [ReduxProviderProps] is a typed props class for [ReduxProvider].
 ///
 /// Props:
-/// - [ReduxProviderProps.store] (Redux Store) The single Redux store in your application.
-/// - [ReduxProviderProps.context] You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
+/// - `store` - (Redux Store) The single Redux store in your application.
+/// - `context -` You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
 ///
 /// See: <https://react-redux.js.org/api/provider>
 class ReduxProviderProps = builder_helpers.UiProps with ReduxProviderPropsMixin;

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -437,7 +437,7 @@ mixin ReduxProviderPropsMixin on UiProps {
 ///
 /// Props:
 /// - `store` - (Redux Store) The single Redux store in your application.
-/// - `context -` You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
+/// - `context` - You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
 ///
 /// See: <https://react-redux.js.org/api/provider>
 class ReduxProviderProps = builder_helpers.UiProps with ReduxProviderPropsMixin;

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -12,7 +12,7 @@ import 'package:over_react/component_base.dart';
 ///
 /// Returns the displayName of the given [component].
 ///
-/// This is preferable to [UiComponent.displayName] since that doesn't include
+/// This is preferable to `UiComponent.displayName` since that doesn't include
 /// the generated displayName passed to [registerComponent]/
 String? getDebugNameForDartComponent(UiComponent component) {
   // We don't have a great way of looking up the display name the component was

--- a/lib/src/util/promise_interop.dart
+++ b/lib/src/util/promise_interop.dart
@@ -7,7 +7,7 @@ import 'package:js/js.dart';
 /// Creates JS `Promise` which is resolved when [future] completes.
 ///
 /// See also:
-/// - [promiseToFuture]
+/// - dart:js_util's `promiseToFuture`
 Promise futureToPromise<T>(Future<T> future) {
   return Promise(allowInterop((Function resolve, Function reject) {
     future.then((result) => resolve(result), onError: reject);

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -96,7 +96,7 @@ String? _getDartComponentVersionFromInstance(Object/* ReactElement|ReactComponen
 /// - `false` for DDC
 final bool _canUseExpandoOnReactElement = (() {
   var expando = Expando<bool>('_canUseExpandoOnReactElement test');
-  var reactElement = react.div({}) as ReactElement;
+  var reactElement = react.div({});
 
   try {
     expando[reactElement] = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dev_dependencies:
   over_react_test: ^2.10.2
   pedantic: ^1.11.1
   test: ^1.20.0
+  workiva_analysis_options: ^1.4.0
   yaml: ^3.1.0
 
 dependency_overrides:

--- a/test/over_react/util/css_value_util_test.dart
+++ b/test/over_react/util/css_value_util_test.dart
@@ -24,7 +24,7 @@ main() {
     group('CssValue', () {
       group('returns the parsed value for', () {
         test('each and every valid unit', () {
-          double value = 34.0;
+          double value = 34;
           var units = ['em', 'ex', 'rem', 'vh', 'vw', 'vmin', 'vmax', '%', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'ch'];
           for (String unit in units) {
             expect(CssValue.parse('$value$unit')!.number, equals(value));

--- a/test/over_react/util/prop_conversion_test.dart
+++ b/test/over_react/util/prop_conversion_test.dart
@@ -1218,8 +1218,8 @@ main() {
             });
 
             void forEachTestCase(
-                void callback(String testCaseName, bool isDartCallbackCase,
-                    bool isDartRefObjectCase, bool isTyped)) {
+                void Function(String testCaseName, bool isDartCallbackCase,
+                    bool isDartRefObjectCase, bool isTyped) callback) {
               for (final testCaseName in testCaseCollection.allTestCaseNames) {
                 final meta =
                     testCaseCollection.testCaseMetaByName(testCaseName);

--- a/test/over_react/util/ref_test_cases.dart
+++ b/test/over_react/util/ref_test_cases.dart
@@ -13,7 +13,7 @@ class RefTestCase {
   /// The ref to be passed into a component.
   final dynamic ref;
 
-  /// Verifies (usually via `expect`) that the ref was updated exactly once with [actualValue].
+  /// Verifies (usually via `expect`) that the ref was updated exactly once with the `actualValue` provided argument.
   final Function(dynamic actualValue) verifyRefWasUpdated;
 
   /// Returns the current value of the ref.

--- a/test/over_react_redux/value_mutation_checker_test.dart
+++ b/test/over_react_redux/value_mutation_checker_test.dart
@@ -32,7 +32,7 @@ main() {
 
         test('returns the correct value for a map', () {
           final map = {'a': 1, 'b': '2'};
-          final domProps = DomProps(react.a as ReactComponentFactoryProxy?);
+          final domProps = DomProps(react.a);
           expect(hasher.hash(map), 2);
           expect(hasher.hash(domProps.props), 0);
 
@@ -103,7 +103,7 @@ void sharedHashTests(InstanceHasher Function() getHasher) {
     });
 
     test('true if the object is a map or iterable', () {
-      final props = DomProps(react.a as ReactComponentFactoryProxy?);
+      final props = DomProps(react.a);
 
       expect(hasher.canHash({'e', 'a', 'b'}), isTrue);
       expect(hasher.canHash([]), isTrue);
@@ -130,7 +130,7 @@ void sharedHashTests(InstanceHasher Function() getHasher) {
       });
 
       test('the object has not been checked before', () {
-        final props = DomProps(react.a as ReactComponentFactoryProxy?);
+        final props = DomProps(react.a);
         expect(hasher.hasHashChanged(props), isFalse);
       });
 

--- a/web/component1/src/demo_components/button_group.dart
+++ b/web/component1/src/demo_components/button_group.dart
@@ -158,14 +158,15 @@ class ButtonGroupSize extends ClassNameConstant {
 /// Mapping from [ButtonSize] values to their analogous [ButtonGroupSize] values.
 ///
 /// __Example:__
+/// ```dart
+/// mixin MyProps on UiProps {
+///   ButtonSize size;
+/// }
 ///
-///     mixin MyProps on UiProps {
-///       ButtonSize size;
-///     }
-///
-///     class MyComponent extends UiComponent<MyProps> {
-///       ButtonGroupSize matchingButtonGroupSize = buttonToButtonGroupSize[props.size];
-///     }
+/// class MyComponent extends UiComponent<MyProps> {
+///   ButtonGroupSize matchingButtonGroupSize = buttonToButtonGroupSize[props.size];
+/// }
+/// ```
 const Map<ButtonSize, ButtonGroupSize> buttonToButtonGroupSize = {
   ButtonSize.SMALL:   ButtonGroupSize.SMALL,
   ButtonSize.DEFAULT: ButtonGroupSize.DEFAULT,

--- a/web/component2/src/demo_components/button_group.dart
+++ b/web/component2/src/demo_components/button_group.dart
@@ -153,16 +153,17 @@ class ButtonGroupSize extends ClassNameConstant {
 /// Mapping from [ButtonSize] values to their analogous [ButtonGroupSize] values.
 ///
 /// __Example:__
+/// ```
+/// @Props()
+/// class MyProps extends UiProps {
+///   ButtonSize size;
+/// }
 ///
-///     @Props()
-///     class MyProps extends UiProps {
-///       ButtonSize size;
-///     }
-///
-///     @Component()
-///     class MyComponent extends UiComponent2<MyProps> {
-///       ButtonGroupSize matchingButtonGroupSize = buttonToButtonGroupSize[props.size];
-///     }
+/// @Component()
+/// class MyComponent extends UiComponent2<MyProps> {
+///   ButtonGroupSize matchingButtonGroupSize = buttonToButtonGroupSize[props.size];
+/// }
+/// ```
 const buttonToButtonGroupSize = {
   ButtonSize.SMALL:   ButtonGroupSize.SMALL,
   ButtonSize.DEFAULT: ButtonGroupSize.DEFAULT,


### PR DESCRIPTION
## Motivation
I noticed our set of enabled lints is out of date, and may be missing some null-safety-related ones.

Also, not as many lints as we'd like have been upgraded to warnings.

## Changes
- Use latest workiva_analysis_options recommended set, with some exceptions.
- Fix miscellaneous lints that were upgraded to warning, mostly unnecessary_cast lints

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
