### PR TITLE
FED-3159 Fix required prop null-safe-conditional linting

### DIFF
--- a/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
+++ b/tools/analyzer_plugin/lib/src/assist/refs/add_create_ref.dart
@@ -11,7 +11,6 @@ import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
 import 'package:over_react_analyzer_plugin/src/indent_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/function_components.dart';
-import 'package:over_react_analyzer_plugin/src/util/null_safety_utils.dart' as utils;
 import 'package:over_react_analyzer_plugin/src/util/util.dart';
 
 enum RefTypeToReplace {
@@ -49,7 +48,7 @@ void addUseOrCreateRef(
   RefTypeToReplace? refTypeToReplace;
   Expression? callbackRefPropRhs;
 
-  final withNullability = utils.withNullability(result);
+  final withNullability = result.libraryElement.isNonNullableByDefault;
   final refTypeName = usage.isDom ? 'Element${withNullability ? '?' : ''}' : 'dynamic';
 
   final refProp = usage.cascadedProps.firstWhereOrNull((prop) => prop.name.name == 'ref');

--- a/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/invalid_child.dart
@@ -6,7 +6,6 @@ import 'package:analyzer/dart/element/type_system.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/constants.dart';
-import 'package:over_react_analyzer_plugin/src/util/null_safety_utils.dart' as utils;
 import 'package:over_react_analyzer_plugin/src/util/react_types.dart';
 import 'package:over_react_analyzer_plugin/src/fluent_interface_util.dart';
 import 'package:over_react_analyzer_plugin/src/util/util.dart';
@@ -71,7 +70,7 @@ class InvalidChildDiagnostic extends ComponentUsageDiagnosticContributor {
       await validateReactChildType(argument.staticType, result.typeSystem, result.typeProvider,
           onInvalidType: (invalidType) async {
         final location = result.locationFor(argument);
-        final withNullability = utils.withNullability(result);
+        final withNullability = result.libraryElement.isNonNullableByDefault;
 
         if (couldBeMissingBuilderInvocation(argument)) {
           await collector.addErrorWithFix(

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
@@ -4,7 +4,6 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic/analyzer_debug_helper.dart';
 import 'package:over_react_analyzer_plugin/src/diagnostic_contributor.dart';
 import 'package:over_react_analyzer_plugin/src/util/ast_util.dart';
-import 'package:over_react_analyzer_plugin/src/util/null_safety_utils.dart';
 import 'package:over_react_analyzer_plugin/src/util/pretty_print.dart';
 import 'package:over_react_analyzer_plugin/src/util/prop_declarations/props_set_by_factory.dart';
 import 'package:over_react_analyzer_plugin/src/util/prop_forwarding/forwarded_props.dart';
@@ -220,7 +219,7 @@ class MissingRequiredPropDiagnostic extends ComponentUsageDiagnosticContributor 
         continue;
       }
 
-      if (withNullability(result) || requiredness != PropRequiredness.late) {
+      if (result.libraryElement.isNonNullableByDefault || requiredness != PropRequiredness.late) {
         await collector.addErrorWithFix(
           _codeForRequiredness(requiredness),
           result.locationFor(usage.builder),

--- a/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
+++ b/tools/analyzer_plugin/lib/src/diagnostic/missing_required_prop.dart
@@ -219,7 +219,8 @@ class MissingRequiredPropDiagnostic extends ComponentUsageDiagnosticContributor 
         continue;
       }
 
-      if (result.libraryElement.isNonNullableByDefault || requiredness != PropRequiredness.late) {
+      // Late required prop validation is only enabled for props classes that have migrated to null safety.
+      if (propsClassElement.library.isNonNullableByDefault || requiredness != PropRequiredness.late) {
         await collector.addErrorWithFix(
           _codeForRequiredness(requiredness),
           result.locationFor(usage.builder),

--- a/tools/analyzer_plugin/lib/src/util/null_safety_utils.dart
+++ b/tools/analyzer_plugin/lib/src/util/null_safety_utils.dart
@@ -1,6 +1,0 @@
-import 'package:analyzer/dart/analysis/features.dart';
-import 'package:analyzer/dart/analysis/results.dart';
-
-/// Returns whether [result] is in a library with null safety enabled.
-bool withNullability(ResolvedUnitResult result) =>
-    result.unit.declaredElement?.library.featureSet.isEnabled(Feature.non_nullable) ?? false;


### PR DESCRIPTION
## Motivation
The over_react analyzer plugin is always supposed to lint for missing required props, unless they're on props declared in non-null safe libraries.

There's a bug in this conditional that instead checks the language version of the library the component is consumed in, as opposed to the library the component is declared in.

This prevents consumers from getting static warnings in cases where they'll get runtime errors.

For example, expected behavior:
```dart
//@dart=2.11

import 'package:null_safe_package/has_required.dart';

class NonNullSafeMixesInRequiredProps = UiProps with HasRequiredProps;
UiFactory<NonNullSafeMixesInRequiredProps>  NonNullSafeMixesInRequiredProps = ...;

example() {
  // Should lint about missing required props
  HasRequired()();
  // Should not lint, because this props class is not null-safe
  NonNullSafeMixesInRequired()(); 
}
```
vs actual behavior:
```dart
example() {
  // Does not lint - incorrect behavior ❌ 
  HasRequired()(); 
  // Does not lint - correct behavior ✅
  NonNullSafeMixesInRequired()(); 
}
```

## Changes
- Update logic to check the null safety status of the library containing the props class, not the file it's being used in
- Add regression test
- Semi-related cleanup: replace `withNullability` util with the `LibraryElement.isNonNullableByDefault` API, which I just learned about!

#### Release Notes
- Fix late required prop linting not working in non-null-safe libraries

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Regression test fails in commit before the fix was added ( https://github.com/Workiva/over_react/pull/948/commits/4e526378355bb1e40b2c7f3f7b8c6106d2f8e859), and passes afterwards (latest CI passes)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
