### PR TITLE
FED-2194 Fix Flux components when using mocked stores

### DIFF
--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -240,8 +240,9 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
 
   void _validateStoreDisposalState(Store store) {
     // We need a null-aware here since there are many mocked store classes
-    // in the wild that return null for isOrWillBeDisposed.
-    if (store.isOrWillBeDisposed) {
+    // in the wild that return null for isOrWillBeDisposed in unsound null safety.
+    // ignore: dead_null_aware_expression
+    if (store.isOrWillBeDisposed ?? false) {
       final componentName = getDebugNameForDartComponent(this);
 
       // Include the component name in the logger name so that:

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -238,11 +238,19 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
   /// These subscriptions are canceled when the component is unmounted.
   List<StreamSubscription> _subscriptions = [];
 
+  /// A utility method to cast a non-nullable value, that might be null in unsound null safety,
+  /// to a nullable value.
+  ///
+  /// This allows us to easily perform null-awares on values that should be null without getting the
+  /// noisy compiler warnings that are emitted when ignoring `dead_null_aware_expression` and
+  // `invalid_null_aware_operator`.
+  // ignore: unnecessary_cast
+  static T? _castAsNullable<T>(T value) => value as T?;
+
   void _validateStoreDisposalState(Store store) {
     // We need a null-aware here since there are many mocked store classes
     // in the wild that return null for isOrWillBeDisposed in unsound null safety.
-    // ignore: dead_null_aware_expression
-    if (store.isOrWillBeDisposed ?? false) {
+    if (_castAsNullable(store.isOrWillBeDisposed) ?? false) {
       final componentName = getDebugNameForDartComponent(this);
 
       // Include the component name in the logger name so that:
@@ -328,8 +336,7 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
     // Cancel all store subscriptions.
     _subscriptions
       // This can be null in unsound null safety when consumers are using mocked stores.
-      // ignore: invalid_null_aware_operator
-      ..forEach((subscription) => subscription?.cancel())
+      ..forEach((subscription) => _castAsNullable(subscription)?.cancel())
       ..clear();
   }
 

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -35,7 +35,7 @@ part 'flux_component.over_react.g.dart';
 /// __Example:__
 ///
 /// ```dart
-/// class YourComponentProps = UiProps 
+/// class YourComponentProps = UiProps
 ///     with FluxUiPropsMixin<YourFluxActionsClass, YourFluxStoreClass>;
 /// ```
 ///
@@ -327,7 +327,9 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
 
     // Cancel all store subscriptions.
     _subscriptions
-      ..forEach((subscription) => subscription.cancel())
+      // This can be null in unsound null safety when consumers are using mocked stores.
+      // ignore: invalid_null_aware_operator
+      ..forEach((subscription) => subscription?.cancel())
       ..clear();
   }
 

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -243,9 +243,11 @@ mixin _FluxComponentMixin<TProps extends FluxUiProps> on component_base.UiCompon
   ///
   /// This allows us to easily perform null-awares on values that should be null without getting the
   /// noisy compiler warnings that are emitted when ignoring `dead_null_aware_expression` and
-  // `invalid_null_aware_operator`.
-  // ignore: unnecessary_cast
-  static T? _castAsNullable<T>(T value) => value as T?;
+  /// `invalid_null_aware_operator`.
+  ///
+  /// Make the argument `T?` instead of `T` to help prevent any null errors if that argument gets
+  /// type-checked.
+  static T? _castAsNullable<T>(T? value) => value as T?; // ignore: unnecessary_cast
 
   void _validateStoreDisposalState(Store store) {
     // We need a null-aware here since there are many mocked store classes

--- a/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/flux_component_test.dart
@@ -325,9 +325,9 @@ class TestStoreWithCustomName extends Store {
 }
 
 class TestStores {
-  TestStore store1 = TestStore();
-  TestStore store2 = TestStore();
-  TestStore store3 = TestStore();
+  final TestStore store1 = TestStore();
+  final TestStore store2 = TestStore();
+  final TestStore store3 = TestStore();
 }
 
 abstract class BaseTestComponents {

--- a/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
@@ -1,0 +1,85 @@
+//@dart=2.11
+
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests adapted from <https://github.com/Workiva/w_flux/blob/1.0.1/test/component_test.dart>.
+
+library over_react.component_declaration.component2.unsound_flux_component_test;
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/test_util.dart';
+import 'flux_component_test.dart';
+
+// These tests are only possible in unsound null safety, otherwise we'll get null errors
+// when the mocks return null when they shouldn't.
+void main() {
+  void sharedComponentTests(BaseTestComponents testComponents) {
+    group(
+        'mounts, rerenders, and unmounts properly when using a mock store that returns null'
+        ' for members like .listen and isOrWillBeDisposed', () {
+      test('basic usage', () async {
+        final mockStore = MockTestStore();
+        final jacket = mount((testComponents.basic()..store = mockStore)());
+        await pumpEventQueue();
+        verify(mockStore.listen(any));
+        jacket.rerender((testComponents.basic()..store = mockStore)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+
+      test('with redrawOn override', () async {
+        final mockStores = MockedTestStores();
+        final jacket = mount((testComponents.redrawOn()..store = mockStores)());
+        await pumpEventQueue();
+        verify(mockStores.store1.listen(any));
+        verify(mockStores.store2.listen(any));
+        jacket.rerender((testComponents.redrawOn()..store = mockStores)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+
+      test('with storeHandlers override', () async {
+        final mockStore = MockTestStore();
+        final jacket = mount((testComponents.storeHandlers()..store = mockStore)());
+        await pumpEventQueue();
+        verify(mockStore.listen(any));
+        jacket.rerender((testComponents.storeHandlers()..store = mockStore)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+    });
+  }
+
+  group('FluxUiComponent', () {
+    sharedComponentTests(TestComponents());
+  });
+
+  group('FluxUiStatefulComponent', () {
+    sharedComponentTests(TestStatefulComponents());
+  });
+}
+
+class MockTestStore extends Mock implements TestStore {}
+
+class MockedTestStores implements TestStores {
+  @override
+  final TestStore store1 = MockTestStore();
+  @override
+  final TestStore store2 = MockTestStore();
+  @override
+  final TestStore store3 = MockTestStore();
+}

--- a/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
@@ -35,9 +35,13 @@ void main() {
         final mockStore = MockTestStore();
         final jacket = mount((testComponents.basic()..store = mockStore)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock store.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStore.listen(any));
+        verify(mockStore.isOrWillBeDisposed);
         jacket.rerender((testComponents.basic()..store = mockStore)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
 
@@ -45,10 +49,15 @@ void main() {
         final mockStores = MockedTestStores();
         final jacket = mount((testComponents.redrawOn()..store = mockStores)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock stores.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStores.store1.listen(any));
+        verify(mockStores.store1.isOrWillBeDisposed);
         verify(mockStores.store2.listen(any));
+        verify(mockStores.store2.isOrWillBeDisposed);
         jacket.rerender((testComponents.redrawOn()..store = mockStores)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
 
@@ -56,9 +65,13 @@ void main() {
         final mockStore = MockTestStore();
         final jacket = mount((testComponents.storeHandlers()..store = mockStore)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock store.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStore.listen(any));
+        verify(mockStore.isOrWillBeDisposed);
         jacket.rerender((testComponents.storeHandlers()..store = mockStore)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
     });

--- a/test/over_react/component_declaration/flux_component_test/flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/flux_component_test.dart
@@ -252,9 +252,9 @@ class TestActions {}
 class TestStore extends Store {}
 
 class TestStores {
-  TestStore store1 = TestStore();
-  TestStore store2 = TestStore();
-  TestStore store3 = TestStore();
+  final TestStore store1 = TestStore();
+  final TestStore store2 = TestStore();
+  final TestStore store3 = TestStore();
 }
 
 abstract class BaseTestComponents {

--- a/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
@@ -1,0 +1,85 @@
+//@dart=2.11
+
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests adapted from <https://github.com/Workiva/w_flux/blob/1.0.1/test/component_test.dart>.
+
+library over_react.component_declaration.unsound_flux_component_test;
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/test_util.dart';
+import 'flux_component_test.dart';
+
+// These tests are only possible in unsound null safety, otherwise we'll get null errors
+// when the mocks return null when they shouldn't.
+void main() {
+  void sharedComponentTests(BaseTestComponents testComponents) {
+    group(
+        'mounts, rerenders, and unmounts properly when using a mock store that returns null'
+        ' for members like .listen and isOrWillBeDisposed', () {
+      test('basic usage', () async {
+        final mockStore = MockTestStore();
+        final jacket = mount((testComponents.basic()..store = mockStore)());
+        await pumpEventQueue();
+        verify(mockStore.listen(any));
+        jacket.rerender((testComponents.basic()..store = mockStore)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+
+      test('with redrawOn override', () async {
+        final mockStores = MockedTestStores();
+        final jacket = mount((testComponents.redrawOn()..store = mockStores)());
+        await pumpEventQueue();
+        verify(mockStores.store1.listen(any));
+        verify(mockStores.store2.listen(any));
+        jacket.rerender((testComponents.redrawOn()..store = mockStores)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+
+      test('with storeHandlers override', () async {
+        final mockStore = MockTestStore();
+        final jacket = mount((testComponents.storeHandlers()..store = mockStore)());
+        await pumpEventQueue();
+        verify(mockStore.listen(any));
+        jacket.rerender((testComponents.storeHandlers()..store = mockStore)());
+        await pumpEventQueue();
+        jacket.unmount();
+      });
+    });
+  }
+
+  group('FluxUiComponent', () {
+    sharedComponentTests(TestComponents());
+  });
+
+  group('FluxUiStatefulComponent', () {
+    sharedComponentTests(TestStatefulComponents());
+  });
+}
+
+class MockTestStore extends Mock implements TestStore {}
+
+class MockedTestStores implements TestStores {
+  @override
+  final TestStore store1 = MockTestStore();
+  @override
+  final TestStore store2 = MockTestStore();
+  @override
+  final TestStore store3 = MockTestStore();
+}

--- a/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
@@ -35,9 +35,13 @@ void main() {
         final mockStore = MockTestStore();
         final jacket = mount((testComponents.basic()..store = mockStore)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock store.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStore.listen(any));
+        verify(mockStore.isOrWillBeDisposed);
         jacket.rerender((testComponents.basic()..store = mockStore)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
 
@@ -45,10 +49,15 @@ void main() {
         final mockStores = MockedTestStores();
         final jacket = mount((testComponents.redrawOn()..store = mockStores)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock stores.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStores.store1.listen(any));
+        verify(mockStores.store1.isOrWillBeDisposed);
         verify(mockStores.store2.listen(any));
+        verify(mockStores.store2.isOrWillBeDisposed);
         jacket.rerender((testComponents.redrawOn()..store = mockStores)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
 
@@ -56,9 +65,13 @@ void main() {
         final mockStore = MockTestStore();
         final jacket = mount((testComponents.storeHandlers()..store = mockStore)());
         await pumpEventQueue();
+        // Mainly verify that the test is set up properly component is interacting with the mock store.
+        // While we're here, we can also verify that it hits all the APIs we've encountered null errors with.
         verify(mockStore.listen(any));
+        verify(mockStore.isOrWillBeDisposed);
         jacket.rerender((testComponents.storeHandlers()..store = mockStore)());
         await pumpEventQueue();
+        // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
     });

--- a/test/over_react_component_declaration_non_null_safe_test.dart
+++ b/test/over_react_component_declaration_non_null_safe_test.dart
@@ -25,6 +25,9 @@ library over_react_test;
 import 'package:over_react/over_react.dart';
 import 'package:test/test.dart';
 
+import 'over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart' as unsound_flux_component_test;
+import 'over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart' as unsound_component2_flux_component_test;
+
 import 'over_react/component_declaration/non_null_safe_builder_integration_tests/abstract_accessor_integration_test.dart' as abstract_accessor_integration_test;
 import 'over_react/component_declaration/non_null_safe_builder_integration_tests/accessor_mixin_integration_test.dart' as accessor_mixin_integration_test;
 import 'over_react/component_declaration/non_null_safe_builder_integration_tests/component_integration_test.dart' as component_integration_test;
@@ -74,6 +77,9 @@ import 'over_react/component_declaration/non_null_safe_builder_integration_tests
 
 main() {
   enableTestMode();
+
+  unsound_flux_component_test.main();
+  unsound_component2_flux_component_test.main();
 
   abstract_accessor_integration_test.main();
   accessor_mixin_integration_test.main();


### PR DESCRIPTION
## Motivation
When using mocked stores in flux components, consumers currently get errors like this:
```
NoSuchMethodError: method not found: 'cancel$0' on null
  /packages/over_react/src/component_declaration/flux_component.dart 329:35  _FluxUiComponent2.UiComponent2.BatchedRedraws._FluxComponentMixin.componentWillUnmount.<fn>
  /_internal/js_runtime/lib/js_array.dart 322:7                              Interceptor.forEach
  /packages/react/src/react_client/dart_interop_statics.dart 289:9           ReactDartInteropStatics2.handleComponentWillUnmount.<fn>
  /async/zone.dart 1398:12                                                   StaticClosure._rootRun
  /async/zone.dart 1299:34                                                   _CustomZone.run
  /packages/react/src/react_client/dart_interop_statics.dart 288:7           StaticClosure.ReactDartInteropStatics2.handleComponentWillUnmount
```
This is because the return value of `listen` is expected to be a non-null `StreamSubscription`, but for mock classes that haven't stubbed that method, it returns null.

In unsound null safety, this causes the above error stemming from over_react. 

A similar error happens with `.isOrWillBeDisposed`.

In sound null safety, the error happens earlier when the mock's null return value is casted to a non-nullable method by Dart, yielding a similar error, with a `dart:sdk_internal` `as`in the stack. For this case, we get the error when the subscription is created, before it can even get put in the subscriptions list.
```dart
Expected a value of type 'StreamSubscription<Store>', but got one of type 'Null'
  dart:sdk_internal                                                                                       as_C
  package:over_react/src/component_declaration/flux_component.dart 296:46                                 <fn>
```
This is clearer in the JS stack trace
```
Expected a value of type 'StreamSubscription<Store>', but got one of type 'Null'
    at Object.throw_ [as throw] (dart_sdk.sound.js:4726:11)
    at Object.castError (dart_sdk.sound.js:4685:15)
    at Object.cast [as as] (dart_sdk.sound.js:5006:17)
    at StreamSubscription.as_C [as as] (dart_sdk.sound.js:4608:19)
    at unsound_flux_component_test.MockTestStore.new.listen (unsound_flux_component_test.sound.ddc.js:385:45)
    at flux_component_test._$TestBasicComponent.new.listenToStoreForRedraw (component_base.sound.ddc.js:27803:50)
```

Once consumers get to sound null safety, it seems like the only option may be to actually stub in those members.

## Changes
- Add regression tests
- Work around null errors in unsound null safety for `.listen` and `. isOrWillBeDisposed`

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify regression tests fail in ff0a17baec1ff8a1c2b4f6f346ab50a44bb2944c, before the fix was implemented
        - Verify CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
