### PR TITLE
FED-2239 Analyze analyzer_plugin in CI, fix warnings

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -154,6 +154,10 @@ jobs:
         run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
+      - name: Analyze
+        run: dart run dart_dev analyze
+        if: always() && steps.install.outcome == 'success'
+
       - name: Verify formatting
         run: dart run dart_dev format --check
         if: always() && matrix.sdk == '2.7.2' && steps.install.outcome == 'success'

--- a/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
+++ b/tools/analyzer_plugin/lib/src/async_plugin_apis/diagnostic.dart
@@ -44,7 +44,6 @@ import 'package:analyzer_plugin/protocol/protocol_generated.dart';
 
 // ignore: implementation_imports
 import 'package:analyzer_plugin/src/utilities/fixes/fixes.dart' show DartFixesRequestImpl;
-import 'package:analyzer_plugin/utilities/completion/completion_core.dart';
 import 'package:analyzer_plugin/utilities/fixes/fixes.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react_analyzer_plugin/src/async_plugin_apis/error_severity_provider.dart';

--- a/tools/analyzer_plugin/lib/src/component_usage.dart
+++ b/tools/analyzer_plugin/lib/src/component_usage.dart
@@ -152,12 +152,12 @@ class FluentComponentUsage {
   Iterable<PropAssignment> get cascadedProps => cascadeSections
       .whereType<AssignmentExpression>()
       .where((assignment) => assignment.leftHandSide is PropertyAccess)
-      .map((assignment) => PropAssignment(assignment));
+      .map(PropAssignment.new);
 
   /// The prop reads cascaded on this usage's builder.
   ///
   /// See also: other `cascaded`* methods in this class.
-  Iterable<PropRead> get cascadedGetters => cascadeSections.whereType<PropertyAccess>().map((p) => PropRead(p));
+  Iterable<PropRead> get cascadedGetters => cascadeSections.whereType<PropertyAccess>().map(PropRead.new);
 
   /// The index prop assignments cascaded on this usage's builder.
   ///
@@ -165,14 +165,14 @@ class FluentComponentUsage {
   Iterable<IndexPropAssignment> get cascadedIndexAssignments => cascadeSections
       .whereType<AssignmentExpression>()
       .where((assignment) => assignment.leftHandSide is IndexExpression)
-      .map((assignment) => IndexPropAssignment(assignment));
+      .map(IndexPropAssignment.new);
 
   /// The method calls cascaded on this usage's builder.
   ///
   /// See also: other `cascaded`* methods in this class.
   Iterable<BuilderMethodInvocation> get cascadedMethodInvocations => cascadeSections
       .whereType<MethodInvocation>()
-      .map((methodInvocation) => BuilderMethodInvocation(methodInvocation));
+      .map(BuilderMethodInvocation.new);
 
   /// All the cascades on this usage's builder, each wrapped in one of the
   /// [BuilderMemberAccess] subtypes.
@@ -188,7 +188,7 @@ class FluentComponentUsage {
 
     final allUnhandledMembers = cascadeSections
         .where((section) => !allHandledMembers.any((m) => m.node == section))
-        .map((section) => OtherBuilderMemberAccess(section))
+        .map(OtherBuilderMemberAccess.new)
         .toList();
 
     return [

--- a/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/boilerplate_validator.dart
@@ -80,7 +80,7 @@ class BoilerplateValidatorDiagnostic extends DiagnosticContributor {
     final debugMatch = _debugCommentPattern.firstMatch(result.content);
     final debug = debugMatch != null;
     if (debug) {
-      collector.addError(debugCode, result.location(offset: debugMatch!.start, end: debugMatch.end),
+      collector.addError(debugCode, result.location(offset: debugMatch.start, end: debugMatch.end),
           errorMessageArgs: ['Boilerplate debugging hints enabled']);
     }
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/exhaustive_deps.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/exhaustive_deps.dart
@@ -926,7 +926,7 @@ class ExhaustiveDeps extends DiagnosticContributor {
         }
 
         Expression? maybeID = declaredDependencyNode;
-        while (maybeID is PropertyAccess || maybeID is PrefixedIdentifier) {
+        while (maybeID != null && (maybeID is PropertyAccess || maybeID is PrefixedIdentifier)) {
           if (maybeID is PropertyAccess) {
             maybeID = maybeID.target;
           } else {

--- a/tools/analyzer_plugin/lib/src/diagnostic/visitors/non_static_reference_visitor.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/visitors/non_static_reference_visitor.dart
@@ -59,6 +59,7 @@ class ReferenceVisitor extends RecursiveAstVisitor<void> {
 bool referencesImplicitThis(SimpleIdentifier identifier) {
   // prepare element
   final element = identifier.staticElement;
+  if (element == null) return false;
   if (!(element is MethodElement || element is PropertyAccessorElement)) {
     return false;
   }

--- a/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/boilerplate_validator_test.dart
@@ -7,8 +7,6 @@ import 'package:test/test.dart';
 import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import '../matchers.dart';
-import '../matchers.dart';
-import '../matchers.dart';
 import '../test_bases/diagnostic_test_base.dart';
 
 void main() {

--- a/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/ast_util_test.dart
@@ -183,7 +183,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as FunctionDeclaration).name.lexeme, 'foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as FunctionDeclaration).name.lexeme, 'foo');
         });
 
         test('looks up a variable', () async {
@@ -196,7 +196,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as VariableDeclaration).name.lexeme, 'foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as VariableDeclaration).name.lexeme, 'foo');
         });
 
         test('looks up a class', () async {
@@ -210,7 +210,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'Foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as ClassDeclaration).name.lexeme, 'Foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as ClassDeclaration).name.lexeme, 'Foo');
         });
 
         group('returns null when', () {

--- a/tools/analyzer_plugin/test/unit/util/component_usage_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/component_usage_test.dart
@@ -281,9 +281,9 @@ void main() {
                 isResolved: true,
               );
 
-              expect(expressionNode.argumentList.arguments.firstOrNull, isNotNull);
-              expect(expressionNode.argumentList.arguments.firstOrNull, isA<InvocationExpression>());
-              childExpression = expressionNode.argumentList.arguments.firstOrNull as InvocationExpression;
+              expect(expressionNode.argumentList.arguments, isNotEmpty);
+              expect(expressionNode.argumentList.arguments.first, isA<InvocationExpression>());
+              childExpression = expressionNode.argumentList.arguments.first as InvocationExpression;
               expect(childExpression.toSource(), childSource);
             });
 

--- a/tools/analyzer_plugin/test/unit/util/non_null_safe/ast_util_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/non_null_safe/ast_util_test.dart
@@ -196,7 +196,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as FunctionDeclaration).name.lexeme, 'foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as FunctionDeclaration).name.lexeme, 'foo');
         });
 
         test('looks up a variable', () async {
@@ -210,7 +210,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as VariableDeclaration).name.lexeme, 'foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as VariableDeclaration).name.lexeme, 'foo');
         });
 
         test('looks up a class', () async {
@@ -225,7 +225,7 @@ void main() {
           final usage = getAllPrintedExpressions(unit).single as Identifier;
           expect(usage.name, 'Foo', reason: 'test setup check');
           expect(usage.staticElement, isNotNull, reason: 'test setup check');
-          expect((lookUpDeclaration(usage.staticElement!, unit) as ClassDeclaration).name.lexeme, 'Foo');
+          expect((lookUpDeclaration(usage.staticElement!, unit)! as ClassDeclaration).name.lexeme, 'Foo');
         });
 
         group('returns null when', () {

--- a/tools/analyzer_plugin/test/unit/util/non_null_safe/component_usage_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/non_null_safe/component_usage_test.dart
@@ -282,9 +282,9 @@ void main() {
                 isResolved: true,
               );
 
-              expect(expressionNode.argumentList.arguments.firstOrNull, isNotNull);
-              expect(expressionNode.argumentList.arguments.firstOrNull, isA<InvocationExpression>());
-              childExpression = expressionNode.argumentList.arguments.firstOrNull as InvocationExpression;
+              expect(expressionNode.argumentList.arguments, isNotEmpty);
+              expect(expressionNode.argumentList.arguments.first, isA<InvocationExpression>());
+              childExpression = expressionNode.argumentList.arguments.first as InvocationExpression;
               expect(childExpression.toSource(), childSource);
             });
 

--- a/tools/analyzer_plugin/tool/doc.dart
+++ b/tools/analyzer_plugin/tool/doc.dart
@@ -50,9 +50,9 @@ final configs = [
     getSortedContributorMetas: () => RulesIndexer.rules,
     typeNameOfContributorClass: 'DiagnosticContributor',
     typeNameOfAnnotatedField: 'DiagnosticCode',
-    getMeta: (el) => DocumentedDiagnosticContributorMeta.fromAnnotatedField(el),
+    getMeta: DocumentedDiagnosticContributorMeta.fromAnnotatedField,
     getPageGenerator: (meta) => RuleDocGenerator(meta as DocumentedDiagnosticContributorMeta),
-    getIndexGenerator: () => RulesIndexer(),
+    getIndexGenerator: RulesIndexer.new,
     generateAdditionalDocs: (outDir) => OptionsSample(RulesIndexer.rules).generate(outDir),
   ),
   DocsGenerationConfig(
@@ -63,9 +63,9 @@ final configs = [
     typeNameOfContributorClass: 'AssistContributorBase',
     typeNameOfAnnotatedField: 'AssistKind',
     packageNameContainingAnnotatedFieldType: 'analyzer_plugin',
-    getMeta: (el) => DocumentedAssistContributorMeta.fromAnnotatedFieldAst(el),
+    getMeta: DocumentedAssistContributorMeta.fromAnnotatedFieldAst,
     getPageGenerator: (meta) => AssistDocGenerator(meta as DocumentedAssistContributorMeta),
-    getIndexGenerator: () => AssistsIndexer(),
+    getIndexGenerator: AssistsIndexer.new,
   ),
 ];
 


### PR DESCRIPTION
## Motivation
I kept seeing analysis warnings locally in the analyzer plugin directory, and figured they must be only happening locally, otherwise they'd be failing CI.

Turns out, we weren't analyzing the analyzer plugin in CI 😅.

## Changes
- Add CI step to run analysis on the analyzer_plugin directory
- Fix all warnings

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI runs analysis and fails on warnings before they were fixed in https://github.com/Workiva/over_react/actions/runs/7908062168/job/21586466107
        - CI passes on latest commit
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
