### PR TITLE
w_flux Migration: Action class to ActionV2

### DIFF
--- a/test/over_react_redux/connect_flux_integration_test.dart
+++ b/test/over_react_redux/connect_flux_integration_test.dart
@@ -46,8 +46,8 @@ main() {
       connectableFluxStore = TestConnectableFluxStore(connectableStoreActions);
       anotherConnectableFluxStore =
           TestConnectableFluxStore(connectableStoreActions);
-      connectableFluxAdaptedStore =
-          ConnectFluxAdapterStore(connectableFluxStore, connectableStoreActions);
+      connectableFluxAdaptedStore = ConnectFluxAdapterStore(
+          connectableFluxStore, connectableStoreActions);
     });
 
     group('FluxToReduxAdapterStore', () {
@@ -105,8 +105,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
           )(ConnectFluxCounter);
 
           final ConnectedReduxComponent = connect<FluxStore, CounterProps>(
@@ -154,8 +154,8 @@ main() {
           mapStateToProps: (state) =>
               (ConnectFluxCounter()..currentCount = state.count),
           mapActionsToProps: (actions) => (ConnectFluxCounter()
-            ..increment = actions.incrementAction
-            ..decrement = actions.decrementAction),
+            ..increment = (() => actions.incrementAction)
+            ..decrement = (() => actions.decrementAction)),
         )(ConnectFluxCounter);
 
         final ConnectedReduxComponent = connect<FluxStore, CounterProps>(
@@ -241,8 +241,8 @@ main() {
           mapStateToProps: (state) =>
               (ConnectFluxCounter()..currentCount = state.count),
           mapActionsToProps: (actions) => (ConnectFluxCounter()
-            ..increment = actions.incrementAction
-            ..decrement = actions.decrementAction),
+            ..increment = (() => actions.incrementAction)
+            ..decrement = (() => actions.decrementAction)),
         )(ConnectFluxCounter);
 
         ConnectedReduxComponent =
@@ -259,8 +259,7 @@ main() {
           (FluxCounter()
             ..store = connectableFluxStore
             ..actions = connectableStoreActions
-            ..addTestId('flux-component')
-          )(),
+            ..addTestId('flux-component'))(),
         ));
 
         connectFluxCounter =

--- a/test/over_react_redux/connect_flux_integration_test.dart
+++ b/test/over_react_redux/connect_flux_integration_test.dart
@@ -105,8 +105,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
           )(ConnectFluxCounter);
 
           final ConnectedReduxComponent = connect<FluxStore, CounterProps>(
@@ -154,8 +154,8 @@ main() {
           mapStateToProps: (state) =>
               (ConnectFluxCounter()..currentCount = state.count),
           mapActionsToProps: (actions) => (ConnectFluxCounter()
-            ..increment = (() => actions.incrementAction)
-            ..decrement = (() => actions.decrementAction)),
+            ..increment = (() => actions.incrementAction(null))
+            ..decrement = (() => actions.decrementAction(null))),
         )(ConnectFluxCounter);
 
         final ConnectedReduxComponent = connect<FluxStore, CounterProps>(
@@ -241,8 +241,8 @@ main() {
           mapStateToProps: (state) =>
               (ConnectFluxCounter()..currentCount = state.count),
           mapActionsToProps: (actions) => (ConnectFluxCounter()
-            ..increment = (() => actions.incrementAction)
-            ..decrement = (() => actions.decrementAction)),
+            ..increment = (() => actions.incrementAction(null))
+            ..decrement = (() => actions.decrementAction(null))),
         )(ConnectFluxCounter);
 
         ConnectedReduxComponent =

