### PR TITLE
FED-2432: Don't lint required props that are set in factory

### DIFF
--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
@@ -168,8 +168,13 @@ class MissingRequiredPropDiagnostic extends ComponentUsageDiagnosticContributor 
 
     // Use a late variable to compute this only when we need to.
     late final propsSetByFactory = () {
-      final factoryElement = usage.factory.tryCast<Identifier>()?.staticElement;
-      return factoryElement == null ? null : _cachedGetPropsSetByFactory(factoryElement);
+      final factory = usage.factory;
+      if (factory == null) return null;
+
+      final factoryElement = getFactoryElement(factory);
+      if (factoryElement == null) return null;
+
+      return _cachedGetPropsSetByFactory(factoryElement);
     }();
 
     // Include debug info for each invocation ahout all the props and their requirednesses.

--- a/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
+++ b/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
@@ -76,5 +76,11 @@ Set<String>? getPropsSetByFactory(Element factoryElement) {
       .where((assignment) => assignment.leftHandSide is PropertyAccess)
       .map(PropAssignment.new);
 
-  return cascadedProps?.map((p) => p.name.name).toSet();
+  return cascadedProps?.map((p) {
+    final prefix = p.prefix;
+    return <String>[
+      if (prefix != null) prefix.name,
+      p.name.name,
+    ].join('.');
+  }).toSet();
 }

--- a/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
+++ b/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
@@ -1,0 +1,68 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:over_react_analyzer_plugin/src/component_usage.dart';
+import 'package:over_react_analyzer_plugin/src/util/analyzer_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/util.dart';
+
+Set<String>? getPropsSetByFactory(Element factoryElement) {
+  // We'll use the name offset/length to find the AST node that declares this element.
+  final factoryNameOffset = factoryElement.nameOffset;
+  if (factoryNameOffset == -1) return null;
+
+  final factoryNameLength = factoryElement.nameLength;
+  if (factoryNameLength == 0) return null;
+
+  //
+  // Get the AST for the file that declares factoryElement.
+
+  final factoryFileSource = factoryElement.source;
+  if (factoryFileSource == null) return null;
+
+  final session = factoryElement.session;
+  if (session == null) return null;
+
+  // We don't need resolved AST, so get unresolved AST with getParsedUnit since it's synchronous.
+  // Unfortunately it looks like there's no caching in the current implementation, so this will parse the file from
+  // scratch. This isn't ideal, but shouldn't be too bad from a performance perspective.
+  final result = session.getParsedUnit(factoryFileSource.fullName);
+  if (result is! ParsedUnitResult) return null;
+
+  //
+  // Look up the factory and retrieve its return value.
+  //
+
+  final factoryDeclaration =
+      NodeLocator2(factoryNameOffset, factoryNameOffset + factoryNameLength).searchWithin(result.unit);
+
+  FunctionBody? factoryBody;
+  if (factoryDeclaration is MethodDeclaration) {
+    factoryBody = factoryDeclaration.body;
+  } else if (factoryDeclaration is FunctionDeclaration) {
+    factoryBody = factoryDeclaration.functionExpression.body;
+  } else if (factoryDeclaration is VariableDeclaration) {
+    factoryBody = factoryDeclaration.initializer?.unParenthesized.tryCast<FunctionExpression>()?.body;
+  }
+  if (factoryBody == null) return null;
+
+  final returnValue = factoryBody.returnExpressions.singleOrNull;
+  if (returnValue == null) return null;
+
+  //
+  // Return the props set on any returned builder
+  //
+
+  // Since it's a factory, we're returning a UiProps, so any cascaded properties on the return value
+  // are most likely also be props being set.
+  final cascadedProps = returnValue
+      // Consumers often wrap in unnecessary parentheses, so make sure to strip these off.
+      .unParenthesized
+      .tryCast<CascadeExpression>()
+      ?.cascadeSections
+      .whereType<AssignmentExpression>()
+      .where((assignment) => assignment.leftHandSide is PropertyAccess)
+      .map(PropAssignment.new);
+
+  return cascadedProps?.map((p) => p.name.name).toSet();
+}

