### PR TITLE
FED-2015 Opt out of required props from mixin declaration

### DIFF
--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -26,7 +26,7 @@ mixin SharedPropsMixin on UiProps {
   String? aPropToBePassed;
 }
 
-@Props(ignoreRequiredPropsFrom: {SharedPropsMixin})
+@Props(ignoreRequiredProps: {'SharedPropsMixin.requiredProp'})
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
@@ -42,6 +42,7 @@ UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
   _$SomeParentConfig, // ignore: undefined_identifier
 );
 
+@Props(ignoreRequiredProps: {'SharedPropsMixin.requiredProp'})
 class SomeChildProps = UiProps with SharedPropsMixin;
 
 UiFactory<SomeChildProps> SomeChild = uiFunction((props) {

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -26,7 +26,7 @@ mixin SharedPropsMixin on UiProps {
   String? aPropToBePassed;
 }
 
-@Props(ignoreRequiredProps: {'SharedPropsMixin.requiredProp'})
+@Props(ignoreRequiredProps: {'requiredProp'})
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
@@ -42,7 +42,7 @@ UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
   _$SomeParentConfig, // ignore: undefined_identifier
 );
 
-@Props(ignoreRequiredProps: {'SharedPropsMixin.requiredProp'})
+@Props(ignoreRequiredProps: {'requiredProp'})
 class SomeChildProps = UiProps with SharedPropsMixin;
 
 UiFactory<SomeChildProps> SomeChild = uiFunction((props) {

--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -22,9 +22,11 @@ mixin ParentOnlyPropsMixin on UiProps {
 }
 
 mixin SharedPropsMixin on UiProps {
+  late String requiredProp;
   String? aPropToBePassed;
 }
 
+@Props(ignoreRequiredPropsFrom: {SharedPropsMixin})
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {

--- a/example/builder/src/props_mixin.dart
+++ b/example/builder/src/props_mixin.dart
@@ -18,7 +18,7 @@ part 'props_mixin.over_react.g.dart';
 
 mixin ExamplePropsMixin on UiProps {
   String? propMixin1;
-  String? requiredProp;
+  late String requiredProp;
 }
 
 mixin RequiresOtherMixinPropsMixin<T extends Iterable, U>

--- a/example/builder/src/props_mixin.dart
+++ b/example/builder/src/props_mixin.dart
@@ -18,6 +18,7 @@ part 'props_mixin.over_react.g.dart';
 
 mixin ExamplePropsMixin on UiProps {
   String? propMixin1;
+  late String requiredProp;
 }
 
 mixin RequiresOtherMixinPropsMixin<T extends Iterable, U>

--- a/example/builder/src/props_mixin.dart
+++ b/example/builder/src/props_mixin.dart
@@ -18,7 +18,7 @@ part 'props_mixin.over_react.g.dart';
 
 mixin ExamplePropsMixin on UiProps {
   String? propMixin1;
-  late String requiredProp;
+  String? requiredProp;
 }
 
 mixin RequiresOtherMixinPropsMixin<T extends Iterable, U>

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -205,7 +205,8 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
           isPotentiallyNullable = true;
 
           if (type.isProps && disableRequiredPropValidation == null) {
-            requiredPropChecks.add('  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains($keyValue)) {\n'
+            requiredPropChecks.add(
+                '  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains(\'$accessorName\')) {\n'
                 '  throw MissingRequiredPropsError(${stringLiteral('Required prop `$accessorName` is missing.')});\n'
                 '}\n');
           }

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -206,7 +206,7 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
 
           if (type.isProps && disableRequiredPropValidation == null) {
             requiredPropChecks.add(
-                '  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains(\'$accessorName\')) {\n'
+                '  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains(${stringLiteral(accessorName)})) {\n'
                 '  throw MissingRequiredPropsError(${stringLiteral('Required prop `$accessorName` is missing.')});\n'
                 '}\n');
           }

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -205,8 +205,8 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
           isPotentiallyNullable = true;
 
           if (type.isProps && disableRequiredPropValidation == null) {
-            requiredPropChecks.add('  if(!props.containsKey($keyValue)) {\n'
-                '  throw MissingRequiredPropsError(${stringLiteral('Required prop `$accessorName` is missing.')});\n'
+            requiredPropChecks.add('  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains($keyValue)) {\n'
+                '  throw MissingRequiredPropsError(requiredPropNamesToSkipValidation.join(\',\'));\n'
                 '}\n');
           }
         }

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -374,11 +374,23 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
     if (type.isProps &&
         version != Version.v3_legacyDart2Only &&
         version != Version.v2_legacyBackwardsCompat) {
+      List<String> implLines;
+      if (requiredPropChecks.isEmpty) {
+        implLines = [];
+      } else {
+        implLines = [
+          '  if (requiredPropClassesToSkipValidation.contains(${names.publicName})) {',
+          '    return;',
+          '  }',
+          '',
+          ...requiredPropChecks,
+        ];
+      }
       final validateRequiredPropsMethod = '\n  @override\n'
           '  @mustCallSuper\n'
           '  void validateRequiredProps() {\n'
           '    super.validateRequiredProps();\n'
-          '    ${requiredPropChecks.join('\n')}\n'
+          '${implLines.map((line) => '  $line\n').join()}'
           '  }\n';
       output.write(validateRequiredPropsMethod);
     }
@@ -518,6 +530,7 @@ class TypedMapType {
   final bool isProps;
   final bool isAbstract;
   final bool isMixin;
+
   // ignore: avoid_positional_boolean_parameters
   const TypedMapType(this.isProps, this.isAbstract, this.isMixin);
 

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -206,7 +206,7 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
 
           if (type.isProps && disableRequiredPropValidation == null) {
             requiredPropChecks.add('  if(!props.containsKey($keyValue) && !requiredPropNamesToSkipValidation.contains($keyValue)) {\n'
-                '  throw MissingRequiredPropsError(requiredPropNamesToSkipValidation.join(\',\'));\n'
+                '  throw MissingRequiredPropsError(${stringLiteral('Required prop `$accessorName` is missing.')});\n'
                 '}\n');
           }
         }
@@ -374,23 +374,11 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
     if (type.isProps &&
         version != Version.v3_legacyDart2Only &&
         version != Version.v2_legacyBackwardsCompat) {
-      List<String> implLines;
-      if (requiredPropChecks.isEmpty) {
-        implLines = [];
-      } else {
-        implLines = [
-          '  if (requiredPropClassesToSkipValidation.contains(${names.publicName})) {',
-          '    return;',
-          '  }',
-          '',
-          ...requiredPropChecks,
-        ];
-      }
       final validateRequiredPropsMethod = '\n  @override\n'
           '  @mustCallSuper\n'
           '  void validateRequiredProps() {\n'
           '    super.validateRequiredProps();\n'
-          '${implLines.map((line) => '  $line\n').join()}'
+          '    ${requiredPropChecks.join('\n')}\n'
           '  }\n';
       output.write(validateRequiredPropsMethod);
     }

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -19,6 +19,7 @@ import '../parsing.dart';
 import '../util.dart';
 import 'names.dart';
 import 'util.dart';
+import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
 
 /// Base class for generating concrete factory and props/state class implementations.
 abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
@@ -134,7 +135,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
     String? componentFactoryName,
     String? propKeyNamespace,
     List<String>? allPropsMixins,
-    required String? requiredPropNamesToSkipValidation,
+    required Set<String>? requiredPropNamesToSkipValidation,
   }) {
     if (isProps) {
       if (componentFactoryName == null || propKeyNamespace == null) {
@@ -249,7 +250,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
         ..writeln()
         ..writeln('  @override')
         ..writeln(
-            '  Set<String> get requiredPropNamesToSkipValidation => const $requiredPropNamesToSkipValidation;');
+            '  Set<String> get requiredPropNamesToSkipValidation => const {${requiredPropNamesToSkipValidation.map(stringLiteral).join(', ')}};');
     }
 
     // End of class body
@@ -340,7 +341,8 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
     outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
-      requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
+      requiredPropNamesToSkipValidation:
+          member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 
@@ -462,7 +464,8 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       // This doesn't really apply to the new boilerplate
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
-      requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
+      requiredPropNamesToSkipValidation:
+          member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -19,7 +19,6 @@ import '../parsing.dart';
 import '../util.dart';
 import 'names.dart';
 import 'util.dart';
-import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
 
 /// Base class for generating concrete factory and props/state class implementations.
 abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
@@ -136,9 +135,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
     String? propKeyNamespace,
     List<String>? allPropsMixins,
     required String? requiredPropNamesToSkipValidation,
-    required String? requiredPropClassesToSkipValidationSetSource,
   }) {
-    // throw ArgumentError(requiredPropNamesToSkipValidation);
     if (isProps) {
       if (componentFactoryName == null || propKeyNamespace == null) {
         throw ArgumentError('componentFactoryName/propKeyNamespace must be specified for props');
@@ -254,13 +251,6 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
         ..writeln(
             '  Set<String> get requiredPropNamesToSkipValidation => const $requiredPropNamesToSkipValidation;');
     }
-    if (requiredPropClassesToSkipValidationSetSource != null) {
-      buffer
-        ..writeln()
-        ..writeln('  @override')
-        ..writeln(
-            '  Set<Type> get requiredPropClassesToSkipValidation => const $requiredPropClassesToSkipValidationSetSource;');
-    }
 
     // End of class body
     buffer.writeln('}');
@@ -350,7 +340,6 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
     outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
-      requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
       requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
       // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
@@ -359,7 +348,6 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
   @override
   void _generateStateImpl() {
     outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
-      requiredPropClassesToSkipValidationSetSource: null,
       requiredPropNamesToSkipValidation: null,
     ));
   }
@@ -475,7 +463,6 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       // This doesn't really apply to the new boilerplate
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
-      requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
       requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
       // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
@@ -484,7 +471,6 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
   @override
   void _generateStateImpl() {
     outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
-      requiredPropClassesToSkipValidationSetSource: null,
       requiredPropNamesToSkipValidation: null,
     ));
   }

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -341,7 +341,6 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
       requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
