### PR TITLE
FED-3197 Fix mermaid diagram newlines in migration guide

### DIFF
--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -176,24 +176,24 @@ title: Should My Prop Be Required?
 ---
 flowchart TD
   HasDefault== No ==> NotDefaulted
-    NotDefaulted((Is it set for \nevery invocation?))-- No --> End_Optional_No_Public_Api_Check
+    NotDefaulted((Is it set for <br>every invocation?))-- No --> End_Optional_No_Public_Api_Check
     NotDefaulted-- Yes ---> PublicAPICheck
-  HasDefault((Does the prop have \na default value?))== Yes ==> Defaulted
-    Defaulted((Where is the value \ndefaulted?))--> ClassDefault
+  HasDefault((Does the prop have <br>a default value?))== Yes ==> Defaulted
+    Defaulted((Where is the value <br>defaulted?))--> ClassDefault
     Defaulted--> LocalDefault
-      ClassDefault(["defaultProps getter\n(Class Component)"])--> PublicAPICheck
-      LocalDefault(["local var\n(Function Component)"])--> End_Optional_No_Public_Api_Check
+      ClassDefault(["defaultProps getter<br>(Class Component)"])--> PublicAPICheck
+      LocalDefault(["local var<br>(Function Component)"])--> End_Optional_No_Public_Api_Check
 
   subgraph Public API Check
-    PublicAPICheck((Is the prop \npublic API?))-- Yes --> PublicAlwaysSpecified
-      PublicAlwaysSpecified((Is the prop mixed \nin by any other \ncomponent?))-- Yes --> End_Optional
+    PublicAPICheck((Is the prop <br>public API?))-- Yes --> PublicAlwaysSpecified
+      PublicAlwaysSpecified((Is the prop mixed <br>in by any other <br>component?))-- Yes --> End_Optional
       PublicAlwaysSpecified-- No --> End_Required
     PublicAPICheck-- No --> End_Required
   end
 
-  End_Optional_No_Public_Api_Check[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
-  End_Optional[/"Make it <strong>optional</strong>\n<code>SomeType? propName;</code>"\]
-  End_Required[/"Make it <strong>required</strong>\n<code>late SomeType propName;</code>"\]
+  End_Optional_No_Public_Api_Check[/"Make it <strong>optional</strong><br><code>SomeType? propName;</code>"\]
+  End_Optional[/"Make it <strong>optional</strong><br><code>SomeType? propName;</code>"\]
+  End_Required[/"Make it <strong>required</strong><br><code>late SomeType propName;</code>"\]
 ```
 
 ### Wrapper and `connect`ed components and required props


### PR DESCRIPTION
## Motivation
In the null safety migration guide [prop requiredness](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#prop-requiredness-and-nullability) section, what're supposed to be newlines in the mermaid diagram are rendering as `\n`.


<img src=https://github.com/user-attachments/assets/3d78a6a2-428b-4a53-8eed-8ebb9396aab8 width=500>



## Changes
Replace `\n` with `<br>` to fix newline rendering

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Open docs in GitHub and verify the diagram's newlines render as intended: https://github.com/Workiva/over_react/blob/2a0ed809cdb99da18fa6d32d20697843c281855b/doc/null_safety/null_safe_migration.md#prop-requiredness-and-nullability
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
