### PR TITLE
FED-2139 Fix ProviderProps.value being optional/nullable, refactor internal impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
     - ReduxProviderProps (for extension, mix in ReduxProviderPropsMixin instead)
     - ProviderProps (factory: `Context.Provider`)
     - ConsumerProps (factory: `Context.Consumer`)
+- The following props are now required:
+    - `FluxUiPropsMixin.actions`, `FluxUiPropsMixin.store`
+    - `ProviderProps.value` (`ProviderProps` is the return type of `Context.Provider`)
+    - `ReduxMultiProviderProps.storesByContext`
+    - `ReduxProviderProps.store`
 - UiPropsMapView (deprecated) is now abstract and requires subclasses to override `selfFactory`
 - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
 - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
     - FragmentProps
     - StrictModeProps
     - ReduxProviderProps (for extension, mix in ReduxProviderPropsMixin instead)
+    - ProviderProps (factory: `Context.Provider`)
+    - ConsumerProps (factory: `Context.Cosnumer`)
 - UiPropsMapView (deprecated) is now abstract and requires subclasses to override `selfFactory`
 - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
 - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
     - StrictModeProps
     - ReduxProviderProps (for extension, mix in ReduxProviderPropsMixin instead)
     - ProviderProps (factory: `Context.Provider`)
-    - ConsumerProps (factory: `Context.Cosnumer`)
+    - ConsumerProps (factory: `Context.Consumer`)
 - UiPropsMapView (deprecated) is now abstract and requires subclasses to override `selfFactory`
 - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
 - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)

--- a/lib/src/util/context.dart
+++ b/lib/src/util/context.dart
@@ -155,16 +155,19 @@ typedef _ConsumerPropsImpl<TValue> = _$$ConsumerProps<TValue>;
 
 /// A typed props class for the [Context.Provider] from a [Context] object created with [createContext].
 ///
-/// Props:
-///
-/// * [_ProviderPropsMixin.value] The value that you want to provide to all consumers.
-///
 /// See: <https://react.dev/reference/react/createContext#provider>
 class ProviderProps<TValue> = UiProps with _ProviderPropsMixin<TValue>;
 
 // Private to mirror `ConsumerPropsMixin` being private.
 @Props(keyNamespace: '')
 mixin _ProviderPropsMixin<TValue> on UiProps {
+  /// The value that you want to pass to all the components reading this context inside this provider,
+  /// no matter how deep.
+  ///
+  /// The context value can be of any type.
+  ///
+  /// A component calling `useContext(SomeContext)` inside of the provider receives the value of
+  /// the innermost corresponding context provider above it.
   late TValue value;
 }
 

--- a/lib/src/util/context.dart
+++ b/lib/src/util/context.dart
@@ -160,7 +160,7 @@ typedef _ConsumerPropsImpl<TValue> = _$$ConsumerProps<TValue>;
 /// * [_ProviderPropsMixin.value] The value that you want to provide to all consumers.
 ///
 /// See: <https://react.dev/reference/react/createContext#provider>
-class ProviderProps<TValue> = UiProps with _ProviderPropsMixin;
+class ProviderProps<TValue> = UiProps with _ProviderPropsMixin<TValue>;
 
 // Private to mirror `ConsumerPropsMixin` being private.
 @Props(keyNamespace: '')