--- a/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
+++ b/tools/analyzer_plugin/lib/src/util/prop_declarations/props_set_by_factory.dart
@@ -6,7 +6,19 @@ import 'package:over_react_analyzer_plugin/src/util/analyzer_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/util.dart';
 
+Element? getFactoryElement(Expression factory) {
+  factory = factory.unParenthesized;
+  if (factory is Identifier) return factory.staticElement;
+  if (factory is PropertyAccess) return factory.propertyName.staticElement;
+
+  return null;
+}
+
 Set<String>? getPropsSetByFactory(Element factoryElement) {
+  if (factoryElement.isSynthetic) {
+    factoryElement = factoryElement.nonSynthetic;
+  }
+
   // We'll use the name offset/length to find the AST node that declares this element.
   final factoryNameOffset = factoryElement.nameOffset;
   if (factoryNameOffset == -1) return null;

--- a/tools/analyzer_plugin/lib/src/util/weak_map.dart
+++ b/tools/analyzer_plugin/lib/src/util/weak_map.dart
@@ -12,36 +12,69 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A wrapper around [Expando] with a more [Map]-like interface, with typing on keys.
+/// A wrapper around [Expando] with typing on keys, and also allowing nullable values.
 ///
 /// Keys may not be primitive values, and as a result keys are also non-nullable.
 ///
-/// Values may also not be nullable in order to simplify the [has]/[putIfAbsent] implementations
-/// by assuming that `null` Expando values correspond unambiguously to unset keys.
-class WeakMap<K extends Object, V extends Object> {
-  final _valueFor = Expando<V>();
+/// Similar to the JS `WeakMap`.
+class WeakMap<K extends Object, V> {
+  final _wrappedValues = Expando<_ValueWrapper<V>>();
 
-  V? get(K key) => _valueFor[key];
+  /// Returns the value for the given [key], or null if there is no entry.
+  V? get(K key) => _wrappedValues[key]?.value;
 
+  /// Returns the value for the given [key], or null if there is no entry.
+  ///
+  /// This method the same as [get], but also allows nullable keys for convenience.
+  ///
+  /// `getNullableKey(null)` will always return null.
   V? getNullableKey(K? key) => key == null ? null : get(key);
 
-  void set(K key, V value) => _valueFor[key] = value;
+  /// Sets the [value] for the given [key], overwriting any existing value.
+  void set(K key, V value) => _wrappedValues[key] = _ValueWrapper(value);
 
-  bool has(K key) => get(key) != null;
+  /// Returns whether a value has been set for [key].
+  bool has(K key) => _wrappedValues[key] != null;
 
-  void remove(K key) => _valueFor[key] = null;
+  /// Removes any value previously set for [key].
+  void remove(K key) => _wrappedValues[key] = null;
 
-  V putIfAbsent(K key, V Function() ifAbsent) {
-    final existingValue = get(key);
-    if (existingValue != null) return existingValue;
-    final value = ifAbsent();
-    set(key, value);
-    return value;
+  /// Look up the value of [key], or add a new entry if it isn't there.
+  ///
+  /// Returns the value associated to [key], if there is one.
+  /// Otherwise calls [ifAbsent] to get a new value, associates [key] to
+  /// that value, and then returns the new value.
+  V putIfAbsent(K key, V Function() ifAbsent) => (_wrappedValues[key] ??= _ValueWrapper(ifAbsent())).value;
+}
+
+/// A wrapper around a WeakMap value.
+///
+/// Used to allow null values in [WeakMap] and tell them apart from unset values,
+/// since [Expando] doesn't allow nullable values.
+class _ValueWrapper<T> {
+  final T value;
+
+  _ValueWrapper(this.value);
+}
+
+extension MemoizeWithWeakMap<K extends Object, V> on V Function(K) {
+  /// Memoizes this function by storing the return value in a WeakMap, keyed by the single argument.
+  ///
+  /// Optionally uses [map], or creates a new WeakMap if not specified.
+  ///
+  /// Note that return values will be retained by their corresponding argument values,
+  /// unless they're explicitly removed in the map.
+  V Function(K) memoizeWithWeakMap([WeakMap<K, V>? map]) {
+    final _map = map ?? WeakMap();
+    return (key) => _map.putIfAbsent(key, () => this(key));
   }
 }
 
-extension MemoizeWithWeakMap<K extends Object, V extends Object> on V Function(K) {
-  V Function(K) memoizeWithWeakMap(WeakMap<K, V> map) {
-    return (key) => map.putIfAbsent(key, () => this(key));
-  }
-}
+/// Memoizes [computeValue] by storing the return value in a WeakMap, keyed by the single argument.
+///
+/// Optionally uses [map], or creates a new WeakMap if not specified.
+///
+/// Note that return values will be retained by their corresponding argument values,
+/// unless they're explicitly removed in the map.
+V Function(K) memoizeWithWeakMap<K extends Object, V>(V Function(K) computeValue, [WeakMap<K, V>? map]) =>
+    computeValue.memoizeWithWeakMap(map);

--- a/tools/analyzer_plugin/playground/web/missing_required_props.dart
+++ b/tools/analyzer_plugin/playground/web/missing_required_props.dart
@@ -86,6 +86,9 @@ main() {
 
   (WithLateRequired()..disableRequiredPropValidation())();
 
+  WithLateRequiredProps factoryThatSetsSomeLateRequired() => WithLateRequired()..required1 = '';
+  (factoryThatSetsSomeLateRequired()..required2 = '')();
+
   WithLateRequired()();
 
   InheritsLateRequired()();

--- a/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
+++ b/tools/analyzer_plugin/test/integration/diagnostics/missing_required_prop_test.dart
@@ -265,6 +265,32 @@ class MissingRequiredPropTest_MissingLateRequired extends MissingRequiredPropTes
       )();
     '''));
   }
+
+  Future<void> test_noErrorsAllRequiredPropsSetInFactory() async {
+    await expectNoErrors(newSourceWithPrefix(/*language=dart*/ r'''
+      WithLateRequiredProps testFactory() => WithLateRequired()
+        ..required1 = ''
+        ..required2 = '';
+
+      test() => testFactory()();
+    '''));
+  }
+
+  Future<void> test_onlySomeRequiredPropsSetInFactory() async {
+    final source = newSourceWithPrefix(/*language=dart*/ r'''
+      WithLateRequiredProps testFactory() => WithLateRequired()
+        ..required2 = '';
+  
+      test() => testFactory()();
+    ''');
+    final selection = createSelection(source, '#testFactory()#()');
+    final allErrors = await getAllErrors(source);
+    expect(
+        allErrors,
+        unorderedEquals(<dynamic>[
+          isAnErrorUnderTest(locatedAt: selection).havingMessage(contains("'required1' from 'WithLateRequiredProps'")),
+        ]));
+  }
 }
 
 @reflectiveTest

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
@@ -169,6 +169,30 @@ void main() {
             expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
           });
         });
+
+        test('unwraps parentheses in return values', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''            
+            TestProps testFactory() => ((Test()..prop1 = '1'..prop2 = '2'));
+            returnsUsageOfFactory() => testFactory()();
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+        });
+
+        test('returns prefixed props with their prefix', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''            
+            TestProps testFactory() => ((Test()..prop1 = '1'..aria.label = 'label'));
+            returnsUsageOfFactory() => testFactory()();
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'aria.label']));
+        });
+
+        test('does not return non-assignment cascaded members', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''            
+            TestProps testFactory() => Test()..prop1 = '1'..addProps({})..hashCode;
+            returnsUsageOfFactory() => testFactory()();
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1']));
+        });
       });
     });
   });

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
@@ -193,6 +193,55 @@ void main() {
           ''');
           expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1']));
         });
