### PR TITLE
FED-2294 Work around dart2js compilation slowdown by not implementing UiProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
     - `ReduxProviderProps.store`
 - UiPropsMapView (deprecated) 
     - is now abstract and requires subclasses to override `selfFactory`
-    - no longer implements `MapView` (it still implements `Map`)
+    - now extends directly from UiProps, and longer implements `MapView` (it still implements `Map`)
+    - `props` now returns the backing map instead of `this`
 - Other changes that we don't expect to affect consumers:
   - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
   - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@
     - `ProviderProps.value` (`ProviderProps` is the return type of `Context.Provider`)
     - `ReduxMultiProviderProps.storesByContext`
     - `ReduxProviderProps.store`
-- UiPropsMapView (deprecated) is now abstract and requires subclasses to override `selfFactory`
+- UiPropsMapView (deprecated) 
+    - is now abstract and requires subclasses to override `selfFactory`
+    - no longer implements `MapView` (it still implements `Map`)
 - Other changes that we don't expect to affect consumers:
   - `PropsMeta`/`StateMeta` constructor arguments `fields` and `keys` are now required
   - `ProviderProps.props` type has been widened from `JsMap` to `Map` (now matches `ConsumerProps` and other props classes)

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:collection';
-
 import 'package:meta/meta.dart';
 import 'package:over_react/over_react.dart';
 import 'package:over_react/src/component_declaration/util.dart';
@@ -27,20 +25,14 @@ const _getPropKey = getPropKey;
 /// DEPRECATED: Use new boilerplate mixin pattern instead (see the New Boilerplate Migration
 /// Guide for more information).
 @Deprecated('This pattern is deprecated in favor of the mixin props mixin pattern. See the New Boilerplate Migration guide for more information.')
-abstract class UiPropsMapView extends MapView
-    with
-        ReactPropsMixin,
-        UbiquitousDomPropsMixin,
-        CssClassPropsMixin
-    implements
-        UiProps {
+abstract class UiPropsMapView extends UiProps {
   /// Create a new instance backed by the specified map.
-  UiPropsMapView(Map map) : super(map);
+  UiPropsMapView(this.props);
 
   /// The props to be manipulated via the getters/setters.
   /// In this case, it's the current MapView object.
   @override
-  Map get props => this;
+  final Map props;
 
   /// Returns a new instance of the current class backed by the given [props].
   ///
@@ -65,8 +57,7 @@ abstract class UiPropsMapView extends MapView
   // ----- builder_helpers.UiProps ----- //
 
   @override
-  bool get $isClassGenerated =>
-      throw UnimplementedError('@PropsMixin instances do not implement \$isClassGenerated');
+  bool get $isClassGenerated => true;
 
   @override
   PropsMetaCollection get staticMeta => throw UnimplementedError('@PropsMixin instances do not implement instance meta');
@@ -129,6 +120,7 @@ abstract class UiPropsMapView extends MapView
   ReactElement call([c1 = notSpecified, c2 = notSpecified, c3 = notSpecified, c4 = notSpecified, c5 = notSpecified, c6 = notSpecified, c7 = notSpecified, c8 = notSpecified, c9 = notSpecified, c10 = notSpecified, c11 = notSpecified, c12 = notSpecified, c13 = notSpecified, c14 = notSpecified, c15 = notSpecified, c16 = notSpecified, c17 = notSpecified, c18 = notSpecified, c19 = notSpecified, c20 = notSpecified, c21 = notSpecified, c22 = notSpecified, c23 = notSpecified, c24 = notSpecified, c25 = notSpecified, c26 = notSpecified, c27 = notSpecified, c28 = notSpecified, c29 = notSpecified, c30 = notSpecified, c31 = notSpecified, c32 = notSpecified, c33 = notSpecified, c34 = notSpecified, c35 = notSpecified, c36 = notSpecified, c37 = notSpecified, c38 = notSpecified, c39 = notSpecified, c40 = notSpecified]) => throw UnimplementedError('@PropsMixin instances do not implement call');
 
   @override
+  // ignore: must_call_super
   void validateRequiredProps() => throw UnimplementedError('@PropsMixin instances do not implement validateRequiredProps');
 
   @override

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -29,8 +29,7 @@ abstract class UiPropsMapView extends UiProps {
   /// Create a new instance backed by the specified map.
   UiPropsMapView(this.props);
 
-  /// The props to be manipulated via the getters/setters.
-  /// In this case, it's the current MapView object.
+  /// The backing props map proxied by this class.
   @override
   final Map props;
 

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -36,7 +36,8 @@ main() {
       mapView.id = 'something else';
       mapView['foo'] = 'bar';
       expect({...mapView}, {'id': 'something else', 'foo': 'bar'});
-      expect({...mapView}, backingMap);
+      expect(backingMap, {...mapView},
+          reason: 'backing map should reflect all changes in the map view');
     });
 
     test('getPropKey works as expected and uses selfFactory to construct a new instance', () {

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -52,10 +52,6 @@ main() {
     });
 
     group('throws an `UnimplementedError` when unimplemented fields/methods are accessed/called:', () {
-      test('`\$isClassGenerated`', () {
-        expect(() => mapView.$isClassGenerated, throwsUnimplementedError);
-      });
-
       test('`propKeyNamespace`', () {
         expect(() => mapView.propKeyNamespace, throwsUnimplementedError);
       });

--- a/test/over_react/util/react_util_test.dart
+++ b/test/over_react/util/react_util_test.dart
@@ -21,12 +21,14 @@ import 'package:test/test.dart';
 
 main() {
   group('UiPropsMapView', () {
+    late Map backingMap;
     late UiPropsMapView mapView;
 
     setUp(() {
-      mapView = TestUiPropsMapView({
+      backingMap = {
         'id': 'test-id',
-      });
+      };
+      mapView = TestUiPropsMapView(backingMap);
     });
 
     test('reads from and writes to the backing map as expected', () {
@@ -34,6 +36,7 @@ main() {
       mapView.id = 'something else';
       mapView['foo'] = 'bar';
       expect({...mapView}, {'id': 'something else', 'foo': 'bar'});
+      expect({...mapView}, backingMap);
     });
 
     test('getPropKey works as expected and uses selfFactory to construct a new instance', () {


### PR DESCRIPTION
## Motivation
While testing the v5_wip branch within certain large, unsound applications, we encountered a significant slowdown in dart2js compilation speed.

We identified `UiPropsMapView` implementing `UiProps` as the main trigger of the issue, and changing it to extend `UiProps` instead works around the slowdown.

We'll be following up shortly with a lot more info in a dart-lang/sdk issue, but in the meantime, we know that this workaround works.

## Changes
- Apply workaround: have `UiPropsMapView` extend `UiProps` instead of just implementing it
- Update changelog
- Add a little more test coverage to ensure UiPropsMapView reads to and writes from the underlying backing map

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - CI passes in WSD, which has all known UiPropsMapView subclasses: https://github.com/Workiva/web_skin_dart/actions/runs/8102955553
            - Also pulls in changes in a PR to that repo (https://github.com/Workiva/web_skin_dart/pull/2162) needed for compatibility with this PR
        - Performance regression is fixed in test build (see Slack)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
