### PR TITLE
FED-2112 Required props lint: respect @Props(ignoreRequiredProps: ...) 

### DIFF
--- a/example/boilerplate_versions/dart2_only/basic_component1.over_react.g.dart
+++ b/example/boilerplate_versions/dart2_only/basic_component1.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_component1.dart';
 
 // **************************************************************************

--- a/example/boilerplate_versions/dart2_only/basic_component2.over_react.g.dart
+++ b/example/boilerplate_versions/dart2_only/basic_component2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_component2.dart';
 
 // **************************************************************************

--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -253,6 +253,17 @@ class OverReactBuilder extends Builder {
     return null;
   }
 
+  static const _ignoreForFileCodes = {
+    // Needed when the component itself or some of its props are deprecated,
+    // or if deprecated types are referenced within the boilerplate.
+    'deprecated_member_use_from_same_package',
+    // These two are needed for the `?? null` workaround in prop accessors.
+    'unnecessary_null_in_if_null_operators',
+    'prefer_null_aware_operators',
+    // Needed to ignore the `requiredPropNamesToSkipValidation` checks.
+    'invalid_use_of_visible_for_overriding_member',
+  };
+
   static FutureOr<void> _writePart(BuildStep buildStep, AssetId outputId, Iterable<String> outputs,
       {required String nullSafetyCommentText, String? languageVersionComment}) async {
     final partOf = "'${p.basename(buildStep.inputId.uri.toString())}'";
@@ -264,7 +275,7 @@ class OverReactBuilder extends Builder {
     buffer
       ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
       ..writeln()
-      ..writeln('// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators')
+      ..writeln('// ignore_for_file: ${_ignoreForFileCodes.join(', ')}')
       ..writeln('part of $partOf;')
       ..writeln()
       ..writeln(_headerLine)

--- a/lib/src/builder/parsing/members.dart
+++ b/lib/src/builder/parsing/members.dart
@@ -14,6 +14,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:build/build.dart' show log;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:meta/meta.dart';
 import 'package:over_react/src/builder/codegen/names.dart';

--- a/lib/src/component/_deprecated/abstract_transition.over_react.g.dart
+++ b/lib/src/component/_deprecated/abstract_transition.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition.dart';
 
 // **************************************************************************

--- a/lib/src/component/_deprecated/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/_deprecated/abstract_transition_props.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition_props.dart';
 
 // **************************************************************************

--- a/lib/src/component/_deprecated/error_boundary.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'error_boundary.dart';
 
 // **************************************************************************

--- a/lib/src/component/_deprecated/error_boundary_mixins.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary_mixins.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'error_boundary_mixins.dart';
 
 // **************************************************************************

--- a/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/_deprecated/error_boundary_recoverable.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'error_boundary_recoverable.dart';
 
 // **************************************************************************

--- a/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
+++ b/lib/src/component/_deprecated/resize_sensor.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'resize_sensor.dart';
 
 // **************************************************************************

--- a/lib/src/component/abstract_transition.over_react.g.dart
+++ b/lib/src/component/abstract_transition.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition.dart';
 
 // **************************************************************************

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition_props.dart';
 
 // **************************************************************************

--- a/lib/src/component/aria_mixin.over_react.g.dart
+++ b/lib/src/component/aria_mixin.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'aria_mixin.dart';
 
 // **************************************************************************

--- a/lib/src/component/dummy_component2.over_react.g.dart
+++ b/lib/src/component/dummy_component2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'dummy_component2.dart';
 
 // **************************************************************************

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'error_boundary.dart';
 
 // **************************************************************************

--- a/lib/src/component/error_boundary_recoverable.over_react.g.dart
+++ b/lib/src/component/error_boundary_recoverable.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'error_boundary_recoverable.dart';
 
 // **************************************************************************

--- a/lib/src/component/fragment_component.over_react.g.dart
+++ b/lib/src/component/fragment_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'fragment_component.dart';
 
 // **************************************************************************

--- a/lib/src/component/prop_mixins.over_react.g.dart
+++ b/lib/src/component/prop_mixins.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'prop_mixins.dart';
 
 // **************************************************************************

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'resize_sensor.dart';
 
 // **************************************************************************

--- a/lib/src/component/strictmode_component.over_react.g.dart
+++ b/lib/src/component/strictmode_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'strictmode_component.dart';
 
 // **************************************************************************

--- a/lib/src/component/suspense_component.over_react.g.dart
+++ b/lib/src/component/suspense_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'suspense_component.dart';
 
 // **************************************************************************

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'with_transition.dart';
 
 // **************************************************************************

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flux_component.dart';
 
 // **************************************************************************

--- a/lib/src/over_react_redux/over_react_flux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_flux.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'over_react_flux.dart';
 
 // **************************************************************************

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'over_react_redux.dart';
 
 // **************************************************************************

--- a/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'redux_multi_provider.dart';
 
 // **************************************************************************

--- a/lib/src/util/class_names.over_react.g.dart
+++ b/lib/src/util/class_names.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'class_names.dart';
 
 // **************************************************************************

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'safe_render_manager_helper.dart';
 
 // **************************************************************************

--- a/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/_deprecated/abstract_transition_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
+++ b/test/over_react/component/_deprecated/fixtures/custom_error_boundary_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'custom_error_boundary_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_transition_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/element_type_test.over_react.g.dart
+++ b/test/over_react/component/element_type_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'element_type_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/error_boundary/shared_stack_tests.over_react.g.dart
+++ b/test/over_react/component/error_boundary/shared_stack_tests.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'shared_stack_tests.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_child_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_child_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/basic_ui_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_ui_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'context_provider_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/context_type_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_type_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'context_type_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/dummy_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/dummy_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'dummy_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/flawed_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flawed_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_on_mount.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flawed_component_on_mount.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_a_string.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flawed_component_that_renders_a_string.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
+++ b/test/over_react/component/fixtures/flawed_component_that_renders_nothing.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flawed_component_that_renders_nothing.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/lazy_load_me_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/lazy_load_me_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'lazy_load_me_component.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/lazy_load_me_props.over_react.g.dart
+++ b/test/over_react/component/fixtures/lazy_load_me_props.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'lazy_load_me_props.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
+++ b/test/over_react/component/fixtures/prop_typedef_fixtures.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'prop_typedef_fixtures.dart';
 
 // **************************************************************************

--- a/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
+++ b/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'pure_test_components.dart';
 
 // **************************************************************************

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'memo_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'ref_util_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/typed_factory_test.over_react.g.dart
+++ b/test/over_react/component/typed_factory_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'typed_factory_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component/with_transition_test.over_react.g.dart
+++ b/test/over_react/component/with_transition_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'with_transition_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'accessor_mixin_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'accessor_mixin_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'annotation_error_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'constant_required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'do_not_generate_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'namespaced_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/null_safe_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/null_safe_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'null_safe_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'private_props_ddc_bug.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'stateful_component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'unassigned_prop_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/component_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'constant_required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'do_not_generate_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'namespaced_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/null_safe_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/null_safe_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'null_safe_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'private_props_ddc_bug.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'stateful_component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'unassigned_prop_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_a2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'test_a2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/test_b2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'test_b2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/abstract2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/abstract2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/abstract_inheritance/extendedtype2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'extendedtype2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/parent2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'parent2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subsubtype2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subsubtype_of_component1.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subsubtype_of_component1.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subtype2.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
+++ b/test/over_react/component_declaration/component2_type_checking_test/type_inheritance/subtype_of_component1.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subtype_of_component1.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_a.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'test_a.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/test_b.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'test_b.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/abstract.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/abstract.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/abstract_inheritance/extendedtype.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'extendedtype.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/parent.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'parent.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subsubtype.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subsubtype.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
+++ b/test/over_react/component_declaration/component_type_checking_test/type_inheritance/subtype.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'subtype.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flux_component_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flux_component_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'components.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/abstract_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/accessor_mixin_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'accessor_mixin_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/abstract_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'abstract_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/accessor_mixin_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'accessor_mixin_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/annotation_error_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'annotation_error_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/component_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'constant_required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'do_not_generate_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'namespaced_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/private_props_ddc_bug.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'private_props_ddc_bug.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/required_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/stateful_component_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'stateful_component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component2/unassigned_prop_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'unassigned_prop_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/component_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/constant_required_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'constant_required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/do_not_generate_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'do_not_generate_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/namespaced_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'namespaced_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/private_props_ddc_bug.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/private_props_ddc_bug.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'private_props_ddc_bug.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/required_accessor_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/required_accessor_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'required_accessor_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/stateful_component_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/stateful_component_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'stateful_component_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/non_null_safe_builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
+++ b/test/over_react/component_declaration/non_null_safe_builder_integration_tests/unassigned_prop_integration_test.over_react.g.dart
@@ -1,7 +1,7 @@
 // @dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'unassigned_prop_integration_test.dart';
 
 // **************************************************************************

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'ui_props_self_typed_extension_test.dart';
 
 // **************************************************************************

--- a/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
+++ b/test/over_react/dom/fixtures/dummy_composite_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'dummy_composite_component.dart';
 
 // **************************************************************************

--- a/test/over_react/util/cast_ui_factory_test.over_react.g.dart
+++ b/test/over_react/util/cast_ui_factory_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'cast_ui_factory_test.dart';
 
 // **************************************************************************

--- a/test/over_react/util/component_debug_name_test.over_react.g.dart
+++ b/test/over_react/util/component_debug_name_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'component_debug_name_test.dart';
 
 // **************************************************************************

--- a/test/over_react/util/dom_util_test.over_react.g.dart
+++ b/test/over_react/util/dom_util_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'dom_util_test.dart';
 
 // **************************************************************************

--- a/test/over_react/util/js_component_test.over_react.g.dart
+++ b/test/over_react/util/js_component_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'js_component_test.dart';
 
 // **************************************************************************

--- a/test/over_react/util/prop_conversion_test.over_react.g.dart
+++ b/test/over_react/util/prop_conversion_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'prop_conversion_test.dart';
 
 // **************************************************************************

--- a/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
+++ b/test/over_react/util/prop_key_util_test_dart2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'prop_key_util_test_dart2.dart';
 
 // **************************************************************************

--- a/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
+++ b/test/over_react/util/safe_render_manager/test_component.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'test_component.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/connect_flux_counter.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'connect_flux_counter.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/fixtures/counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'counter.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/fixtures/counter_fn.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter_fn.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'counter_fn.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/flux_counter.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'flux_counter.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
+++ b/test/over_react_redux/fixtures/non_component_two_counter.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'non_component_two_counter.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'use_dispatch_test.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/hooks/use_store_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_store_test.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'use_store_test.dart';
 
 // **************************************************************************

--- a/test/over_react_redux/store_bindings_tests.over_react.g.dart
+++ b/test/over_react_redux/store_bindings_tests.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'store_bindings_tests.dart';
 
 // **************************************************************************

--- a/test/test_util/component2/one_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/one_level_wrapper2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'one_level_wrapper2.dart';
 
 // **************************************************************************

--- a/test/test_util/component2/two_level_wrapper2.over_react.g.dart
+++ b/test/test_util/component2/two_level_wrapper2.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'two_level_wrapper2.dart';
 
 // **************************************************************************

--- a/test/test_util/one_level_wrapper.over_react.g.dart
+++ b/test/test_util/one_level_wrapper.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'one_level_wrapper.dart';
 
 // **************************************************************************

--- a/test/test_util/two_level_wrapper.over_react.g.dart
+++ b/test/test_util/two_level_wrapper.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'two_level_wrapper.dart';
 
 // **************************************************************************

--- a/test/vm_tests/builder/parsing/meta_test.dart
+++ b/test/vm_tests/builder/parsing/meta_test.dart
@@ -27,8 +27,7 @@ void main() {
       ''');
       final meta = InstantiatedMeta.fromNode<TestAnnotation>(member)!;
 
-      expect(meta.metaNode, isNotNull);
-      expect(meta.metaNode!.name.name, 'TestAnnotation');
+      expect(meta.metaNode.name.name, 'TestAnnotation');
       expect(meta.value, isNotNull);
       expect(meta.value.positional, 'hello');
     });
@@ -40,8 +39,7 @@ void main() {
       ''');
       final meta = InstantiatedMeta.fromNode<TestAnnotation>(member)!;
 
-      expect(meta.metaNode, isNotNull);
-      expect(meta.metaNode!.name.name, 'TestAnnotation');
+      expect(meta.metaNode.name.name, 'TestAnnotation');
 
       expect(meta.isIncomplete, isTrue);
       expect(meta.unsupportedArguments, hasLength(1));

--- a/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/basic_library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/backwards_compatible/props_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/props_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'props_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/backwards_compatible/state_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/backwards_compatible/state_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'state_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/basic.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/basic_library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/component2/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/component2/basic.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/component2/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/component2/basic_library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/missing_over_react_g_part/library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/missing_over_react_g_part/library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/props_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/props_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'props_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/dart2_only/state_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/dart2_only/state_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'state_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/basic_two_nine.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_two_nine.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'basic_two_nine.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/missing_over_react_g_part/library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/missing_over_react_g_part/library.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'library.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/props_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/props_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'props_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/state_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/state_mixin.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'state_mixin.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/two_nine_with_multiple_factories.over_react.g.dart.goldfile
+++ b/test_fixtures/gold_output_files/mixin_based/two_nine_with_multiple_factories.over_react.g.dart.goldfile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'two_nine_with_multiple_factories.dart';
 
 // **************************************************************************

--- a/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
@@ -1,7 +1,7 @@
 //@dart=2.11
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'type_parameters.dart';
 
 // **************************************************************************

--- a/tools/analyzer_plugin/playground/web/missing_required_props.dart
+++ b/tools/analyzer_plugin/playground/web/missing_required_props.dart
@@ -2,11 +2,14 @@ import 'package:over_react/over_react.dart';
 
 part 'missing_required_props.over_react.g.dart';
 
+UiFactory<UiProps> GenericFactory = uiFunction((_) {}, UiFactoryConfig());
+
 UiFactory<NoRequiredProps> NoRequired = uiFunction((_) {}, _$NoRequiredConfig);
 mixin NoRequiredProps on UiProps {
   String? optional1;
   String? optional2;
 }
+
 
 UiFactory<WithLateRequiredProps> WithLateRequired = uiFunction((_) {}, _$WithLateRequiredConfig);
 mixin WithLateRequiredProps on UiProps {
@@ -16,27 +19,40 @@ mixin WithLateRequiredProps on UiProps {
   String? optional2;
 }
 
+
 UiFactory<InheritsLateRequiredProps> InheritsLateRequired = uiFunction((_) {}, _$InheritsLateRequiredConfig);
 mixin InheritsLateRequiredPropsMixin on UiProps {
   late String requiredInSubclass;
 }
+class InheritsLateRequiredProps = UiProps with WithLateRequiredProps, InheritsLateRequiredPropsMixin;
 
 
-UiFactory<RequiredWithSameNameAsPrefixedProps> RequiredWithSameNameAsPrefixed = uiFunction((_) {},
-    _$RequiredWithSameNameAsPrefixedConfig);
+UiFactory<RequiredWithSameNameAsPrefixedProps> RequiredWithSameNameAsPrefixed = uiFunction((_) {}, _$RequiredWithSameNameAsPrefixedConfig);
 mixin RequiredWithSameNameAsPrefixedProps on UiProps {
   late bool hidden;
 }
 
 
-class InheritsLateRequiredProps = UiProps with WithLateRequiredProps, InheritsLateRequiredPropsMixin;
+UiFactory<DisableValidationProps> DisableValidation = uiFunction((_) {}, _$DisableValidationConfig);
+mixin DisableValidationProps on UiProps {
+  @disableRequiredPropValidation
+  late String requiredPropWithDisabledValidation;
+}
+
+
+UiFactory<IgnoresSomeRequiredProps> IgnoresSomeRequired = uiFunction((_) {}, _$IgnoresSomeRequiredConfig);
+mixin IgnoresSomeRequiredPropsMixin on UiProps {
+  late String requiredInSubclass1;
+  late String requiredInSubclass2;
+}
+@Props(ignoreRequiredProps: {'required1', 'requiredInSubclass1'})
+class IgnoresSomeRequiredProps = UiProps with WithLateRequiredProps, IgnoresSomeRequiredPropsMixin;
+
 
 UiFactory<WithAnnotationRequiredProps> WithAnnotationRequired = uiFunction((_) {}, _$WithAnnotationRequiredConfig);
 mixin WithAnnotationRequiredProps on UiProps {
-  @requiredProp
-  String? required1;
-  @requiredProp
-  String? required2;
+  @requiredProp String? required1;
+  @requiredProp String? required2;
   String? optional1;
   String? optional2;
 }
@@ -55,6 +71,10 @@ main() {
   InheritsLateRequired()();
 
   WithAnnotationRequired()();
+
+  DisableValidation()();
+
+  IgnoresSomeRequired()();
 
   // Make sure prefixed props aren't mistaken for the missing required prop.
   (RequiredWithSameNameAsPrefixed()..dom.hidden = true)();

--- a/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
@@ -60,6 +60,11 @@ mixin RequiredWithSameNameAsPrefixedProps on UiProps {
 }
 
 
+UiFactory<DisableValidationProps> DisableValidation = uiFunction((_) {}, _$DisableValidationConfig);
+mixin DisableValidationProps on UiProps {
+  @disableRequiredPropValidation
+  late String requiredPropWithDisabledValidation;
+}
 
 
 UiFactory<WithAnnotationRequiredProps> WithAnnotationRequired = uiFunction((_) {}, _$WithAnnotationRequiredConfig);
@@ -213,6 +218,28 @@ class MissingRequiredPropTest_MissingLateRequired extends MissingRequiredPropTes
               .havingMessage(contains("'hidden' from 'RequiredWithSameNameAsPrefixedProps'")),
         ]));
   }
