### PR TITLE
FED-2156 Unsafe required props lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ pubspec.lock
 # Should not track the output of code coverage for now
 coverage/
 
-tools/analyzer_plugin/test/test_fixtures/**/lib/dynamic_test_files/
+tools/analyzer_plugin/test/test_fixtures/**/dynamic_test_files/
 tools/analyzer_plugin/test/temporary_test_fixtures/**

--- a/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
@@ -119,7 +119,7 @@ class UnsafeRequiredPropAccessDiagnostic extends DiagnosticContributor {
 
     for (final requiredPropRead in requiredPropReads) {
       if (cachedIsComponentProps(requiredPropRead.realTarget)) continue;
-      if (isPropsSafeUtilityMethodArg(requiredPropRead.realTarget)) continue;
+      if (_isPropsSafeUtilityMethodArg(requiredPropRead.realTarget)) continue;
       if (_isSafeDueToContainsPropCheck(requiredPropRead)) continue;
       if (_isWithinLifecycleMethodWithPropsArg(requiredPropRead)) continue;
       if (_isProbablyWithinMemoAreEqualFunction(requiredPropRead)) continue;
@@ -166,7 +166,9 @@ bool _isWithinLifecycleMethodWithPropsArg(LateRequiredPropRead read) {
   }.contains(lifecycleMethod.name.lexeme);
 }
 
-//
+/// Returns whether [read] is either in the `areEqual` function arg to `memo`,
+/// or in a top-level function that's probably used as an areEqual arg
+/// (based on whether its name matches [_memoAreEqualNamePattern]).
 bool _isProbablyWithinMemoAreEqualFunction(LateRequiredPropRead read) {
   final functionExpression = read.node.thisOrAncestorOfType<FunctionExpression>();
   if (functionExpression == null) return false;
@@ -206,7 +208,7 @@ final _memoAreEqualNamePattern = RegExp(r'[aA]reEqual');
 ///
 /// For example, in `props.containsProp((p) => p.requiredProp)`,
 /// returns `true` for the `p` that's followed by `.requiredProp`.
-bool isPropsSafeUtilityMethodArg(Expression target) {
+bool _isPropsSafeUtilityMethodArg(Expression target) {
   if (target is! Identifier) return false;
 
   final staticElement = target.staticElement;

--- a/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
@@ -180,14 +180,20 @@ bool _isProbablyWithinMemoAreEqualFunction(LateRequiredPropRead read) {
 
   // Consumers commonly split out the areEqual function.
   // Instead of looking up whether the functions are used in memo calls,
-  // just assume functions named /[aA]reEqual/ are safe.
-  String? functionName;
+  // just assume top-level functions and variables named /[aA]reEqual/ are safe.
+  String functionName;
+  bool isTopLevelDeclaration;
   if (functionParent is FunctionDeclaration) {
     functionName = functionParent.name.lexeme;
+    isTopLevelDeclaration = functionParent.parent is CompilationUnit;
   } else if (functionParent is VariableDeclaration && functionParent.initializer == functionExpression) {
     functionName = functionParent.name.lexeme;
+    // VariableDeclaration < VariableDeclarationList < TopLevelVariableDeclaration
+    isTopLevelDeclaration = functionParent.parent?.parent is TopLevelVariableDeclaration;
+  } else {
+    return false;
   }
-  if (functionName != null) {
+  if (isTopLevelDeclaration) {
     return _memoAreEqualNamePattern.hasMatch(functionName);
   }
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
@@ -15,6 +15,8 @@ const _details = r'''
 
 **DO NOT** access required props when they're not guaranteed to be present, since that can cause errors and bad behavior.
 
+Required props are only validated to be present on props a component was rendered with, and not on other props objects.
+
 For example, given props:
 ```dart
 mixin FooProps {
@@ -29,10 +31,6 @@ example() {
   props.requiredProp;  
 }
 ```
-
-This only applies when interacting with arbitrary props objects, and not with the props a component was rendered with,
-since we validate via the `over_react_late_required_prop` diagnostic and via runtime checks that all required props are supplied.
-
 
 **DO** use utility methods `getRequiredProp`, getRequiredPropOrNull`, or `containsProp` checks to safely access the prop.
 

--- a/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
@@ -76,7 +76,7 @@ renderFoo([Map? _additionalFooProps]) {
   // Also, there's a static analysis error on the condition because 
   // the non-nulllable requiredProp3 will always `!= null`.
   final otherPropsToAdd = Foo();
-  if (p.requiredProp3 != null) {
+  if (fooProps.requiredProp3 != null) {
     otherPropsToAdd.aria.label = fooProps.requiredProp3;
   }
   

--- a/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/unsafe_required_prop_access.dart
@@ -1,0 +1,215 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
+import 'package:over_react_analyzer_plugin/src/doc_utils/maturity.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/is_component_props.dart';
+import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
+import 'package:over_react_analyzer_plugin/src/util/util.dart';
+
+const _desc = r'';
+// <editor-fold desc="Documentation Details">
+const _details = r'''
+
+''';
+// </editor-fold>
+
+class UnsafeRequiredPropAccessDiagnostic extends DiagnosticContributor {
+  @DocsMeta(_desc, details: _details, maturity: Maturity.experimental)
+  static const code = DiagnosticCode(
+      'over_react_unsafe_required_prop_access',
+      "Accessing required prop '{0}' on a potentially incomplete props map can throw.",
+      AnalysisErrorSeverity.WARNING,
+      AnalysisErrorType.STATIC_WARNING,
+      correction:
+          "Use safe utility methods to access the prop: 'getRequiredProp', 'getRequiredPropOrNull', or 'containsProp'.");
+
+  @override
+  get codes => const [code];
+
+  static final fixKind =
+      FixKind('use_get_required_prop_or_null', 200, "Use 'getRequiredPropOrNull' to safely access the prop.");
+
+  // static final fixKind = FixKind('use_or_null', 200, "Add required prop '{0}'");
+
+  @override
+  computeErrors(result, collector) async {
+    final requiredPropReads = <LateRequiredPropRead>[];
+    result.unit.accept(LateRequiredPropReadVisitor(requiredPropReads.add));
+
+    // The overhead of isComponentProps is non-negligible; cache by the element to optimize
+    // the very common case of `props.` being accessed multiple times within a component.
+    final _cacheByElement = <Element, bool>{};
+    bool cachedIsComponentProps(Expression target) {
+      final element = target.tryCast<Identifier>()?.staticElement;
+      return element != null
+          ? _cacheByElement.putIfAbsent(element, () => isComponentProps(target))
+          : isComponentProps(target);
+    }
+
+    for (final requiredPropRead in requiredPropReads) {
+      if (cachedIsComponentProps(requiredPropRead.target)) continue;
+      if (isPropsSafeUtilityMethodArg(requiredPropRead.target)) continue;
+
+      final prop = requiredPropRead.prop;
+
+      if (requiredPropRead.isCompoundAssignment) {
+        // This case is rare and providing a fix is complicated, so we'll just provide an error.
+        collector.addError(code, result.locationFor(prop), errorMessageArgs: [prop.name]);
+      } else {
+        await collector.addErrorWithFix(
+          code,
+          result.locationFor(prop),
+          errorMessageArgs: [prop.name],
+          fixKind: fixKind,
+          computeFix: () => buildFileEdit(result, (builder) {
+            builder.addSimpleReplacement(range.node(prop), 'getRequiredPropOrNull((p) => p.${prop.name})');
+          }),
+        );
+      }
+    }
+  }
+}
+
+bool isPropsSafeUtilityMethodArg(Expression target) {
+  if (target is! Identifier) return false;
+
+  final staticElement = target.staticElement;
+  if (staticElement is! ParameterElement) return false;
+
+  final parameter = lookUpParameter(staticElement, target.root);
+  if (parameter == null) return false;
+
+  final methodCallReceivingFunction = parameter
+      .thisOrAncestorOfType<FormalParameterList>()
+      ?.parent
+      .tryCast<FunctionExpression>()
+      ?.parent
+      .tryCast<ArgumentList>()
+      ?.parent
+      .tryCast<MethodInvocation>();
+  if (methodCallReceivingFunction == null) return false;
+
+  return const {
+    'getPropKey', // top-level, UiComponent, UiPropsSelfTypedExtension
+    'keyForProp', // UiComponent
+    'containsProp', // UiPropsSelfTypedExtension
+    'getRequiredProp', // UiPropsSelfTypedExtension
+    'getRequiredPropOrNull', // UiPropsSelfTypedExtension
+  }.contains(methodCallReceivingFunction.methodName.name);
+}
+
+class LateRequiredPropRead {
+  final Expression target;
+  final SimpleIdentifier prop;
+  final AssignmentExpression? compoundAssignment;
+
+  bool get isCompoundAssignment => compoundAssignment != null;
+
+  LateRequiredPropRead({
+    required this.target,
+    required this.prop,
+    required this.compoundAssignment,
+  });
+}
+
+class LateRequiredPropReadVisitor extends RecursiveAstVisitor<void> {
+  final void Function(LateRequiredPropRead) onRead;
+
+  LateRequiredPropReadVisitor(this.onRead);
+
+  @override
+  void visitComment(Comment node) {
+    // Don't recurse into doc comments
+  }
+
+  @override
+  void visitPropertyAccess(PropertyAccess node) {
+    super.visitPropertyAccess(node);
+
+    final staticElement = node.propertyName.staticElement ?? _getElementFromParentAssignment(node);
+    if (staticElement == null) return;
+
+    _handlePrefixedOrPropertyAccess(
+      node: node,
+      target: node.realTarget,
+      property: node.propertyName,
+      propertyElement: staticElement,
+    );
+  }
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    super.visitPrefixedIdentifier(node);
+
+    final staticElement = node.identifier.staticElement ?? _getElementFromParentAssignment(node);
+    if (staticElement == null) return;
+
+    _handlePrefixedOrPropertyAccess(
+      node: node,
+      target: node.prefix,
+      property: node.identifier,
+      propertyElement: staticElement,
+    );
+  }
+
+  static Element? _getElementFromParentAssignment(Expression node) {
+    final parent = node.parent;
+    if (parent is AssignmentExpression && parent.leftHandSide == node) {
+      return parent.readElement ?? parent.writeElement;
+    }
+    return null;
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+
+    final realTarget = node.realTarget;
+    if (realTarget == null) return;
+
+    final staticElement = node.methodName.staticElement;
+    if (staticElement == null) return;
+
+    _handlePrefixedOrPropertyAccess(
+      node: node,
+      target: realTarget,
+      property: node.methodName,
+      propertyElement: staticElement,
+    );
+  }
+
+  void _handlePrefixedOrPropertyAccess({
+    required AstNode node,
+    required Expression target,
+    required SimpleIdentifier property,
+    required Element propertyElement,
+  }) {
+    final fieldElement = propertyElement.tryCast<FieldElement>() ??
+        propertyElement.tryCast<PropertyAccessorElement>()?.variable.tryCast<FieldElement>();
+    if (fieldElement == null) return;
+
+    if (!_isLateRequiredProp(fieldElement)) return;
+
+    final parent = node.parent;
+    if (parent is AssignmentExpression && parent.leftHandSide == node) {
+      /// Whether it's a compound assignment, which also involves a read.
+      /// E.g., `builder.fooProp ??= 'foo'`
+      final isCompoundAssignment = parent.readElement != null;
+      if (isCompoundAssignment) {
+        onRead(LateRequiredPropRead(target: target, prop: property, compoundAssignment: parent));
+      } else {
+        // Do nothing for non-compound assignments, since they don't involve reading the prop.
+      }
+    } else {
+      onRead(LateRequiredPropRead(target: target, prop: property, compoundAssignment: null));
+    }
+  }
+}
+
+bool _isLateRequiredProp(FieldElement propertyElement) {
+  return propertyElement.isLate &&
+      !propertyElement.isStatic &&
+      (propertyElement.enclosingElement.tryCast<InterfaceElement>()?.isPropsClass ?? false);
+}

--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -36,6 +36,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer_plugin/plugin/plugin.dart';
 import 'package:analyzer_plugin/protocol/protocol_generated.dart' as plugin;
+import 'package:path/path.dart' as p;
 import 'package:over_react_analyzer_plugin/src/analysis_options/error_severity_provider.dart';
 import 'package:over_react_analyzer_plugin/src/analysis_options/plugin_analysis_options.dart';
 import 'package:over_react_analyzer_plugin/src/analysis_options/reader.dart';
@@ -112,6 +113,8 @@ mixin OverReactAnalyzerPluginBase
     final options = pluginOptionsReader.getOptionsForContextRoot(analysisContext.contextRoot);
     final severityProvider = AnalysisOptionsErrorSeverityProvider(options);
 
+    final isInTestDir = p.isWithin(p.absolute(analysisContext.contextRoot.root.path, 'test'), path);
+
     return [
       PropTypesReturnValueDiagnostic(),
       DuplicatePropCascadeDiagnostic(),
@@ -150,7 +153,11 @@ mixin OverReactAnalyzerPluginBase
       ),
       NonDefaultedPropDiagnostic(),
       CreateRefUsageDiagnostic(),
-      UnsafeRequiredPropAccessDiagnostic(),
+      // Prop accesses on the result of getProps are pretty common in tests and get flagged by this diagnostic,
+      // causing a lot of noise. Since these usages are more complicated to identify, and are usually safe within tests
+      // (and if they're not, the worst case scenario is test failures, as opposed to runtime errors in prod code),
+      // we'll just disable this diagnostic within the test directory.
+      if (!isInTestDir) UnsafeRequiredPropAccessDiagnostic(),
     ];
   }
 

--- a/tools/analyzer_plugin/lib/src/plugin.dart
+++ b/tools/analyzer_plugin/lib/src/plugin.dart
@@ -70,6 +70,7 @@ import 'package:over_react_analyzer_plugin/src/diagnostic/render_return_value.da
 import 'package:over_react_analyzer_plugin/src/diagnostic/rules_of_hooks.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/string_ref.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/style_value_diagnostic.dart';
+import 'package:over_react_analyzer_plugin/src/diagnostic/unsafe_required_prop_access.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/variadic_children.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/variadic_children_with_keys.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
@@ -149,6 +150,7 @@ mixin OverReactAnalyzerPluginBase
       ),
       NonDefaultedPropDiagnostic(),
       CreateRefUsageDiagnostic(),
+      UnsafeRequiredPropAccessDiagnostic(),
     ];
   }
 

--- a/tools/analyzer_plugin/lib/src/util/is_component_props.dart
+++ b/tools/analyzer_plugin/lib/src/util/is_component_props.dart
@@ -1,0 +1,42 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/function_components.dart';
+import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
+
+bool isComponentProps(Expression expression) {
+  if (expression is SimpleIdentifier) {
+    final targetElement = expression.staticElement;
+    if (targetElement == null) return false;
+
+    // Class Component props with implicit `this`
+    if (expression.name == 'props' && (targetElement.enclosingElement?.isComponentClass ?? false)) {
+      return true;
+    }
+
+    // Function component props
+    final closestFunctionComponentParameters = getClosestFunctionComponent(expression)?.functionExpression.parameters;
+    if (closestFunctionComponentParameters != null) {
+      final targetElementParameterNode = lookUpParameter(targetElement, closestFunctionComponentParameters);
+      final parameterList = targetElementParameterNode?.parent;
+      if (parameterList != null && closestFunctionComponentParameters == parameterList) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // Class component: `this.props`, `componentVariable.props`, 'otherProperty.componentVariable.props`
+  if (expression is PrefixedIdentifier) {
+    return _isComponentPropsAccess(target: expression.prefix, property: expression.identifier);
+  }
+  if (expression is PropertyAccess) {
+    final target = expression.target;
+    return target != null && _isComponentPropsAccess(target: target, property: expression.propertyName);
+  }
+
+  return false;
+}
+
+bool _isComponentPropsAccess({required Expression target, required Identifier property}) =>
+    property.name == 'props' && (target.staticType?.typeOrBound.isComponentClass ?? false);

--- a/tools/analyzer_plugin/lib/src/util/is_props_from_render.dart
+++ b/tools/analyzer_plugin/lib/src/util/is_props_from_render.dart
@@ -3,7 +3,15 @@ import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/function_components.dart';
 import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
 
-bool isComponentProps(Expression expression) {
+/// Returns whether [expression] definitely represents the props a component was rendered with,
+/// as opposed to some other props object that could be a partial set of props.
+///
+/// Returns true if [expression] is either:
+/// - the `props` argument in a function component
+/// - the `props` getter in a component class
+///   - accessed from within the component class (handles both `props` and `this.props`)
+///   - accessed on a component instance (for example: `componentRef.props`)
+bool isPropsFromRender(Expression expression) {
   if (expression is SimpleIdentifier) {
     final targetElement = expression.staticElement;
     if (targetElement == null) return false;
@@ -14,6 +22,9 @@ bool isComponentProps(Expression expression) {
     }
 
     // Function component props
+    //
+    // Technically only checking against the closest function components could have false negatives when there are
+    // nested function components, but function components shouldn't ever be nested, so don't worry about that case.
     final closestFunctionComponentParameters = getClosestFunctionComponent(expression)?.functionExpression.parameters;
     if (closestFunctionComponentParameters != null) {
       final targetElementParameterNode = lookUpParameter(targetElement, closestFunctionComponentParameters);
@@ -31,8 +42,7 @@ bool isComponentProps(Expression expression) {
     return _isComponentPropsAccess(target: expression.prefix, property: expression.identifier);
   }
   if (expression is PropertyAccess) {
-    final target = expression.target;
-    return target != null && _isComponentPropsAccess(target: target, property: expression.propertyName);
+    return  _isComponentPropsAccess(target: expression.realTarget, property: expression.propertyName);
   }
 
   return false;

--- a/tools/analyzer_plugin/playground/web/unsafe_required_props_access.dart
+++ b/tools/analyzer_plugin/playground/web/unsafe_required_props_access.dart
@@ -40,6 +40,22 @@ foo(BarProps props, BarComponent component) {
 
   otherCallback((p) => p.barRequired);
 
+  // Unrelated conditional reads
+  if (props.containsProp((p) => p.barRequiredInt)) {
+    print(props.barRequired);
+  }
+  final otherProps = Bar();
+  if (otherProps.containsProp((p) => p.barRequired)) {
+    print(props.barRequired);
+  }
+
+  // Unsafe complex contains prop nesting
+  if (props.containsProp((p) => p.barRequired)) {
+    Future(() {
+      print(props.barRequired);
+    });
+  }
+
   // Safe
 
   // Safe write
@@ -55,6 +71,10 @@ foo(BarProps props, BarComponent component) {
   print(props.getRequiredProp((p) => p.barRequired, orElse: () => 'foo'));
   print(props.getPropKey((p) => p.barRequired));
   print(props.containsProp((p) => p.barRequired));
+  // Safe conditional read.
+  if (props.containsProp((p) => p.barRequired)) {
+    print(props.barRequired);
+  }
 }
 
 otherCallback(Function(BarProps) callback) {}

--- a/tools/analyzer_plugin/playground/web/unsafe_required_props_access.dart
+++ b/tools/analyzer_plugin/playground/web/unsafe_required_props_access.dart
@@ -1,0 +1,60 @@
+//@dart=2.12
+import 'package:over_react/over_react.dart';
+
+part 'unsafe_required_props_access.over_react.g.dart';
+
+// debug:over_react_metrics
+
+
+UiFactory<BarProps> Bar = castUiFactory(_$Bar); // ignore: undefined_identifier
+
+mixin BarProps on UiProps {
+  late String barRequired;
+  late String? barRequiredNullable;
+  late int barRequiredInt;
+
+  String? notRequired;
+}
+
+class BarComponent extends UiComponent2<BarProps> {
+  @override
+  render() {
+    print(props.barRequired);
+    print(this.props.barRequired);
+    return Dom.div()();
+  }
+}
+
+
+foo(BarProps props, BarComponent component) {
+  // Unsafe
+
+  // Unsafe read
+  print(props.barRequired);
+  // Unsafe read, nested
+  print(props.barRequired.toString());
+
+  // Unsafe read via compound assignment
+  props.barRequiredNullable ??= '';
+  props.barRequiredInt |= 1;
+
+  otherCallback((p) => p.barRequired);
+
+  // Safe
+
+  // Safe write
+  props.barRequired = '';
+
+  // Reading props from a component is safe
+  print(component.props.barRequired);
+
+  // Safe non-required read
+  print(props.notRequired);
+  // Safe helper method accesses
+  print(props.getRequiredPropOrNull((p) => p.barRequired));
+  print(props.getRequiredProp((p) => p.barRequired, orElse: () => 'foo'));
+  print(props.getPropKey((p) => p.barRequired));
+  print(props.containsProp((p) => p.barRequired));
+}
+
+otherCallback(Function(BarProps) callback) {}

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -1,19 +1,246 @@
-// ignore_for_file: camel_case_types
-import 'dart:async';
-
 import 'package:over_react_analyzer_plugin/src/diagnostic/unsafe_required_prop_access.dart';
 import 'package:test/test.dart';
-import 'package:test_reflective_loader/test_reflective_loader.dart';
 
 import '../test_bases/diagnostic_test_base.dart';
 
 void main() {
-  defineReflectiveSuite(() {
-    defineReflectiveTests(UnsafeRequiredPropAccessTest);
+  group('UnsafeRequiredPropAccess', () {
+    late UnsafeRequiredPropAccessTest testBase;
+
+    setUp(() async {
+      testBase = UnsafeRequiredPropAccessTest();
+      await testBase.setUp();
+    });
+
+    tearDown(() async {
+      await testBase.tearDown();
+    });
+
+    group('warns for unsafe prop accesses', () {
+      group('on arbitrary props objects:', () {
+        test('basic cases', () async {
+          final source = testBase.newSourceWithPrefix(/*language=dart*/ r'''
+            test(HasRequiredProps props) {
+              print(props.requiredProp);
+              print(props.optionalProp);
+            }
+          ''');
+
+          expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+            testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'props.#requiredProp#')),
+          ]);
+        });
+
+        test('in different parent nodes and syntaxes', () async {
+          final source = testBase.newSourceWithPrefix(/*language=dart*/ r'''
+            test(HasRequiredProps props) {
+              // Nested in property access
+              props.requiredProp.hashCode;
+              (props.requiredProp).hashCode;
+              
+              // Nested in method call
+              props.requiredProp.toString(); 
+              (props.requiredProp).toString();
+              
+              // Target is an arbitrary expression
+              (props).requiredProp;
+              
+              // Nested in cascade
+              props..requiredProp;  
+              props..requiredProp.hashCode;  
+              props..requiredProp.toString();
+              
+              // Compound assignment
+              props.requiredProp += "";
+            }
+          ''');
+
+          final createSelection = testBase.createSelection;
+          final isAnErrorUnderTest = testBase.isAnErrorUnderTest;
+          expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp#.hashCode;')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, '(props.#requiredProp#).hashCode;')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp#.toString();')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, '(props.#requiredProp#).toString();')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, '(props).#requiredProp#;')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#;')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#.hashCode;')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#.toString();')),
+            isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp# += "";'), hasFix: false),
+          ]);
+        });
+      });
+
+      group('inside a component', () {
+        test('', () async {
+          final source = testBase.newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
+            test(HasRequiredProps otherProps) {
+              print(otherProps.requiredProp);
+            }
+          '''));
+
+          expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+            testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'otherProps.#requiredProp#')),
+          ]);
+        });
+
+        test('when shadowing `props`', () async {
+          final source = testBase.newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
+            // Statically access props so we know it's being shadowed in this test setup.
+            // If it's not, we'll get a built-in analysis error that will fail the test.
+            print(props.requiredProp);
+            
+            // Shadow `props` with another variable of the same name.
+            test(HasRequiredProps props) {
+              print(props.requiredProp + "");
+            }
+          '''));
+          expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+            testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'props.#requiredProp# + ""')),
+          ]);
+        });
+      });
+    });
+
+    group('does not warn for non-prop accesses:', () {
+      test('fields on non-prop classes', () async {
+        await testBase.expectNoErrors(testBase.newSource(/*language=Dart*/ r'''
+          // End with "Props" because we short-circuit on types that end with props.
+          class NotProps {
+            String? someField;
+            // This declaration is identical to that of a required prop,
+            // but it isn't one.
+            late String lateField;
+          }
+          
+          test(NotProps notProps) {
+            notProps.lateField;
+            notProps.someField;
+            notProps.hashCode;
+          }
+        '''));
+      });
+
+      test('static fields on props objects', () async {
+        await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=Dart*/ r'''
+          mixin HasStaticMembersProps {
+            static late String lateStaticField;
+            static String staticField = '';
+          }
+          
+          test() {
+            HasStaticMembersProps.lateStaticField;
+            HasStaticMembersProps.staticField;
+          }
+        '''));
+      });
+    });
+
+    group('does not warn for safe prop accesses:', () {
+      group('a component\'s own props', () {
+        test('within a uiFunction', () async {
+          await testBase
+              .expectNoErrors(testBase.newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
+            print(props.requiredProp);
+            print(props.optionalProp);
+          ''')));
+        });
+
+        test('within a uiForwardRef', () async {
+          await testBase.expectNoErrors(
+              testBase.newSourceWithPrefix(componentSource(ComponentType.uiForwardRef, componentBody: r'''
+            print(props.requiredProp);
+            print(props.optionalProp);
+          ''')));
+        });
+
+        test('within a class component', () async {
+          await testBase
+              .expectNoErrors(testBase.newSourceWithPrefix(componentSource(ComponentType.component2, componentBody: r'''
+            render() {
+              print(props.requiredProp);
+              print(props.optionalProp);
+              _renderHelper();
+            }
+            _renderHelper() {
+              print(props.requiredProp);
+              print(props.optionalProp);
+            }
+          ''')));
+        });
+      });
+
+      test('within utility method callbacks', () async {
+        await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ '''
+          test1(HasRequiredProps props) {
+            // UiProps methods
+            print(props.getPropKey((p) => p.requiredProp));
+            print(props.containsProp((p) => p.requiredProp));
+            print(props.getRequiredProp((p) => p.requiredProp, orElse: () => ''));
+            print(props.getRequiredPropOrNull((p) => p.requiredProp));
+          }
+          
+          testTopLevel(HasRequiredProps props) {
+            // Top-level functions  
+            print(getPropKey<HasRequiredProps>((p) => p.requiredProp, HasRequired));
+          }
+          
+          ${componentSource(ComponentType.component2, componentBody: r'''
+            render() {
+              // UiComponent methods
+              print(keyForProp((p) => p.requiredProp));
+              // `this.` is necessary to avoid top-level getPropKey taking precedence.
+              print(this.getPropKey((p) => p.requiredProp)); // ignore: deprecated_member_use
+            }
+          ''')}
+        '''));
+      });
+
+      group('when gated by a containsProp check', () {
+        test('', () async {
+          await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+            test(HasRequiredProps props) {
+              if (props.containsProp((p) => p.requiredProp)) {
+                print(props.requiredProp);
+              }
+            }
+          '''));
+        });
+
+        // FIXME add tests for negative cases
+      });
+
+      // FIXME add tests for other lifecycle methods here or above
+
+      test('within certain component lifecycle methods', () async {
+        // FIXME clarify that even unsafe accesses aren't linted
+        await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+          abstract class TestComponent2 extends UiComponent2<HasRequiredProps> {
+            get propTypes => {
+              keyForProp((p) => p.requiredProp): (props, _) {
+                print(typedPropsFactory(props).requiredProp);
+                return null;
+              },
+            };
+            @override componentDidUpdate(prevProps, _, [__]) { print(typedPropsFactory(prevProps).requiredProp); }  
+            @override getDerivedStateFromProps(nextProps, _) { print(typedPropsFactory(nextProps).requiredProp); return {}; }  
+            @override getSnapshotBeforeUpdate(prevProps, _)  { print(typedPropsFactory(prevProps).requiredProp); return null; }  
+            @override shouldComponentUpdate(nextProps, _)    { print(typedPropsFactory(nextProps).requiredProp); return true; }
+          }
+          
+          abstract class TestComponent1 extends UiComponent<HasRequiredProps> {
+            // Just test UiComponent-specific methods
+            @override componentWillReceiveProps(nextProps)               { print(typedPropsFactory(nextProps).requiredProp); super.componentWillReceiveProps(nextProps); }  
+            @override componentWillReceivePropsWithContext(nextProps, _) { print(typedPropsFactory(nextProps).requiredProp); }  
+            @override componentWillUpdate(prevProps, _, [__])            { print(typedPropsFactory(prevProps).requiredProp); }  
+            @override shouldComponentUpdateWithContext(nextProps, _, __) { print(typedPropsFactory(nextProps).requiredProp); return true; }
+          }
+        '''));
+      });
+    });
   });
 }
 
-@reflectiveTest
 class UnsafeRequiredPropAccessTest extends DiagnosticTestBase {
   @override
   get errorUnderTest => UnsafeRequiredPropAccessDiagnostic.code;
@@ -22,203 +249,6 @@ class UnsafeRequiredPropAccessTest extends DiagnosticTestBase {
   get fixKindUnderTest => UnsafeRequiredPropAccessDiagnostic.fixKind;
 
   Source newSourceWithPrefix(String sourceFragment) => newSource(sourcePrefix + sourceFragment);
-
-  Future<void> test_arbitraryProps() async {
-    final source = newSourceWithPrefix(/*language=dart*/ r'''
-      test(HasRequiredProps props) {
-        print(props.requiredProp);
-        print(props.optionalProp);
-      }
-    ''');
-
-    expect(await getAllErrors(source, includeOtherCodes: true), [
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp#')),
-    ]);
-  }
-
-  Future<void> test_arbitraryPropsAccessVariations() async {
-    final source = newSourceWithPrefix(/*language=dart*/ r'''
-      test(HasRequiredProps props) {
-        // Nested in property access
-        props.requiredProp.hashCode;
-        (props.requiredProp).hashCode;
-        
-        // Nested in method call
-        props.requiredProp.toString(); 
-        (props.requiredProp).toString();
-        
-        // Target is an arbitrary expression
-        (props).requiredProp;
-        
-        // Nested in cascade
-        props..requiredProp;  
-        props..requiredProp.hashCode;  
-        props..requiredProp.toString();
-        
-        // Compound assignment
-        props.requiredProp += "";
-      }
-    ''');
-
-    expect(await getAllErrors(source, includeOtherCodes: true), [
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp#.hashCode;')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, '(props.#requiredProp#).hashCode;')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp#.toString();')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, '(props.#requiredProp#).toString();')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, '(props).#requiredProp#;')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#;')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#.hashCode;')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props..#requiredProp#.toString();')),
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp# += "";'), hasFix: false),
-    ]);
-  }
-
-  Future<void> test_arbitraryPropsInComponent() async {
-    final source = newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
-      test(HasRequiredProps otherProps) {
-        print(otherProps.requiredProp);
-      }
-    '''));
-
-    expect(await getAllErrors(source, includeOtherCodes: true), [
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'otherProps.#requiredProp#')),
-    ]);
-  }
-
-  Future<void> test_arbitraryPropsInComponentShadowed() async {
-    final source = newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
-      // Statically access props so we know it's being shadowed in this test setup.
-      // If it's not, we'll get a built-in analysis error that will fail the test.
-      print(props.requiredProp);
-      
-      // Shadow `props` with another variable of the same name.
-      test(HasRequiredProps props) {
-        print(props.requiredProp + "");
-      }
-    '''));
-    expect(await getAllErrors(source, includeOtherCodes: true), [
-      isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp# + ""')),
-    ]);
-  }
-
-  Future<void> test_noErrors_NonPropAccesses() async {
-    await expectNoErrors(newSource(/*language=Dart*/r'''
-      // End with "Props" because we short-circuit on types that end with props.
-      class NotProps {
-        String? someField;
-        // This declaration is identical to that of a required prop,
-        // but it isn't one.
-        late String lateField;
-      }
-      
-      test(NotProps notProps) {
-        notProps.lateField;
-        notProps.someField;
-        notProps.hashCode;
-      }
-    '''));
-  }
-
-  Future<void> test_noErrors_staticAccesses() async {
-    await expectNoErrors(newSourceWithPrefix(/*language=Dart*/r'''
-      mixin HasStaticMembersProps {
-        static late String lateStaticField;
-        static String staticField = '';
-      }
-      
-      test() {
-        HasStaticMembersProps.lateStaticField;
-        HasStaticMembersProps.staticField;
-      }
-    '''));
-  }
-
-  Future<void> test_noErrors_withinFunctionComponent() async {
-    await expectNoErrors(newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
-      print(props.requiredProp);
-      print(props.optionalProp);
-    ''')));
-    await expectNoErrors(newSourceWithPrefix(componentSource(ComponentType.uiForwardRef, componentBody: r'''
-      print(props.requiredProp);
-      print(props.optionalProp);
-    ''')));
-  }
-
-  Future<void> test_noErrors_withinClassComponent() async {
-    await expectNoErrors(newSourceWithPrefix(componentSource(ComponentType.component2, componentBody: r'''
-      render() {
-        print(props.requiredProp);
-        print(props.optionalProp);
-        _renderHelper();
-      }
-      _renderHelper() {
-        print(props.requiredProp);
-        print(props.optionalProp);
-      }
-    ''')));
-  }
-
-  Future<void> test_noErrors_withinUtilityMethods() async {
-    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ '''
-      test1(HasRequiredProps props) {
-        // UiProps methods
-        print(props.getPropKey((p) => p.requiredProp));
-        print(props.containsProp((p) => p.requiredProp));
-        print(props.getRequiredProp((p) => p.requiredProp, orElse: () => ''));
-        print(props.getRequiredPropOrNull((p) => p.requiredProp));
-      }
-      
-      testTopLevel(HasRequiredProps props) {
-        // Top-level functions  
-        print(getPropKey<HasRequiredProps>((p) => p.requiredProp, HasRequired));
-      }
-      
-      ${componentSource(ComponentType.component2, componentBody: r'''
-        render() {
-          // UiComponent methods
-          print(keyForProp((p) => p.requiredProp));
-          // `this.` is necessary to avoid top-level getPropKey taking precedence.
-          print(this.getPropKey((p) => p.requiredProp)); // ignore: deprecated_member_use
-        }
-      ''')}
-    '''));
-  }
-
-  // FIXME clarify that even unsafe accesses aren't linted
-  Future<void> test_noErrors_withinSpecificLifecycleMethods() async {
-    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
-      abstract class TestComponent2 extends UiComponent2<HasRequiredProps> {
-        get propTypes => {
-          keyForProp((p) => p.requiredProp): (props, _) {
-            print(typedPropsFactory(props).requiredProp);
-            return null;
-          },
-        };
-        @override componentDidUpdate(prevProps, _, [__]) { print(typedPropsFactory(prevProps).requiredProp); }  
-        @override getDerivedStateFromProps(nextProps, _) { print(typedPropsFactory(nextProps).requiredProp); return {}; }  
-        @override getSnapshotBeforeUpdate(prevProps, _)  { print(typedPropsFactory(prevProps).requiredProp); return null; }  
-        @override shouldComponentUpdate(nextProps, _)    { print(typedPropsFactory(nextProps).requiredProp); return true; }
-      }
-      
-      abstract class TestComponent1 extends UiComponent<HasRequiredProps> {
-        // Just test UiComponent-specific methods
-        @override componentWillReceiveProps(nextProps)               { print(typedPropsFactory(nextProps).requiredProp); super.componentWillReceiveProps(nextProps); }  
-        @override componentWillReceivePropsWithContext(nextProps, _) { print(typedPropsFactory(nextProps).requiredProp); }  
-        @override componentWillUpdate(prevProps, _, [__])            { print(typedPropsFactory(prevProps).requiredProp); }  
-        @override shouldComponentUpdateWithContext(nextProps, _, __) { print(typedPropsFactory(nextProps).requiredProp); return true; }
-      }
-    '''));
-  }
-
-  Future<void> test_noErrorsWithContainsPropCheck() async {
-    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
-      test(HasRequiredProps props) {
-        if (props.containsProp((p) => p.requiredProp)) {
-          print(props.requiredProp);
-        }
-      }
-    '''));
-  }
 }
 
 const sourcePrefix = /*language=dart*/ r'''

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -318,6 +318,27 @@ void main() {
         });
       });
 
+      group('props on a class component instance:', () {
+        const testComponentName = 'Test';
+        const testComponentClassName = '${testComponentName}Component';
+        late final testComponentSource =
+            componentSource(ComponentType.component2, componentBody: 'render() {}', componentName: testComponentName);
+
+        test('single level of property access', () async {
+          await testBase.expectNoErrors(testBase.newSourceWithPrefix('''
+            $testComponentSource
+            test($testComponentClassName component) => component.props.requiredProp;
+          '''));
+        });
+
+        test('multiple levels of property access', () async {
+          await testBase.expectNoErrors(testBase.newSourceWithPrefix('''
+            $testComponentSource
+            test(Ref<$testComponentClassName?> ref) => ref.current?.props.requiredProp;
+          '''));
+        });
+      });
+
       test('within utility method callbacks', () async {
         await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ '''
           test1(HasRequiredProps props) {

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -125,6 +125,43 @@ void main() {
             isAnErrorUnderTest(locatedAt: createSelection(source, 'props.#requiredProp# += "";'), hasFix: false),
           ]);
         });
