### PR TITLE
FED-2167 Validate required props in UiProps.build

### DIFF
--- a/lib/src/component_declaration/component_base.dart
+++ b/lib/src/component_declaration/component_base.dart
@@ -561,7 +561,15 @@ abstract class UiProps extends MapBase
     return getTestId();
   }
 
-  void _assertComponentFactoryIsNotNull() {
+  /// Shared `assert` statements for use in [call] and [build].
+  void _sharedAsserts() {
+    assert(() {
+      if (_shouldValidateRequiredProps) {
+        validateRequiredProps();
+      }
+      return true;
+    }());
+
     // This is an assert since we're in a performance-sensitive area of the code, and only need
     // to provide this error message during development; in prod, a null exception will be triggered
     // down the line instead.
@@ -579,8 +587,8 @@ abstract class UiProps extends MapBase
   /// Returns a new component with this builder's [props] and the specified [children].
   ReactElement build([dynamic children]) {
     assert(_validateChildren(children));
+    _sharedAsserts();
 
-    _assertComponentFactoryIsNotNull();
     return componentFactory!(props, children);
   }
 
@@ -620,19 +628,14 @@ abstract class UiProps extends MapBase
         .toList();
     }
 
+    // Ideally we'd put this assert into _sharedAsserts, but we want to make sure this conditional child logic
+    // gets compiled out by directly nesting it within an `assert`.
     assert(_validateChildren(childArguments.length == 1 ? childArguments.single : childArguments));
-
-    assert(() {
-      if (_shouldValidateRequiredProps) {
-        validateRequiredProps();
-      }
-      return true;
-    }());
+    _sharedAsserts();
 
     // Use `build` instead of using emulated function behavior to work around DDC issue
     // https://github.com/dart-lang/sdk/issues/29904
     // Should have the benefit of better performance;
-    _assertComponentFactoryIsNotNull();
     return componentFactory!.build(props, childArguments);
   }
 

--- a/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
+++ b/test/over_react/component_declaration/builder_integration_tests/new_boilerplate/null_safety_validate_required_props_test.dart
@@ -24,17 +24,32 @@ void main() {
   group('(New boilerplate) validates required props:', () {
     group('non-nullable required prop', () {
       group('throws when a prop is required and not set', () {
-        test('on invocation', () {
-          expect(() {
-            (ComponentTest()
-              ..requiredNullable = true
-            )();
-          },
-              throwsA(isA<MissingRequiredPropsError>().having(
-                  (e) => e.toString(),
-                  'toString value',
-                  contains(
-                      'Required prop `requiredNonNullable` is missing.'))));
+        group('on invocation', () {
+          test('via call()', () {
+            expect(() {
+              (ComponentTest()
+                ..requiredNullable = true
+              )();
+            },
+                throwsA(isA<MissingRequiredPropsError>().having(
+                    (e) => e.toString(),
+                    'toString value',
+                    contains(
+                        'Required prop `requiredNonNullable` is missing.'))));
+          });
+
+          test('via build()', () {
+            expect(() {
+              (ComponentTest()
+                ..requiredNullable = true
+              ).build();
+            },
+                throwsA(isA<MissingRequiredPropsError>().having(
+                    (e) => e.toString(),
+                    'toString value',
+                    contains(
+                        'Required prop `requiredNonNullable` is missing.'))));
+          });
         });
 
         test('on mount', () {
@@ -85,16 +100,30 @@ void main() {
 
     group('nullable required prop', () {
       group('throws when a prop is required and not set', () {
-        test('on invocation', () {
-          expect(() {
-            (ComponentTest()
-              ..requiredNonNullable = true
-            )();
-          },
-              throwsA(isA<MissingRequiredPropsError>().having(
-                  (e) => e.toString(),
-                  'toString value',
-                  contains('Required prop `requiredNullable` is missing.'))));
+        group('on invocation', () {
+          test('via call()', () {
+            expect(() {
+              (ComponentTest()
+                ..requiredNonNullable = true
+              )();
+            },
+                throwsA(isA<MissingRequiredPropsError>().having(
+                    (e) => e.toString(),
+                    'toString value',
+                    contains('Required prop `requiredNullable` is missing.'))));
+          });
+
+          test('via build()', () {
+            expect(() {
+              (ComponentTest()
+                ..requiredNonNullable = true
+              ).build();
+            },
+                throwsA(isA<MissingRequiredPropsError>().having(
+                    (e) => e.toString(),
+                    'toString value',
+                    contains('Required prop `requiredNullable` is missing.'))));
+          });
         });
 
         test('on mount', () {
@@ -227,7 +256,8 @@ void main() {
 
   test('(New boilerplate) validates required props: does not throw in dart2js', () {
     expect(() {
-      rtl.render((ComponentTest())());
+      rtl.render(ComponentTest()());
+      rtl.render(ComponentTest().build());
     },
     returnsNormally);
   }, tags: 'no-ddc');

--- a/test/over_react/component_declaration/component_base_test.dart
+++ b/test/over_react/component_declaration/component_base_test.dart
@@ -47,10 +47,18 @@ main() {
       stopRecordingValidationWarnings();
     });
 
-    test('when a single non-invoked builder child is passed in', () {
-      expect(() => builder(Dom.div()), throwsArgumentError);
-      verifyValidationWarning(contains(
-          'It looks like you are trying to use a non-invoked builder as a child.'));
+    group('when a single non-invoked builder child is passed into', () {
+      test('call()', () {
+        expect(() => builder(Dom.div()), throwsArgumentError);
+        verifyValidationWarning(contains(
+            'It looks like you are trying to use a non-invoked builder as a child.'));
+      });
+
+      test('build()', () {
+        expect(() => builder.build(Dom.div()), throwsArgumentError);
+        verifyValidationWarning(contains(
+            'It looks like you are trying to use a non-invoked builder as a child.'));
+      });
     });
 
     test('when a list with a non-invoked builder child passed in', () {


### PR DESCRIPTION
## Motivation
I noticed in UiProps that we only perform required prop asserts in `call`, but not in `build`.

## Changes
- Move shared asserts for required prop validation and `componentFactory != null` into shared function, `_sharedAsserts`, and call from both `call` and `build`.
- Add tests for required prop validation in `build`
- Add missing test case for children validation in `build`

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
