### PR TITLE
Improve null safety docs and messages for wrapper components and connect 

### DIFF
--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -138,6 +138,14 @@ Run the null safety migrator tool:
 
 Below are some common cases that might come up while running the migrator tool on a repo using over_react.
 
+* [Prop requiredness and nullability](#prop-requiredness-and-nullability)
+* [Wrapper and `connect`ed components and required props](#wrapper-and-connected-components-and-required-props)
+* [Implementing abstract `Ref`s](#implementing-abstract-refs)
+* [Incorrect `getDerivedStateFromProps` Return Signature](#incorrect-getderivedstatefromprops-return-signature)
+* [Verbose function component return signature for `uiForwardRef`](#verbose-function-component-return-signature-for-uiforwardref)
+* [Nullable store/actions generics on `FluxUiPropsMixin`](#nullable-storeactions-generics-on-fluxuipropsmixin)
+* [Nullable props generic on `UiComponent2` mixins](#nullable-props-generic-on-uicomponent2-mixins)
+
 #### Prop requiredness and nullability
 
 First, check out our documentation around [null safety and required props](../null_safety_and_required_props.md).
@@ -187,6 +195,21 @@ flowchart TD
   End_Optional[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
   End_Required[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
 ```
+
+### Wrapper and `connect`ed components and required props
+
+There may be some cases where you have a wrapper component or `connect`ed component that sets some required props, 
+but you get lints and runtime errors about missing props when consuming them.
+
+See [this section](../null_safety_and_required_props.md#disabling-required-prop-validation-for-certain-props)
+of the null safety and required props docs for instructions on how to handle these cases and suppress this validation.
+
+#### connect
+
+We'll be adding a codemod to help migrate the `connect` case: https://github.com/Workiva/over_react_codemod/issues/295
+
+Alternatively, you could refactor your component to instead utilize [OverReact Redux hooks](./over_react_redux_documentation.md#hooks), 
+which avoid this problem by accessing store data and dispatchers directly in the component as opposed to passing it in via props.
 
 #### Implementing abstract `Ref`s
 

--- a/doc/null_safety_and_required_props.md
+++ b/doc/null_safety_and_required_props.md
@@ -120,8 +120,9 @@ This mechanism does not apply to function components, which use a different prop
 
 Sometimes, you want to declare a prop as non-nullable and required, but not enforce that consumers explicitly set it.
 
-There are two ways to opt out of prop validation for certain props, targeted toward to main use-cases:
+There are two ways to opt out of prop validation for certain props, targeted toward these main use-cases:
 - [wrapper components](#disabling-validation-use-case-wrapper-components)
+- [connect](#disabling-validation-use-case-connect)
 - [cloned props](#disabling-validation-use-case-cloned-props)
 
 #### Disabling validation use-case: wrapper components
@@ -179,6 +180,40 @@ class WrapperProps = UiProps with FooProps, WrapperPropsMixin;
 > 
 > See the [unsafe required prop reads](#unsafe-required-prop-reads) section for more info 
 
+
+#### Disabling validation use-case: `connect`
+Similar to [the wrapper component case](#disabling-validation-use-case-wrapper-components) in the previous section, 
+we'll want to disable validation similarly using `@Props(disableRequiredPropValidation: {...})` 
+for any late required props assigned within connect.
+
+For example:
+```dart
+mixin CounterPropsMixin on UiProps {
+  // Set in connect.
+  late int count;
+  late void Function() increment;
+  
+  // Must be set by consumers of the connected compoennt.
+  late String requiredByConsumer;
+}
+
+@Props(disableRequiredPropValidation: {'count', 'increment'})
+class CounterProps = UiProps with CounterPropsMixin, OtherPropsMixin;
+
+UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
+  mapStateToProps: (state) => (Counter()
+    ..count = state.count
+  ),
+  mapDispatchToProps: (dispatch) => (Counter()
+    ..increment = (() => dispatch(IncrementAction()))
+  ),
+)(_$Counter);
+
+example() => (Counter()..requiredByConsumer = 'foo')();
+```
+
+Note that [OverReact Redux hooks](./over_react_redux_documentation.md#hooks) 
+avoid this problem by accessing store data and dispatchers directly in the component as opposed to passing it in via props.
 
 #### Disabling validation use-case: cloned props
 

--- a/doc/over_react_redux_documentation.md
+++ b/doc/over_react_redux_documentation.md
@@ -181,6 +181,24 @@ UiFactory<CounterProps> Counter = connect<CounterState, CounterProps>(
 )(_$Counter);
 ```
 
+Note that any required props assigned in connect must have their validation disabled; see docs [here](./null_safety_and_required_props.md#disabling-validation-use-case-connect)
+for more info. 
+
+For example:
+```dart
+mixin CounterPropsMixin on UiProps {
+  // Set in connect.
+  late int count;
+  late void Function() increment;
+  
+  // Must be set by consumers of the connected compoennt.
+  late String requiredByConsumer;
+}
+
+@Props(disableRequiredPropValidation: {'count', 'increment'})
+class CounterProps = UiProps with CounterPropsMixin, OtherPropsMixin;
+```
+
 ### `connect` Parameters
 
 - #### `mapStateToProps`

--- a/lib/src/component_declaration/builder_helpers.dart
+++ b/lib/src/component_declaration/builder_helpers.dart
@@ -158,8 +158,13 @@ class MissingRequiredPropsError extends Error {
 
   MissingRequiredPropsError(this._message);
 
+  static const _messageSuffix = ' Ensure this prop is either directly set, or indirectly set via prop forwarding.'
+      'If this error seems unexpected and this component uses connect or mixes in required props from another component,'
+      ' please refer to the null safety migration guide for instructions on how to proceed:'
+      ' https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#wrapper-and-connected-components-and-required-props';
+
   @override
-  String toString() => 'RequiredPropsError: $_message';
+  String toString() => 'RequiredPropsError: $_message$_messageSuffix';
 }
 
 /// Helper static extension methods to make forwarding props easier.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
