### PR TITLE
FED-2250 Fix Redux dev tools middleware leak in v5_wip

### DIFF
--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -37,6 +37,7 @@ class _ReduxDevToolsExtensionConnection {
 external _ReduxDevToolsExtensionConnection reduxExtConnect([dynamic options]);
 
 final Logger log = Logger('OverReactReduxDevToolsMiddleware')
+  // This listener gets set up when `log` is lazy-initialized, the first time it's accessed.
   ..onRecord.listen((rec) {
     // This return is to safeguard against this listener acting like
     // `Logger.root.onRecord` when `hierarchicalLoggingEnabled` is false.

--- a/lib/src/over_react_redux/devtools/middleware.dart
+++ b/lib/src/over_react_redux/devtools/middleware.dart
@@ -36,23 +36,25 @@ class _ReduxDevToolsExtensionConnection {
 @JS('__REDUX_DEVTOOLS_EXTENSION__.connect')
 external _ReduxDevToolsExtensionConnection reduxExtConnect([dynamic options]);
 
+final Logger log = Logger('OverReactReduxDevToolsMiddleware')
+  ..onRecord.listen((rec) {
+    // This return is to safeguard against this listener acting like
+    // `Logger.root.onRecord` when `hierarchicalLoggingEnabled` is false.
+    if (rec.loggerName != log.name) return;
+
+    final windowConsole = getProperty(window, 'console') as Object;
+    final consoleMethodName = rec.level >= Level.WARNING ? 'warn' : 'log';
+    callMethod(windowConsole, consoleMethodName, [
+      '${log.name} [${rec.level.name}]: ${rec.message}',
+      if (rec.error != null) rec.error,
+    ]);
+  });
+
 class _OverReactReduxDevToolsMiddleware extends MiddlewareClass {
   Store? _store;
   _ReduxDevToolsExtensionConnection? devToolsExt;
-  final Logger log = Logger('OverReactReduxDevToolsMiddleware');
 
   _OverReactReduxDevToolsMiddleware([Map<String, dynamic> options = const {}]) {
-    var windowConsole = getProperty(window, 'console') as Object;
-    log.onRecord.listen((rec) {
-      // This return is to safeguard against this listener acting like
-      // `Logger.root.onRecord` when `hierarchicalLoggingEnabled` is false.
-      if (rec.loggerName != log.name) return;
-      if (rec.level == Level.WARNING) {
-        callMethod(windowConsole, 'warn', ['${log.name} [${rec.level.name}]: ${rec.message}', if (rec.error != null) rec.error]);
-      } else {
-        callMethod(windowConsole, 'log', ['${log.name} [${rec.level.name}]: ${rec.message}', if (rec.error != null) rec.error]);
-      }
-    });
     try {
       devToolsExt = reduxExtConnect(jsify(options))..subscribe(allowInterop(handleEventFromRemote));
     } catch (e) {


### PR DESCRIPTION
## Motivation

When testing v5_wip, we discovered a leak originating from the log listener in `_OverReactReduxDevToolsMiddleware`'s constructor.


`dart2js` was compiling the old log listener as a closure, `_OverReactReduxDevToolsMiddleware_closure`, which retained a reference to  `_OverReactReduxDevToolsMiddleware` in order to access the instance variable `log`. However, retaining the middleware instance also caused it and its store to be leaked.

![redux-middleware-leak-retainers](https://github.com/Workiva/over_react/assets/1713967/919f73d1-a49c-46c3-ba06-7deeca9091dd)

<details>
<summary> dart2js-compiled code, for reference: </summary>

```js
// The middleware class, which constructs the closure in its constructor
A._OverReactReduxDevToolsMiddleware.prototype = {
  _OverReactReduxDevToolsMiddleware$1(options) {
    var e, t2, exception, _this = this, _null = null,
      windowConsole = window.console,
      t1 = _this.log;
    t1._getStream$0().listen$1(new A._OverReactReduxDevToolsMiddleware_closure(_this, windowConsole));
    // ...
  }
  // ...
}

// The closure:
//...
  _OverReactReduxDevToolsMiddleware_closure: function _OverReactReduxDevToolsMiddleware_closure(t0, t1) {
    this.$this = t0;
    this.windowConsole = t1;
  }
//...
A._OverReactReduxDevToolsMiddleware_closure.prototype = {
  call$1(rec) {
    var t1 = rec.get$loggerName(),
      t2 = this.$this.log.name;
    if (t1 !== t2)
      return;
    t1 = this.windowConsole;
    t2 += " [";
    if (J.$eq$(rec.get$level(rec), B.Level_WARNING_900)) {
      t2 = [t2 + rec.get$level(rec).name + "]: " + A.S(rec.get$message(rec))];
      if (rec.get$error(rec) != null)
        t2.push(rec.get$error(rec));
      A.callMethod(t1, "warn", t2);
    } else {
      t2 = [t2 + rec.get$level(rec).name + "]: " + A.S(rec.get$message(rec))];
      if (rec.get$error(rec) != null)
        t2.push(rec.get$error(rec));
      A.callMethod(t1, "log", t2);
    }
  },
  $signature: 1891
};
```
</details>

Interestingly, this area of the code was almost unchanged in v5_wip:
```diff
   final Logger log = Logger('OverReactReduxDevToolsMiddleware');

   _OverReactReduxDevToolsMiddleware([Map<String, dynamic> options = const {}]) {
-    var windowConsole = getProperty(window, 'console');
+    var windowConsole = getProperty(window, 'console') as Object; 
     log.onRecord.listen((rec) {
       // This return is to safeguard against this listener acting like
       // `Logger.root.onRecord` when `hierarchicalLoggingEnabled` is false.
       if (rec.loggerName != log.name) return;
       if (rec.level == Level.WARNING) {
         callMethod(windowConsole, 'warn', ['${log.name} [${rec.level.name}]: ${rec.message}', if (rec.error != null) rec.error]);
       } else {
         callMethod(windowConsole, 'log', ['${log.name} [${rec.level.name}]: ${rec.message}', if (rec.error != null) rec.error]);
       }
     });
```

Either that new `as Object`, migrating to null-safety, or some other unrelated changes caused dart2js to compile things a little differently than it had before.

## Changes
- Move listener out of constructor (and make logger a non-instance variable) so it doesn't get compiled as a closure, fixing the leak
    - This also cleans things up a little bit, since `log` didn't need to be an instance variable

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - Redux dev tools middleware logging still works as expected:
            - Serve the web examples: `webdev serve web`
            - Go to http://localhost:8080/over_react_redux/examples/dev_tools/
            - Open the dev tools, go to the Redux tab, click the "Reset" button, and verify you get a warning printed to the console that looks like this:
                > OverReactReduxDevToolsMiddleware [WARNING]: Unknown command: RESET. Ignoring
        - No manual validation is necessary for this leak fix; we can merge this fix and have our consumer test builds verify this for us
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