--- a/test/over_react_redux/connect_flux_test.dart
+++ b/test/over_react_redux/connect_flux_test.dart
@@ -787,7 +787,7 @@ main() {
         mapStateToProps: (state) => (ConnectFluxCounter()
           ..mutatedList = state.listYouDefShouldntMutate),
         mapActionsToProps: (actions) => (ConnectFluxCounter()
-          ..mutateStoreDirectly = (() => actions.mutateStoreDirectly)),
+          ..mutateStoreDirectly = (() => actions.mutateStoreDirectly(null))),
       )(ConnectFluxCounter);
 
       final jacket = mount((ReduxProvider()..store = store1)(

--- a/test/over_react_redux/connect_flux_test.dart
+++ b/test/over_react_redux/connect_flux_test.dart
@@ -90,8 +90,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
           )(ConnectFluxCounter);
 
           expect(() => render(ConnectedCounter()('test')), throwsA(anything));
@@ -153,8 +153,8 @@ main() {
                   mapStateToProps: (state) =>
                       (ConnectFluxCounter()..currentCount = state.count),
                   mapActionsToProps: (actions) => (ConnectFluxCounter()
-                    ..increment = (() => actions.incrementAction)
-                    ..decrement = (() => actions.decrementAction)),
+                    ..increment = (() => actions.incrementAction(null))
+                    ..decrement = (() => actions.decrementAction(null))),
                   forwardRef: true)(ConnectFluxCounter);
 
           jacket = mount(
@@ -204,8 +204,8 @@ main() {
             mapStateToPropsWithOwnProps: (state, ownProps) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -240,8 +240,8 @@ main() {
               return ConnectFluxCounter()..currentCount = state.count;
             },
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -280,8 +280,8 @@ main() {
               return ConnectFluxCounter()..currentCount = state.count;
             },
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -319,7 +319,7 @@ main() {
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) {
               return ConnectFluxCounter()
-                ..decrement = (() => actions.decrementAction);
+                ..decrement = (() => actions.decrementAction(null));
             },
             mergeProps: (stateProps, dispatchProps, ownProps) {
               propsReferences.addAll([stateProps, dispatchProps, ownProps]);
@@ -417,7 +417,7 @@ main() {
                 return ConnectFluxCounter()..currentCount = state.count;
               },
               mapActionsToProps: (actions) => (ConnectFluxCounter()
-                ..increment = (() => actions.incrementAction)),
+                ..increment = (() => actions.incrementAction(null))),
               areStatePropsEqual: (next, prev) {
                 methodsCalled.add({
                   'called': 'areStatePropsEqual',
@@ -593,8 +593,8 @@ main() {
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) {
               return ConnectFluxCounter()
-                ..increment = (() => actions.incrementAction)
-                ..decrement = (() => actions.decrementAction);
+                ..increment = (() => actions.incrementAction(null))
+                ..decrement = (() => actions.decrementAction(null));
             },
             forwardRef: true,
           )(ConnectFluxCounter);
@@ -603,8 +603,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             context: bigCounterContext,
             forwardRef: true,
           )(ConnectFluxCounter);
@@ -637,8 +637,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -647,8 +647,8 @@ main() {
             mapStateToProps: (state) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = (() => actions.incrementAction)
-              ..decrement = (() => actions.decrementAction)),
+              ..increment = (() => actions.incrementAction(null))
+              ..decrement = (() => actions.decrementAction(null))),
             context: bigCounterContext,
             forwardRef: true,
           )(ConnectFluxCounter);
@@ -822,12 +822,12 @@ typedef MapActionsToPropsWithOwnPropsCallback = Map Function(
 MapStateToPropsCallback get testMapStateToProps =>
     (state) => (ConnectFluxCounter()..currentCount = state.count);
 MapActionsToPropsCallback get testMapActionsToProps => (actions) =>
-    (ConnectFluxCounter()..increment = (() => actions.incrementAction));
+    (ConnectFluxCounter()..increment = (() => actions.incrementAction(null)));
 MapStateToPropsWithOwnPropsCallback get testMapStateToPropsWithOwnProps =>
     (state, ownProps) => (ConnectFluxCounter()..currentCount = state.count);
 MapActionsToPropsWithOwnPropsCallback get testMapActionsToPropsWithOwnProps =>
-    (actions, ownProps) =>
-        (ConnectFluxCounter()..increment = (() => actions.incrementAction));
+    (actions, ownProps) => (ConnectFluxCounter()
+      ..increment = (() => actions.incrementAction(null)));
 
 class ParameterTestCase {
   final String name;

--- a/test/over_react_redux/connect_flux_test.dart
+++ b/test/over_react_redux/connect_flux_test.dart
@@ -53,7 +53,8 @@ main() {
         JsConnectOptions options,
       ]) {
         connectOptions = options;
-        return originalConnect(mapStateToProps, mapDispatchToProps, mergeProps, options);
+        return originalConnect(
+            mapStateToProps, mapDispatchToProps, mergeProps, options);
       };
     });
 
