### PR TITLE
Consume null-safe over_react v5 and over_react_test v3

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   color: ^3.0.0
   memoize: ^3.0.0
   meta: ^1.6.0
-  over_react: '>=4.8.4 <6.0.0'
+  over_react: ^5.0.0
   json_annotation: ^4.6.0
   redux: '>=3.0.0 <6.0.0'
   redux_dev_tools: '>=0.4.0 <0.8.0'
@@ -21,7 +21,7 @@ dev_dependencies:
   dart_dev: ^4.0.0
   glob: ^2.0.0
   json_serializable: ^6.0.0
-  over_react_test: '>=2.10.2 <4.0.0'
+  over_react_test: ^3.0.0
   pedantic: ^1.8.0
   test: ^1.15.7
   test_html_builder: ^3.0.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 environment:
   sdk: ">=2.13.0 <3.0.0"
 dependencies:
-  over_react: '>=3.5.3 <6.0.0'
+  over_react: ^5.0.0
 dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers: ^3.0.0


### PR DESCRIPTION
This PR sets the lower bound of over_react to `^5.0.0` and over_react_test to `^3.0.0` so that all repos at Workiva 
are consuming the null-safe versions of these packages.

These major versions are a critical step towards unlocking null safety in Workiva's Dart ecosystem - 
and **have already been tested and verified as safe for consumption** using the 
`over_react` test PR [listed in this SourceGraph batch](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/over_react_5_test).

Due to the exhaustive consumption testing already performed in this repository by the FED team prior to 
releasing over_react 5.0.0, **these changes can be merged without approval from a FED team member.**

For more information about these changes, see [this post](https://workiva.slack.com/archives/C05GYDT1Z0E/p1711564946578809) in the [#frontend-advocate-network](https://workiva.enterprise.slack.com/archives/C05GYDT1Z0E) channel.
Otherwise, reach out to the FED team in [#support-ui-platform](https://workiva.enterprise.slack.com/archives/CEFTMBPAA) with any specific questions or concerns.

[_Created by Sourcegraph batch change `Workiva/over_react-5.0_raise-lower`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/over_react-5.0_raise-lower)