+
+  Future<void> test_noErrorsAllRequiredPropsSpecified() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+        test() => Fragment()(
+          (WithLateRequired()
+            ..required1 = ''
+            ..required2 = ''
+          )(),
+          (InheritsLateRequired()
+            ..required1 = ''
+            ..required2 = ''
+            ..requiredInSubclass = ''
+          )(),
+        );
+    '''));
+  }
+
+  Future<void> test_noErrorsForPropsWithDisabledValidation() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+      test() => DisableValidation()();
+    '''));
+  }
 }
 
 @reflectiveTest
@@ -271,5 +298,14 @@ over_react:
           isAnErrorUnderTest(locatedAt: selection)
               .havingMessage(contains("'required2' from 'WithAnnotationRequiredProps'")),
         ]));
+  }
+
+  Future<void> test_noErrorsAllRequiredPropsSpecified() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+        test() => (WithAnnotationRequired()
+          ..required1 = ''
+          ..required2 = ''
+        )();
+    '''));
   }
 }

--- a/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
@@ -67,6 +67,15 @@ mixin DisableValidationProps on UiProps {
 }
 
 
+UiFactory<IgnoresSomeRequiredProps> IgnoresSomeRequired = uiFunction((_) {}, _$IgnoresSomeRequiredConfig);
+mixin IgnoresSomeRequiredPropsMixin on UiProps {
+  late String requiredInSubclass1;
+  late String requiredInSubclass2;
+}
+@Props(ignoreRequiredProps: {'required1', 'requiredInSubclass1'})
+class IgnoresSomeRequiredProps = UiProps with WithLateRequiredProps, IgnoresSomeRequiredPropsMixin;
+
+
 UiFactory<WithAnnotationRequiredProps> WithAnnotationRequired = uiFunction((_) {}, _$WithAnnotationRequiredConfig);
 mixin WithAnnotationRequiredProps on UiProps {
   @requiredProp String? required1;
@@ -238,6 +247,16 @@ class MissingRequiredPropTest_MissingLateRequired extends MissingRequiredPropTes
   Future<void> test_noErrorsForPropsWithDisabledValidation() async {
     await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
       test() => DisableValidation()();
+    '''));
+  }
+
+  Future<void> test_noErrorsForIgnoredProps() async {
+    // All props except for required2 and requiredInSubclass2 should be ignored
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+      test() => (IgnoresSomeRequired()
+        ..required2 = ''
+        ..requiredInSubclass2 = ''
+      )();
     '''));
   }
 }

--- a/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/server_plugin_contributor_test_base.dart
@@ -141,7 +141,7 @@ abstract class ServerPluginContributorTestBase extends AnalysisDriverTestBase {
 
   /// Will fail the test if any unexpected plugin errors were sent on the plugin
   /// communication channel.
-  void expectNoPluginErrors() {
+  void expectNoPluginErrorNotifications() {
     if (_channel == null) {
       throw ArgumentError(
           '_channel was unexpectedly null, meaning setUp may have thrown an error that wasn\'t handled yet. '
@@ -176,7 +176,7 @@ abstract class ServerPluginContributorTestBase extends AnalysisDriverTestBase {
   @override
   @mustCallSuper
   Future<void> tearDown() async {
-    expectNoPluginErrors();
+    expectNoPluginErrorNotifications();
     _channel = null;
     _plugin = null;
     super.tearDown();

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
@@ -98,6 +98,23 @@ void main() {
         });
       });
 
+      group('getIgnoredRequiredPropNames', () {
+        test('returns the set of props specified in the @Props() annotation', () {
+          final propsElement = getInterfaceElement(result, 'IgnoreRequiredPropsAnnotationTest_WithIgnoresProps');
+          expect(getIgnoredRequiredPropNames(propsElement), unorderedEquals(<String>{'foo', 'bar'}));
+        });
+
+        test('returns null when @Props annotation does not have ignoreRequiredProps argument', () {
+          final propsElement = getInterfaceElement(result, 'IgnoreRequiredPropsAnnotationTest_WithoutIgnoresProps');
+          expect(getIgnoredRequiredPropNames(propsElement), isNull);
+        });
+
+        test('returns null when no @Props annotation is present', () {
+          final propsElement = getInterfaceElement(result, 'IgnoreRequiredPropsAnnotationTest_WithoutAnnotationProps');
+          expect(getIgnoredRequiredPropNames(propsElement), isNull);
+        });
+      });
+
       group('getAllRequiredProps', () {
         void verifyRequiredProps(RequiredPropInfo info, {required Map<String, PropRequiredness> expected}) {
           expect(info.propRequirednessByName, expected);
@@ -288,6 +305,37 @@ void main() {
                 'v4_annotationRequiredProp_lateRequiredInOtherType': PropRequiredness.late,
                 'v4_optionalProp_annotationRequiredInOtherType': PropRequiredness.annotation,
                 'v4_optionalProp_lateRequiredInOtherType': PropRequiredness.late,
+              });
+            });
+          });
+
+          group('props classes where requiredness is ignored', () {
+            setUpAll(() {
+              // Verify without ignores present
+              final propsElement = getInterfaceElement(result, 'Ignore2PropsMixin');
+              verifyRequiredProps(getAllRequiredProps(propsElement), expected: {
+                'lateRequired_1_ignored': PropRequiredness.late,
+                'lateRequired_1_notIgnored': PropRequiredness.late,
+                'optional_1_lateRequiredInOtherType_ignored': PropRequiredness.late,
+                'optional_1_lateRequiredInOtherType_notIgnored': PropRequiredness.late,
+                'lateRequired_1_optionalInOtherType_ignored': PropRequiredness.late,
+                'lateRequired_1_optionalInOtherType_notIgnored': PropRequiredness.late,
+                'lateRequired_2_ignored': PropRequiredness.late,
+                'lateRequired_2_notIgnored': PropRequiredness.late,
+              });
+            });
+
+            test('in concrete type', () {
+              final propsElement = getInterfaceElement(result, 'IgnoreInConcreteClassProps');
+              verifyRequiredProps(getAllRequiredProps(propsElement), expected: {
+                'lateRequired_1_ignored': PropRequiredness.ignoredByConsumingClass,
+                'lateRequired_1_notIgnored': PropRequiredness.late,
+                'optional_1_lateRequiredInOtherType_ignored': PropRequiredness.ignoredByConsumingClass,
+                'optional_1_lateRequiredInOtherType_notIgnored': PropRequiredness.late,
+                'lateRequired_1_optionalInOtherType_ignored': PropRequiredness.ignoredByConsumingClass,
+                'lateRequired_1_optionalInOtherType_notIgnored': PropRequiredness.late,
+                'lateRequired_2_ignored': PropRequiredness.ignoredByConsumingClass,
+                'lateRequired_2_notIgnored': PropRequiredness.late,
               });
             });
           });

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
@@ -342,4 +342,48 @@ mixin DisableRequiredPropValidationProps on UiProps {
 
 UiFactory<ExtendsDisableRequiredPropValidationProps> ExtendsDisableRequiredPropValidation = castUiFactory(_$ExtendsDisableRequiredPropValidation);
 class ExtendsDisableRequiredPropValidationProps = UiProps with DisableRequiredPropValidationProps;
+
+
+mixin Ignore1PropsMixin on UiProps {
+  late String lateRequired_1_ignored;
+  late String lateRequired_1_notIgnored;
+  
+  String? optional_1_lateRequiredInOtherType_ignored;
+  String? optional_1_lateRequiredInOtherType_notIgnored;
+  
+  late String? lateRequired_1_optionalInOtherType_ignored;
+  late String? lateRequired_1_optionalInOtherType_notIgnored;
+}
+
+mixin Ignore2PropsMixin on UiProps, Ignore1PropsMixin {
+  late String lateRequired_2_ignored;
+  late String lateRequired_2_notIgnored;
+  
+  @override late String? optional_1_lateRequiredInOtherType_ignored;
+  @override late String? optional_1_lateRequiredInOtherType_notIgnored;
+  
+  @override String? lateRequired_1_optionalInOtherType_ignored;
+  @override String? lateRequired_1_optionalInOtherType_notIgnored;
+}
+
+@Props(ignoreRequiredProps: {
+  'lateRequired_1_ignored',
+  'optional_1_lateRequiredInOtherType_ignored',
+  'lateRequired_1_optionalInOtherType_ignored',
+  'lateRequired_2_ignored',
+})
+class IgnoreInConcreteClassProps = UiProps with Ignore1PropsMixin, Ignore2PropsMixin;
+UiFactory<IgnoreInConcreteClassProps> IgnoreInConcreteClass = castUiFactory(_$IgnoreInConcreteClass);
+
+@Props(ignoreRequiredProps: {'foo', 'bar'})
+class IgnoreRequiredPropsAnnotationTest_WithIgnoresProps extends UiProps {}
+UiFactory<IgnoreRequiredPropsAnnotationTest_WithIgnoresProps> IgnoreRequiredPropsAnnotationTest_WithIgnores = castUiFactory(_$IgnoreRequiredPropsAnnotationTest_WithIgnores);
+
+@Props(keyNamespace: 'foo')
+class IgnoreRequiredPropsAnnotationTest_WithoutIgnoresProps extends UiProps {}
+UiFactory<IgnoreRequiredPropsAnnotationTest_WithoutIgnoresProps> IgnoreRequiredPropsAnnotationTest_WithoutIgnores = castUiFactory(_$IgnoreRequiredPropsAnnotationTest_WithoutIgnores);
+
+class IgnoreRequiredPropsAnnotationTest_WithoutAnnotationProps extends UiProps {}
+UiFactory<IgnoreRequiredPropsAnnotationTest_WithoutAnnotationProps> IgnoreRequiredPropsAnnotationTest_WithoutAnnotation = castUiFactory(_$IgnoreRequiredPropsAnnotationTest_WithoutAnnotation);
+
 ''';

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_util.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_util.dart
@@ -37,6 +37,8 @@ Future<ResolvedUnitResult> setUpResult(SharedAnalysisContext sharedContext) asyn
 
   List<AnalysisError> filterErrors(List<AnalysisError> errors) => errors
       .where((e) => e.severity != Severity.info && !e.errorCode.name.toLowerCase().startsWith('unused_'))
+      // FIXME(FED-2015) remove once these are properly ignored in generated code
+      .where((e) => e.errorCode.name.toLowerCase() != 'invalid_use_of_visible_for_overriding_member')
       .toList();
 
   final libraryResult = await getResolvedUnit(libraryFullPath);

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_util.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_util.dart
@@ -37,8 +37,6 @@ Future<ResolvedUnitResult> setUpResult(SharedAnalysisContext sharedContext) asyn
 
   List<AnalysisError> filterErrors(List<AnalysisError> errors) => errors
       .where((e) => e.severity != Severity.info && !e.errorCode.name.toLowerCase().startsWith('unused_'))
-      // FIXME(FED-2015) remove once these are properly ignored in generated code
-      .where((e) => e.errorCode.name.toLowerCase() != 'invalid_use_of_visible_for_overriding_member')
       .toList();
 
   final libraryResult = await getResolvedUnit(libraryFullPath);

--- a/web/component1/src/demo_components/button.over_react.g.dart
+++ b/web/component1/src/demo_components/button.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'button.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/button_group.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'button_group.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/list_group.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'list_group.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/list_group_item.over_react.g.dart
+++ b/web/component1/src/demo_components/list_group_item.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'list_group_item.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/progress.over_react.g.dart
+++ b/web/component1/src/demo_components/progress.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'progress.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/tag.over_react.g.dart
+++ b/web/component1/src/demo_components/tag.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'tag.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/toggle_button.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'toggle_button.dart';
 
 // **************************************************************************

--- a/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
+++ b/web/component1/src/demo_components/toggle_button_group.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'toggle_button_group.dart';
 
 // **************************************************************************

--- a/web/component1/src/shared/constants.over_react.g.dart
+++ b/web/component1/src/shared/constants.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'constants.dart';
 
 // **************************************************************************


### PR DESCRIPTION
## Dependent PR
These changes are dependent on two different PRs:
- https://github.com/Workiva/over_react/pull/871
- https://github.com/Workiva/over_react/pull/874

For review, I've set the base as a branch that merges the two together.

## Motivation
Part of adding `ignoreRequiredProps` functionality is supporting it in the analyzer plugin, by making the required props lint not treat those props as required.

## Changes
- Update `getAllRequiredProps` logic to mark props specified within `@Props(ignoreRequiredProps: ...)` as ignored
    - Add unit tests
    - Add diagnostic integration tests
    - Add playground example
- Add ignore for `invalid_use_of_visible_for_overriding_member` to generated code, since it was causing analyzer plugin test setups to fail when verifying that there are no analysis errors in generated parts
    - Update generated code and golds
- Update boilerplate parsing to not throw when failing to instantiate an annotation, and instead severe-log. 
    - That way, analyzer plugin functionality that relies on boilerplate parsing doesn't emit an IDE error notification when typing an annotation (I noticed this while QAing this change): 
        <img alt="ide-error-screenshot" height=121  src="https://github.com/Workiva/over_react/assets/1713967/03090c33-d6c3-4f44-b7a1-725bd5cf9ba6">
     - Add regression test

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify in playground (tools/analyzer_plugin/playground/web/missing_required_props.dart) that:
            - the added `IgnoresSomeRequired` example doesn't warn for props that are ignored
            - adding/removing the `ignoreRequiredProps` argument doesn't cause IDE error notifications as you're typing
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
