### PR TITLE
RM-272801 RM-272800 Release over_react 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## 5.2.1
+- [#934] Tighten dependency ranges following null-safety release
+
 ## 5.2.0
 - [#920] Support conversion of prop values via annotations: `@ConvertProp`, `@convertJsMapProp`, `@convertJsRefProp`
 - [#925] Remove publish action that always fails due to dry run warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.2.1
 - [#934] Tighten dependency ranges following null-safety release
+- [#935] Docs: update null safety migration guide with required props codemod instructions
 
 ## 5.2.0
 - [#920] Support conversion of prop values via annotations: `@ConvertProp`, `@convertJsMapProp`, `@convertJsRefProp`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.2.0
+version: 5.2.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.2.0
+  over_react: 5.2.1
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* [FED-2979 Clean up dependency ranges, clean out the lint trap](https://github.com/Workiva/over_react/pull/934)
* [FED-3009 Update migration guide with required props codemod instructions](https://github.com/Workiva/over_react/pull/935)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.2.0...Workiva:release_over_react_5.2.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.2.0...5.2.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=936)