--- a/lib/src/util/context.over_react.g.dart
+++ b/lib/src/util/context.over_react.g.dart
@@ -1,0 +1,263 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+part of 'context.dart';
+
+// **************************************************************************
+// OverReactBuilder (package:over_react/src/builder.dart)
+// **************************************************************************
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $_ProviderPropsMixin<TValue> on _ProviderPropsMixin<TValue> {
+  static const PropsMeta meta = _$metaFor_ProviderPropsMixin;
+  @override
+  TValue get value =>
+      (props[_$key__value___ProviderPropsMixin] ?? null) as TValue;
+  @override
+  set value(TValue value) => props[_$key__value___ProviderPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor _$prop__value___ProviderPropsMixin =
+      PropDescriptor(_$key__value___ProviderPropsMixin,
+          isRequired: true, isNullable: true);
+  static const String _$key__value___ProviderPropsMixin = 'value';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__value___ProviderPropsMixin
+  ];
+  static const List<String> $propKeys = [_$key__value___ProviderPropsMixin];
+
+  @override
+  @mustCallSuper
+  void validateRequiredProps() {
+    super.validateRequiredProps();
+    if (!props.containsKey('value') &&
+        !requiredPropNamesToSkipValidation.contains('value')) {
+      throw MissingRequiredPropsError('Required prop `value` is missing.');
+    }
+  }
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaFor_ProviderPropsMixin = PropsMeta(
+  fields: $_ProviderPropsMixin.$props,
+  keys: $_ProviderPropsMixin.$propKeys,
+);
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.'
+    ' EXCEPTION: this may be used in legacy boilerplate until'
+    ' it is transitioned to the new mixin-based boilerplate.')
+mixin $_ConsumerPropsMixin<TValue> on _ConsumerPropsMixin<TValue> {
+  static const PropsMeta meta = _$metaFor_ConsumerPropsMixin;
+  @override
+  @experimental
+  dynamic get unstable_observedBits =>
+      (props[_$key__unstable_observedBits___ConsumerPropsMixin] ?? null)
+          as dynamic;
+  @override
+  @experimental
+  set unstable_observedBits(dynamic value) =>
+      props[_$key__unstable_observedBits___ConsumerPropsMixin] = value;
+  /* GENERATED CONSTANTS */
+  static const PropDescriptor
+      _$prop__unstable_observedBits___ConsumerPropsMixin =
+      PropDescriptor(_$key__unstable_observedBits___ConsumerPropsMixin);
+  static const String _$key__unstable_observedBits___ConsumerPropsMixin =
+      'unstable_observedBits';
+
+  static const List<PropDescriptor> $props = [
+    _$prop__unstable_observedBits___ConsumerPropsMixin
+  ];
+  static const List<String> $propKeys = [
+    _$key__unstable_observedBits___ConsumerPropsMixin
+  ];
+
+  @override
+  @mustCallSuper
+  void validateRequiredProps() {
+    super.validateRequiredProps();
+  }
+}
+
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+const PropsMeta _$metaFor_ConsumerPropsMixin = PropsMeta(
+  fields: $_ConsumerPropsMixin.$props,
+  keys: $_ConsumerPropsMixin.$propKeys,
+);
+
+_$$ProviderProps _$_Provider([Map? backingProps]) => backingProps == null
+    ? _$$ProviderProps$JsMap(JsBackedMap())
+    : _$$ProviderProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$ProviderProps<TValue> extends UiProps
+    with
+        _ProviderPropsMixin,
+        // If this generated mixin is undefined, it's likely because _ProviderPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _ProviderPropsMixin, and check that $_ProviderPropsMixin is exported/imported properly.
+        $_ProviderPropsMixin
+    implements
+        ProviderProps<TValue> {
+  _$$ProviderProps._();
+
+  factory _$$ProviderProps(Map? backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$ProviderProps$JsMap(backingMap as JsBackedMap?);
+    } else {
+      return _$$ProviderProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because _ProviderPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _ProviderPropsMixin, and check that $_ProviderPropsMixin is exported/imported properly.
+        _ProviderPropsMixin: $_ProviderPropsMixin.meta,
+      });
+
+  @override
+  String $getPropKey(void Function(Map m) accessMap) =>
+      _$getPropKey$_$$ProviderProps(accessMap, (map) => _$$ProviderProps(map));
+}
+
+/// An alias for [getPropKey] so it can be referenced within the props class impl
+/// without being shadowed by the `getPropKey` instance extension member.
+const _$getPropKey$_$$ProviderProps = getPropKey;
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$ProviderProps$PlainMap<TValue> extends _$$ProviderProps<TValue> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$ProviderProps$PlainMap(Map? backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$ProviderProps$JsMap<TValue> extends _$$ProviderProps<TValue> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$ProviderProps$JsMap(JsBackedMap? backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}
+
+_$$ConsumerProps _$_Consumer([Map? backingProps]) => backingProps == null
+    ? _$$ConsumerProps$JsMap(JsBackedMap())
+    : _$$ConsumerProps(backingProps);
+
+// Concrete props implementation.
+//
+// Implements constructor and backing map, and links up to generated component factory.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+abstract class _$$ConsumerProps<TValue> extends UiProps
+    with
+        _ConsumerPropsMixin<TValue>,
+        // If this generated mixin is undefined, it's likely because _ConsumerPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _ConsumerPropsMixin, and check that $_ConsumerPropsMixin is exported/imported properly.
+        $_ConsumerPropsMixin<TValue>
+    implements
+        ConsumerProps<TValue> {
+  _$$ConsumerProps._();
+
+  factory _$$ConsumerProps(Map? backingMap) {
+    if (backingMap == null || backingMap is JsBackedMap) {
+      return _$$ConsumerProps$JsMap(backingMap as JsBackedMap?);
+    } else {
+      return _$$ConsumerProps$PlainMap(backingMap);
+    }
+  }
+
+  /// Let `UiProps` internals know that this class has been generated.
+  @override
+  bool get $isClassGenerated => true;
+
+  /// The default namespace for the prop getters/setters generated for this class.
+  @override
+  String get propKeyNamespace => '';
+
+  @override
+  PropsMetaCollection get staticMeta => const PropsMetaCollection({
+        // If this generated mixin is undefined, it's likely because _ConsumerPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _ConsumerPropsMixin, and check that $_ConsumerPropsMixin is exported/imported properly.
+        _ConsumerPropsMixin: $_ConsumerPropsMixin.meta,
+      });
+
+  @override
+  String $getPropKey(void Function(Map m) accessMap) =>
+      _$getPropKey$_$$ConsumerProps(accessMap, (map) => _$$ConsumerProps(map));
+}
+
+/// An alias for [getPropKey] so it can be referenced within the props class impl
+/// without being shadowed by the `getPropKey` instance extension member.
+const _$getPropKey$_$$ConsumerProps = getPropKey;
+
+// Concrete props implementation that can be backed by any [Map].
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$ConsumerProps$PlainMap<TValue> extends _$$ConsumerProps<TValue> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$ConsumerProps$PlainMap(Map? backingMap)
+      : this._props = {},
+        super._() {
+    this._props = backingMap ?? {};
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  Map get props => _props;
+  Map _props;
+}
+
+// Concrete props implementation that can only be backed by [JsMap],
+// allowing dart2js to compile more optimal code for key-value pair reads/writes.
+@Deprecated('This API is for use only within generated code.'
+    ' Do not reference it in your code, as it may change at any time.')
+class _$$ConsumerProps$JsMap<TValue> extends _$$ConsumerProps<TValue> {
+  // This initializer of `_props` to an empty map, as well as the reassignment
+  // of `_props` in the constructor body is necessary to work around a DDC bug: https://github.com/dart-lang/sdk/issues/36217
+  _$$ConsumerProps$JsMap(JsBackedMap? backingMap)
+      : this._props = JsBackedMap(),
+        super._() {
+    this._props = backingMap ?? JsBackedMap();
+  }
+
+  /// The backing props map proxied by this class.
+  @override
+  JsBackedMap get props => _props;
+  JsBackedMap _props;
+}

--- a/lib/src/util/context.over_react.g.dart
+++ b/lib/src/util/context.over_react.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators
+// ignore_for_file: deprecated_member_use_from_same_package, unnecessary_null_in_if_null_operators, prefer_null_aware_operators, invalid_use_of_visible_for_overriding_member
 part of 'context.dart';
 
 // **************************************************************************

--- a/lib/src/util/context.over_react.g.dart
+++ b/lib/src/util/context.over_react.g.dart
@@ -101,9 +101,9 @@ _$$ProviderProps _$_Provider([Map? backingProps]) => backingProps == null
     ' Do not reference it in your code, as it may change at any time.')
 abstract class _$$ProviderProps<TValue> extends UiProps
     with