-      // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 
@@ -464,7 +463,6 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
       requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
-      // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -135,9 +135,10 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
     String? componentFactoryName,
     String? propKeyNamespace,
     List<String>? allPropsMixins,
-    required Set<String>? requiredPropNamesToSkipValidation,
+    required String? requiredPropNamesToSkipValidation,
     required String? requiredPropClassesToSkipValidationSetSource,
   }) {
+    // throw ArgumentError(requiredPropNamesToSkipValidation);
     if (isProps) {
       if (componentFactoryName == null || propKeyNamespace == null) {
         throw ArgumentError('componentFactoryName/propKeyNamespace must be specified for props');
@@ -251,7 +252,7 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
         ..writeln()
         ..writeln('  @override')
         ..writeln(
-            '  Set<String> get requiredPropNamesToSkipValidation => const {${requiredPropNamesToSkipValidation.map(stringLiteral).join(', ')}};');
+            '  Set<String> get requiredPropNamesToSkipValidation => const $requiredPropNamesToSkipValidation;');
     }
     if (requiredPropClassesToSkipValidationSetSource != null) {
       buffer
@@ -350,7 +351,8 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
       requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
-      requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
+      requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
+      // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 
@@ -474,7 +476,8 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
       requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
-      requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
+      requiredPropNamesToSkipValidation: props_ignoreRequiredProps_source[member.meta],
+      // requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -19,6 +19,7 @@ import '../parsing.dart';
 import '../util.dart';
 import 'names.dart';
 import 'util.dart';
+import 'package:over_react/src/component_declaration/annotations.dart' as annotations;
 
 /// Base class for generating concrete factory and props/state class implementations.
 abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
@@ -134,6 +135,8 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
     String? componentFactoryName,
     String? propKeyNamespace,
     List<String>? allPropsMixins,
+    required Set<String>? requiredPropNamesToSkipValidation,
+    required String? requiredPropClassesToSkipValidationSetSource,
   }) {
     if (isProps) {
       if (componentFactoryName == null || propKeyNamespace == null) {
@@ -243,6 +246,20 @@ abstract class TypedMapImplGenerator extends BoilerplateDeclarationGenerator {
         ..writeln(
             '  String \$getPropKey(void Function(Map m) accessMap) => $topLevelGetPropKeyAliasName(accessMap, (map) => ${names.implName}(map));');
     }
+    if (requiredPropNamesToSkipValidation != null) {
+      buffer
+        ..writeln()
+        ..writeln('  @override')
+        ..writeln(
+            '  Set<String> get requiredPropNamesToSkipValidation => const {${requiredPropNamesToSkipValidation.map(stringLiteral).join(', ')}};');
+    }
+    if (requiredPropClassesToSkipValidationSetSource != null) {
+      buffer
+        ..writeln()
+        ..writeln('  @override')
+        ..writeln(
+            '  Set<Type> get requiredPropClassesToSkipValidation => const $requiredPropClassesToSkipValidationSetSource;');
+    }
 
     // End of class body
     buffer.writeln('}');
@@ -332,12 +349,17 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
     outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
+      requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
+      requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 
   @override
   void _generateStateImpl() {
-    outputContentsBuffer.write(_generateConcretePropsOrStateImpl());
+    outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
+      requiredPropClassesToSkipValidationSetSource: null,
+      requiredPropNamesToSkipValidation: null,
+    ));
   }
 
   @override
@@ -451,12 +473,17 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       // This doesn't really apply to the new boilerplate
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
+      requiredPropClassesToSkipValidationSetSource: props_ignoreRequiredPropsFrom_source[member.meta],
+      requiredPropNamesToSkipValidation: member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
     ));
   }
 
   @override
   void _generateStateImpl() {
-    outputContentsBuffer.write(_generateConcretePropsOrStateImpl());
+    outputContentsBuffer.write(_generateConcretePropsOrStateImpl(
+      requiredPropClassesToSkipValidationSetSource: null,
+      requiredPropNamesToSkipValidation: null,
+    ));
   }
 
   @override

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -65,7 +65,6 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
           InstantiatedMeta.fromNode<annotations.StateMixin>(node));
 
   if (meta != null && meta.potentiallyIncompleteValue is annotations.Props) {
-    // print('unsupportedArguments ${meta.unsupportedArguments} ${meta.unsupportedArguments.map((e) => e.runtimeType)}');
     // fixme error when this case isn't well formed
     if (meta.unsupportedArguments.length == 1) {
       final arg = meta.unsupportedArguments[0];

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -51,6 +51,7 @@ class _PropsStateStringHelpersImpl extends Object with PropsStateStringHelpers {
 }
 
 final Expando<String> props_ignoreRequiredPropsFrom_source = Expando();
+final Expando<String> props_ignoreRequiredProps_source = Expando();
 
 /// Uses [InstantiatedMeta] to analyze [node] and determine the proper annotation.
 annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node) {
@@ -71,6 +72,10 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
       final arg = meta.unsupportedArguments[0];
       if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredPropsFrom') {
         props_ignoreRequiredPropsFrom_source[meta.potentiallyIncompleteValue] =
+            arg.expression.toSource();
+        return meta.potentiallyIncompleteValue;
+      } else if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredProps') {
+        props_ignoreRequiredProps_source[meta.potentiallyIncompleteValue] =
             arg.expression.toSource();
         return meta.potentiallyIncompleteValue;
       }

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -50,7 +50,6 @@ class _PropsStateStringHelpersImpl extends Object with PropsStateStringHelpers {
   _PropsStateStringHelpersImpl({required this.isProps});
 }
 
