### PR TITLE
FED-2041 Fix whenComplete null error

### DIFF
--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -140,7 +140,8 @@ class ConnectFluxAdapterStore<S extends flux.Store> extends redux.Store<S> {
     // should have also been unmounted, leaving nothing to retain it.
     //
     // Use a null-aware to accommodate mock stores in unit tests that return null for `didDispose`.
-    store.didDispose.whenComplete(teardown);
+    // ignore: unnecessary_cast
+    (store.didDispose as Future<Null>?)?.whenComplete(teardown);
   }
 
   bool _teardownCalled = false;

--- a/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/component2/unsound_flux_component_test.dart
@@ -19,6 +19,7 @@
 library over_react.component_declaration.component2.unsound_flux_component_test;
 
 import 'package:mockito/mockito.dart';
+import 'package:over_react/over_react_flux.dart';
 import 'package:test/test.dart';
 
 import '../../../../test_util/test_util.dart';
@@ -74,6 +75,16 @@ void main() {
         // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
+    });
+
+    test(
+      'mounts properly when using ConnectFluxAdapterStore with a mock store that returns null for members like didDispose (called in constructor)', () async {
+      final mockStore = ConnectFluxAdapterStore(MockTestStore(), null);
+      final jacket = mount((testComponents.basic()..store = mockStore)());
+      await pumpEventQueue();
+      jacket.rerender((testComponents.basic()..store = mockStore)());
+      await pumpEventQueue();
+      jacket.unmount();
     });
   }
 

--- a/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
+++ b/test/over_react/component_declaration/flux_component_test/unsound_flux_component_test.dart
@@ -19,6 +19,7 @@
 library over_react.component_declaration.unsound_flux_component_test;
 
 import 'package:mockito/mockito.dart';
+import 'package:over_react/over_react_flux.dart';
 import 'package:test/test.dart';
 
 import '../../../test_util/test_util.dart';
@@ -74,6 +75,16 @@ void main() {
         // This triggers `.cancel()` and verifies works with the null return value of `.listen`.
         jacket.unmount();
       });
+    });
+
+    test(
+        'mounts properly when using ConnectFluxAdapterStore with a mock store that returns null for members like didDispose (called in constructor)', () async {
+      final mockStore = ConnectFluxAdapterStore(MockTestStore(), null);
+      final jacket = mount((testComponents.basic()..store = mockStore)());
+      await pumpEventQueue();
+      jacket.rerender((testComponents.basic()..store = mockStore)());
+      await pumpEventQueue();
+      jacket.unmount();
     });
   }
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Similar to https://github.com/Workiva/over_react/pull/885, there is one more case where we should cast a store value as nullable to account for mock stores in unsound null safety
```
TypeError: Cannot read properties of null (reading 'whenComplete')
```
## Changes
  <!-- What this PR changes to fix the problem. -->
- cast didDispose as nullable
- Add tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes on this PR
      - [ ] CI fails with new tests without the fix https://github.com/Workiva/over_react/actions/runs/7980000955/job/21788683883?pr=890
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
