### PR TITLE
Run CI on release tag commits

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - 'master'
       - 'test_consume_**'
+    tags:
+      - "**"
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
The 5.1.0 release failed to run a build on the tag commit because we were missing a crucial line in our github workflow file.

This adds the tag, and we can release this as a 5.1.1 patch