### PR TITLE
Rollout react_testing_library 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dev_dependencies:
   glob: ^2.0.0
   io: '>=0.3.2+1 <2.0.0'
   mockito: ^5.3.1
-  react_testing_library: ^2.1.0
+  react_testing_library: ^3.0.1
   over_react_test: ^2.10.2
   pedantic: ^1.8.0
   test: ^1.15.7


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!
This updates react_testing_library to ^3.0.1

react_testing_library is for your tests, so if your tests pass
you can feel confident reviewing and merging this.

Reach out to #support-frontend-dx or #support-ui-platform

[_Created by Sourcegraph batch change `Workiva/rtl_3`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/rtl_3)