### PR TITLE
FED-2242 Stop exporting meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@
     - `ReduxMultiProviderProps.storesByContext`
     - `ReduxProviderProps.store`
 - UiPropsMapView (deprecated) is now abstract and requires subclasses to override `selfFactory`
-- `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
-- `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)
+- Other changes that we don't expect to affect consumers:
+  - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
+  - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)
+  - `ConnectPropsMixin` now `implements UiProps` (the one exported from `package:over_react/over_react.dart`) instead of `UiProps`'s superclass of the name, `component_base.UiProps`.
  
 ## [4.10.3](https://github.com/Workiva/over_react/compare/4.10.2...4.10.3)
 - [#846] Update internals to prepare for react-dart 7.0.0

--- a/lib/src/builder/codegen/accessors_generator.dart
+++ b/lib/src/builder/codegen/accessors_generator.dart
@@ -376,7 +376,7 @@ abstract class TypedMapAccessorsGenerator extends BoilerplateDeclarationGenerato
         version != Version.v3_legacyDart2Only &&
         version != Version.v2_legacyBackwardsCompat) {
       final validateRequiredPropsMethod = '\n  @override\n'
-          '  @mustCallSuper\n'
+          '  @UiProps.\$mustCallSuper\n'
           '  void validateRequiredProps() {\n'
           '    super.validateRequiredProps();\n'
           '    ${requiredPropChecks.join('\n')}\n'

--- a/lib/src/component/abstract_transition_props.over_react.g.dart
+++ b/lib/src/component/abstract_transition_props.over_react.g.dart
@@ -105,7 +105,7 @@ mixin $TransitionPropsMixin on TransitionPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/component/error_boundary.over_react.g.dart
+++ b/lib/src/component/error_boundary.over_react.g.dart
@@ -367,7 +367,7 @@ mixin $ErrorBoundaryProps on ErrorBoundaryProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/component/resize_sensor.over_react.g.dart
+++ b/lib/src/component/resize_sensor.over_react.g.dart
@@ -281,7 +281,7 @@ mixin $ResizeSensorProps on ResizeSensorProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/component/suspense_component.over_react.g.dart
+++ b/lib/src/component/suspense_component.over_react.g.dart
@@ -30,7 +30,7 @@ mixin $SuspensePropsMixin on SuspensePropsMixin {
   static const List<String> $propKeys = [_$key__fallback__SuspensePropsMixin];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/component/with_transition.over_react.g.dart
+++ b/lib/src/component/with_transition.over_react.g.dart
@@ -315,7 +315,7 @@ mixin $WithTransitionPropsMixin on WithTransitionPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/component_declaration/annotations.dart
+++ b/lib/src/component_declaration/annotations.dart
@@ -15,9 +15,6 @@
 // Dummy annotations that would be used by Pub code generator
 library over_react.component_declaration.annotations;
 
-// Exported for use in generated code.
-export 'package:meta/meta.dart' show mustCallSuper;
-
 /// Annotation used with the `over_react` builder to declare a `UiFactory` for a component.
 ///
 ///     @Factory()

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -146,6 +146,11 @@ abstract class UiProps extends component_base.UiProps with GeneratedClass {
   @toBeGenerated
   @visibleForOverriding
   String $getPropKey(void Function(Map m) accessMap) => throw UngeneratedError(member: #$getPropKey);
+
+  /// An alias to [mustCallSuper] so that generated code can reference it without us having
+  /// to re-export it from `package:over_react/over_react.dart`.
+  @protected
+  static const $mustCallSuper = mustCallSuper;
 }
 
 class MissingRequiredPropsError extends Error {

--- a/lib/src/component_declaration/flux_component.over_react.g.dart
+++ b/lib/src/component_declaration/flux_component.over_react.g.dart
@@ -51,7 +51,7 @@ mixin $FluxUiPropsMixin<ActionsT, StoresT>
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('FluxUiPropsMixin.actions') &&

--- a/lib/src/over_react_redux/over_react_redux.dart
+++ b/lib/src/over_react_redux/over_react_redux.dart
@@ -18,10 +18,8 @@ library over_react_redux;
 
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/component_base.dart';
-import 'package:over_react/src/component_declaration/annotations.dart';
-import 'package:over_react/src/component_declaration/builder_helpers.dart' as builder_helpers;
-import 'package:over_react/src/component_declaration/builder_helpers.dart' show MissingRequiredPropsError;
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:over_react/src/component_declaration/function_component.dart';
 import 'package:over_react/src/util/context.dart';
@@ -157,7 +155,7 @@ typedef dynamic Dispatcher(dynamic action);
 /// - [forwardRef] if `true`, the `ref` prop provided to the connected component will be return the wrapped component.
 ///
 /// For more info see: https://react-redux.js.org/api/connect#connect
-UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extends UiProps>({
+UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extends component_base.UiProps>({
   Map Function(TReduxState state)? mapStateToProps,
   Map Function(TReduxState state, TProps ownProps)? mapStateToPropsWithOwnProps,
   Map Function(TReduxState state) Function(TReduxState initialState, TProps initialOwnProps)? makeMapStateToProps,
@@ -196,7 +194,7 @@ UiFactory<TProps> Function(UiFactory<TProps>) connect<TReduxState, TProps extend
     final dartComponentClass = dartComponentFactory.type;
     enforceMinimumComponentVersionFor(dartComponentFactory);
 
-    JsMap jsMapFromProps(Map props) => jsBackingMapOrJsCopy(props is UiProps ? props.props : props);
+    JsMap jsMapFromProps(Map props) => jsBackingMapOrJsCopy(props is component_base.UiProps ? props.props : props);
 
     TProps jsPropsToTProps(JsMap jsProps) => factory(JsBackedMap.backedBy(jsProps));
 
@@ -444,7 +442,7 @@ mixin ReduxProviderPropsMixin on UiProps {
 /// - `context` - You may provide a context instance. If you do so, you will need to provide the same context instance to all of your connected components as well.
 ///
 /// See: <https://react-redux.js.org/api/provider>
-class ReduxProviderProps = builder_helpers.UiProps with ReduxProviderPropsMixin;
+class ReduxProviderProps = UiProps with ReduxProviderPropsMixin;
 
 /// [ReduxProvider] makes the store available to any nested components that have been wrapped in the `connect()` function.
 ///

--- a/lib/src/over_react_redux/over_react_redux.over_react.g.dart
+++ b/lib/src/over_react_redux/over_react_redux.over_react.g.dart
@@ -79,7 +79,7 @@ mixin $ReduxProviderPropsMixin on ReduxProviderPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('store') &&

--- a/lib/src/util/context.over_react.g.dart
+++ b/lib/src/util/context.over_react.g.dart
@@ -30,7 +30,7 @@ mixin $_ProviderPropsMixin<TValue> on _ProviderPropsMixin<TValue> {
   static const List<String> $propKeys = [_$key__value___ProviderPropsMixin];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('value') &&
@@ -77,7 +77,7 @@ mixin $_ConsumerPropsMixin<TValue> on _ConsumerPropsMixin<TValue> {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.over_react.g.dart
@@ -300,7 +300,7 @@ mixin $SafeRenderManagerHelperProps on SafeRenderManagerHelperProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/abstract_transition_test.over_react.g.dart
+++ b/test/over_react/component/abstract_transition_test.over_react.g.dart
@@ -406,7 +406,7 @@ mixin $TransitionerPropsMixin on TransitionerPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/context_test.over_react.g.dart
+++ b/test/over_react/component/context_test.over_react.g.dart
@@ -501,7 +501,7 @@ mixin $ContextTypeDynamicProps on ContextTypeDynamicProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -526,7 +526,7 @@ mixin $ContextTypeWithoutDefaultProps on ContextTypeWithoutDefaultProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -551,7 +551,7 @@ mixin $ContextTypeWithDefaultProps on ContextTypeWithDefaultProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/element_type_test.over_react.g.dart
+++ b/test/over_react/component/element_type_test.over_react.g.dart
@@ -175,7 +175,7 @@ mixin $CustomTestProps on CustomTestProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -200,7 +200,7 @@ mixin $CustomFnTestProps on CustomFnTestProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/error_boundary/shared_stack_tests.over_react.g.dart
+++ b/test/over_react/component/error_boundary/shared_stack_tests.over_react.g.dart
@@ -276,7 +276,7 @@ mixin $ThrowingComponent2Props on ThrowingComponent2Props {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -301,7 +301,7 @@ mixin $ThrowingFunctionComponentProps on ThrowingFunctionComponentProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -326,7 +326,7 @@ mixin $ThrowingForwardRefComponentProps on ThrowingForwardRefComponentProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/fixtures/lazy_load_me_props.over_react.g.dart
+++ b/test/over_react/component/fixtures/lazy_load_me_props.over_react.g.dart
@@ -33,7 +33,7 @@ mixin $LazyLoadMePropsMixin on LazyLoadMePropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
+++ b/test/over_react/component/fixtures/pure_test_components.over_react.g.dart
@@ -456,7 +456,7 @@ mixin $PureTestPropsMixin on PureTestPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -508,7 +508,7 @@ mixin $SharedPureTestPropsMixin on SharedPureTestPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/memo_test.over_react.g.dart
+++ b/test/over_react/component/memo_test.over_react.g.dart
@@ -220,7 +220,7 @@ mixin $FunctionCustomPropsProps on FunctionCustomPropsProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component/ref_util_test.over_react.g.dart
+++ b/test/over_react/component/ref_util_test.over_react.g.dart
@@ -180,7 +180,7 @@ mixin $BasicProps on BasicProps {
   static const List<String> $propKeys = [_$key__childId__BasicProps];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -205,7 +205,7 @@ mixin $BasicUiFunctionProps on BasicUiFunctionProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
+++ b/test/over_react/component_declaration/function_type_checking_test/components.over_react.g.dart
@@ -201,7 +201,7 @@ mixin $TestAProps on TestAProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -226,7 +226,7 @@ mixin $TestBProps on TestBProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -251,7 +251,7 @@ mixin $TestParentProps on TestParentProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -276,7 +276,7 @@ mixin $TestSubtypeProps on TestSubtypeProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -301,7 +301,7 @@ mixin $TestSubsubtypeProps on TestSubsubtypeProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -326,7 +326,7 @@ mixin $TestExtendtypeProps on TestExtendtypeProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -351,7 +351,7 @@ mixin $OneLevelWrapperProps on OneLevelWrapperProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -376,7 +376,7 @@ mixin $TwoLevelWrapperProps on TwoLevelWrapperProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -403,7 +403,7 @@ mixin $DoNotReferenceThisFactoryExceptForInASingleTestProps
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -429,7 +429,7 @@ mixin $TestUninitializedParentProps on TestUninitializedParentProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
+++ b/test/over_react/component_declaration/ui_props_self_typed_extension_test.over_react.g.dart
@@ -58,7 +58,7 @@ mixin $TestProps on TestProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
     if (!props.containsKey('TestProps.requiredProp') &&

--- a/test/over_react/util/cast_ui_factory_test.over_react.g.dart
+++ b/test/over_react/util/cast_ui_factory_test.over_react.g.dart
@@ -173,7 +173,7 @@ mixin $BasicProps on BasicProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/util/component_debug_name_test.over_react.g.dart
+++ b/test/over_react/util/component_debug_name_test.over_react.g.dart
@@ -270,7 +270,7 @@ mixin $TestComponent2Props on TestComponent2Props {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/util/js_component_test.over_react.g.dart
+++ b/test/over_react/util/js_component_test.over_react.g.dart
@@ -72,7 +72,7 @@ mixin $TestPropsMixin on TestPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -121,7 +121,7 @@ mixin $ASecondPropsMixin on ASecondPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react/util/prop_conversion_test.over_react.g.dart
+++ b/test/over_react/util/prop_conversion_test.over_react.g.dart
@@ -190,7 +190,7 @@ mixin $ExpectsDartMapPropProps on ExpectsDartMapPropProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -215,7 +215,7 @@ mixin $ExpectsDartStylePropProps on ExpectsDartStylePropProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -240,7 +240,7 @@ mixin $ExpectsListChildrenPropProps on ExpectsListChildrenPropProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -265,7 +265,7 @@ mixin $ClassComponentProps on ClassComponentProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -290,7 +290,7 @@ mixin $BasicForwardRefProps on BasicForwardRefProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -330,7 +330,7 @@ mixin $DartTestJsWrapperPropsMixin on DartTestJsWrapperPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -443,7 +443,7 @@ mixin $TestJsProps on TestJsProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react_redux/fixtures/counter_fn.over_react.g.dart
+++ b/test/over_react_redux/fixtures/counter_fn.over_react.g.dart
@@ -34,7 +34,7 @@ mixin $CounterFnProps on CounterFnProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -79,7 +79,7 @@ mixin $ModelCounterFnPropsMixin on ModelCounterFnPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -124,7 +124,7 @@ mixin $CustomContextCounterFnPropsMixin on CustomContextCounterFnPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_dispatch_test.over_react.g.dart
@@ -19,7 +19,7 @@ mixin $UseDispatchCounterFnProps on UseDispatchCounterFnProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -45,7 +45,7 @@ mixin $CustomContextUseDispatchCounterFnProps
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react_redux/hooks/use_store_test.over_react.g.dart
+++ b/test/over_react_redux/hooks/use_store_test.over_react.g.dart
@@ -19,7 +19,7 @@ mixin $UseStoreCounterFnProps on UseStoreCounterFnProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -45,7 +45,7 @@ mixin $CustomContextUseStoreCounterFnProps
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test/over_react_redux/store_bindings_tests.over_react.g.dart
+++ b/test/over_react_redux/store_bindings_tests.over_react.g.dart
@@ -47,7 +47,7 @@ mixin $TestSelectorProps on TestSelectorProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -87,7 +87,7 @@ mixin $TestConnectPropsMixin on TestConnectPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic.over_react.g.dart.goldFile
@@ -239,7 +239,7 @@ mixin $BasicProps on BasicProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_library.over_react.g.dart.goldFile
@@ -352,7 +352,7 @@ mixin $BasicPartOfLibPropsMixin on BasicPartOfLibPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -592,7 +592,7 @@ mixin $SuperPartOfLibPropsMixin on SuperPartOfLibPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -631,7 +631,7 @@ mixin $SubPartOfLibPropsMixin on SubPartOfLibPropsMixin {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/basic_two_nine.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/basic_two_nine.over_react.g.dart.goldFile
@@ -239,7 +239,7 @@ mixin $BasicProps on BasicProps {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/missing_over_react_g_part/library.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/missing_over_react_g_part/library.over_react.g.dart.goldFile
@@ -189,7 +189,7 @@ mixin $BasicPartOfLibProps on BasicPartOfLibProps {
   static const List<String> $propKeys = [_$key__basicProp__BasicPartOfLibProps];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/props_mixin.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/props_mixin.over_react.g.dart.goldFile
@@ -32,7 +32,7 @@ mixin $ExamplePropsMixin on ExamplePropsMixin {
   static const List<String> $propKeys = [_$key__propMixin1__ExamplePropsMixin];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -74,7 +74,7 @@ mixin $RequiresOtherMixinPropsMixin<T extends Iterable, U>
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/two_nine_with_multiple_factories.over_react.g.dart.goldfile
+++ b/test_fixtures/gold_output_files/mixin_based/two_nine_with_multiple_factories.over_react.g.dart.goldfile
@@ -184,7 +184,7 @@ mixin $CounterPropsMixin on CounterPropsMixin {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }

--- a/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
+++ b/test_fixtures/gold_output_files/mixin_based/type_parameters.over_react.g.dart.goldFile
@@ -20,7 +20,7 @@ mixin $NoneProps on NoneProps {
   static const List<String> $propKeys = [];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -52,7 +52,7 @@ mixin $SingleProps<T> on SingleProps<T> {
   static const List<String> $propKeys = [_$key__single__SingleProps];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -96,7 +96,7 @@ mixin $SingleThatWontBeSpecifiedProps<T> on SingleThatWontBeSpecifiedProps<T> {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -135,7 +135,7 @@ mixin $SingleWithBoundProps<S extends Pattern> on SingleWithBoundProps<S> {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }
@@ -180,7 +180,7 @@ mixin $DoubleProps<A, B> on DoubleProps<A, B> {
   ];
 
   @override
-  @mustCallSuper
+  @UiProps.$mustCallSuper
   void validateRequiredProps() {
     super.validateRequiredProps();
   }


### PR DESCRIPTION
## Motivation
I noticed when pulling v5_wip into a test project that there were a lot of infos that looked like:

> info: The import of 'package:meta/meta.dart' is unnecessary because all of the used elements are also provided by the import of 'package:over_react/over_react.dart'. (unnecessary_import at …)

This is because we export `mustCallSuper` so we can use it in generated code. 

Initially I thought this was going to be okay: https://github.com/Workiva/over_react/pull/862#discussion_r1427412583
> > ```diff
> > +export 'package:meta/meta.dart' show mustCallSuper;
> > ```
> ##### @greglittlefield-wf
> Oh interesting, this is so that generated code can use @mustCallSuper, right? Could we add a comment here to that effect.
> 
> Kind of gross that it has to be exported from over_react and added to its public API, though I don't think it would cause any issues...
> 
> And I can't think of any better alternatives, unless we created an alias for it that was named something else, and maybe deprecated (e.g., `@Deprecated('For generated use only) const $overReact$mustCallSuper = mustCallSuper;`)... Not sure if that's worth the trouble though.

These new lints are definitely enough to make me think it is worth the trouble 🙂.

## Changes
**Note: diff best reviewed commit-by-commit**

- 9306f6b3412990f0337c60397dd7acaf43dfd1f6 f236c025f89a04ab3777556c510644676a9cf59d Make ConnectPropsMixin implement `builder_helpers.UiProps` instead of `component_base.UiProps`
    - Without this, because of the way things were imported, the generated code was referencing `component_base.UiProps.$mustCallSuper`, when it needs to reference `component_base.UiProps.$mustCallSuper`
    - We should have been doing this anyway; this is technically a breaking change for any existing consumers extending only from `component_base.UiProps`, but we don't really support consumers using the component_base version in declarations, and I don't see any consumers that would be impacted. If there are any that would be impacted, it'd be a compilation error we'd catch in testing.
- 53999664806ae3657575c5ac7a5840a7ae2f2795 Stop exporting package:meta, and use a custom constant instead (I was able to use `@protected` to help prevent other code from using it)
- 1cd247b78a3ec3e43f637a993042a43421440427 Update generated code
- fca76c6c0c2f2ce4e700deed615c87af8ce2cafc Update generated gold files

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Everything analyzes cleanly with these changes (CI passes)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
