### PR TITLE
RM-276972 RM-276971 Release over_react 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OverReact Changelog
 
+## 5.3.0
+- [#937] Use and export a new, [more expressive typedef for `Object?` called `ReactNode`](https://github.com/Workiva/react-dart/pull/384)
+
 ## 5.2.1
 - [#934] Tighten dependency ranges following null-safety release
 - [#935] Docs: update null safety migration guide with required props codemod instructions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.2.1
+version: 5.3.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.2.1
+  over_react: 5.3.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-2299 Utilize new ReactNode typedef](https://github.com/Workiva/over_react/pull/937)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.2.1...Workiva:release_over_react_5.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.2.1...5.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=938)