### PR TITLE
FED-2960 Update the null safety migration documentation

### DIFF
--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -50,6 +50,10 @@ especially as it pertains to [prop nullability](#prop-nullability).
    * If the number of new lints / errors is overwhelming, you an also use this snippet to disable all lints except for the ones that are particularly useful during a null-safety migration:
        ```yaml
        analyzer:
+         plugins:
+           over_react
+     
+       over_react:
          errors:
            over_react_exhaustive_deps: ignore
            over_react_invalid_render_return_type: ignore
@@ -77,8 +81,6 @@ especially as it pertains to [prop nullability](#prop-nullability).
            over_react_string_ref: ignore
            over_react_unnecessary_key: ignore
            over_react_variadic_children: ignore
-         plugins:
-           over_react
        ```
 
 ## Step 4: Run the migration tool

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -38,7 +38,8 @@ This codemod will:
 
 ### Codemod to run as part of a null safety migration
 
-Once you're ready to begin a null safety migration, run the `null_safety_migrator_companion` codemod:
+Once you're ready to begin a null safety migration, run the `null_safety_migrator_companion` codemod, and commit the
+hints it adds as a separate commit before proceeding with the rest of the migration. 
 
 ```bash
 dart pub global activate over_react_codemod
@@ -100,6 +101,9 @@ especially as it pertains to [prop nullability](#prop-nullability).
        ```
 
 ## Step 4: Run the migration tool
+
+> [!TIP]
+> **Be sure to commit any changes from step 3 prior to running the migrator tool!**
 
 Run the null safety migrator tool:
 

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -119,11 +119,8 @@ Below is a table of the possible options for prop nullability:
 If you aren't sure whether the prop should be nullable, or required, or both, this decision tree might help:
 
 ```mermaid
----
-title: Prop Nullability Decision Tree
----
 flowchart TD
-    Start[Should My Prop By Required Or Optional]==>HasDefault
+    Start[<strong>Should My Prop Be Required</strong>]==>HasDefault
       HasDefault((Does the \nprop have a \ndefault value?))== Yes ==> Defaulted
         Defaulted((Where is \nthe default?))-- defaultProps getter\n(Class Component) --> End_Defaulted1[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
         Defaulted-- local var\n(Function Component) --> End_Optional1[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -215,9 +215,12 @@ mixin Foo<TProps extends FooProps?> on UiComponent2<TProps> {/*...*/}
 
 **Generic props applied to the `UiComponent2` constraint should always be non-nullable.**
 
-### Migrator Bugs
+### Migrator Tool Bug
 
 #### Migrator treats emulated function calls as nullable
+
+> [!TIP]
+> **If you are a Workiva employee, this bug is fixed in [the official Workiva fork of the migrator](https://github.com/Workiva/dart_null_tools), so there is no need to read any further.**
 
 The migrator tool [incorrectly treats the result of emulated function calls as nullable](https://github.com/dart-lang/sdk/issues/46263).
 
@@ -234,43 +237,44 @@ To work around this issue, you can either:
 - manually fix these after running the migrator
 - use a fork of the migrator tool that contains a bugfix - see the following section for instructions on how to run that locally
 
-#### Using the forked migrator tool
+<details>
+  <summary><strong>Using the forked migrator tool</strong> <em>(Not relevant for Workiva employees)</em></summary>
+  
+  The `dart migrate` tool comes bundled with the Dart SDK, so we'll need a local copy of the SDK to pull in [a fix](https://github.com/dart-lang/sdk/issues/46263#issuecomment-967647710) for it.
 
-The `dart migrate` tool comes bundled with the Dart SDK, so we'll need a local copy of the SDK to pull in [a fix](https://github.com/dart-lang/sdk/issues/46263#issuecomment-967647710) for it.
-
-First, clone the Dart SDK using the instructions from the Dart SDK wiki (just cloning the repo normally won't work). The only steps on this wiki you need to follow are:
-1. [Dependencies](https://github.com/dart-lang/sdk/wiki/Building#dependencies)
-2. [Getting the source](https://github.com/dart-lang/sdk/wiki/Building#source)
-
-After that's done, we'll check out the branch containing the bugfix, and get the migrator tool ready to run:
-```sh
-# Enter the dart-sdk/sdk directory we set up above
-cd sdk
-
-# Check out the forked Dart SDK branch with the fix from:
-# https://github.com/dart-lang/sdk/issues/46263#issuecomment-967647710
-git remote add sdk-fork https://github.com/greglittlefield-wf/sdk.git
-git fetch sdk-fork
-git checkout fix-emulated-function-migration-2.19
-
-# After changing branches, update files needed for generate_package_config  
-gclient sync -D --nohooks
-
-# Generate a package config in place of doing `pub get` (the Dart SDK's package setup is special),
-# allowing us to run the migrator tool.
-dart tools/generate_package_config.dart
-```
-
-Now, we're all set!
-
-In place of running `dart migrate`, we can run our local copy of the migrator tool. Start in the package you want to migrate, then run the tool located at `pkg/nnbd_migration/bin/migrate.dart` within the Dart SDK clone.
-```sh
-cd your_package
-# This can be an absolute or relative path
-dart /full/path/to/dart-sdk/sdk/pkg/nnbd_migration/bin/migrate.dart
-```
-
-This command behaves the same as `dart migrate`, and accepts the same arguments it does. 
-
+  First, clone the Dart SDK using the instructions from the Dart SDK wiki (just cloning the repo normally won't work). The only steps on this wiki you need to follow are:
+  1. [Dependencies](https://github.com/dart-lang/sdk/wiki/Building#dependencies)
+  2. [Getting the source](https://github.com/dart-lang/sdk/wiki/Building#source)
+  
+  After that's done, we'll check out the branch containing the bugfix, and get the migrator tool ready to run:
+  ```sh
+  # Enter the dart-sdk/sdk directory we set up above
+  cd sdk
+  
+  # Check out the forked Dart SDK branch with the fix from:
+  # https://github.com/dart-lang/sdk/issues/46263#issuecomment-967647710
+  git remote add sdk-fork https://github.com/greglittlefield-wf/sdk.git
+  git fetch sdk-fork
+  git checkout fix-emulated-function-migration-2.19
+  
+  # After changing branches, update files needed for generate_package_config  
+  gclient sync -D --nohooks
+  
+  # Generate a package config in place of doing `pub get` (the Dart SDK's package setup is special),
+  # allowing us to run the migrator tool.
+  dart tools/generate_package_config.dart
+  ```
+  
+  Now, we're all set!
+  
+  In place of running `dart migrate`, we can run our local copy of the migrator tool. Start in the package you want to migrate, then run the tool located at `pkg/nnbd_migration/bin/migrate.dart` within the Dart SDK clone.
+  ```sh
+  cd your_package
+  # This can be an absolute or relative path
+  dart /full/path/to/dart-sdk/sdk/pkg/nnbd_migration/bin/migrate.dart
+  ```
+  
+  This command behaves the same as `dart migrate`, and accepts the same arguments it does.
+</details>
 
 [orcm]: https://github.com/Workiva/over_react_codemod

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -127,18 +127,29 @@ Below is a table of the possible options for prop nullability:
 > components since it will automate the vast majority of this process.
 
 ```mermaid
+---
+title: Should My Prop Be Required?
+---
 flowchart TD
-    Start[<strong>Should My Prop Be Required</strong>]==>HasDefault
-      HasDefault((Does the \nprop have a \ndefault value?))== Yes ==> Defaulted
-        Defaulted((Where is \nthe default?))-- defaultProps getter\n(Class Component) --> End_Defaulted1[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
-        Defaulted-- local var\n(Function Component) --> End_Optional1[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
-      HasDefault == No ==> NotDefaulted
-        NotDefaulted((Is it set \nfor every \ninvocation?))-- No --> End_Optional2[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
-        NotDefaulted-- Yes --> AlwaysSpecified
-          AlwaysSpecified((Is the prop \npublic API?))-- Yes --> PublicAlwaysSpecified
-            PublicAlwaysSpecified((Is the prop mixed in \nby any other component?))-- Yes --> End_PublicAlwaysSpecifiedMixedIn[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
-            PublicAlwaysSpecified-- No --> End_PublicAlwaysSpecifiedNotMixedIn[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
-          AlwaysSpecified-- No --> PublicAlwaysSpecifiedNotConsumed[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
+  HasDefault== No ==> NotDefaulted
+    NotDefaulted((Is it set for \nevery invocation?))-- No --> End_Optional_No_Public_Api_Check
+    NotDefaulted-- Yes ---> PublicAPICheck
+  HasDefault((Does the prop have \na default value?))== Yes ==> Defaulted
+    Defaulted((Where is the value \ndefaulted?))--> ClassDefault
+    Defaulted--> LocalDefault
+      ClassDefault(["defaultProps getter\n(Class Component)"])--> PublicAPICheck
+      LocalDefault(["local var\n(Function Component)"])--> End_Optional_No_Public_Api_Check
+
+  subgraph Public API Check
+    PublicAPICheck((Is the prop \npublic API?))-- Yes --> PublicAlwaysSpecified
+      PublicAlwaysSpecified((Is the prop mixed \nin by any other \ncomponent?))-- Yes --> End_Optional
+      PublicAlwaysSpecified-- No --> End_Required
+    PublicAPICheck-- No --> End_Required
+  end
+
+  End_Optional_No_Public_Api_Check[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
+  End_Optional[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
+  End_Required[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
 ```
 
 #### Implementing abstract `Ref`s

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -19,17 +19,33 @@ If you haven't already, familiarize yourself with the concepts of Dart null safe
 
 ## Step 2: Run the preparation codemods
 
-Start out by running the [codemod][orcm]s on your repo:
+There are two different codemods that can help migrate your over_react code to null safety. 
+One of them should be run prior to a migration, the other should be run at the beginning of the migration itself.
 
-```
+### Codemod to run before a null safety migration
+
+Before you begin a null safety migration, you should run the `null_safety_prep` [codemod][orcm] on your repo.
+**These changes should be reviewed / merged prior to the null safety migration begins.**
+
+```bash
 dart pub global activate over_react_codemod
 dart pub global run over_react_codemod:null_safety_prep --yes-to-all
+```
+
+This codemod will:
+- Migrate as many over_react specific use cases as possible.
+- Get the repo into a state where the migration tool can be run with less manual intervention.
+
+### Codemod to run as part of a null safety migration
+
+Once you're ready to begin a null safety migration, run the `null_safety_migrator_companion` codemod:
+
+```bash
+dart pub global activate over_react_codemod
 dart pub global run over_react_codemod:null_safety_migrator_companion --yes-to-all
 ```
 
-These codemods will:
-- Migrate as many over_react specific use cases as possible.
-- Get the repo into a state where the migration tool can be run with less manual intervention.
+This codemod will:
 - Add nullability hints to props/state that are defaulted/initialized in class components.
   - These hints will cause defaulted/initialized values to be migrated as "late required". 
     See our [prop nullability](#prop-nullability) docs for more details on whether you should keep them required following the migration.

--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -116,7 +116,13 @@ Below is a table of the possible options for prop nullability:
   - **Nullable**: If the prop is required, but can be explicitly set to `null`.
   - **Non-nullable**: If the prop is required and should never be set to `null`.
 
-If you aren't sure whether the prop should be nullable, or required, or both, this decision tree might help:
+> [!TIP]
+> **Determining prop nullability manually can be extremely tedious and error-prone.**
+>
+> If you are a Workiva employee, and you don't want to have to go through the process shown
+> in the decision tree below for every prop in every component in your library, you should wait for the
+> [codemod that is being built](https://jira.atl.workiva.net/browse/FED-1885) before migrating your UI
+> components since it will automate the vast majority of this process.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
The null safety migration documentation needs to be updated. This PR updates it with more helpful information for consumers.