### PR TITLE
Consume react-dart 7.1.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.6.0
   package_config: ^2.1.0
   path: ^1.5.1
-  react: ^7.0.0
+  react: ^7.1.3
   redux: '>=5.0.0 <6.0.0'
   source_span: ^1.4.1
   transformer_utils: ^0.2.6


### PR DESCRIPTION
Consume [react-dart 7.1.3](https://github.com/Workiva/react-dart/releases/tag/7.1.3)

Pull Requests included in release:
* Patch changes:
	* [FEDX-973 Remove Workiva Build files](https://github.com/Workiva/react-dart/pull/404)
	* [RM-264497 Release react-dart 7.1.3](https://github.com/Workiva/react-dart/pull/405)


Requested by: @rmconsole6-wk
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4948379952742400/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4948379952742400/?repo_name=Workiva%2Fover_react&pull_number=931)