-        _ProviderPropsMixin,
+        _ProviderPropsMixin<TValue>,
         // If this generated mixin is undefined, it's likely because _ProviderPropsMixin is not a valid `mixin`-based props mixin, or because it is but the generated mixin was not imported. Check the declaration of _ProviderPropsMixin, and check that $_ProviderPropsMixin is exported/imported properly.
-        $_ProviderPropsMixin
+        $_ProviderPropsMixin<TValue>
     implements
         ProviderProps<TValue> {
   _$$ProviderProps._();

--- a/test/over_react/component/context_test.dart
+++ b/test/over_react/component/context_test.dart
@@ -33,7 +33,9 @@ void main() {
       expect(context, isA<Context>());
       expect(context, isA<Context<int?>>(), reason: 'should have a nullable generic type');
       expect(context.Consumer(), isA<ConsumerProps>());
+      expect(context.Consumer(), isA<ConsumerProps<int?>>(), reason: 'should have the correct generic type');
       expect(context.Provider(), isA<ProviderProps>());
+      expect(context.Provider(), isA<ProviderProps<int?>>(), reason: 'should have the correct generic type');
       expect(context.jsThis, isA<JsMap>());
       expect(context.reactDartContext, isA<react.Context>());
     });
@@ -43,7 +45,9 @@ void main() {
       expect(context, isA<Context>());
       expect(context, isA<Context<int>>(), reason: 'should have a non-nullable generic type');
       expect(context.Consumer(), isA<ConsumerProps>());
+      expect(context.Consumer(), isA<ConsumerProps<int>>(), reason: 'should have the correct generic type');
       expect(context.Provider(), isA<ProviderProps>());
+      expect(context.Provider(), isA<ProviderProps<int>>(), reason: 'should have the correct generic type');
       expect(context.jsThis, isA<JsMap>());
       expect(context.reactDartContext, isA<react.Context>());
     });
