### PR TITLE
FED-2136 Deprecate optional value argument in useRef hook & createContext fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OverReact Changelog
 
+## 5.1.0
+- [#909] Deprecate the optional `initialValue` argument in the `useRef` hook. 
+  - Use the `useRefInit` hook instead if you need to set an initial value. 
+- [#909] Deprecate the optional `defaultValue` argument in `createContext`. 
+  - Use `createContextInit` instead if you need to set a default value.
+
 ## 5.0.1
 - Consume over_react_test 3.0.0
 

--- a/lib/src/component/hooks.dart
+++ b/lib/src/component/hooks.dart
@@ -324,10 +324,9 @@ T useContext<T>(Context<T> context) => react_hooks.useContext(context.reactDartC
 ///
 /// Learn more: <https://reactjs.org/docs/hooks-reference.html#useref>.
 Ref<T?> useRef<T>([
-  // TODO(FED-2136) uncomment this deprecation
-  // @Deprecated('Use `useRefInit` instead to create refs with initial values.'
-  //     ' Since the argument to useRefInit is required, it can be used to create a Ref that holds a non-nullable type,'
-  //     ' whereas this function can only create Refs with nullable type arguments.')
+  @Deprecated('Use `useRefInit` instead to create refs with initial values.'
+      ' Since the argument to useRefInit is required, it can be used to create a Ref that holds a non-nullable type,'
+      ' whereas this function can only create Refs with nullable type arguments.')
   T? initialValue,
 ]) =>
     // ignore: deprecated_member_use

--- a/lib/src/util/context.dart
+++ b/lib/src/util/context.dart
@@ -262,10 +262,9 @@ class _DO_NOT_USE_OR_YOU_WILL_BE_FIRED {
 ///
 /// Learn more: <https://react.dev/reference/react/createContext>
 Context<TValue?> createContext<TValue>([
-  // TODO(FED-2136) uncomment this deprecation
-  // @Deprecated('Use `createContextInit` instead to create contexts with initial values.'
-  //      ' Since the argument to createContextInit is required, it can be used to create a context that holds a non-nullable type,'
-  //      ' whereas this function can only create contexts with nullable type arguments.')
+  @Deprecated('Use `createContextInit` instead to create contexts with initial values.'
+       ' Since the argument to createContextInit is required, it can be used to create a context that holds a non-nullable type,'
+       ' whereas this function can only create contexts with nullable type arguments.')
   TValue? defaultValue,
   int Function(TValue?, TValue?)? calculateChangedBits,
 ]) => createContextInit(defaultValue, calculateChangedBits);


### PR DESCRIPTION
## Motivation
Consumers of `useRef`/`createContext` setting an initial / default value should use `useRefInit` / `createContextInit` instead to prepare for null safety.

## Changes
Formally deprecate the optional `initialValue` / `defaultValue` args in the aforementioned hooks.

## QA
- [ ] Passing CI