### PR TITLE
RM-262845 RM-262844 Release over_react 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # OverReact Changelog
+
+## 5.2.0
+- [#920] Support prop conversion in OverReact to simplify RMUI converted props
+- [#925] Remove publish action that always fails due to dry run warnings
+- [#928] Fix num keys incorrectly linting as not unique
+- [#930] Fix Analyzer Plugin error when typing keys
+- [#932] Update the null safety migration documentation
+
 ## 5.1.1 & 5.1.2
 - Fixes to CI [#921] [#922]
 - Add auto-publish to pub.dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # OverReact Changelog
 
 ## 5.2.0
-- [#920] Support prop conversion in OverReact to simplify RMUI converted props
+- [#920] Support conversion of prop values via annotations: `@ConvertProp`, `@convertJsMapProp`, `@convertJsRefProp`
 - [#925] Remove publish action that always fails due to dry run warnings
 - [#928] Fix num keys incorrectly linting as not unique
 - [#930] Fix Analyzer Plugin error when typing keys

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.1.2
+version: 5.2.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.1.2
+  over_react: 5.2.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-1945 Support prop conversion in OverReact to simplify RMUI converted props](https://github.com/Workiva/over_react/pull/920)
* Patch changes:
	* [Remove publish action that always fails due to dry run warnings](https://github.com/Workiva/over_react/pull/925)
	* [FED-2854 Fix num keys incorrectly linting as not unique](https://github.com/Workiva/over_react/pull/928)
	* [FED-2855 Fix Analyzer Plugin error when typing keys](https://github.com/Workiva/over_react/pull/930)
	* [FED-2960 Update the null safety migration documentation](https://github.com/Workiva/over_react/pull/932)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.1.2...Workiva:release_over_react_5.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.1.2...5.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=933)