### PR TITLE
RM-284056 RM-284055 Release over_react 5.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## 5.3.2
+- [#948] Fix late required prop linting not working in non-null-safe libraries
+- [#949] Add docs around migrating connect and wrapper components, improve helpfulness of required prop lints and runtime errors
+
 ## 5.3.1
 - [#944] Analyzer plugin: Don't lint for required props that are specified due to prop forwarding
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.3.1
+version: 5.3.2
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.3.1
+  over_react: 5.3.2
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3159 Fix required prop null-safe-conditional linting](https://github.com/Workiva/over_react/pull/948)
	* [FED-3160 Improve null safety docs and messages for wrapper components and connect ](https://github.com/Workiva/over_react/pull/949)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.3.1...Workiva:release_over_react_5.3.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.3.1...5.3.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=950)