### PR TITLE
FED-1763 Fix reenabled contributor tests 

### DIFF
--- a/tools/analyzer_plugin/test/integration/assists/add_create_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/add_create_ref_test.dart
@@ -21,7 +21,7 @@ class AddUseOrCreateRefAssistTest extends AssistTestBase {
   String usageSourceWithinClassComponent({required bool fixed}) => '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<HasNoRefsProps> HasNoRefs = castUiFactory(_\$HasNoRefs); // ignore: undefined_identifier
 
@@ -84,7 +84,7 @@ final HasRefs = uiFunction<UiProps>(
     final source = newSource('''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<HasRefsProps> HasRefs = castUiFactory(_\$HasRefs); // ignore: undefined_identifier
 
@@ -114,7 +114,7 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, 'return (#Child#()');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinClassComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinClassComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_classComponentAssist_zeroWidthSelection() async {
@@ -122,7 +122,7 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, 'return (##Child()');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinClassComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinClassComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_classComponentAssist_propCascadeSelection() async {
@@ -130,7 +130,7 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, '..id ##= \'foo\'');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinClassComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinClassComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_fnComponentAssist_componentNameSelection() async {
@@ -138,7 +138,7 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, 'return (#Child#()');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinFnComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinFnComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_fnComponentAssist_zeroWidthSelection() async {
@@ -146,7 +146,7 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, 'return (##Child()');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinFnComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinFnComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_fnComponentAssist_propCascadeSelection() async {
@@ -154,6 +154,6 @@ class HasRefsComponent extends UiComponent2<HasRefsProps> {
     var selection = createSelection(source, '..id ##= \'foo\'');
     final change = await expectAndGetSingleAssist(selection);
     source = applySourceChange(change, source);
-    expect(source.contents.data, usageSourceWithinFnComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinFnComponent(fixed: true), path: source.uri.path));
   }
 }

--- a/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
+++ b/tools/analyzer_plugin/test/integration/assists/boilerplate_assist_utils.dart
@@ -1,6 +1,6 @@
-mixin BoilerplateAssistTestStrings {
-  String fileName = 'test.dart';
+import 'package:path/path.dart' as p;
 
+mixin BoilerplateAssistTestStrings {
   static const prefix = 'Foo';
 
   static const stateMixin = '''
@@ -27,10 +27,10 @@ mixin ${prefix}State on UiState {}
       withState ? 'FluxUiStatefulComponent2<${prefix}Props, ${prefix}State>' : 'FluxUiComponent2<${prefix}Props>';
 
   String simpleUiComponentSource(
-      {bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
+      {required String filename, bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
     return '''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '${p.basenameWithoutExtension(filename)}.over_react.g.dart';
 
 UiFactory<${prefix}Props> $prefix = _\$$prefix; // ignore: undefined_identifier
 
@@ -46,10 +46,10 @@ ${includeDefaultProps ? getDefaultProps : ''}${includeDefaultProps && isStateful
   }
 
   String fluxUiComponentSource(
-      {bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
+      {required String filename, bool isStateful = false, bool shouldIncludeSelection = false, bool includeDefaultProps = true}) {
     return '''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '${p.basenameWithoutExtension(filename)}.over_react.g.dart';
 
 UiFactory<${prefix}Props> $prefix = _\$$prefix; // ignore: undefined_identifier
 

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -9,11 +9,10 @@ import '../test_bases/assist_test_base.dart';
 import 'boilerplate_assist_utils.dart';
 
 void main() {
-  // These tests can't run until this diagnostic is re-enabled in the plugin.
-  // defineReflectiveSuite(() {
-  //   defineReflectiveTests(AddStatefulnessAssist);
-  //   defineReflectiveTests(RemoveStatefulnessAssist);
-  // });
+  defineReflectiveSuite(() {
+    defineReflectiveTests(AddStatefulnessAssist);
+    defineReflectiveTests(RemoveStatefulnessAssist);
+  });
 }
 
 @reflectiveTest
@@ -30,16 +29,16 @@ class AddStatefulnessAssist extends AssistTestBase with BoilerplateAssistTestStr
   }
 
   Future<void> test_noAssistOnFactory() async {
-    final generatedSource = simpleUiComponentSource();
-
+    final fileName = uniqueSourceFileName();
+    final generatedSource = simpleUiComponentSource(filename: fileName);
     var source = newSource(generatedSource, path: fileName);
     var selection = createSelection(source, r'UiFactory<FooProps> #Foo# = _$Foo;');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnProps() async {
-    final generatedSource = simpleUiComponentSource();
-
+    final fileName = uniqueSourceFileName();
+    final generatedSource = simpleUiComponentSource(filename: fileName);
     var source = newSource(generatedSource, path: fileName);
     var selection = createSelection(source, 'mixin #FooProps# on UiProps {}');
     await expectNoAssist(selection);
@@ -48,7 +47,7 @@ class AddStatefulnessAssist extends AssistTestBase with BoilerplateAssistTestStr
   Future<void> test_noAssistOnOldBoilerplate() async {
     const oldBoilerplate = '''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 @Factory()
 UiFactory<TestProps> Test = _\$Test;
@@ -63,6 +62,7 @@ class TestComponent extends UiComponent<TestProps> {
 }
 ''';
 
+    final fileName = uniqueSourceFileName();
     var source = newSource(oldBoilerplate, path: fileName);
     var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
@@ -71,7 +71,7 @@ class TestComponent extends UiComponent<TestProps> {
   Future<void> test_noAssistOnUnknownBase() async {
     const unknownBase = '''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<TestProps> Test = _\$Test; // ignore: undefined_identifier
 
@@ -83,41 +83,47 @@ class TestComponent extends AbstractBazComponent<TestProps> {
 }
 ''';
 
+    final fileName = uniqueSourceFileName();
     var source = newSource(unknownBase, path: fileName);
     var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
   }
 
   Future<void> test_addsStatefulness() async {
-    var retrievedSource = newSource(simpleUiComponentSource(), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(simpleUiComponentSource(filename: fileName), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
+    print('selection: $selection');
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, simpleUiComponentSource(isStateful: true));
+    expect(retrievedSource.contents.data, simpleUiComponentSource(filename: fileName, isStateful: true));
   }
 
   Future<void> test_addsStatefulnessWithoutDefaultProps() async {
-    var retrievedSource = newSource(simpleUiComponentSource(includeDefaultProps: false), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(simpleUiComponentSource(filename: fileName, includeDefaultProps: false), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, simpleUiComponentSource(isStateful: true, includeDefaultProps: false));
+    expect(retrievedSource.contents.data, simpleUiComponentSource(filename: fileName, isStateful: true, includeDefaultProps: false));
   }
 
   Future<void> test_addsStatefulnessToFlux() async {
-    var retrievedSource = newSource(fluxUiComponentSource(), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(fluxUiComponentSource(filename: fileName), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, fluxUiComponentSource(isStateful: true));
+    expect(retrievedSource.contents.data, fluxUiComponentSource(filename: fileName, isStateful: true));
   }
 
   Future<void> test_addsStatefulnessToFluxWithoutDefaultProps() async {
-    var retrievedSource = newSource(fluxUiComponentSource(includeDefaultProps: false), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(fluxUiComponentSource(filename: fileName, includeDefaultProps: false), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, fluxUiComponentSource(isStateful: true, includeDefaultProps: false));
+    expect(retrievedSource.contents.data, fluxUiComponentSource(filename: fileName, isStateful: true, includeDefaultProps: false));
   }
 }
 
@@ -135,16 +141,17 @@ class RemoveStatefulnessAssist extends AssistTestBase with BoilerplateAssistTest
   }
 
   Future<void> test_noAssistOnFactory() async {
-    final generatedSource = simpleUiComponentSource(isStateful: true);
-
+    final fileName = uniqueSourceFileName();
+    final generatedSource = simpleUiComponentSource(filename: fileName, isStateful: true);
     var source = newSource(generatedSource, path: fileName);
     var selection = createSelection(source, r'UiFactory<FooProps> #Foo# = _$Foo;');
     await expectNoAssist(selection);
   }
 
   Future<void> test_noAssistOnProps() async {
-    final generatedSource = simpleUiComponentSource(isStateful: true);
 
+    final fileName = uniqueSourceFileName();
+    final generatedSource = simpleUiComponentSource(filename: fileName, isStateful: true);
     var source = newSource(generatedSource, path: fileName);
     var selection = createSelection(source, 'mixin #FooProps# on UiProps {}');
     await expectNoAssist(selection);
@@ -153,7 +160,7 @@ class RemoveStatefulnessAssist extends AssistTestBase with BoilerplateAssistTest
   Future<void> test_noAssistOnOldBoilerplate() async {
     const oldBoilerplate = '''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 @Factory()
 UiFactory<TestProps> Test = _\$Test;
@@ -171,23 +178,25 @@ class TestComponent extends UiStatefulComponent<TestProps, TestState> {
 }
 ''';
 
+    final fileName = uniqueSourceFileName();
     var source = newSource(oldBoilerplate, path: fileName);
     var selection = createSelection(source, 'class #TestComponent# extends');
     await expectNoAssist(selection);
   }
 
   Future<void> test_removesStatefulness() async {
-    var retrievedSource = newSource(simpleUiComponentSource(isStateful: true), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(simpleUiComponentSource(filename: fileName, isStateful: true), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, simpleUiComponentSource());
+    expect(retrievedSource.contents.data, simpleUiComponentSource(filename: fileName, ));
   }
 
   Future<void> test_removesStatefulnessWithNoInitalState() async {
     const statefulComponentWithNoInitialState = r'''
 import 'package:over_react/over_react.dart';
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
 
@@ -205,18 +214,20 @@ class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
 }
 ''';
 
+    final fileName = uniqueSourceFileName();
     var retrievedSource = newSource(statefulComponentWithNoInitialState, path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, simpleUiComponentSource());
+    expect(retrievedSource.contents.data, simpleUiComponentSource(filename: fileName));
   }
 
   Future<void> test_removesStatefulnessToFlux() async {
-    var retrievedSource = newSource(fluxUiComponentSource(isStateful: true), path: fileName);
+    final fileName = uniqueSourceFileName();
+    var retrievedSource = newSource(fluxUiComponentSource(filename: fileName, isStateful: true), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
-    expect(retrievedSource.contents.data, fluxUiComponentSource());
+    expect(retrievedSource.contents.data, fluxUiComponentSource(filename: fileName));
   }
 }

--- a/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
+++ b/tools/analyzer_plugin/test/integration/assists/toggle_statefulness_test.dart
@@ -93,7 +93,6 @@ class TestComponent extends AbstractBazComponent<TestProps> {
     final fileName = uniqueSourceFileName();
     var retrievedSource = newSource(simpleUiComponentSource(filename: fileName), path: fileName);
     var selection = createSelection(retrievedSource, componentNameSelector);
-    print('selection: $selection');
     final change = await expectAndGetSingleAssist(selection);
     retrievedSource = applySourceChange(change, retrievedSource);
     expect(retrievedSource.contents.data, simpleUiComponentSource(filename: fileName, isStateful: true));

--- a/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/arrow_function_prop_test.dart
@@ -48,7 +48,7 @@ var foo = (Dom.div()
     final source = newSource(/*language=dart*/ r'''
       import 'package:over_react/over_react.dart';
 
-      part 'test.over_react.g.dart';
+      part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
       
       mixin FooState on UiState {
         var foo;

--- a/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
@@ -7,13 +7,12 @@ import 'package:test_reflective_loader/test_reflective_loader.dart';
 import '../test_bases/diagnostic_test_base.dart';
 
 void main() {
-  // These tests can't run until this diagnostic is re-enabled in the plugin.
-  // defineReflectiveSuite(() {
-  //   defineReflectiveTests(BoilerplateValidatorDiagnosticTestFalsePositives);
-  //   defineReflectiveTests(BoilerplateValidatorDiagnosticTestMissingGeneratedPart);
-  //   defineReflectiveTests(BoilerplateValidatorDiagnosticTestUnnecessaryGeneratedPart);
-  //   defineReflectiveTests(BoilerplateValidatorDiagnosticTestInvalidGeneratedPartName);
-  // });
+  defineReflectiveSuite(() {
+    defineReflectiveTests(BoilerplateValidatorDiagnosticTestFalsePositives);
+    defineReflectiveTests(BoilerplateValidatorDiagnosticTestMissingGeneratedPart);
+    defineReflectiveTests(BoilerplateValidatorDiagnosticTestUnnecessaryGeneratedPart);
+    defineReflectiveTests(BoilerplateValidatorDiagnosticTestInvalidGeneratedPartName);
+  });
 }
 
 @reflectiveTest

--- a/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
@@ -96,6 +96,8 @@ class BoilerplateValidatorDiagnosticTestUnnecessaryGeneratedPart extends Boilerp
 import 'package:over_react/over_react.dart';
 
 part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
+
+codeThatDoesNotRequireBoilerplate() => Dom.div()();
 ''';
 
   Future<void> test_error() async {
@@ -126,6 +128,8 @@ part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 import 'package:over_react/over_react.dart';
 
 
+
+codeThatDoesNotRequireBoilerplate() => Dom.div()();
 ''');
   }
 }

--- a/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:over_react_analyzer_plugin/src/diagnostic/boilerplate_validator.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
@@ -68,6 +69,7 @@ ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
 
   Future<void> test_errorFix() async {
     var _source = newSource(source);
+    final basenameWithoutExtension = p.basenameWithoutExtension(_source.uri.path);
     final selection = createSelection(_source, "UiFactory<FooProps> #Foo# =");
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
@@ -75,7 +77,7 @@ ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
     expect(_source.contents.data, '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '$basenameWithoutExtension.over_react.g.dart';
 
 ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
 ''');
@@ -93,18 +95,21 @@ class BoilerplateValidatorDiagnosticTestUnnecessaryGeneratedPart extends Boilerp
   static const source = /*language=dart*/ '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 ''';
 
   Future<void> test_error() async {
     final _source = newSource(source);
+    final basenameWithoutExtension = p.basenameWithoutExtension(_source.uri.path);
     final allErrors = await getAllErrors(_source);
     expect(
       allErrors,
       allOf(
         everyElement(isAnErrorUnderTest(hasFix: true)),
         unorderedEquals(<Matcher>[
-          isAnErrorUnderTest(locatedAt: createSelection(_source, "#part 'test.over_react.g.dart';#"), hasFix: true),
+          isAnErrorUnderTest(
+              locatedAt: createSelection(_source, "#part '$basenameWithoutExtension.over_react.g.dart';#"),
+              hasFix: true),
         ]),
       ),
     );
@@ -112,7 +117,8 @@ part 'test.over_react.g.dart';
 
   Future<void> test_errorFix() async {
     var _source = newSource(source);
-    final selection = createSelection(_source, "#part 'test.over_react.g.dart';#");
+    final basenameWithoutExtension = p.basenameWithoutExtension(_source.uri.path);
+    final selection = createSelection(_source, "#part '$basenameWithoutExtension.over_react.g.dart';#");
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
     _source = applyErrorFixes(errorFix, _source);
@@ -158,6 +164,7 @@ ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
 
   Future<void> test_errorFix() async {
     var _source = newSource(source);
+    final basenameWithoutExtension = p.basenameWithoutExtension(_source.uri.path);
     final selection = createSelection(_source, "#part 'invalid_generated_part_filename.over_react.g.dart';#");
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
@@ -165,7 +172,7 @@ ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
     expect(_source.contents.data, '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '$basenameWithoutExtension.over_react.g.dart';
 
 ${BoilerplateValidatorDiagnosticTest.boilerplateThatRequiresGeneratedPart}
 ''');

--- a/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/callback_ref_test.dart
@@ -246,7 +246,7 @@ class CallbackRefDiagnosticClassComponentTest extends CallbackRefDiagnosticWithF
   static const usageSourceWithinClassComponent = '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
 
@@ -269,7 +269,7 @@ class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
   static const usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
 
@@ -292,7 +292,7 @@ class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
   static const usageSourceWithinClassComponentFixedArrowFnRefAssignment = '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<UsesCallbackRefProps> UsesCallbackRef = castUiFactory(_\$UsesCallbackRef); // ignore: undefined_identifier
 
@@ -324,7 +324,8 @@ class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
         createSelection(source, CallbackRefDiagnosticTest.selectionToFixBlockFnBodyRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment);
+    expect(source.contents.data,
+        substituteSource(usageSourceWithinClassComponentFixedBlockFnBodyRefAssignment, path: source.uri.path));
   }
 
   Future<void> test_arrowFnRefAssignmentError() async {
@@ -338,7 +339,8 @@ class UsesCallbackRefComponent extends UiComponent2<UsesCallbackRefProps> {
         createSelection(source, CallbackRefDiagnosticTest.selectionToFixArrowFnRefAssignment));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinClassComponentFixedArrowFnRefAssignment);
+    expect(source.contents.data,
+        substituteSource(usageSourceWithinClassComponentFixedArrowFnRefAssignment, path: source.uri.path));
   }
 }
 

--- a/tools/analyzer_plugin/test/integration/diagnostics/create_ref_usage_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/create_ref_usage_test.dart
@@ -37,7 +37,7 @@ ReactElement someFunction(Map props) {
     final source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<FooProps> Foo = castUiFactory(_$Foo); // ignore: undefined_identifier
 
@@ -61,7 +61,7 @@ class FooComponent extends UiComponent2<FooProps> {
     final source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart' hide createRef;
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {}
 
@@ -81,7 +81,7 @@ final Foo = uiFunction<FooProps>(
     final source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart' hide createRef;
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {}
 
@@ -101,6 +101,7 @@ final Foo = uiFunction<FooProps>(
   /// the fix will replace it with `useRef`.
   Future<void> _expectErrorAndFix(String input, String expectedOutput) async {
     var source = newSource(input);
+    expectedOutput = substituteSource(expectedOutput, path: source.uri.path);
     final selection = createSelection(source, "#createRef#");
 
     // Verify error.
@@ -117,7 +118,7 @@ final Foo = uiFunction<FooProps>(
     String content(String createRefUsage) => '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {}
 
@@ -137,7 +138,7 @@ final Foo = uiFunction<FooProps>(
     String content(String createRefUsage) => '''
 import 'package:over_react/over_react.dart' as or;
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on or.UiProps {}
 
@@ -159,7 +160,7 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {}
 

--- a/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/duplicate_prop_cascade_test.dart
@@ -23,7 +23,7 @@ class DuplicatePropCascadeDiagnosticTest extends DiagnosticTestBase {
   static const customComponentDefinition = /*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin CustomProps on UiProps {
   int size;
@@ -107,14 +107,14 @@ final componentUsage = (Custom()
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, /*language=dart*/ '''
+    expect(source.contents.data, substituteSource(/*language=dart*/ '''
 $customComponentDefinition
 
 final componentUsage = (Custom()
   ..hidden = true
   ..dom.hidden = false
 )();
-''');
+''', path: source.uri.path));
   }
 
   // ********************************************************

--- a/tools/analyzer_plugin/test/integration/diagnostics/exhaustive_deps_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/exhaustive_deps_test.dart
@@ -20,7 +20,7 @@ import 'exhaustive_deps_test_cases.dart' as test_cases;
 
 void main() {
   group('ExhaustiveDeps', () {
-    const preamble = r'''
+    String getPreamble([String fileName = 'test.dart']) => '''
 // ignore_for_file: unused_import, unused_local_variable
     
 import 'dart:html';
@@ -28,7 +28,7 @@ import 'dart:html';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react.dart' as over_react;
 
-part 'test.over_react.g.dart';
+part '${fileName.replaceFirst('.dart', '.over_react.g.dart')}';
 
 // Implement APIs not defined in MockSdk
 dynamic window;
@@ -147,7 +147,9 @@ class ObjectWithWritableField {
               printOnFailure('Test case source (before adding preamble): ```\n${testCase.code}\n```');
 
               final testBase = await setUpTestBase(testCase);
-              final source = testBase.newSource(preamble + testCase.code);
+
+              final fileName = testBase.uniqueSourceFileName();
+              final source = testBase.newSource(getPreamble(fileName) + testCase.code, path: fileName);
               await testBase.expectNoErrors(source, errorFilter: errorFilter);
             });
           });
@@ -166,7 +168,10 @@ class ObjectWithWritableField {
               final expectedErrors = testCase.errors;
               expect(expectedErrors, isNotEmpty);
 
-              final source = testBase.newSource(preamble + testCase.code);
+
+              final fileName = testBase.uniqueSourceFileName();
+              final preamble = getPreamble(fileName);
+              final source = testBase.newSource(preamble + testCase.code, path: fileName);
               final errors = await testBase.getAllErrors(source, includeOtherCodes: true, errorFilter: errorFilter);
               expect(errors.dartErrors, isEmpty,
                   reason: 'Expected there to be no errors coming from the analyzer and not the plugin.'

--- a/tools/analyzer_plugin/test/integration/diagnostics/forward_only_dom_props_to_dom_builders_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/forward_only_dom_props_to_dom_builders_test.dart
@@ -23,7 +23,7 @@ class ForwardOnlyDomPropsToDomBuildersDiagnosticTest extends DiagnosticTestBase 
   String usageSourceWithinClassComponent({required bool fixed}) => '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 UiFactory<DomWrapperProps> DomWrapper = castUiFactory(_\$DomWrapper); // ignore: undefined_identifier
 
@@ -59,7 +59,7 @@ final DomWrapperFn = uiFunction<UiProps>(
     final errorFix = await expectSingleErrorFix(createSelection(source, "..modifyProps(#addUnconsumedProps#)"));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinClassComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinClassComponent(fixed: true), path: source.uri.path));
   }
 
   Future<void> test_fnComponentUsageErrorAndFix() async {
@@ -67,6 +67,6 @@ final DomWrapperFn = uiFunction<UiProps>(
     final errorFix = await expectSingleErrorFix(createSelection(source, "..#addUnconsumedProps#(props, const [])"));
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, usageSourceWithinFnComponent(fixed: true));
+    expect(source.contents.data, substituteSource(usageSourceWithinFnComponent(fixed: true), path: source.uri.path));
   }
 }

--- a/tools/analyzer_plugin/test/integration/diagnostics/non_defaulted_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/non_defaulted_prop_test.dart
@@ -24,7 +24,7 @@ class NonDefaultedPropDiagnosticTest extends DiagnosticTestBase {
     final source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String content;
@@ -49,7 +49,7 @@ final Foo = uiFunction<FooProps>(
     final source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String content;
@@ -75,7 +75,7 @@ final Foo = uiFunction<FooProps>(
     String contents(String propUsage) => '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String content;
@@ -100,14 +100,14 @@ final Foo = uiFunction<FooProps>(
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, contents('content'));
+    expect(source.contents.data, substituteSource(contents('content'), path: source.uri.path));
   }
 
   Future<void> test_errorFixWithDifferentName() async {
     String contents(String propUsage) => '''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String content;
@@ -132,14 +132,14 @@ final Foo = uiFunction<FooProps>(
     final errorFix = await expectSingleErrorFix(selection);
     expect(errorFix.fixes.single.change.selection, isNull);
     source = applyErrorFixes(errorFix, source);
-    expect(source.contents.data, contents('defaultContent'));
+    expect(source.contents.data, substituteSource(contents('defaultContent'), path: source.uri.path));
   }
 
   Future<void> test_multipleErrorsAndFixes() async {
     var source = newSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String fooId;
@@ -189,10 +189,10 @@ final Foo = uiFunction<FooProps>(
       source = applyErrorFixes(errorFix, source);
     }
 
-    expect(source.contents.data, /*language=dart*/ r'''
+    expect(source.contents.data, substituteSource(/*language=dart*/ r'''
 import 'package:over_react/over_react.dart';
 
-part 'test.over_react.g.dart';
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 mixin FooProps on UiProps {
   String fooId;
@@ -225,6 +225,6 @@ final Foo = uiFunction<FooProps>(
   },
   _$FooConfig, // ignore: undefined_identifier
 );
-''');
+''', path: source.uri.path));
   }
 }

--- a/tools/analyzer_plugin/test/integration/test_bases/analysis_driver_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/analysis_driver_test_base.dart
@@ -35,10 +35,7 @@ abstract class AnalysisDriverTestBase {
   /// If provided, [path] must be relative, and also must be unique so that it
   /// doesn't conflict with paths created by other tests using the same [sharedContext].
   ///
-  /// For convenience, [contents] will have the following mustache-like templates substituted:
-  ///
-  /// - `{{FILE_BASENAME_WITHOUT_EXTENSION}}` - the filename without any extension.
-  ///   Useful for creating sources that reference generated parts that are based on auto-generated unique filenames.
+  /// For convenience [substituteSource] will be applied to [contents] first.
   Source newSource(String contents, {String? path}) {
     if (path != null && p.isAbsolute(path)) {
       throw ArgumentError.value(path, 'path', 'must be a relative path');
@@ -49,10 +46,15 @@ abstract class AnalysisDriverTestBase {
     return resourceProvider.getFile(testFilePath).createSource();
   }
 
+  /// Returns [contents] with the following mustache-like templates substituted:
+  ///
+  /// - `{{FILE_BASENAME_WITHOUT_EXTENSION}}` - the filename without any extension.
+  ///   Useful for creating sources that reference generated parts that are based on auto-generated unique filenames.
   String substituteSource(String contents, {required String path}) {
     return contents.replaceAll(RegExp(r'{{\s*FILE_BASENAME_WITHOUT_EXTENSION\s*}}'), p.basenameWithoutExtension(path));
   }
 
+  /// Returns a new unique filename that can be used as a path in [newSource].
   String uniqueSourceFileName() => sharedContext.nextFilename();
 
   void modifyFile(String path, String contents) {

--- a/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/src/generated/source.dart' show Source, SourceRange;
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:source_span/source_span.dart';
 import 'package:test/test.dart';
 
 import '../stubs.dart';
@@ -28,6 +29,15 @@ class SourceSelection {
   final String? target;
 
   SourceSelection(this.source, this.offset, this.length, {this.target});
+
+  @override
+  String toString() {
+    return 'SourceSelection ${{
+      'target': target,
+      'offset': offset,
+      'length': length,
+    }}. Preview:\n' + SourceFile.fromString(source.contents.data, url: source.uri).span(offset, offset + length).highlight();
+  }
 }
 
 extension AsRange$SourceRange on SourceSelection {


### PR DESCRIPTION
## Motivation
In a previous over_react release, we had to disable some diagnostics and assists that imported over_react builder code due to issues with the plugin running in unsound null safety.

As part of the over_react null-safety major release, we want to reenable those diagnostics, and have done so in v5_wip.

As a result to test refactors and other changes that were made while those contributors were disabled, there are test failures that need to be addressed, mostly to do with unique file names.

## Changes
- Update `AnalysisDriverTestBase` to automatically substitute auto-generated filenames within source (using  `{{FILE_BASENAME_WITHOUT_EXTENSION}}`)
- Uncomment tests:
    - test/integration/assists/toggle_statefulness_test.dart
    - test/integration/diagnostics/boilerplate_validator_test.dart
- Fix all analyzer_plugin test failures
    - Update tests referencing `.over_react.g.dart` parts to reference the correct auto-generated file names. Without them, we get unrelated `BoilerplateValidatorDiagnostic` errors in unrelated tests.
        - Most of these are just switching to `{{FILE_BASENAME_WITHOUT_EXTENSION}}`, but some required more custom updates
    - Fix toggle statefulness diagnostic due to logic (in boilerplate_assist_apis.dart) being broken while it was turned off, in the last analyzer package upgrade 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - All CI is passing (analyzer_plugin tests were previously failing in v5_wip)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