+
+        group('returns null for factories', () {
+          test('that do not set any props', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''            
+              TestProps testFactory() => Test();
+              returnsUsageOfFactory() => testFactory()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), isNull);
+          });
+
+          group('declared as part of over_react boilerplate:', () {
+            test('non-function-component', () async {
+              final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+                returnsUsageOfFactory() => Test()();
+              ''');
+              expect(getPropsSetByFactory(factoryElement), isNull);
+            });
+
+            test('function-component', () async {
+              final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+                mixin TestFunctionProps on UiProps {}
+                UiFactory<TestFunctionProps> TestFunction = uiFunction((_) {}, _$TestFunctionConfig);
+                returnsUsageOfFactory() => TestFunction()();
+              ''');
+              expect(getPropsSetByFactory(factoryElement), isNull);
+            });
+          });
+
+          test('with more than one return value', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              TestProps testFactory([bool condition = false]) {
+                if (condition) return Test()..prop1 = '1';
+                return Test()..prop2 = '1';
+              }
+              returnsUsageOfFactory() => testFactory()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), isNull);
+          });
+
+          test('that are abstract', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              abstract class SomeClass {
+                TestProps testFactory();
+              }
+              returnsUsageOfFactory(SomeClass instance) => instance.testFactory()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), isNull);
+          });
+        });
       });
     });
   });

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/props_set_by_factory_test.dart
@@ -1,0 +1,173 @@
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:over_react_analyzer_plugin/src/component_usage.dart';
+import 'package:over_react_analyzer_plugin/src/over_react_builder_parsing.dart';
+import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
+import 'package:over_react_analyzer_plugin/src/util/prop_declarations/props_set_by_factory.dart';
+import 'package:test/test.dart';
+
+import '../../../util/shared_analysis_context.dart';
+import 'util.dart';
+
+void main() {
+  group('props_set_by_factory', () {
+    final sharedContext = SharedAnalysisContext.overReact;
+
+    setUpAll(sharedContext.warmUpAnalysis);
+
+    group('getPropsSetByFactory', () {
+      /// Parses and resolves [source] and returns the expression that is returned from
+      /// a function named `returnsUsageOfFactory`.
+      ///
+      /// There must be exactly one function with that name, and it can either be an arrow function
+      /// or a block function with exactly one return statement with an explicit value.
+      ///
+      /// For example,
+      /// ```dart
+      /// await getExpressionToTest(r'''
+      ///   returnsUsageOfFactory() => Foo()();
+      /// ''');
+      /// ```
+      /// Returns the element referenced by `Foo`.
+      Future<Element> getFactoryElementToTest(String source) async {
+        final result = await resolveFileAndGeneratedPart(
+            sharedContext,
+            r'''
+              // @dart=2.12
+              import 'package:over_react/over_react.dart';
+              part '{{PART_PATH}}';
+              
+              mixin TestProps on UiProps {
+                String? prop1;
+                String? prop2;
+                String? prop3;
+              }
+              UiFactory<TestProps> Test = castUiFactory(_$Test);
+            ''' +
+                source);
+
+        final testFunction = allDescendantsOfType<FunctionDeclaration>(result.unit)
+            .singleWhere((e) => e.name.name == 'returnsUsageOfFactory');
+        final returnValue = testFunction.functionExpression.body.returnExpressions.single;
+
+        final componentUsage = getComponentUsageFromExpression(returnValue);
+        if (componentUsage == null) {
+          throw ArgumentError('returnsUsageOfFactory return value $returnValue'
+              ' is not a component usage that can be identified by `getComponentUsageFromExpression`');
+        }
+
+        final factory = componentUsage.factory;
+        if (factory == null) {
+          throw ArgumentError('Usage in returnsUsageOfFactory ${componentUsage.node} does not have a factory');
+        }
+
+        final factoryElement = getFactoryElement(factory);
+        if (factoryElement == null) {
+          throw ArgumentError('factoryElement for factory $factory was null');
+        }
+
+        return factoryElement;
+      }
+
+      group('returns props set in factories defined in class', () {
+        group('methods:', () {
+          test('instance', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              class SomeClass {
+                TestProps factoryInstanceMethod() => Test()..prop1 = '1'..prop2 = '2';
+              }
+              returnsUsageOfFactory() => SomeClass().factoryInstanceMethod()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+          });
+
+          test('static', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              class SomeClass {
+                static TestProps factoryStaticMethod() => Test()..prop1 = '1'..prop2 = '2';
+              }
+              returnsUsageOfFactory() => SomeClass.factoryStaticMethod()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+          });
+        });
+
+        group('fields:', () {
+          test('instance', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              class SomeClass {
+                BuilderOnlyUiFactory<TestProps> factoryInstanceVar = () => Test()..prop1 = '1'..prop2 = '2';
+              }
+              returnsUsageOfFactory() => SomeClass().factoryInstanceVar()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+          });
+
+          test('static', () async {
+            final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+              class SomeClass {
+                static BuilderOnlyUiFactory<TestProps> factoryStaticVar = () => Test()..prop1 = '1'..prop2 = '2';
+              }
+              returnsUsageOfFactory() => SomeClass.factoryStaticVar()();
+            ''');
+            expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+          });
+        });
+      });
+
+      group('returns props set in factories that are top-level function', () {
+        test('declarations', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+            TestProps topLevelFunctionDeclaration() => Test()..prop1 = '1'..prop2 = '2';
+            returnsUsageOfFactory() => topLevelFunctionDeclaration()();
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+        });
+
+        test('variables', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+            BuilderOnlyUiFactory<TestProps> topLevelFunctionVar = () => Test()..prop1 = '1'..prop2 = '2';
+            returnsUsageOfFactory() => topLevelFunctionVar()();
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+        });
+      });
+
+      group('returns props set in factories that are local function', () {
+        test('declarations', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+            test() {
+              TestProps localFunctionDeclaration() => Test()..prop1 = '1'..prop2 = '2';
+              returnsUsageOfFactory() => localFunctionDeclaration()();
+            }
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+        });
+
+        test('variables', () async {
+          final factoryElement = await getFactoryElementToTest(/*language=dart*/ r'''
+            test() {
+              BuilderOnlyUiFactory<TestProps> localFunctionVar = () => Test()..prop1 = '1'..prop2 = '2';
+              returnsUsageOfFactory() => localFunctionVar()();
+            }
+          ''');
+          expect(getPropsSetByFactory(factoryElement), unorderedEquals(<String>['prop1', 'prop2']));
+        });
+      });
+    });
+  });
+}

--- a/tools/analyzer_plugin/test/unit/util/weak_map_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/weak_map_test.dart
@@ -1,0 +1,174 @@
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_analyzer_plugin/src/util/weak_map.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WeakMap', () {
+    test('associates a value with a key', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final key = TestObject('key');
+      final value = TestObject('value');
+      weakMap.set(key, value);
+      expect(weakMap.get(key), same(value));
+    });
+
+    test('associates more than one value with a key', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final key1 = TestObject('key1');
+      final value1 = TestObject('value1');
+      final key2 = TestObject('key2');
+      final value2 = TestObject('value2');
+
+      expect(key1, isNot(same(key2)), reason: 'test setup check');
+      expect(value1, isNot(same(value2)), reason: 'test setup check');
+
+      weakMap.set(key1, value1);
+      weakMap.set(key2, value2);
+      expect(weakMap.get(key1), same(value1));
+      expect(weakMap.get(key2), same(value2));
+    });
+
+    test('works with null values', () {
+      final weakMap = WeakMap<TestObject, TestObject?>();
+      final key = TestObject('key');
+      weakMap.set(key, null);
+      expect(weakMap.get(key), isNull);
+      expect(weakMap.has(key), isTrue);
+    });
+
+    test('.get returns null if no value is associated with a key', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      expect(weakMap.get(TestObject('key')), isNull);
+    });
+
+    group('.getNullableKey', () {
+      test('returns null for null', () {
+        final weakMap = WeakMap<TestObject, TestObject>();
+        expect(weakMap.getNullableKey(null), isNull);
+        weakMap.set(TestObject('key'), TestObject('value'));
+        expect(weakMap.getNullableKey(null), isNull);
+      });
+
+      test('returns the same value as .get for non-null arguments', () {
+        final weakMap = WeakMap<TestObject, TestObject>();
+        final key = TestObject('key');
+        final value = TestObject('value');
+        weakMap.set(key, value);
+        expect(weakMap.getNullableKey(key), same(value));
+      });
+    });
+
+    test('.set overwrites existing values', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final key = TestObject('key');
+      weakMap.set(key, TestObject('originalValue'));
+
+      final newValue = TestObject('newValue');
+      weakMap.set(key, newValue);
+      expect(weakMap.get(key), same(newValue));
+    });
+
+    test('.remove removes values', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final key = TestObject('key');
+      final value = TestObject('value');
+      weakMap.set(key, value);
+      expect(weakMap.get(key), same(value), reason: 'test setup check');
+
+      weakMap.remove(key);
+      expect(weakMap.has(key), isFalse);
+      expect(weakMap.get(key), isNull);
+    });
+
+    test('.has returns whether a key has a value', () {
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final key = TestObject('key');
+      final value = TestObject('value');
+
+      expect(weakMap.has(key), isFalse);
+
+      weakMap.set(key, value);
+      expect(weakMap.has(key), isTrue);
+
+      expect(weakMap.has(value), isFalse);
+    });
+
+    group('.putIfAbsent', () {
+      test('stores a value if not present', () {
+        final weakMap = WeakMap<TestObject, TestObject>();
+        final key = TestObject('key');
+
+        final ifAbsentValue = TestObject('ifAbsentValue');
+        weakMap.putIfAbsent(key, () => ifAbsentValue);
+
+        expect(weakMap.get(key), same(ifAbsentValue));
+      });
+
+      test('does not recompute or store the value if already present', () {
+        final weakMap = WeakMap<TestObject, TestObject>();
+        final key = TestObject('key');
+        final originalValue = TestObject('originalValue');
+        weakMap.set(key, originalValue);
+
+        final ifAbsentValue = TestObject('ifAbsentValue');
+        var ifAbsentCalled = false;
+        weakMap.putIfAbsent(key, () {
+          ifAbsentCalled = true;
+          return ifAbsentValue;
+        });
+
+        expect(weakMap.get(key), same(originalValue));
+        expect(ifAbsentCalled, isFalse);
+      });
+    });
+
+    test('does not share data across instances', () {
+      final weakMap1 = WeakMap<TestObject, TestObject>();
+      final weakMap2 = WeakMap<TestObject, TestObject>();
+      final key = TestObject('key');
+      final value1 = TestObject('value1');
+      final value2 = TestObject('value2');
+
+      weakMap1.set(key, value1);
+      expect(weakMap1.get(key), same(value1));
+      expect(weakMap1.has(key), isTrue);
+      expect(weakMap2.get(key), isNull);
+      expect(weakMap2.has(key), isFalse);
+
+      weakMap2.set(key, value2);
+      expect(weakMap1.get(key), same(value1));
+      expect(weakMap1.has(key), isTrue);
+      expect(weakMap2.get(key), same(value2));
+      expect(weakMap2.has(key), isTrue);
+
+      weakMap1.remove(key);
+      expect(weakMap1.get(key), isNull);
+      expect(weakMap1.has(key), isFalse);
+      expect(weakMap2.get(key), same(value2));
+      expect(weakMap2.has(key), isTrue);
+    });
+  });
+}
+
+/// A test object with a name, for better toString values and error messages.
+class TestObject {
+  final String debugName;
+
+  TestObject(this.debugName);
+
+  @override
+  toString() => 'TestObject: $debugName';
+}

--- a/tools/analyzer_plugin/test/unit/util/weak_map_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/weak_map_test.dart
@@ -161,6 +161,61 @@ void main() {
       expect(weakMap2.has(key), isTrue);
     });
   });
+
+  group('memoizeWithWeakMap memoizes a function by storing the result on the object', () {
+    test('when provided an existing WeakMap', () {
+      final calls = <TestObject>[];
+      TestObject function(TestObject input) {
+        calls.add(input);
+        return TestObject('output for ${input.debugName}');
+      }
+
+      final weakMap = WeakMap<TestObject, TestObject>();
+      final memoizedFunction = function.memoizeWithWeakMap(weakMap);
+
+      final inputA = TestObject('inputA');
+
+      final outputA1 = memoizedFunction(inputA);
+      expect(outputA1, isA<TestObject>().having((o) => o.debugName, 'debugName', 'output for inputA'));
+      expect(calls, [inputA]);
+
+      final outputA2 = memoizedFunction(inputA);
+      expect(calls, [inputA], reason: 'should not have called the function an additional time for the same input');
+      expect(outputA2, same(outputA1), reason: 'should have returned the cached result');
+
+      expect(weakMap.get(inputA), same(outputA1), reason: 'should have used the provided WeakMap to associate the output with the input');
+
+      final inputB = TestObject('inputB');
+      final outputB = memoizedFunction(inputB);
+      expect(calls, [inputA, inputB], reason: 'should have recomputed the function for a new input');
+      expect(outputB, isA<TestObject>().having((o) => o.debugName, 'debugName', 'output for inputB'));
+    });
+
+    test('when not provided an existing WeakMap', () {
+      final calls = <TestObject>[];
+      TestObject function(TestObject input) {
+        calls.add(input);
+        return TestObject('output for ${input.debugName}');
+      }
+
+      final memoizedFunction = function.memoizeWithWeakMap();
+
+      final inputA = TestObject('inputA');
+
+      final outputA1 = memoizedFunction(inputA);
+      expect(outputA1, isA<TestObject>().having((o) => o.debugName, 'debugName', 'output for inputA'));
+      expect(calls, [inputA]);
+
+      final outputA2 = memoizedFunction(inputA);
+      expect(calls, [inputA], reason: 'should not have called the function an additional time for the same input');
+      expect(outputA2, same(outputA1), reason: 'should have returned the cached result');
+
+      final inputB = TestObject('inputB');
+      final outputB = memoizedFunction(inputB);
+      expect(calls, [inputA, inputB], reason: 'should have recomputed the function for a new input');
+      expect(outputB, isA<TestObject>().having((o) => o.debugName, 'debugName', 'output for inputB'));
+    });
+  });
 }
 
 /// A test object with a name, for better toString values and error messages.

--- a/tools/analyzer_plugin/test/util/over_react_builder.dart
+++ b/tools/analyzer_plugin/test/util/over_react_builder.dart
@@ -32,7 +32,11 @@ Future<String> generateOverReactPart({
   final recordedLogs = <LogRecord>[];
   final logSubscription = builderLogger.onRecord.listen(recordedLogs.add);
 
-  await runBuilder(overReactBuilder(null), [inputAsset], reader, writer, null, logger: builderLogger);
+  try {
+    await runBuilder(overReactBuilder(null), [inputAsset], reader, writer, null, logger: builderLogger);
+  } catch(e, st) {
+    throw Exception('Error running over_react builder:\n$e\n$st');
+  }
 
   await logSubscription.cancel();
 


### PR DESCRIPTION
## Motivation
There are some common use-cases where consumers declare BuilderOnlyUiFactory functions that are to be used as the main entrypoint of their components, and assign required props within them.

For example, the custom `FooComponents.content` factory:
```dart
UiFactory<FooProps> Foo = ...;
class FooProps = UiProps with FluxUiPropsMixin<...>, ...;

class FooComponents {
  ...
  FooProps content() => Foo()
    ..store = store
    ..actions = actions;
}
```

Currently, the `missing_required_prop` lint occurs when using that factory, even though it sets required props:
```dart
void renderApp(FooComponents components) {
  react_dom.render(components.content()(), mountNode);
  //               ^^^^^^^^^^^^^^^^^^^^
  // warning: over_react_late_required_prop 
  //   Missing required late prop 'actions' from 'FluxUiPropsMixin'
  //   Missing required late prop 'store' from 'FluxUiPropsMixin'
}
```

As opposed to making all consumers of those types of factories ignore errors, or some other solution involving annotation, we want to not lint when we can determine which props are set in the factory.

## Changes
- Add `getPropsSetByFactory` utility to look up props set in factories, add tests
- Update `missing_required_prop` lint
    - Take into account props set by factories, add tests
    - Update `// debug: over_react_required_props` information with props set by factory, and whether props set by factory were computed
- Add playground example
- Update function Expando-based memoization to work with nullable return values (this wasn't 100% necessary, but cleaned things up a fair bit)
   - Replace `_memoizeWithExpando` usages with with `memoizeWithWeakMap`
   - Refactor `WeakMap` to support nullable values, add tests
   - Add `memoizeWithWeakMap` tests


#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - Test in playground example that:
            - The diagnostic no longer lints for props set in factories
            - Add `// debug: over_react_required_props` and verify that _propsSetByFactory needed to be computed_ is true **only** for usages where either:
               - props were set in the factory
               - there are missing required props that resulted in a lint
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
