### PR TITLE
RM-285743 RM-285742 Release over_react 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## 5.4.0
+- [#941] Add Dart wrapper for React [lazy](https://react.dev/reference/react/lazy)
+- [#952] Docs: fix diagram formatting in null safety migration guide
+
 ## 5.3.3
 - [#951] Internal CI fixes
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.3.3
+version: 5.4.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.3.3
+  over_react: 5.4.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-3114: Lazy](https://github.com/Workiva/over_react/pull/941)
* Patch changes:
	* [FED-3197 Fix mermaid diagram newlines in migration guide](https://github.com/Workiva/over_react/pull/952)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.3.3...Workiva:release_over_react_5.4.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.3.3...5.4.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=956)