### PR TITLE
FED-2154 Rename `ignoreRequiredProps` to `disableRequiredPropValidation` in @Props annotation

### DIFF
--- a/example/builder/src/functional_consumed_props.dart
+++ b/example/builder/src/functional_consumed_props.dart
@@ -26,7 +26,7 @@ mixin SharedPropsMixin on UiProps {
   String? aPropToBePassed;
 }
 
-@Props(ignoreRequiredProps: {'requiredProp'})
+@Props(disableRequiredPropValidation: {'requiredProp'})
 class SomeParentProps = UiProps with ParentOnlyPropsMixin, SharedPropsMixin;
 
 UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
@@ -42,7 +42,7 @@ UiFactory<SomeParentProps> SomeParent = uiFunction((props) {
   _$SomeParentConfig, // ignore: undefined_identifier
 );
 
-@Props(ignoreRequiredProps: {'requiredProp'})
+@Props(disableRequiredPropValidation: {'requiredProp'})
 class SomeChildProps = UiProps with SharedPropsMixin;
 
 UiFactory<SomeChildProps> SomeChild = uiFunction((props) {

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -342,7 +342,7 @@ class _LegacyTypedMapImplGenerator extends TypedMapImplGenerator {
       componentFactoryName: ComponentNames(declaration.component.name.name).componentFactoryName,
       propKeyNamespace: getAccessorKeyNamespace(names, member.meta),
       requiredPropNamesToSkipValidation:
-          member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
+          member.meta.tryCast<annotations.Props>()?.disableRequiredPropValidation,
     ));
   }
 
@@ -465,7 +465,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
       propKeyNamespace: '',
       allPropsMixins: allPropsMixins,
       requiredPropNamesToSkipValidation:
-          member.meta.tryCast<annotations.Props>()?.ignoreRequiredProps,
+          member.meta.tryCast<annotations.Props>()?.disableRequiredPropValidation,
     ));
   }
 

--- a/lib/src/builder/parsing/members/props_and_state_util.dart
+++ b/lib/src/builder/parsing/members/props_and_state_util.dart
@@ -71,7 +71,7 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
     if (meta.potentiallyIncompleteValue is annotations.Props) {
       if (meta.unsupportedArguments.length == 1) {
         final arg = meta.unsupportedArguments[0];
-        if (arg is NamedExpression && arg.name.label.name == 'ignoreRequiredProps') {
+        if (arg is NamedExpression && arg.name.label.name == 'disableRequiredPropValidation') {
           // Attempt to parse the value, and fall through if something goes wrong,
           // and let `meta?.value` below throw.
           final expression = arg.expression;
@@ -81,7 +81,7 @@ annotations.TypedMap getPropsOrStateAnnotation(bool isProps, AnnotatedNode node)
             if (simpleStringElements.length == expression.elements.length) {
               return annotations.Props(
                 keyNamespace: meta.potentiallyIncompleteValue.keyNamespace,
-                ignoreRequiredProps: simpleStringElements.map((e) => e.value).toSet(),
+                disableRequiredPropValidation: simpleStringElements.map((e) => e.value).toSet(),
               );
             }
           }

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -70,7 +70,7 @@ class Props implements TypedMap {
   ///   // ...
   /// }, _$FooConfig);
   ///
-  /// @Props(ignoreRequiredProps: {'requiredPropAlwaysSetInWrapper'})
+  /// @Props(disableRequiredPropValidation: {'requiredPropAlwaysSetInWrapper'})
   /// class WrapperProps = UiProps with FooProps, WrapperPropsMixin;
   ///
   /// UiFactory<WrapperProps> Wrapper = uiForwardRef((props, ref) {
@@ -81,9 +81,9 @@ class Props implements TypedMap {
   ///   )();
   /// }, _$WrapperConfig);
   ///```
-  final Set<String>? ignoreRequiredProps;
+  final Set<String>? disableRequiredPropValidation;
 
-  const Props({this.keyNamespace, this.ignoreRequiredProps});
+  const Props({this.keyNamespace, this.disableRequiredPropValidation});
 }
 
 /// Annotation used with the `over_react` builder to declare a `UiState` mixin for a component.

--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -694,14 +694,14 @@ abstract class UiProps extends MapBase
   /// Allows validation to be skipped to support cases where required props are cloned onto an element.
   ///
   /// Prop validation for specific props can also be disabled via [annotations.disableRequiredPropValidation]
-  /// or [annotations.Props.ignoreRequiredProps].
+  /// or [annotations.Props.disableRequiredPropValidation].
   void disableRequiredPropValidation() {
     _shouldValidateRequiredProps = false;
   }
 
   /// Names of props to opt out of required prop validation for.
   ///
-  /// Overridden in generated code, based on the value of `@Props(ignoreRequiredProps: ...)`.
+  /// Overridden in generated code, based on the value of `@Props(disableRequiredPropValidation: ...)`.
   @visibleForOverriding
   Set<String> get requiredPropNamesToSkipValidation => const {};
 }

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
@@ -206,7 +206,7 @@ void main() {
                     'Required prop `secondRequiredProp` is missing.'))));
       });
 
