### PR TITLE
TEST: over_react v5 and over_react_test v3 null-safe majors

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -31,4 +31,10 @@ dev_dependencies:
 
 dependency_overrides:
   over_react:
-    path: '../../../'
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: v5_wip
+  over_react_test:
+    git:
+      url: https://github.com/Workiva/over_react_test.git
+      ref: v3_wip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,3 +54,13 @@ dependency_validator:
     - tools/**
   ignore:
     - mockito
+
+dependency_overrides:
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: v5_wip
+  over_react_test:
+    git:
+      url: https://github.com/Workiva/over_react_test.git
+      ref: v3_wip

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -12,8 +12,8 @@ dev_dependencies:
 dependency_overrides:
   # Pull in the local copy of over_react so it pulls in the local copy of the plugin
   over_react:
-      path: ../../..
-
-workiva:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: v5_wipworkiva:
   core_checks:
     react_boilerplate: disabled

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -53,3 +53,13 @@ workiva:
 # dependency_overrides:
 #   over_react:
 #     path: /Users/me/workspaces/over_react
+
+dependency_overrides:
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: v5_wip
+  over_react_test:
+    git:
+      url: https://github.com/Workiva/over_react_test.git
+      ref: v3_wip

--- a/tools/analyzer_plugin/test/test_fixtures/over_react_project/pubspec.yaml
+++ b/tools/analyzer_plugin/test/test_fixtures/over_react_project/pubspec.yaml
@@ -4,3 +4,13 @@ environment:
 dependencies:
   over_react:
     path: ../../../../..
+
+dependency_overrides:
+  over_react:
+    git:
+      url: https://github.com/Workiva/over_react.git
+      ref: v5_wip
+  over_react_test:
+    git:
+      url: https://github.com/Workiva/over_react_test.git
+      ref: v3_wip


### PR DESCRIPTION
DO NOT MERGE. This PR adds dependency overrides to https://github.com/Workiva/over_react/tree/v5_wip and https://github.com/Workiva/over_react_test/tree/v3_wip
in order to test all consumers before merging and releasing them.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/over_react_5_test`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/over_react_5_test)