### PR TITLE
FED-2609 Fix getAllProps not picking up props from AbstractProps classes

### DIFF
--- a/tools/analyzer_plugin/lib/src/util/prop_declarations/get_all_props.dart
+++ b/tools/analyzer_plugin/lib/src/util/prop_declarations/get_all_props.dart
@@ -52,7 +52,7 @@ List<FieldElement> getAllProps(InterfaceElement propsElement) {
     final isMixinBasedPropsMixin =
         interface is MixinElement && interface.superclassConstraints.any((s) => s.element.name == 'UiProps');
     late final isLegacyPropsOrPropsMixinConsumerClass =
-        !isFromGeneratedFile && interface.metadata.any(_isPropsOrPropsMixinAnnotation);
+        !isFromGeneratedFile && interface.metadata.any(_isOneOfThePropsAnnotations);
 
     if (!isMixinBasedPropsMixin && !isLegacyPropsOrPropsMixinConsumerClass) {
       continue;
@@ -74,10 +74,11 @@ List<FieldElement> getAllProps(InterfaceElement propsElement) {
   return allProps;
 }
 
-bool _isPropsOrPropsMixinAnnotation(ElementAnnotation e) {
+bool _isOneOfThePropsAnnotations(ElementAnnotation e) {
   // [2]
   final element = e.element;
-  return element is ConstructorElement && const {'Props', 'PropsMixin'}.contains(element.enclosingElement.name);
+  return element is ConstructorElement &&
+      const {'Props', 'PropsMixin', 'AbstractProps'}.contains(element.enclosingElement.name);
 }
 
 bool _isPropsMixinAnnotation(ElementAnnotation e) {

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/get_all_props_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/get_all_props_test.dart
@@ -56,6 +56,15 @@ void main() {
             ]);
           });
 
+          test('concrete props class', () {
+            final propsElement = getInterfaceElement(result, 'V2AbstractProps');
+            verifyAllProps(getAllProps(propsElement), expectedNames: [
+              'v2_lateRequiredProp',
+              'v2_optionalProp',
+              'v2_annotationRequiredProp',
+            ]);
+          });
+
           test('props mixin', () {
             final propsElement = getInterfaceElement(result, 'V2PropsMixin');
             verifyAllProps(getAllProps(propsElement), expectedNames: [

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/required_props_test.dart
@@ -215,6 +215,15 @@ void main() {
               });
             });
 
+            test('abstract props class', () {
+              final propsElement = getInterfaceElement(result, 'V2Props');
+              verifyRequiredProps(getAllRequiredProps(propsElement), expected: {
+                'v2_lateRequiredProp': PropRequiredness.late,
+                'v2_optionalProp': PropRequiredness.none,
+                'v2_annotationRequiredProp': PropRequiredness.annotation,
+              });
+            });
+
             test('props mixin', () {
               final propsElement = getInterfaceElement(result, 'V2PropsMixin');
               verifyRequiredProps(getAllRequiredProps(propsElement), expected: {

--- a/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
+++ b/tools/analyzer_plugin/test/unit/util/prop_declaration/shared_test_source.dart
@@ -67,6 +67,52 @@ class V2Component extends UiComponent2<V2Props> {
   render() {}
 }
 
+// ignore: undefined_class, mixin_of_non_class
+abstract class V2AbstractProps extends _$V2AbstractProps with _$V2AbstractPropsAccessorsMixin {
+  // ignore: undefined_identifier, const_initialized_with_non_constant_value, invalid_assignment
+  static const PropsMeta meta = _$metaForV2AbstractProps;
+}
+
+@AbstractProps()
+// ignore: mixin_of_non_class,undefined_class
+abstract class _$V2AbstractProps extends UiProps {
+  late String v2_lateRequiredProp;
+  String? v2_optionalProp;
+  @requiredProp
+  String? v2_annotationRequiredProp;
+
+  //
+  // Non-props: edge-cases
+  //
+  @Accessor(doNotGenerate: true)
+  String? v2_doNotGenerate;
+
+  //
+  // Non-props: instance members
+  //
+  String get v2_getter => '';
+  // ignore: avoid_setters_without_getters
+  set v2_setter(_) => '';
+  String get v2_getterAndSetter => '';
+  set v2_getterAndSetter(String _) {}
+
+  //
+  // Non-props: static members
+  //
+  static String v2_static_field = '';
+  static String get v2_static_getter => '';
+  // ignore: avoid_setters_without_getters
+  static set v2_static_setter(_) => '';
+  static String get v2_static_getterAndSetter => '';
+  static set v2_static_getterAndSetter(String _) {}
+}
+
+@AbstractComponent()
+abstract class V2AbstractComponent<TProps extends V2AbstractProps> extends UiComponent2<TProps> {
+  @override
+  render() {}
+}
+
 @Factory()
 UiFactory<V3Props> V3 = castUiFactory(_$V3);
 


### PR DESCRIPTION
## Motivation
Props declared directly in legacy abstract props classes (with `@AbstractProps`) weren't being picked up properly in `getAllProps`.

## Changes
- Update `getAllProps` to not skip over `@AbstractProps`-annotated classes
- Add regression tests

This bugfix will cause any required props declared directly in abstract props classes to start linting if they're missing. There aren't any of these in over_react `lib/`, nor are there any that would currently be affected within the Workiva ecosystem, so this change should have minimal risk of breaking something.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - New regression test failed before the issue was fixed ([CI run](https://github.com/Workiva/over_react/actions/runs/8805982903/job/24169755556))
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