-final Expando<String> props_ignoreRequiredPropsFrom_source = Expando();
 final Expando<String> props_ignoreRequiredProps_source = Expando();
 
 /// Uses [InstantiatedMeta] to analyze [node] and determine the proper annotation.
@@ -70,11 +69,7 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
     // fixme error when this case isn't well formed
     if (meta.unsupportedArguments.length == 1) {
       final arg = meta.unsupportedArguments[0];
-      if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredPropsFrom') {
-        props_ignoreRequiredPropsFrom_source[meta.potentiallyIncompleteValue] =
-            arg.expression.toSource();
-        return meta.potentiallyIncompleteValue;
-      } else if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredProps') {
+      if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredProps') {
         props_ignoreRequiredProps_source[meta.potentiallyIncompleteValue] =
             arg.expression.toSource();
         return meta.potentiallyIncompleteValue;

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -50,6 +50,8 @@ class _PropsStateStringHelpersImpl extends Object with PropsStateStringHelpers {
   _PropsStateStringHelpersImpl({required this.isProps});
 }
 
+final Expando<String> props_ignoreRequiredPropsFrom_source = Expando();
+
 /// Uses [InstantiatedMeta] to analyze [node] and determine the proper annotation.
 annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node) {
   final meta = isProps
@@ -61,6 +63,19 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
           InstantiatedMeta.fromNode<annotations.AbstractState>(node) ??
           // ignore: deprecated_member_use_from_same_package
           InstantiatedMeta.fromNode<annotations.StateMixin>(node));