@@ -77,18 +78,20 @@ main() {
     group('behaves like redux with', () {
       test('errors when wrapping a UiComponent', () {
         expect(
-            () => connectFlux<FluxStore, FluxActions, NonComponentTwoCounterProps>()(
-                NonComponentTwoCounter),
+            () => connectFlux<FluxStore, FluxActions,
+                NonComponentTwoCounterProps>()(NonComponentTwoCounter),
             throwsArgumentError);
       });
 
       group('Provider Usage', () {
         test('throws without a provider', () {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
           )(ConnectFluxCounter);
 
           expect(() => render(ConnectedCounter()('test')), throwsA(anything));
@@ -96,7 +99,8 @@ main() {
 
         test('does not throw with a provider', () {
           ConnectedCounter =
-              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>()(ConnectFluxCounter);
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>()(
+                  ConnectFluxCounter);
 
           expect(
             () => render(
@@ -111,8 +115,9 @@ main() {
 
       group('forwardRef', () {
         test('when true: forwards the ref to the wrapped component', () {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-              forwardRef: true)(ConnectFluxCounter);
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+                  forwardRef: true)(ConnectFluxCounter);
 
           render(
             (ReduxProvider()..store = store1)(
@@ -123,11 +128,14 @@ main() {
         });
       });
 
-      group('mapStateToProps properly maps the state to the components props', () {
+      group('mapStateToProps properly maps the state to the components props',
+          () {
         test('on inital load', () {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-              mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
-              forwardRef: true)(ConnectFluxCounter);
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+                  mapStateToProps: (state) =>
+                      (ConnectFluxCounter()..currentCount = state.count),
+                  forwardRef: true)(ConnectFluxCounter);
 
           jacket = mount(
             (ReduxProvider()..store = store1)(
@@ -140,12 +148,14 @@ main() {
         });
 
         test('after triggered', () async {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-              mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
-              mapActionsToProps: (actions) => (ConnectFluxCounter()
-                ..increment = actions.incrementAction
-                ..decrement = actions.decrementAction),
-              forwardRef: true)(ConnectFluxCounter);
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+                  mapStateToProps: (state) =>
+                      (ConnectFluxCounter()..currentCount = state.count),
+                  mapActionsToProps: (actions) => (ConnectFluxCounter()
+                    ..increment = (() => actions.incrementAction)
+                    ..decrement = (() => actions.decrementAction)),
+                  forwardRef: true)(ConnectFluxCounter);
 
           jacket = mount(
             (ReduxProvider()..store = store1)(
@@ -156,7 +166,8 @@ main() {
           expect(counterRef.current.props.currentCount, 0);
           expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
-          var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
+          var dispatchButton =
+              queryByTestId(jacket.mountNode, 'button-increment');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
@@ -167,12 +178,15 @@ main() {
         });
       });
 
-      group('mapStateToPropsWithOwnProps properly maps the state to the components props', () {
+      group(
+          'mapStateToPropsWithOwnProps properly maps the state to the components props',
+          () {
         test('on inital load', () {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-              mapStateToPropsWithOwnProps: (state, ownProps) =>
-                  (ConnectFluxCounter()..currentCount = state.count),
-              forwardRef: true)(ConnectFluxCounter);
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+                  mapStateToPropsWithOwnProps: (state, ownProps) =>
+                      (ConnectFluxCounter()..currentCount = state.count),
+                  forwardRef: true)(ConnectFluxCounter);
 
           jacket = mount(
             (ReduxProvider()..store = store1)(
@@ -185,12 +199,13 @@ main() {
         });
 
         test('after dispatch', () async {
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
             mapStateToPropsWithOwnProps: (state, ownProps) =>
                 (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -203,7 +218,8 @@ main() {
           expect(counterRef.current.props.currentCount, 0);
           expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
-          var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
+          var dispatchButton =
+              queryByTestId(jacket.mountNode, 'button-increment');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
@@ -218,13 +234,14 @@ main() {
         test('maps actions to props correctly', () async {
           final stateReferences = <FluxStore>[];
 
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
             mapStateToProps: (state) {
               return ConnectFluxCounter()..currentCount = state.count;
             },
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -240,7 +257,8 @@ main() {
           expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
           // Click button mapped to trigger `propFromDispatch` prop.
-          var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
+          var dispatchButton =
+              queryByTestId(jacket.mountNode, 'button-decrement');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
@@ -255,14 +273,15 @@ main() {
       group('mapActionsToPropsWithOwnProps', () {
         test('maps actions to props correctly', () async {
           final stateReferences = <FluxStore>[];
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
             mapStateToProps: (state) {
               stateReferences.add(state);
               return ConnectFluxCounter()..currentCount = state.count;
             },
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             forwardRef: true,
           )(ConnectFluxCounter);
 
@@ -278,7 +297,8 @@ main() {
           expect(jacket.mountNode.innerHtml, contains('Count: 0'));
 
           // Click button mapped to trigger `propFromDispatch` prop.
-          var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
+          var dispatchButton =
+              queryByTestId(jacket.mountNode, 'button-decrement');
           click(dispatchButton);
 
           // wait for the next tick for the async dispatch to propagate
@@ -293,17 +313,21 @@ main() {
       group('mergeProps', () {
         test('properly merges props based on consumer map', () async {
           final propsReferences = <ConnectFluxCounterProps>[];
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) {
-              return ConnectFluxCounter()..decrement = actions.decrementAction;
+              return ConnectFluxCounter()
+                ..decrement = (() => actions.decrementAction);
             },
             mergeProps: (stateProps, dispatchProps, ownProps) {
               propsReferences.addAll([stateProps, dispatchProps, ownProps]);
               return ConnectFluxCounter()
                 // Return whatever value is passed through ownProps until the state count is over 1
-                ..currentCount =
-                    stateProps.currentCount < 1 ? ownProps.currentCount : stateProps.currentCount
+                ..currentCount = stateProps.currentCount < 1
+                    ? ownProps.currentCount
+                    : stateProps.currentCount
                 ..decrement = ownProps.decrement;
             },
             forwardRef: true,
@@ -321,7 +345,8 @@ main() {
             ),
           );
           // `button-decrement` will be incrementing now
-          var dispatchButton = queryByTestId(jacket.mountNode, 'button-decrement');
+          var dispatchButton =
+              queryByTestId(jacket.mountNode, 'button-decrement');
 
           expect(counterRef.current.props.decrement, isA<Function>());
 
@@ -337,7 +362,8 @@ main() {
 
           expect(counterRef.current.props.currentCount, 1);
           expect(jacket.mountNode.innerHtml, contains('Count: 1'));
-          propsReferences.forEach((store) => expect(store, isA<ConnectFluxCounterProps>()));
+          propsReferences.forEach(
+              (store) => expect(store, isA<ConnectFluxCounterProps>()));
         });
       });
 
@@ -345,7 +371,8 @@ main() {
         group('areOwnPropsEqual', () {
           test('', () {
             final propsReferences = <ConnectFluxCounterProps>[];
-            ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            ConnectedCounter =
+                connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
               areOwnPropsEqual: expectAsync2((next, prev) {
                 propsReferences.addAll([prev, next]);
                 expect(next.id, 'test');
@@ -359,7 +386,8 @@ main() {
                 JsBackedMap.from({'id': 'test2'}).jsObject);
 
             expect(whatever, isTrue);
-            propsReferences.forEach((store) => expect(store, isA<ConnectFluxCounterProps>()));
+            propsReferences.forEach(
+                (store) => expect(store, isA<ConnectFluxCounterProps>()));
           });
         });
 
@@ -381,13 +409,15 @@ main() {
           });
 
           test('', () async {
-            ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            ConnectedCounter =
+                connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
               mapStateToProps: (state) {
-                methodsCalled.add({'called': 'mapStateToProps', 'state': state});
+                methodsCalled
+                    .add({'called': 'mapStateToProps', 'state': state});
                 return ConnectFluxCounter()..currentCount = state.count;
               },
-              mapActionsToProps: (actions) =>
-                  (ConnectFluxCounter()..increment = actions.incrementAction),
+              mapActionsToProps: (actions) => (ConnectFluxCounter()
+                ..increment = (() => actions.incrementAction)),
               areStatePropsEqual: (next, prev) {
                 methodsCalled.add({
                   'called': 'areStatePropsEqual',
@@ -421,7 +451,8 @@ main() {
 
             methodsCalled.clear();
 
-            var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
+            var dispatchButton =
+                queryByTestId(jacket.mountNode, 'button-increment');
             click(dispatchButton);
 
             // wait for the next tick for the async dispatch to propagate
@@ -443,11 +474,13 @@ main() {
             expect(jacket.mountNode.innerHtml, contains('Count: 0'));
           });
 
-          test('matches a Redux component with impure state when `areStatesEqual` is false',
+          test(
+              'matches a Redux component with impure state when `areStatesEqual` is false',
               () async {
             final localReduxRef = createRef<CounterComponent>();
 
-            final ReduxConnectedCounter = connect<redux_store.ImpureCounterState, CounterProps>(
+            final ReduxConnectedCounter =
+                connect<redux_store.ImpureCounterState, CounterProps>(
               mapStateToProps: (state) {
                 methodsCalled.add({
                   'called': 'mapStateToProps',
@@ -475,7 +508,8 @@ main() {
             // which allows react-redux's memoization to skip the extra calls after the component renders.
             //
             // Simulate this by using an Redux store that has the same impurity as Flux stores.
-            final impureReduxStore = redux.Store(redux_store.impureCounterStateReducer,
+            final impureReduxStore = redux.Store(
+                redux_store.impureCounterStateReducer,
                 initialState: redux_store.ImpureCounterState());
 
             jacket = mount(
@@ -498,7 +532,8 @@ main() {
             }
             methodsCalled.clear();
 
-            var dispatchButton = queryByTestId(jacket.mountNode, 'button-increment');
+            var dispatchButton =
+                queryByTestId(jacket.mountNode, 'button-increment');
             click(dispatchButton);
 
             // wait for the next tick for the async dispatch to propagate
@@ -510,7 +545,8 @@ main() {
                 expectedUpdateMethodCalls
                     .map((expected) => containsPair('called', expected))
                     .toList(),
-                reason: 'connect\'s sequence of calls should match expectedUpdateMethodCalls');
+                reason:
+                    'connect\'s sequence of calls should match expectedUpdateMethodCalls');
 
             for (final methodCall in methodsCalled) {
               if (methodCall['called'] == 'areStatePropsEqual') {
@@ -527,7 +563,8 @@ main() {
           test('', () {
             final propsReferences = <ConnectFluxCounterProps>[];
 
-            ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            ConnectedCounter =
+                connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
               areMergedPropsEqual: expectAsync2((next, prev) {
                 expect(next.id, 'test');
                 expect(prev.id, 'test2');
@@ -541,7 +578,8 @@ main() {
                 JsBackedMap.from({'id': 'test2'}).jsObject);
 
             expect(whatever, isTrue);
-            propsReferences.forEach((store) => expect(store, isA<ConnectFluxCounterProps>()));
+            propsReferences.forEach(
+                (store) => expect(store, isA<ConnectFluxCounterProps>()));
           });
         });
       });
@@ -549,20 +587,24 @@ main() {
       group('context', () {
         test('correctly renders with multiple contexts/stores', () async {
           var bigCounterContext = createContext();
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) {
               return ConnectFluxCounter()
-                ..increment = actions.incrementAction
-                ..decrement = actions.decrementAction;
+                ..increment = (() => actions.incrementAction)
+                ..decrement = (() => actions.decrementAction);
             },
             forwardRef: true,
           )(ConnectFluxCounter);
-          var ConnectedBigCounter = connectFlux<FluxStore2, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          var ConnectedBigCounter =
+              connectFlux<FluxStore2, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             context: bigCounterContext,
             forwardRef: true,
           )(ConnectFluxCounter);
@@ -590,19 +632,23 @@ main() {
         test('correctly renders when contexts are nested', () async {
           var bigCounterContext = createContext();
 
-          ConnectedCounter = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          ConnectedCounter =
+              connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             forwardRef: true,
           )(ConnectFluxCounter);
 
-          var ConnectedBigCounter = connectFlux<FluxStore2, FluxActions, ConnectFluxCounterProps>(
-            mapStateToProps: (state) => (ConnectFluxCounter()..currentCount = state.count),
+          var ConnectedBigCounter =
+              connectFlux<FluxStore2, FluxActions, ConnectFluxCounterProps>(
+            mapStateToProps: (state) =>
+                (ConnectFluxCounter()..currentCount = state.count),
             mapActionsToProps: (actions) => (ConnectFluxCounter()
-              ..increment = actions.incrementAction
-              ..decrement = actions.decrementAction),
+              ..increment = (() => actions.incrementAction)
+              ..decrement = (() => actions.decrementAction)),
             context: bigCounterContext,
             forwardRef: true,
           )(ConnectFluxCounter);
@@ -625,7 +671,8 @@ main() {
           var bigCounter = queryByTestId(jacket.mountNode, 'big-counter');
           var smallCounter = queryByTestId(jacket.mountNode, 'small-counter');
 
-          var smallDispatchButton = queryByTestId(smallCounter, 'button-increment');
+          var smallDispatchButton =
+              queryByTestId(smallCounter, 'button-increment');
           var dispatchButton = queryByTestId(bigCounter, 'button-increment');
 
           click(dispatchButton);
@@ -638,7 +685,8 @@ main() {
               reason: 'Should have a count of 100');
 
           // Normal counter incremented only 1 at both instances
-          expect(findDomNode(queryByTestId(jacket.mountNode, 'outside')).innerHtml,
+          expect(
+              findDomNode(queryByTestId(jacket.mountNode, 'outside')).innerHtml,
               contains('Count: 1</div>'));
           expect(findDomNode(bigCounter).innerHtml, contains('Count: 1</div>'));
         });
@@ -686,7 +734,8 @@ main() {
       ];
 
       for (final parameterCase in testCases) {
-        bool shouldDomUpdate() => parameterCase.mapStateToProps != null ||
+        bool shouldDomUpdate() =>
+            parameterCase.mapStateToProps != null ||
             parameterCase.mapStateToPropsWithOwnProps != null;
 
         test(parameterCase.name, () async {
@@ -694,8 +743,10 @@ main() {
               connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
             mapStateToProps: parameterCase.mapStateToProps,
             mapActionsToProps: parameterCase.mapActionsToProps,
-            mapStateToPropsWithOwnProps: parameterCase.mapStateToPropsWithOwnProps,
-            mapActionsToPropsWithOwnProps: parameterCase.mapActionsToPropsWithOwnProps,
+            mapStateToPropsWithOwnProps:
+                parameterCase.mapStateToPropsWithOwnProps,
+            mapActionsToPropsWithOwnProps:
+                parameterCase.mapActionsToPropsWithOwnProps,
           )(ConnectFluxCounter);
 
           final jacket2 = mount((ReduxProvider()..store = store1)(
@@ -704,7 +755,8 @@ main() {
               ..addTestId('flux-component'))(),
           ));
 
-          final fluxCounter = queryByTestId(jacket2.mountNode, 'flux-component');
+          final fluxCounter =
+              queryByTestId(jacket2.mountNode, 'flux-component');
           final fluxButton = queryByTestId(fluxCounter, 'button-increment');
 
           expect(fluxStore.state.count, 0);
@@ -730,11 +782,12 @@ main() {
     });
 
     test('prints a warning when state is mutated directly', () async {
-      final ConnectedFluxComponent = connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
-        mapStateToProps: (state) =>
-            (ConnectFluxCounter()..mutatedList = state.listYouDefShouldntMutate),
-        mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..mutateStoreDirectly = actions.mutateStoreDirectly),
+      final ConnectedFluxComponent =
+          connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
+        mapStateToProps: (state) => (ConnectFluxCounter()
+          ..mutatedList = state.listYouDefShouldntMutate),
+        mapActionsToProps: (actions) => (ConnectFluxCounter()
+          ..mutateStoreDirectly = (() => actions.mutateStoreDirectly)),
       )(ConnectFluxCounter);
 
       final jacket = mount((ReduxProvider()..store = store1)(
@@ -749,7 +802,8 @@ main() {
         await Future(() {});
       });
 
-      logs.removeWhere((log) => log.contains('Cannot find native JavaScript type'));
+      logs.removeWhere(
+          (log) => log.contains('Cannot find native JavaScript type'));
       expect(
           logs.first,
           contains(
@@ -760,17 +814,20 @@ main() {
 
 typedef MapStateToPropsCallback = Map Function(FluxStore);
 typedef MapActionsToPropsCallback = Map Function(FluxActions);
-typedef MapStateToPropsWithOwnPropsCallback = Map Function(FluxStore, ConnectFluxCounterProps);
-typedef MapActionsToPropsWithOwnPropsCallback = Map Function(FluxActions, ConnectFluxCounterProps);
+typedef MapStateToPropsWithOwnPropsCallback = Map Function(
+    FluxStore, ConnectFluxCounterProps);
+typedef MapActionsToPropsWithOwnPropsCallback = Map Function(
+    FluxActions, ConnectFluxCounterProps);
 
 MapStateToPropsCallback get testMapStateToProps =>
     (state) => (ConnectFluxCounter()..currentCount = state.count);
-MapActionsToPropsCallback get testMapActionsToProps =>
-    (actions) => (ConnectFluxCounter()..increment = actions.incrementAction);
+MapActionsToPropsCallback get testMapActionsToProps => (actions) =>
+    (ConnectFluxCounter()..increment = (() => actions.incrementAction));
 MapStateToPropsWithOwnPropsCallback get testMapStateToPropsWithOwnProps =>
     (state, ownProps) => (ConnectFluxCounter()..currentCount = state.count);
 MapActionsToPropsWithOwnPropsCallback get testMapActionsToPropsWithOwnProps =>
-    (actions, ownProps) => (ConnectFluxCounter()..increment = actions.incrementAction);
+    (actions, ownProps) =>
+        (ConnectFluxCounter()..increment = (() => actions.incrementAction));
 
 class ParameterTestCase {
   final String name;
@@ -780,7 +837,8 @@ class ParameterTestCase {
   final MapStateToPropsWithOwnPropsCallback mapStateToPropsWithOwnProps;
   final MapActionsToPropsWithOwnPropsCallback mapActionsToPropsWithOwnProps;
 
-  ParameterTestCase(this.name, {
+  ParameterTestCase(
+    this.name, {
     this.mapStateToProps,
     this.mapActionsToProps,
     this.mapStateToPropsWithOwnProps,

--- a/test/over_react_redux/fixtures/connect_flux_counter.dart
+++ b/test/over_react_redux/fixtures/connect_flux_counter.dart
@@ -57,7 +57,7 @@ class ConnectFluxCounterComponent
           } else if (props.increment != null) {
             props.increment();
           } else {
-            props.actions.incrementAction();
+            props.actions.incrementAction(null);
           }
         }
       )('+'),

--- a/test/over_react_redux/fixtures/connect_flux_store.dart
+++ b/test/over_react_redux/fixtures/connect_flux_store.dart
@@ -23,10 +23,10 @@ int _resetCounterReducer(int currentCount, ResetAction action) {
 }
 
 class FluxActions {
-  final flux.Action<int> incrementAction = flux.Action();
-  final flux.Action<int> decrementAction = flux.Action();
-  final flux.Action resetAction = flux.Action();
-  final flux.Action mutateStoreDirectly = flux.Action();
+  final flux.ActionV2<int> incrementAction = flux.ActionV2();
+  final flux.ActionV2<int> decrementAction = flux.ActionV2();
+  final flux.ActionV2 resetAction = flux.ActionV2();
+  final flux.ActionV2 mutateStoreDirectly = flux.ActionV2();
 }
 
 class FluxStore extends flux.Store with InfluxStoreMixin<FluxCounterState> {

--- a/test/over_react_redux/fixtures/flux_counter.dart
+++ b/test/over_react_redux/fixtures/flux_counter.dart
@@ -36,13 +36,13 @@ class FluxCounterComponent extends FluxUiComponent2<FluxCounterProps> {
       (Dom.button()
         ..addTestId('button-increment')
         ..onClick = (_) {
-          props.actions.incrementAction();
+          props.actions.incrementAction(null);
         }
       )('+'),
       (Dom.button()
         ..addTestId('button-decrement')
         ..onClick = (_) {
-          props.actions.decrementAction();
+          props.actions.decrementAction(null);
         }
       )('-'),
       props.children,

--- a/test/over_react_redux/redux_multi_provider_test.dart
+++ b/test/over_react_redux/redux_multi_provider_test.dart
@@ -43,14 +43,15 @@ main() {
 
       final anotherFluxActionsInstance = FluxActions();
       final anotherFluxStore = FluxStore(anotherFluxActionsInstance);
-      final store3 = FluxToReduxAdapterStore(anotherFluxStore, anotherFluxActionsInstance);
+      final store3 =
+          FluxToReduxAdapterStore(anotherFluxStore, anotherFluxActionsInstance);
 
       final Context1ConnectedFluxComponent =
           connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
         mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = actions.incrementAction),
+            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
         context: context1,
       )(ConnectFluxCounter);
 
@@ -59,7 +60,7 @@ main() {
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
         mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = actions.incrementAction),
+            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
         context: context2,
       )(ConnectFluxCounter);
 
@@ -68,7 +69,7 @@ main() {
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
         mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = actions.incrementAction),
+            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
         context: context3,
       )(ConnectFluxCounter);
 
@@ -79,8 +80,7 @@ main() {
                 context1: store1,
                 context2: store2,
                 context3: store3,
-              }
-            )(
+              })(
               (Context1ConnectedFluxComponent()..addTestId('context1'))(),
               (Context2ConnectedFluxComponent()..addTestId('context2'))(),
               (Context3ConnectedFluxComponent()..addTestId('context3'))(),

--- a/test/over_react_redux/redux_multi_provider_test.dart
+++ b/test/over_react_redux/redux_multi_provider_test.dart
@@ -50,8 +50,8 @@ main() {
           connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
-        mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
+        mapActionsToProps: (actions) => (ConnectFluxCounter()
+          ..increment = (() => actions.incrementAction(null))),
         context: context1,
       )(ConnectFluxCounter);
 
@@ -59,8 +59,8 @@ main() {
           connectFlux<FluxStore2, FluxActions, ConnectFluxCounterProps>(
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
-        mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
+        mapActionsToProps: (actions) => (ConnectFluxCounter()
+          ..increment = (() => actions.incrementAction(null))),
         context: context2,
       )(ConnectFluxCounter);
 
@@ -68,8 +68,8 @@ main() {
           connectFlux<FluxStore, FluxActions, ConnectFluxCounterProps>(
         mapStateToProps: (state) =>
             (ConnectFluxCounter()..currentCount = state.count),
-        mapActionsToProps: (actions) =>
-            (ConnectFluxCounter()..increment = (() => actions.incrementAction)),
+        mapActionsToProps: (actions) => (ConnectFluxCounter()
+          ..increment = (() => actions.incrementAction(null))),
         context: context3,
       )(ConnectFluxCounter);
 

--- a/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/components/big_block.dart
@@ -59,25 +59,25 @@ class BigBlockComponent extends FluxUiComponent2<BigBlockProps> {
         )(
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeMainBackgroundColor();
+              props.actions.changeMainBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Main Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockOneBackgroundColor();
+              props.actions.changeBlockOneBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 1 Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockTwoBackgroundColor();
+              props.actions.changeBlockTwoBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 2 Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockThreeBackgroundColor();
+              props.actions.changeBlockThreeBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 3 Background Color'),

--- a/web/flux_to_redux/advanced/examples/flux_implementation/store.dart
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/store.dart
@@ -17,13 +17,13 @@ import 'dart:math';
 import 'package:w_flux/w_flux.dart' as flux;
 
 class RandomColorActions {
-  final flux.Action<String> changeMainBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeMainBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockOneBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockOneBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockTwoBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockTwoBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockThreeBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockThreeBackgroundColor = flux.ActionV2();
 }
 
 class RandomColorStore extends flux.Store {

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/big_block.dart
@@ -61,25 +61,25 @@ class BigBlockComponent extends FluxUiComponent2<BigBlockProps> {
         )(
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeMainBackgroundColor();
+              props.actions.changeMainBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Main Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockOneBackgroundColor();
+              props.actions.changeBlockOneBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 1 Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockTwoBackgroundColor();
+              props.actions.changeBlockTwoBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 2 Background Color'),
           (Dom.button()
             ..onClick = (_) {
-              props.actions.changeBlockThreeBackgroundColor();
+              props.actions.changeBlockThreeBackgroundColor(null);
             }
             ..style = {'padding': '10px', 'margin': '10px'}
           )('Change Block 3 Background Color'),

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.dart
@@ -41,9 +41,10 @@ UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock = composeHocs([
       ..backgroundColor = state.mainBackgroundColor
       ..blockOneBackgroundColor = state.blockOneBackgroundColor),
     mapActionsToProps: (actions) => (ConnectFluxBigBlock()
-      ..changeMainBackgroundColor = (() => actions.changeMainBackgroundColor)
+      ..changeMainBackgroundColor =
+          (() => actions.changeMainBackgroundColor(null))
       ..changeBlockOneBackgroundColor =
-          (() => actions.changeBlockOneBackgroundColor)),
+          (() => actions.changeBlockOneBackgroundColor(null))),
   ),
   // [5]
   connectFlux<LowLevelStore, RandomColorActions, ConnectFluxBigBlockProps>(
@@ -53,7 +54,7 @@ UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock = composeHocs([
       ..blockTwoBackgroundColor = state.backgroundColor),
     mapActionsToProps: (actions) => (ConnectFluxBigBlock()
       ..changeBlockTwoBackgroundColor =
-          (() => actions.changeBlockTwoBackgroundColor)),
+          (() => actions.changeBlockTwoBackgroundColor(null))),
   ),
   // [5]
   connectFlux<AnotherColorStore, RandomColorActions, ConnectFluxBigBlockProps>(
@@ -63,7 +64,7 @@ UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock = composeHocs([
       ..blockThreeBackgroundColor = state.backgroundColor),
     mapActionsToProps: (actions) => (ConnectFluxBigBlock()
       ..changeBlockThreeBackgroundColor =
-          (() => actions.changeBlockThreeBackgroundColor)),
+          (() => actions.changeBlockThreeBackgroundColor(null))),
   ),
 ])(castUiFactory(_$ConnectFluxBigBlock)); // ignore: undefined_identifier
 

--- a/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/components/connect_flux_big_block.dart
@@ -39,28 +39,31 @@ UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock = composeHocs([
     // [7]
     mapStateToProps: (state) => (ConnectFluxBigBlock()
       ..backgroundColor = state.mainBackgroundColor
-      ..blockOneBackgroundColor = state.blockOneBackgroundColor
-    ),
+      ..blockOneBackgroundColor = state.blockOneBackgroundColor),
     mapActionsToProps: (actions) => (ConnectFluxBigBlock()
-      ..changeMainBackgroundColor = actions.changeMainBackgroundColor
-      ..changeBlockOneBackgroundColor = actions.changeBlockOneBackgroundColor
-    ),
+      ..changeMainBackgroundColor = (() => actions.changeMainBackgroundColor)
+      ..changeBlockOneBackgroundColor =
+          (() => actions.changeBlockOneBackgroundColor)),
   ),
   // [5]
   connectFlux<LowLevelStore, RandomColorActions, ConnectFluxBigBlockProps>(
     context: lowLevelStoreContext, // [6]
     // [7]
-    mapStateToProps: (state) => (ConnectFluxBigBlock()..blockTwoBackgroundColor = state.backgroundColor),
-    mapActionsToProps: (actions) =>
-        (ConnectFluxBigBlock()..changeBlockTwoBackgroundColor = actions.changeBlockTwoBackgroundColor),
+    mapStateToProps: (state) => (ConnectFluxBigBlock()
+      ..blockTwoBackgroundColor = state.backgroundColor),
+    mapActionsToProps: (actions) => (ConnectFluxBigBlock()
+      ..changeBlockTwoBackgroundColor =
+          (() => actions.changeBlockTwoBackgroundColor)),
   ),
   // [5]
   connectFlux<AnotherColorStore, RandomColorActions, ConnectFluxBigBlockProps>(
     context: anotherColorStoreContext, // [6]
     // [7]
-    mapStateToProps: (state) => (ConnectFluxBigBlock()..blockThreeBackgroundColor = state.backgroundColor),
-    mapActionsToProps: (actions) =>
-        (ConnectFluxBigBlock()..changeBlockThreeBackgroundColor = actions.changeBlockThreeBackgroundColor),
+    mapStateToProps: (state) => (ConnectFluxBigBlock()
+      ..blockThreeBackgroundColor = state.backgroundColor),
+    mapActionsToProps: (actions) => (ConnectFluxBigBlock()
+      ..changeBlockThreeBackgroundColor =
+          (() => actions.changeBlockThreeBackgroundColor)),
   ),
 ])(castUiFactory(_$ConnectFluxBigBlock)); // ignore: undefined_identifier
 
@@ -76,9 +79,11 @@ mixin ConnectFluxBigBlockPropsMixin on UiProps {
   void Function() changeBlockThreeBackgroundColor; // [2]
 }
 
-class ConnectFluxBigBlockProps = UiProps with ConnectFluxBigBlockPropsMixin, ConnectPropsMixin;
+class ConnectFluxBigBlockProps = UiProps
+    with ConnectFluxBigBlockPropsMixin, ConnectPropsMixin;
 
-class ConnectFluxBigBlockComponent extends UiComponent2<ConnectFluxBigBlockProps> {
+class ConnectFluxBigBlockComponent
+    extends UiComponent2<ConnectFluxBigBlockProps> {
   @override
   render() {
     return (Fragment()(
@@ -90,56 +95,63 @@ class ConnectFluxBigBlockComponent extends UiComponent2<ConnectFluxBigBlockProps
           'display': 'flex',
           'alignItems': 'center',
           'justifyContent': 'space-evenly'
-        }
-      )(
-        Dom.div()('This module uses a ConnectedFlux pattern to change its background color.'),
+        })(
+        Dom.div()(
+            'This module uses a ConnectedFlux pattern to change its background color.'),
         (Dom.div()
           ..style = {
             'display': 'flex',
             'flexDirection': 'column',
-          }
-        )(
+          })(
           (Dom.button()
             ..onClick = (_) {
               props.changeMainBackgroundColor(); // [3]
             }
-            ..style = {'padding': '10px', 'margin': '10px'}
-          )('Change Main Background Color'),
+            ..style = {
+              'padding': '10px',
+              'margin': '10px'
+            })('Change Main Background Color'),
           (Dom.button()
             ..onClick = (_) {
               props.changeBlockOneBackgroundColor(); // [3]
             }
-            ..style = {'padding': '10px', 'margin': '10px'}
-          )('Change Block 1 Background Color'),
+            ..style = {
+              'padding': '10px',
+              'margin': '10px'
+            })('Change Block 1 Background Color'),
           (Dom.button()
             ..onClick = (_) {
               props.changeBlockTwoBackgroundColor(); // [3]
             }
-            ..style = {'padding': '10px', 'margin': '10px'}
-          )('Change Block 2 Background Color'),
+            ..style = {
+              'padding': '10px',
+              'margin': '10px'
+            })('Change Block 2 Background Color'),
           (Dom.button()
             ..onClick = (_) {
               props.changeBlockThreeBackgroundColor(); // [3]
             }
-            ..style = {'padding': '10px', 'margin': '10px'}
-          )('Change Block 3 Background Color'),
+            ..style = {
+              'padding': '10px',
+              'margin': '10px'
+            })('Change Block 3 Background Color'),
         ),
         (Dom.div()..style = {'display': 'flex', 'flexDirection': 'column'})(
           (LittleBlock()
-            ..blockTitle = 'Block 1'
-            ..backgroundColor = props.blockOneBackgroundColor // [3]
-            ..colorString = props.blockOneBackgroundColor // [3]
-          )(),
+                ..blockTitle = 'Block 1'
+                ..backgroundColor = props.blockOneBackgroundColor // [3]
+                ..colorString = props.blockOneBackgroundColor // [3]
+              )(),
           (LittleBlock()
-            ..blockTitle = 'Block 2'
-            ..backgroundColor = props.blockTwoBackgroundColor // [3]
-            ..colorString = props.blockTwoBackgroundColor // [3]
-          )(),
+                ..blockTitle = 'Block 2'
+                ..backgroundColor = props.blockTwoBackgroundColor // [3]
+                ..colorString = props.blockTwoBackgroundColor // [3]
+              )(),
           (LittleBlock()
-            ..blockTitle = 'Block 3'
-            ..backgroundColor = props.blockThreeBackgroundColor // [3]
-            ..colorString = props.blockThreeBackgroundColor // [3]
-          )(),
+                ..blockTitle = 'Block 3'
+                ..backgroundColor = props.blockThreeBackgroundColor // [3]
+                ..colorString = props.blockThreeBackgroundColor // [3]
+              )(),
         ),
       ),
     ));

--- a/web/flux_to_redux/advanced/examples/influx_implementation/store.dart
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/store.dart
@@ -27,13 +27,13 @@ class UpdateBlockTwoBackgroundColorAction {}
 class UpdateBlockThreeBackgroundColorAction {}
 
 class RandomColorActions {
-  final flux.Action<String> changeMainBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeMainBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockOneBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockOneBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockTwoBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockTwoBackgroundColor = flux.ActionV2();
 
-  final flux.Action<String> changeBlockThreeBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBlockThreeBackgroundColor = flux.ActionV2();
 }
 
 class TopLevelReduxState {

--- a/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/components/big_block.dart
@@ -30,7 +30,7 @@ class BigBlockComponent extends FluxUiComponent2<BigBlockProps> {
         'This module uses a flux pattern to change its background color.',
         (Dom.button()
           ..onClick = (_) {
-            props.actions.changeBackgroundColor();
+            props.actions.changeBackgroundColor(null);
           }
           ..style = {'padding': '10px', 'margin': '10px'}
         )('Change Background Color'),

--- a/web/flux_to_redux/simple/examples/flux_implementation/store.dart
+++ b/web/flux_to_redux/simple/examples/flux_implementation/store.dart
@@ -33,7 +33,7 @@ class RandomColorStore extends flux.Store {
 }
 
 class RandomColorActions {
-  final flux.Action<String> changeBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBackgroundColor = flux.ActionV2();
 }
 
 RandomColorActions randomColorActions = RandomColorActions();

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.dart
@@ -34,7 +34,7 @@ UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock =
   mapStateToProps: (state) =>
       (ConnectFluxBigBlock()..backgroundColor = state?.backgroundColor),
   mapActionsToProps: (actions) => (ConnectFluxBigBlock()
-    ..changeBackgroundColor = (() => actions.changeBackgroundColor)),
+    ..changeBackgroundColor = (() => actions.changeBackgroundColor(null))),
 )(castUiFactory(_$ConnectFluxBigBlock)); // ignore: undefined_identifier
 
 mixin ConnectFluxBigBlockPropsMixin on UiProps {

--- a/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/components/connect_flux_big_block.dart
@@ -31,9 +31,10 @@ part 'connect_flux_big_block.over_react.g.dart';
 UiFactory<ConnectFluxBigBlockProps> ConnectFluxBigBlock =
     connectFlux<FluxStore, RandomColorActions, ConnectFluxBigBlockProps>(
   // [5]
-  mapStateToProps: (state) => (ConnectFluxBigBlock()..backgroundColor = state?.backgroundColor),
-  mapActionsToProps: (actions) =>
-      (ConnectFluxBigBlock()..changeBackgroundColor = actions.changeBackgroundColor),
+  mapStateToProps: (state) =>
+      (ConnectFluxBigBlock()..backgroundColor = state?.backgroundColor),
+  mapActionsToProps: (actions) => (ConnectFluxBigBlock()
+    ..changeBackgroundColor = (() => actions.changeBackgroundColor)),
 )(castUiFactory(_$ConnectFluxBigBlock)); // ignore: undefined_identifier
 
 mixin ConnectFluxBigBlockPropsMixin on UiProps {
@@ -42,23 +43,28 @@ mixin ConnectFluxBigBlockPropsMixin on UiProps {
   void Function() changeBackgroundColor; // [2]
 }
 
-class ConnectFluxBigBlockProps = UiProps with ConnectFluxBigBlockPropsMixin, ConnectPropsMixin;
+class ConnectFluxBigBlockProps = UiProps
+    with ConnectFluxBigBlockPropsMixin, ConnectPropsMixin;
 
-class ConnectFluxBigBlockComponent extends UiComponent2<ConnectFluxBigBlockProps> {
+class ConnectFluxBigBlockComponent
+    extends UiComponent2<ConnectFluxBigBlockProps> {
   @override
   render() {
-    return (Dom.div()..style = {
-      'padding': '50px',
-      'backgroundColor': props.backgroundColor, // [3]
-      'color': 'white'
-    })(
+    return (Dom.div()
+      ..style = {
+        'padding': '50px',
+        'backgroundColor': props.backgroundColor, // [3]
+        'color': 'white'
+      })(
       'This module uses a connect flux pattern to change its background color.',
       (Dom.button()
         ..onClick = (_) {
           props.changeBackgroundColor(); // [3]
         }
-        ..style = {'padding': '10px', 'margin': '10px'}
-      )('Change Background Color'),
+        ..style = {
+          'padding': '10px',
+          'margin': '10px'
+        })('Change Background Color'),
     );
   }
 }

--- a/web/flux_to_redux/simple/examples/influx_implementation/store.dart
+++ b/web/flux_to_redux/simple/examples/influx_implementation/store.dart
@@ -43,7 +43,7 @@ class FluxStore extends flux.Store with /*[1]*/ InfluxStoreMixin< /*[2]*/ ReduxS
 }
 
 class RandomColorActions {
-  final flux.Action<String> changeBackgroundColor = flux.Action();
+  final flux.ActionV2<String> changeBackgroundColor = flux.ActionV2();
 }
 
 class UpdateBackgroundColorAction {


### PR DESCRIPTION
Runs a codemod to convert w_flux Action to ActionV2. This is being done in preparation for null-safety.
More information can be found in the `w_flux_codemod` [README.md](https://github.com/Workiva/w_flux/blob/master/w_flux_codemod/README.md).
Contact `#support-frontend-dx` slack channel with any additional questions.

[_Created by Sourcegraph batch change `Workiva/w_flux_action_migration`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_flux_action_migration)