-      test('does not throw when all required props are set or ignored via @Props(ignoreRequiredProps: ...)', () {
+      test('does not throw when all required props are set or ignored via @Props(disableRequiredPropValidation: ...)', () {
         expect(() {
           (MultipleMixinsTest()
             ..requiredNullable = true
@@ -218,7 +218,7 @@ void main() {
       });
     });
 
-    test('@Props(ignoreRequiredProps) turns off validation for specific props', () {
+    test('@Props(disableRequiredPropValidation) turns off validation for specific props', () {
       expect(() {
         rtl.render(WrapperTest()());
       }, returnsNormally);
@@ -236,7 +236,7 @@ void main() {
 // ignore: undefined_identifier, invalid_assignment
 UiFactory<ComponentTestProps> ComponentTest = _$ComponentTest;
 
-@Props(ignoreRequiredProps: {'testIgnoreOnMixin'})
+@Props(disableRequiredPropValidation: {'testIgnoreOnMixin'})
 mixin ComponentTestProps on UiProps {
   late bool requiredNonNullable;
 
@@ -271,7 +271,7 @@ mixin MultipleMixinsTestPropsMixin on UiProps {
   late bool secondRequiredProp;
 }
 
-@Props(ignoreRequiredProps: {'testIgnoreOnMixin'})
+@Props(disableRequiredPropValidation: {'testIgnoreOnMixin'})
 class MultipleMixinsTestProps = UiProps with MultipleMixinsTestPropsMixin, ComponentTestProps;
 
 UiFactory<WrapperTestProps> WrapperTest = uiFunction(
@@ -283,5 +283,5 @@ mixin WrapperTestPropsMixin on UiProps {
   late bool thirdRequiredProp;
 }
 
-@Props(ignoreRequiredProps: {'thirdRequiredProp', 'secondRequiredProp', 'requiredNonNullable', 'requiredNullable', 'testIgnoreOnMixin'})
+@Props(disableRequiredPropValidation: {'thirdRequiredProp', 'secondRequiredProp', 'requiredNonNullable', 'requiredNullable', 'testIgnoreOnMixin'})
 class WrapperTestProps = UiProps with WrapperTestPropsMixin, MultipleMixinsTestPropsMixin, ComponentTestProps;

--- a/tools/analyzer_plugin/lib/src/util/prop_declarations/required_props.dart
+++ b/tools/analyzer_plugin/lib/src/util/prop_declarations/required_props.dart
@@ -87,7 +87,7 @@ enum PropRequiredness {
   annotation(isRequired: true, requirednessLevel: 2),
 
   /// Represents a prop that was considered required in its declaration,
-  /// but is ignored by the consuming class via `@Props(ignoreRequiredProps: {…})`.
+  /// but is ignored by the consuming class via `@Props(disableRequiredPropValidation: {…})`.
   ignoredByConsumingClass(isRequired: false, requirednessLevel: 1),
 
   /// Represents a prop that is not required.
@@ -131,11 +131,11 @@ bool isRequiredPropValidationDisabled(FieldElement propField) {
 }
 
 /// Returns the prop names that should not be considered required for a given concrete props class,
-/// from the `@Props(ignoreRequiredProps: {…})` annotation.
+/// from the `@Props(disableRequiredPropValidation: {…})` annotation.
 Set<String>? getIgnoredRequiredPropNames(InterfaceElement element) {
   final propsAnnotation = element.metadata
       .firstWhereOrNull((m) => m.element.tryCast<ConstructorElement>()?.enclosingElement.name == 'Props');
 
-  final ignoredNamesValue = propsAnnotation?.computeConstantValue()?.getField('ignoreRequiredProps')?.toSetValue();
+  final ignoredNamesValue = propsAnnotation?.computeConstantValue()?.getField('disableRequiredPropValidation')?.toSetValue();
   return ignoredNamesValue?.map((v) => v.toStringValue()).whereNotNull().toSet();
 }

--- a/tools/analyzer_plugin/playground/web/missing_required_props.dart
+++ b/tools/analyzer_plugin/playground/web/missing_required_props.dart
@@ -45,7 +45,7 @@ mixin IgnoresSomeRequiredPropsMixin on UiProps {
   late String requiredInSubclass1;
   late String requiredInSubclass2;
 }
-@Props(ignoreRequiredProps: {'required1', 'requiredInSubclass1'})
+@Props(disableRequiredPropValidation: {'required1', 'requiredInSubclass1'})
 class IgnoresSomeRequiredProps = UiProps with WithLateRequiredProps, IgnoresSomeRequiredPropsMixin;
 
 

--- a/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
@@ -72,7 +72,7 @@ mixin IgnoresSomeRequiredPropsMixin on UiProps {
   late String requiredInSubclass1;
   late String requiredInSubclass2;
 }
-@Props(ignoreRequiredProps: {'required1', 'requiredInSubclass1'})
+@Props(disableRequiredPropValidation: {'required1', 'requiredInSubclass1'})
 class IgnoresSomeRequiredProps = UiProps with WithLateRequiredProps, IgnoresSomeRequiredPropsMixin;
 
 

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
@@ -104,7 +104,7 @@ void main() {
           expect(getIgnoredRequiredPropNames(propsElement), unorderedEquals(<String>{'foo', 'bar'}));
         });
 
-        test('returns null when @Props annotation does not have ignoreRequiredProps argument', () {
+        test('returns null when @Props annotation does not have disableRequiredPropValidation argument', () {
           final propsElement = getInterfaceElement(result, 'IgnoreRequiredPropsAnnotationTest_WithoutIgnoresProps');
           expect(getIgnoredRequiredPropNames(propsElement), isNull);
         });

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
@@ -366,7 +366,7 @@ mixin Ignore2PropsMixin on UiProps, Ignore1PropsMixin {
   @override String? lateRequired_1_optionalInOtherType_notIgnored;
 }
 
-@Props(ignoreRequiredProps: {
+@Props(disableRequiredPropValidation: {
   'lateRequired_1_ignored',
   'optional_1_lateRequiredInOtherType_ignored',
   'lateRequired_1_optionalInOtherType_ignored',
@@ -375,7 +375,7 @@ mixin Ignore2PropsMixin on UiProps, Ignore1PropsMixin {
 class IgnoreInConcreteClassProps = UiProps with Ignore1PropsMixin, Ignore2PropsMixin;
 UiFactory<IgnoreInConcreteClassProps> IgnoreInConcreteClass = castUiFactory(_$IgnoreInConcreteClass);
 
-@Props(ignoreRequiredProps: {'foo', 'bar'})
+@Props(disableRequiredPropValidation: {'foo', 'bar'})
 class IgnoreRequiredPropsAnnotationTest_WithIgnoresProps extends UiProps {}
 UiFactory<IgnoreRequiredPropsAnnotationTest_WithIgnoresProps> IgnoreRequiredPropsAnnotationTest_WithIgnores = castUiFactory(_$IgnoreRequiredPropsAnnotationTest_WithIgnores);
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We should make the `disableRequiredPropValidation` naming consistent across all the disabling options
## Changes
  <!-- What this PR changes to fix the problem. -->

- Rename `ignoreRequiredProps` to `disableRequiredPropValidation` in @Props annotation
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