+
+  if (meta != null && meta.potentiallyIncompleteValue is annotations.Props) {
+    // print('unsupportedArguments ${meta.unsupportedArguments} ${meta.unsupportedArguments.map((e) => e.runtimeType)}');
+    // fixme error when this case isn't well formed
+    if (meta.unsupportedArguments.length == 1) {
+      final arg = meta.unsupportedArguments[0];
+      if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredPropsFrom') {
+        props_ignoreRequiredPropsFrom_source[meta.potentiallyIncompleteValue] =
+            arg.expression.toSource();
+        return meta.potentiallyIncompleteValue;
+      }
+    }
+  }
 
   return meta?.value ?? (isProps ? annotations.Props() : annotations.State());
 }

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -65,7 +65,6 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
           InstantiatedMeta.fromNode<annotations.StateMixin>(node));
 
   if (meta != null && meta.potentiallyIncompleteValue is annotations.Props) {
-    // fixme error when this case isn't well formed
     if (meta.unsupportedArguments.length == 1) {
       final arg = meta.unsupportedArguments[0];
       if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredProps') {

--- a/lib/src/builder/parsing/meta.dart
+++ b/lib/src/builder/parsing/meta.dart
@@ -61,8 +61,7 @@ class InstantiatedMeta<TMeta> {
   /// The original node will be available via [node].
   ///
   /// The instantiated annotation will be available via [value].
-  static InstantiatedMeta<T>? fromNode<T>(AnnotatedNode node,
-      {dynamic Function(Expression argument)? onUnsupportedArgument}) {
+  static InstantiatedMeta<T>? fromNode<T>(AnnotatedNode node) {
     final metaNode = _getMatchingAnnotation(node, T);
     final unsupportedArguments = <Expression>[];
     final value =

--- a/lib/src/builder/parsing/meta.dart
+++ b/lib/src/builder/parsing/meta.dart
@@ -61,7 +61,8 @@ class InstantiatedMeta<TMeta> {
   /// The original node will be available via [node].
   ///
   /// The instantiated annotation will be available via [value].
-  static InstantiatedMeta<T>? fromNode<T>(AnnotatedNode node) {
+  static InstantiatedMeta<T>? fromNode<T>(AnnotatedNode node,
+      {dynamic Function(Expression argument)? onUnsupportedArgument}) {
     final metaNode = _getMatchingAnnotation(node, T);
     final unsupportedArguments = <Expression>[];
     final value =

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -52,7 +52,69 @@ class Props implements TypedMap {
   /// overriding the default of `'${propsClassName}.'`.
   @override
   final String? keyNamespace;
-  const Props({this.keyNamespace});
+
+  /// Mixins to ignore required prop validation for, both statically in the analyzer plugin
+  /// and at runtime when invoking the builder (only with asserts enabled) .
+  ///
+  /// Useful when you have a wrapper component that sets required prop manually.
+  ///
+  /// For example:
+  ///
+  /// ```dart
+  /// mixin FooProps on UiProps {
+  ///   late String requiredPropAlwaysSetInWrapper1;
+  ///   late String requiredPropAlwaysSetInWrapper2;
+  /// }
+  ///
+  /// UiFactory<FooProps> Foo = uiFunction((props) {
+  ///   // ...
+  /// }, _$FooConfig);
+  ///
+  /// @Props(ignoreRequiredPropsFrom: {FooProps})
+  /// class WrapperProps = UiProps with FooProps, WrapperPropsMixin;
+  ///
+  /// UiFactory<WrapperProps> Wrapper = uiForwardRef((props, ref) {
+  ///   return (Foo()
+  ///     ..requiredPropAlwaysSetInWrapper1 = 'foo'
+  ///     ..requiredPropAlwaysSetInWrapper2 = 'bar'
+  ///     ..addProps(props.getPropsToForward(exclude: {WrapperPropsMixin}))
+  ///     ..ref = ref
+  ///   )();
+  /// }, _$WrapperConfig);
+  ///```
+  final Set<Type>? ignoreRequiredPropsFrom;
+
+  /// Names of props to required prop validation for, both statically in the analyzer plugin
+  /// and at runtime when invoking the builder (only with asserts enabled).
+  ///
+  /// Useful when you have a wrapper component that sets required prop manually.
+  ///
+  /// For example:
+  ///
+  /// ```dart
+  /// mixin FooProps on UiProps {
+  ///   late String requiredPropAlwaysSetInWrapper;
+  ///   late String requiredPropNotSetInWrapper;
+  /// }
+  ///
+  /// UiFactory<FooProps> Foo = uiFunction((props) {
+  ///   // ...
+  /// }, _$FooConfig);
+  ///
+  /// @Props(ignoreRequiredProps: {'requiredPropAlwaysSetInWrapper'})
+  /// class WrapperProps = UiProps with FooProps, WrapperPropsMixin;
+  ///
+  /// UiFactory<WrapperProps> Wrapper = uiForwardRef((props, ref) {
+  ///   return (Foo()
+  ///     ..requiredPropAlwaysSetInWrapper = 'foo'
+  ///     ..addProps(props.getPropsToForward(exclude: {WrapperPropsMixin}))
+  ///     ..ref = ref
+  ///   )();
+  /// }, _$WrapperConfig);
+  ///```
+  final Set<String>? ignoreRequiredProps;
+
+  const Props({this.keyNamespace, this.ignoreRequiredPropsFrom, this.ignoreRequiredProps});
 }
 
 /// Annotation used with the `over_react` builder to declare a `UiState` mixin for a component.

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -53,37 +53,6 @@ class Props implements TypedMap {
   @override
   final String? keyNamespace;
 
-  /// Mixins to ignore required prop validation for, both statically in the analyzer plugin
-  /// and at runtime when invoking the builder (only with asserts enabled) .
-  ///
-  /// Useful when you have a wrapper component that sets required prop manually.
-  ///
-  /// For example:
-  ///
-  /// ```dart
-  /// mixin FooProps on UiProps {
-  ///   late String requiredPropAlwaysSetInWrapper1;
-  ///   late String requiredPropAlwaysSetInWrapper2;
-  /// }
-  ///
-  /// UiFactory<FooProps> Foo = uiFunction((props) {
-  ///   // ...
-  /// }, _$FooConfig);
-  ///
-  /// @Props(ignoreRequiredPropsFrom: {FooProps})
-  /// class WrapperProps = UiProps with FooProps, WrapperPropsMixin;
-  ///
-  /// UiFactory<WrapperProps> Wrapper = uiForwardRef((props, ref) {
-  ///   return (Foo()
-  ///     ..requiredPropAlwaysSetInWrapper1 = 'foo'
-  ///     ..requiredPropAlwaysSetInWrapper2 = 'bar'
-  ///     ..addProps(props.getPropsToForward(exclude: {WrapperPropsMixin}))
-  ///     ..ref = ref
-  ///   )();
-  /// }, _$WrapperConfig);
-  ///```
-  final Set<Type>? ignoreRequiredPropsFrom;
-
   /// Names of props to required prop validation for, both statically in the analyzer plugin
   /// and at runtime when invoking the builder (only with asserts enabled).
   ///
@@ -114,7 +83,7 @@ class Props implements TypedMap {
   ///```
   final Set<String>? ignoreRequiredProps;
 
-  const Props({this.keyNamespace, this.ignoreRequiredPropsFrom, this.ignoreRequiredProps});
+  const Props({this.keyNamespace, this.ignoreRequiredProps});
 }
 
 /// Annotation used with the `over_react` builder to declare a `UiState` mixin for a component.

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -53,7 +53,7 @@ class Props implements TypedMap {
   @override
   final String? keyNamespace;
 
-  /// Names of props to required prop validation for, both statically in the analyzer plugin
+  /// Names of props to opt out of required prop validation for, both statically in the analyzer plugin
   /// and at runtime when invoking the builder (only with asserts enabled).
   ///
   /// Useful when you have a wrapper component that sets required prop manually.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -694,6 +694,7 @@ abstract class UiProps extends MapBase
     _shouldValidateRequiredProps = false;
   }
 
+  /// Names of props to opt out of required prop validation for.
   @visibleForOverriding
   Set<String> get requiredPropNamesToSkipValidation => const {};
 }

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -696,9 +696,6 @@ abstract class UiProps extends MapBase
 
   @visibleForOverriding
   Set<String> get requiredPropNamesToSkipValidation => const {};
-
-  @visibleForOverriding
-  Set<Type> get requiredPropClassesToSkipValidation => const {};
 }
 
 /// A class that declares the `_map` getter shared by [PropsMapViewMixin]/[StateMapViewMixin] and [MapViewMixin].

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -693,6 +693,12 @@ abstract class UiProps extends MapBase
   void disableRequiredPropValidation() {
     _shouldValidateRequiredProps = false;
   }
+
+  @visibleForOverriding
+  Set<String> get requiredPropNamesToSkipValidation => const {};
+
+  @visibleForOverriding
+  Set<Type> get requiredPropClassesToSkipValidation => const {};
 }
 
 /// A class that declares the `_map` getter shared by [PropsMapViewMixin]/[StateMapViewMixin] and [MapViewMixin].

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -695,6 +695,8 @@ abstract class UiProps extends MapBase
   }
 
   /// Names of props to opt out of required prop validation for.
+  ///
+  /// Overridden in generated code, based on the value of `@Props(ignoreRequiredProps: ...)`.
   @visibleForOverriding
   Set<String> get requiredPropNamesToSkipValidation => const {};
 }

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -55,13 +55,12 @@ mixin $FluxUiPropsMixin<ActionsT, StoresT>
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('FluxUiPropsMixin.actions') &&
-        !requiredPropNamesToSkipValidation
-            .contains('FluxUiPropsMixin.actions')) {
+        !requiredPropNamesToSkipValidation.contains('actions')) {
       throw MissingRequiredPropsError('Required prop `actions` is missing.');
     }
 
     if (!props.containsKey('FluxUiPropsMixin.store') &&
-        !requiredPropNamesToSkipValidation.contains('FluxUiPropsMixin.store')) {
+        !requiredPropNamesToSkipValidation.contains('store')) {
       throw MissingRequiredPropsError('Required prop `store` is missing.');
     }
   }

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -54,21 +54,15 @@ mixin $FluxUiPropsMixin<ActionsT, StoresT>
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
-    if (requiredPropClassesToSkipValidation.contains(FluxUiPropsMixin)) {
-      return;
-    }
-
     if (!props.containsKey('FluxUiPropsMixin.actions') &&
         !requiredPropNamesToSkipValidation
             .contains('FluxUiPropsMixin.actions')) {
-      throw MissingRequiredPropsError(
-          requiredPropNamesToSkipValidation.join(','));
+      throw MissingRequiredPropsError('Required prop `actions` is missing.');
     }
 
     if (!props.containsKey('FluxUiPropsMixin.store') &&
         !requiredPropNamesToSkipValidation.contains('FluxUiPropsMixin.store')) {
-      throw MissingRequiredPropsError(
-          requiredPropNamesToSkipValidation.join(','));
+      throw MissingRequiredPropsError('Required prop `store` is missing.');
     }
   }
 }

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -58,12 +58,17 @@ mixin $FluxUiPropsMixin<ActionsT, StoresT>
       return;
     }
 