@@ -253,14 +257,24 @@ void main() {
     });
 
     group('ProviderProps', () {
-      late ProviderProps props;
-
-      setUp(() {
-        props = createContext().Provider();
+      test('functions as a map view when constructed from its factory', () {
+        final wrappedProps = {'foo': 'bar'};
+        final props = createContext().Provider(wrappedProps);
+        expect(props, containsPair('foo', 'bar'));
+        props['newEntry'] = 'value';
+        expect(wrappedProps, containsPair('newEntry', 'value'));
       });
 
       group('has functional overrides to members that are typically generated', () {
-        // TODO(FED-1994) implement staticMeta for this props class and add tests here
+        late ProviderProps props;
+
+        setUp(() {
+          props = createContext().Provider();
+        });
+
+        test('staticMeta', () {
+          expect(props.staticMeta.keys, contains('value'));
+        });
 
         test('propKeyNamespace', () {
           expect(props.propKeyNamespace, '');
@@ -280,14 +294,24 @@ void main() {
     });
 
     group('ConsumerProps', () {
-      late ConsumerProps props;
-
-      setUp(() {
-        props = createContext().Consumer();
+      test('functions as a map view when constructed from its factory', () {
+        final wrappedProps = {'foo': 'bar'};
+        final props = createContext().Consumer(wrappedProps);
+        expect(props, containsPair('foo', 'bar'));
+        props['newEntry'] = 'value';
+        expect(wrappedProps, containsPair('newEntry', 'value'));
       });
 
       group('has functional overrides to members that are typically generated', () {
-        // TODO(FED-1994) implement staticMeta for this props class and add tests here
+        late ConsumerProps props;
+
+        setUp(() {
+          props = createContext().Consumer();
+        });
+
+        test('staticMeta', () {
+          expect(props.staticMeta.keys, contains('unstable_observedBits'));
+        });
 
         test('propKeyNamespace', () {
           expect(props.propKeyNamespace, '');

--- a/test/over_react/component/fixtures/context_provider_component.dart
+++ b/test/over_react/component/fixtures/context_provider_component.dart
@@ -27,7 +27,7 @@ class _$ContextProviderWrapperProps extends UiProps {}
 
 @State()
 class _$ContextProviderWrapperState extends UiState {
-  int? latestValue;
+  late int latestValue;
 }
 
 @Component2()
@@ -49,7 +49,7 @@ class ContextProviderWrapperComponent extends UiStatefulComponent2<ContextProvid
   void increment() {
     this.setState(
       (newState()
-        ..latestValue = (this.state.latestValue! + 1)
+        ..latestValue = (this.state.latestValue + 1)
       )
     );
   }

--- a/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
+++ b/test/over_react/component/fixtures/context_provider_component.over_react.g.dart
@@ -126,18 +126,19 @@ abstract class _$ContextProviderWrapperStateAccessorsMixin
 
   /// <!-- Generated from [_$ContextProviderWrapperState.latestValue] -->
   @override
-  int? get latestValue =>
-      (state[_$key__latestValue___$ContextProviderWrapperState] ?? null)
-          as int?;
+  int get latestValue =>
+      (state[_$key__latestValue___$ContextProviderWrapperState] ?? null) as int;
 
   /// <!-- Generated from [_$ContextProviderWrapperState.latestValue] -->
   @override
-  set latestValue(int? value) =>
+  set latestValue(int value) =>
       state[_$key__latestValue___$ContextProviderWrapperState] = value;
   /* GENERATED CONSTANTS */
   static const StateDescriptor
-      _$prop__latestValue___$ContextProviderWrapperState =
-      StateDescriptor(_$key__latestValue___$ContextProviderWrapperState);
+      _$prop__latestValue___$ContextProviderWrapperState = StateDescriptor(
+          _$key__latestValue___$ContextProviderWrapperState,
+          isRequired: true,
+          isNullable: true);
   static const String _$key__latestValue___$ContextProviderWrapperState =
       'ContextProviderWrapperState.latestValue';
 


### PR DESCRIPTION
## Dependent PR

Dependent on https://github.com/Workiva/over_react/pull/875

---

## Motivation
When looking at context APIs in https://github.com/Workiva/over_react/pull/875, I realized that the value prop on Provider wasn't considered required (by runtime checks and static analysis), even though it should be. It was also `TValue?`, when it should have been `TValue`.



`ProviderProps.value` was previously implemented as a custom getter/setter, and required props can only be declared in generated props mixins.

This refactor moves away from manual implementations to relying on generated code, cleaning up certain aspects, but unfortunately the implementations are still pretty custom and messy.


## Changes
- Move declaration of `ProviderProps.value` from a custom getter/setter to a `late` required, potentially non-nullable (when as TValue is non-nullable) prop in a props mixin (required props can only be declared in generated props mixins)
- Refactor the custom implementations of ProviderProps/ConsumerProps to rely more on generated code. 
    - This cleans up certain aspects, but unfortunately the implementations are still pretty custom and messy due to the use of generics, and due to `ConsumerProps`'s `call` override. See code comments for more details.
- Add tests
   - that the generics are wired up properly
   - that the factories work properly when called with maps
   - for staticMeta (there was an existing TODO for those that became invalid with these changes)

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - Merge this branch and the branch in https://github.com/Workiva/over_react/pull/871 together, and verify in the analyzer playground that the analyzer lints about rendering a context provider without a `value` prop
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