+
+        group('when the props object is typed as', () {
+          test('the props mixin that defines the required prop', () async {
+            final source = testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              test(HasRequiredProps props) {
+                print(props.requiredProp);
+              }
+            ''');
+            expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+              testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'props.#requiredProp#')),
+            ]);
+          });
+
+          test('a subclass', () async {
+            final source = testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              UiFactory<SubclassProps> Subclass = castUiFactory(_$Subclass);
+              class SubclassProps = UiProps with HasRequiredProps;
+              test(SubclassProps props) {
+                print(props.requiredProp);
+              }
+            ''');
+            expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+              testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'props.#requiredProp#')),
+            ]);
+          });
+
+          test('a bounded generic', () async {
+            final source = testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              test<T extends HasRequiredProps>(T props) {
+                print(props.requiredProp);
+              }
+            ''');
+            expect(await testBase.getAllErrors(source, includeOtherCodes: true), [
+              testBase.isAnErrorUnderTest(locatedAt: testBase.createSelection(source, 'props.#requiredProp#')),
+            ]);
+          });
+        });
       });
 
       group('inside a component', () {

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -101,6 +101,38 @@ class UnsafeRequiredPropAccessTest extends DiagnosticTestBase {
     ]);
   }
 
+  Future<void> test_noErrors_NonPropAccesses() async {
+    await expectNoErrors(newSource(/*language=Dart*/r'''
+      // End with "Props" because we short-circuit on types that end with props.
+      class NotProps {
+        String? someField;
+        // This declaration is identical to that of a required prop,
+        // but it isn't one.
+        late String lateField;
+      }
+      
+      test(NotProps notProps) {
+        notProps.lateField;
+        notProps.someField;
+        notProps.hashCode;
+      }
+    '''));
+  }
+
+  Future<void> test_noErrors_staticAccesses() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=Dart*/r'''
+      mixin HasStaticMembersProps {
+        static late String lateStaticField;
+        static String staticField = '';
+      }
+      
+      test() {
+        HasStaticMembersProps.lateStaticField;
+        HasStaticMembersProps.staticField;
+      }
+    '''));
+  }
+
   Future<void> test_noErrors_withinFunctionComponent() async {
     await expectNoErrors(newSourceWithPrefix(componentSource(ComponentType.uiFunction, componentBody: r'''
       print(props.requiredProp);

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -1,0 +1,49 @@
+// ignore_for_file: camel_case_types
+import 'dart:async';
+
+import 'package:over_react_analyzer_plugin/src/diagnostic/unsafe_required_prop_access.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../test_bases/diagnostic_test_base.dart';
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(UnsafeRequiredPropAccessTest);
+  });
+}
+
+@reflectiveTest
+class UnsafeRequiredPropAccessTest extends DiagnosticTestBase {
+  @override
+  get errorUnderTest => UnsafeRequiredPropAccessDiagnostic.code;
+
+  @override
+  get fixKindUnderTest => UnsafeRequiredPropAccessDiagnostic.fixKind;
+
+  Source newSourceWithPrefix(String sourceFragment) => newSource(sourcePrefix + sourceFragment);
+
+  static const sourcePrefix = /*language=dart*/ r'''
+import 'package:over_react/over_react.dart';
+
+part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
+
+// ignore_for_file: unused_local_variable
+
+UiFactory<FooProps> Foo = castUiFactory(_$Foo); // ignore: undefined_identifier
+
+mixin FooProps on UiProps {
+  late String requiredProp;
+  String? optionalProp;
+}
+''';
+
+  Future<void> test_noErrorsForPropsWithDisabledValidation() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+      test(FooProps props) {
+        if (props.containsProp((p) => p.requiredProp)) {
+          print(props.requiredProp);
+        }
+      }
+    '''));
+  }
+}

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -1,6 +1,7 @@
 import 'package:over_react_analyzer_plugin/src/diagnostic/unsafe_required_prop_access.dart';
 import 'package:test/test.dart';
 
+import '../matchers.dart';
 import '../test_bases/diagnostic_test_base.dart';
 
 void main() {

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -29,13 +29,46 @@ part '{{FILE_BASENAME_WITHOUT_EXTENSION}}.over_react.g.dart';
 
 // ignore_for_file: unused_local_variable
 
-UiFactory<FooProps> Foo = castUiFactory(_$Foo); // ignore: undefined_identifier
+UiFactory<FooProps> Foo = castUiFactory(_$Foo);
 
 mixin FooProps on UiProps {
   late String requiredProp;
   String? optionalProp;
 }
 ''';
+
+  Future<void> test_noErrors_withinFunctionComponent() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''    
+      class TestUiFunctionProps = UiProps with FooProps;
+      class TestUiForwardRefProps = UiProps with FooProps;
+    
+      UiFactory<TestUiFunctionProps> TestUiFunction = uiFunction((props) {
+        print(props.requiredProp);
+        print(props.optionalProp);
+      }, _$TestUiFunctionConfig);
+      
+      UiFactory<TestUiForwardRefProps> TestUiForwardRef = uiForwardRef((props, ref) {
+        print(props.requiredProp);
+        print(props.optionalProp);
+      }, _$TestUiForwardRefConfig);
+    '''));
+  }
+
+  Future<void> test_noErrors_withinClassComponent() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''    
+      class FooComponent extends UiComponent2<FooProps> {
+        render() {
+          print(props.requiredProp);
+          print(props.optionalProp);
+          _renderHelper();
+        }
+        _renderHelper() {
+          print(props.requiredProp);
+          print(props.optionalProp);
+        }
+      }
+    '''));
+  }
 
   Future<void> test_noErrors_withinUtilityMethods() async {
     await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
@@ -66,7 +99,7 @@ mixin FooProps on UiProps {
   // FIXME clarify that even unsafe accesses aren't linted
   Future<void> test_noErrors_withinSpecificLifecycleMethods() async {
     await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
-      abstract class OtherComponent extends UiComponent2<FooProps> {
+      abstract class FooComponent extends UiComponent2<FooProps> {
         get propTypes => {
           keyForProp((p) => p.requiredProp): (props, _) {
             print(typedPropsFactory(props).requiredProp);

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -219,6 +219,13 @@ void main() {
           }
         '''));
       });
+
+      test('required prop references in doc comments', () async {
+        await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=Dart*/ r'''
+          /// Test doc comment with reference to: [HasRequiredProps.requiredProp]
+          test(HasRequiredProps props) {}
+        '''));
+      });
     });
 
     group('does not warn for safe accesses of late required props:', () {
@@ -304,14 +311,36 @@ void main() {
           '''));
         });
 
-        test('simple if-check `&&` another condition', () async {
-          await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
-            test(HasRequiredProps props, bool otherCondition) {
-              if (props.containsProp((p) => p.requiredProp) && otherCondition) {
-                print(props.requiredProp);
+        group('simple if-check `&&` another condition:', () {
+          test('left-hand condition', () async {
+            await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              test(HasRequiredProps props, bool otherCondition) {
+                if (props.containsProp((p) => p.requiredProp) && otherCondition) {
+                  print(props.requiredProp);
+                }
               }
-            }
-          '''));
+            '''));
+          });
+
+          test('right-hand condition', () async {
+            await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              test(HasRequiredProps props, bool otherCondition) {
+                if (otherCondition && props.containsProp((p) => p.requiredProp)) {
+                  print(props.requiredProp);
+                }
+              }
+            '''));
+          });
+
+          test('more than two `&&`s', () async {
+            await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+              test(HasRequiredProps props, bool otherCondition) {
+                if (otherCondition && props.containsProp((p) => p.requiredProp) && otherCondition) {
+                  print(props.requiredProp);
+                }
+              }
+            '''));
+          });
         });
 
         group('except when the containsProp check', () {

--- a/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/unsafe_required_prop_access_test.dart
@@ -355,6 +355,18 @@ void main() {
           '''));
         });
 
+        test('nested if-check', () async {
+          await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
+            test(HasRequiredProps props, bool otherCondition) {
+              if (props.containsProp((p) => p.requiredProp)) {
+                if (otherCondition) {
+                  print(props.requiredProp);
+                }
+              }
+            }
+          '''));
+        });
+
         test('simple else-if-check', () async {
           await testBase.expectNoErrors(testBase.newSourceWithPrefix(/*language=dart*/ r'''
             test(HasRequiredProps props, bool otherCondition) {

--- a/tools/analyzer_plugin/test/integration/test_bases/analysis_driver_test_base.dart
+++ b/tools/analyzer_plugin/test/integration/test_bases/analysis_driver_test_base.dart
@@ -36,13 +36,16 @@ abstract class AnalysisDriverTestBase {
   /// doesn't conflict with paths created by other tests using the same [sharedContext].
   ///
   /// For convenience [substituteSource] will be applied to [contents] first.
-  Source newSource(String contents, {String? path}) {
+  Source newSource(String contents, {
+    String? path,
+    String topLevelDirectory = 'lib',
+  }) {
     if (path != null && p.isAbsolute(path)) {
       throw ArgumentError.value(path, 'path', 'must be a relative path');
     }
     path ??= uniqueSourceFileName();
     contents = substituteSource(contents, path: path);
-    final testFilePath = sharedContext.createTestFile(contents, filename: path);
+    final testFilePath = sharedContext.createTestFile(contents, filename: path, topLevelDirectory: topLevelDirectory);
     return resourceProvider.getFile(testFilePath).createSource();
   }
 

--- a/tools/analyzer_plugin/test/unit/util/is_props_from_render_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/is_props_from_render_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 Workiva Inc.
+// Copyright 2024 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/analyzer_plugin/test/unit/util/is_props_from_render_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/is_props_from_render_test.dart
@@ -1,0 +1,134 @@
+// Copyright 2021 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/is_props_from_render.dart';
+import 'package:over_react_analyzer_plugin/src/util/util.dart';
+import 'package:test/test.dart';
+
+import '../../test_util.dart';
+
+
+void main() {
+  group('isPropsFromRender', () {
+    /// Parsed and resolves [source] and returns the expression that is returned from
+    /// a function named `returnsExpressionToTest`.
+    ///
+    /// There must be exactly one function with that name, and it can either be an arrow function
+    /// or a block function with exactly one return statement with an explicit value.
+    ///
+    /// For example,
+    /// ```dart
+    /// await getExpressionToTest(r'''
+    ///   returnsExpressionToTest() {
+    ///     return someExpression;
+    ///   }
+    /// ''');
+    /// ```
+    /// Returns `someExpression`.
+    Future<Expression> getExpressionToTest(String source) async {
+      final result = await parseAndGetResolvedUnit('''
+        import 'package:over_react/over_react.dart';
+        
+        late UiFactory<FooProps> Foo;
+        mixin FooProps on UiProps {}
+        
+        $source
+      ''');
+      final functionBody = allDescendants(result.unit).whereType<FunctionBody>().singleWhere((f) {
+        final name =
+            // Top-level and local functions
+            f.parent.tryCast<FunctionExpression>()?.parent.tryCast<FunctionDeclaration>()?.name.lexeme ??
+                // Class methods
+                f.parent?.tryCast<MethodDeclaration>()?.name.lexeme;
+        return name == 'returnsExpressionToTest';
+      });
+      return functionBody.returnExpressions.single;
+    }
+
+    group('returns false for', () {
+      test('arbitrary props arguments', () async {
+        expect(isPropsFromRender(await getExpressionToTest(r'''
+          returnsExpressionToTest(FooProps props) => props;
+        ''')), isFalse);
+      });
+
+      test('arbitrary props variables', () async {
+        expect(isPropsFromRender(await getExpressionToTest(r'''
+          returnsExpressionToTest() {
+            final props = Foo();
+            return props;
+          }
+        ''')), isFalse);
+      });
+
+      test('single-invoked builders', () async {
+        expect(isPropsFromRender(await getExpressionToTest(r'''
+          returnsExpressionToTest() => Foo();
+        ''')), isFalse);
+      });
+
+      // FIXME also inside a component, function component
+    });
+
+    group('returns true for', () {
+      group('function component props', () {
+        test('in a uiFunction', () async {
+          expect(isPropsFromRender(await getExpressionToTest(r'''
+            final Bar = uiFunction<UiProps>((props) {
+              returnsExpressionToTest() => props;
+            }, UiFactoryConfig());
+          ''')), isTrue);
+        });
+
+        test('in a uiForwardRef', () async {
+          expect(isPropsFromRender(await getExpressionToTest(r'''
+            final Bar = uiForwardRef<UiProps>((props, ref) {
+              returnsExpressionToTest() => props;
+            }, UiFactoryConfig());
+          ''')), isTrue);
+        });
+
+        test('even when the name is not "props"', () async {
+          expect(isPropsFromRender(await getExpressionToTest(r'''
+            final Bar = uiFunction<UiProps>((someOtherName) {
+              returnsExpressionToTest() => someOtherName;
+            }, UiFactoryConfig());
+          ''')), isTrue);
+        });
+      });
+
+      group('class component props', () {
+        test('when accessed via implicit this', () async {
+          expect(isPropsFromRender(await getExpressionToTest(r'''
+            class FooComponent extends UiComponent2 {
+              @override render() {}
+              returnsExpressionToTest() => props;
+            }
+          ''')), isTrue);
+        });
+
+        test('when accessed via explicit this', () async {
+          expect(isPropsFromRender(await getExpressionToTest(r'''
+            class FooComponent extends UiComponent2 {
+              @override render() {}
+              returnsExpressionToTest() => this.props;
+            }
+          ''')), isTrue);
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Motivation
While required late props are validated to be present when a component is rendered, there are cases where they won't always be present. For example, "partial" props objects that represent a subset of a component's props.

If required late props are accessed without being set, they'll throw at runtime, and there's currently no static analysis that prevents consumers from doing so, or notifies them that they're doing something unsafe.

So, we want to help prevent consumers from unsafely accessing required late props.

## Changes
- Add new `UnsafeRequiredPropAccessDiagnostic` that warns whenever required props are accessed in an unsafe manner
    - Lints when accessing required props on objects that aren't props a component was rendered with
    - Exceptions where we don't lint
        - Accesses on callback args in utility methods like `.getPropKey((p) => p.requiredProp)`
        - Within `memo` areEqual functions, or top-level functions with `areEqual` in the name since consumers apparently split themout a fair bit
        - In files within the `test/` directory, which typically uses `getProps` a lot (and if unsafe accesses happen, they'll just fail tests instead of crashing an app)
        - Within lifecycle methods that receive props as an argument and typically use `typedPropsFactory`
            - We could track these down and ignore them only if they're safe, but that didn't seem worth the effort/complexity
- Add tests
   - Update `SharedAnalysisContext` to allow creation of files outside of `lib`
- Add playground example

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify CI passes
        - Manually test
            - Test in playground example
            - Test in a consumer that uses required props (e.g., FluxUiProps) and verify there aren't any unexpected errors
            - Double-check with `// debug: over_react_metrics` that performance is acceptable (this lint has to process all property accesses to see if they're on props). From my testing it looked pretty efficient, all things considered, and was hovering around being our 5th slowest lint, which IMO isn't bad at all.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