-    if (!props.containsKey('FluxUiPropsMixin.actions')) {
-      throw MissingRequiredPropsError('Required prop `actions` is missing.');
+    if (!props.containsKey('FluxUiPropsMixin.actions') &&
+        !requiredPropNamesToSkipValidation
+            .contains('FluxUiPropsMixin.actions')) {
+      throw MissingRequiredPropsError(
+          requiredPropNamesToSkipValidation.join(','));
     }
 
-    if (!props.containsKey('FluxUiPropsMixin.store')) {
-      throw MissingRequiredPropsError('Required prop `store` is missing.');
+    if (!props.containsKey('FluxUiPropsMixin.store') &&
+        !requiredPropNamesToSkipValidation.contains('FluxUiPropsMixin.store')) {
+      throw MissingRequiredPropsError(
+          requiredPropNamesToSkipValidation.join(','));
     }
   }
 }

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -54,6 +54,10 @@ mixin $FluxUiPropsMixin<ActionsT, StoresT>
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
+    if (requiredPropClassesToSkipValidation.contains(FluxUiPropsMixin)) {
+      return;
+    }
+
     if (!props.containsKey('FluxUiPropsMixin.actions')) {
       throw MissingRequiredPropsError('Required prop `actions` is missing.');
     }

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -82,14 +82,9 @@ mixin $ReduxProviderPropsMixin on ReduxProviderPropsMixin {
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
-    if (requiredPropClassesToSkipValidation.contains(ReduxProviderPropsMixin)) {
-      return;
-    }
-
     if (!props.containsKey('store') &&
         !requiredPropNamesToSkipValidation.contains('store')) {
-      throw MissingRequiredPropsError(
-          requiredPropNamesToSkipValidation.join(','));
+      throw MissingRequiredPropsError('Required prop `store` is missing.');
     }
   }
 }

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -82,6 +82,10 @@ mixin $ReduxProviderPropsMixin on ReduxProviderPropsMixin {
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
+    if (requiredPropClassesToSkipValidation.contains(ReduxProviderPropsMixin)) {
+      return;
+    }
+
     if (!props.containsKey('store')) {
       throw MissingRequiredPropsError('Required prop `store` is missing.');
     }

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -86,8 +86,10 @@ mixin $ReduxProviderPropsMixin on ReduxProviderPropsMixin {
       return;
     }
 
-    if (!props.containsKey('store')) {
-      throw MissingRequiredPropsError('Required prop `store` is missing.');
+    if (!props.containsKey('store') &&
+        !requiredPropNamesToSkipValidation.contains('store')) {
+      throw MissingRequiredPropsError(
+          requiredPropNamesToSkipValidation.join(','));
     }
   }
 }

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -136,8 +136,5 @@ abstract class UiPropsMapView extends MapView
       throw UnimplementedError('@PropsMixin instances do not implement disableRequiredPropValidation');
 
   @override
-  Set<Type> get requiredPropClassesToSkipValidation => throw UnimplementedError('@PropsMixin instances do not implement requiredPropClassesToSkipValidation');
-
-  @override
   Set<String> get requiredPropNamesToSkipValidation => throw UnimplementedError('@PropsMixin instances do not implement requiredPropNamesToSkipValidation');
 }

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -134,4 +134,10 @@ abstract class UiPropsMapView extends MapView
   @override
   void disableRequiredPropValidation() =>
       throw UnimplementedError('@PropsMixin instances do not implement disableRequiredPropValidation');
+
+  @override
+  Set<Type> get requiredPropClassesToSkipValidation => throw UnimplementedError('@PropsMixin instances do not implement requiredPropClassesToSkipValidation');
+
+  @override
+  Set<String> get requiredPropNamesToSkipValidation => throw UnimplementedError('@PropsMixin instances do not implement requiredPropNamesToSkipValidation');
 }

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
@@ -206,7 +206,7 @@ void main() {
                     'Required prop `secondRequiredProp` is missing.'))));
       });
 
-      test('does not throw when all required props are set', () {
+      test('does not throw when all required props are set or ignored via @Props(ignoreRequiredProps: ...)', () {
         expect(() {
           (MultipleMixinsTest()
             ..requiredNullable = true

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
@@ -217,6 +217,12 @@ void main() {
           returnsNormally);
       });
     });
+
+    test('@Props(ignoreRequiredProps) turns off validation for specific props', () {
+      expect(() {
+        rtl.render(WrapperTest()());
+      }, returnsNormally);
+    });
   }, tags: 'ddc');
 
   test('(New boilerplate) validates required props: does not throw in dart2js', () {
@@ -230,6 +236,7 @@ void main() {
 // ignore: undefined_identifier, invalid_assignment
 UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
 
+@Props(ignoreRequiredProps: {'testIgnoreOnMixin'})
 mixin ComponentTestProps on UiProps {
   late bool requiredNonNullable;
 
@@ -246,6 +253,8 @@ mixin ComponentTestProps on UiProps {
   late dynamic ref;
 
   bool? nullable;
+
+  late bool testIgnoreOnMixin;
 }
 
 class ComponentTestComponent extends UiComponent2<ComponentTestProps> {
@@ -262,4 +271,17 @@ mixin MultipleMixinsTestPropsMixin on UiProps {
   late bool secondRequiredProp;
 }
 
+@Props(ignoreRequiredProps: {'testIgnoreOnMixin'})
 class MultipleMixinsTestProps = UiProps with MultipleMixinsTestPropsMixin, ComponentTestProps;
+
+UiFactory<WrapperTestProps> WrapperTest = uiFunction(
+      (props) {},
+  _$WrapperTestConfig, // ignore: undefined_identifier
+);
+
+mixin WrapperTestPropsMixin on UiProps {
+  late bool thirdRequiredProp;
+}
+
+@Props(ignoreRequiredProps: {'thirdRequiredProp', 'secondRequiredProp', 'requiredNonNullable', 'requiredNullable', 'testIgnoreOnMixin'})
+class WrapperTestProps = UiProps with WrapperTestPropsMixin, MultipleMixinsTestPropsMixin, ComponentTestProps;

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -62,14 +62,13 @@ mixin $TestProps on TestProps {
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('TestProps.requiredProp') &&
-        !requiredPropNamesToSkipValidation.contains('TestProps.requiredProp')) {
+        !requiredPropNamesToSkipValidation.contains('requiredProp')) {
       throw MissingRequiredPropsError(
           'Required prop `requiredProp` is missing.');
     }
 
     if (!props.containsKey('TestProps.requiredNullableProp') &&
-        !requiredPropNamesToSkipValidation
-            .contains('TestProps.requiredNullableProp')) {
+        !requiredPropNamesToSkipValidation.contains('requiredNullableProp')) {
       throw MissingRequiredPropsError(
           'Required prop `requiredNullableProp` is missing.');
     }

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -65,14 +65,17 @@ mixin $TestProps on TestProps {
       return;
     }
 
-    if (!props.containsKey('TestProps.requiredProp')) {
+    if (!props.containsKey('TestProps.requiredProp') &&
+        !requiredPropNamesToSkipValidation.contains('TestProps.requiredProp')) {
       throw MissingRequiredPropsError(
-          'Required prop `requiredProp` is missing.');
+          requiredPropNamesToSkipValidation.join(','));
     }
 
-    if (!props.containsKey('TestProps.requiredNullableProp')) {
+    if (!props.containsKey('TestProps.requiredNullableProp') &&
+        !requiredPropNamesToSkipValidation
+            .contains('TestProps.requiredNullableProp')) {
       throw MissingRequiredPropsError(
-          'Required prop `requiredNullableProp` is missing.');
+          requiredPropNamesToSkipValidation.join(','));
     }
   }
 }

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -61,6 +61,10 @@ mixin $TestProps on TestProps {
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
+    if (requiredPropClassesToSkipValidation.contains(TestProps)) {
+      return;
+    }
+
     if (!props.containsKey('TestProps.requiredProp')) {
       throw MissingRequiredPropsError(
           'Required prop `requiredProp` is missing.');

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -61,21 +61,17 @@ mixin $TestProps on TestProps {
   @mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
-    if (requiredPropClassesToSkipValidation.contains(TestProps)) {
-      return;
-    }
-
     if (!props.containsKey('TestProps.requiredProp') &&
         !requiredPropNamesToSkipValidation.contains('TestProps.requiredProp')) {
       throw MissingRequiredPropsError(
-          requiredPropNamesToSkipValidation.join(','));
+          'Required prop `requiredProp` is missing.');
     }
 
     if (!props.containsKey('TestProps.requiredNullableProp') &&
         !requiredPropNamesToSkipValidation
             .contains('TestProps.requiredNullableProp')) {
       throw MissingRequiredPropsError(
-          requiredPropNamesToSkipValidation.join(','));
+          'Required prop `requiredNullableProp` is missing.');
     }
   }
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Consumers can currently opt props they declare out of required prop vaildation, by annotating individual props with `@disableRequiredPropValidation`, but they can't opt out of validation for props in other mixins.

This becomes an issue for certain use-cases, primarily the declaration of wrapper components.

For example:

```
mixin FooProps on UiProps {
  late String requiredProp1AlwaysSetInWrapper;
  late String requiredProp2;
}

UiFactory<FooProps> Foo = uiFunction((props) {
  // ...
}, _$FooConfig);

class WrapperProps = UiProps with FooProps, WrapperPropsMixin;

UiFactory<WrapperProps> Wrapper = uiForwardRef((props, ref) {
  return (Foo()
    ..requiredProp1AlwaysSetInWrapper = 'foo'
    ..addProps(props.getPropsToForward(exclude: {WrapperPropsMixin}))
    ..ref = ref
  )();
}, _$WrapperConfig);
```

`Wrapper` sets required props on the component it wraps, but doing `(Wrapper()..requiredProp2 = '')()` will still result in runtime errors and lint warnings because `requiredProp1AlwaysSetInWrapper` isn't set set.

This pattern is pretty common, and we need a way for consumers to be able to continue to write these wrappers without required prop validation getting in their way.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Finish spike branch and add ignore option
- Write tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
