### PR TITLE
Docs: add more details around connect vs hooks

### DIFF
--- a/doc/null_safety/null_safe_migration.md
+++ b/doc/null_safety/null_safe_migration.md
@@ -206,11 +206,17 @@ of the null safety and required props docs for instructions on how to handle the
 
 #### connect
 
-For connect, either
+For connect, either:
 - Disable validation using the instructions linked above 
     - Note: for now, this must be done manually, but we'll be adding a codemod to help do this automatically for `connect`: https://github.com/Workiva/over_react_codemod/issues/295
 - Refactor your component to instead utilize [OverReact Redux hooks](../over_react_redux_documentation.md#hooks), 
     which avoid this problem by accessing store data and dispatchers directly in the component as opposed to passing it in via props.
+
+We generally recommend using hooks over `connect`, since the API is simpler, and in over_react is more convenient and doesn't involve worrying about required prop validation.
+
+However, for existing components, converting them to function components may be non-trivial depending on other logic within components that needs to be migrated.
+
+So, for this migration, you'll want to decide whether converting to function components is worth the effort.
 
 #### Implementing abstract `Ref`s
 

--- a/doc/over_react_redux_documentation.md
+++ b/doc/over_react_redux_documentation.md
@@ -10,6 +10,10 @@ A Dart wrapper for React Redux, providing targeted state updates.
   - [Running the Examples](#running-the-examples)
 - **[Using it in your project](#using-it-in-your-project)**
 - **[ReduxProvider](#reduxprovider)**
+- **[Hooks](#hooks)**
+  - [useSelector](#useselector)
+  - [useDispatch](#usedispatch)
+  - [useStore](#usestore)
 - **[Connect](#connect)**
   - [`connect` Parameters](#connect-parameters)
     - [mapStateToProps](#mapstatetoprops)
@@ -22,10 +26,6 @@ A Dart wrapper for React Redux, providing targeted state updates.
     - [context](#context)
     - [pure](#pure)
     - [forwardRef](#forwardref)
-- **[Hooks](#hooks)**
-  - [useSelector](#useselector)
-  - [useDispatch](#usedispatch)
-  - [useStore](#usestore)
 - **[Using Multiple Stores](#using-multiple-stores)**
 - **[Using Redux DevTools](#using-redux-devtools)**
   - [Integrating with DevTools](#integration-with-devtools)
@@ -168,6 +168,8 @@ A wrapper around the JS react-redux `connect` function that supports OverReact c
 
 > See: <https://react-redux.js.org/api/connect>
 
+> ![TIP] connect still works and is supported. However, we recommend using the hooks API as the default.
+
 **Example:**
 
 ```dart
@@ -299,9 +301,17 @@ class CounterProps = UiProps with CounterPropsMixin, OtherPropsMixin;
 > [More information about the `connect` function](https://react-redux.js.org/api/connect#connect)
 
 ## Hooks
+
 OverReact exposes wrappers around React Redux hook APIs, which serve as an alternative to the existing [`connect()`](#connect) Higher Order Component. 
 These APIs allow you to subscribe to the Redux store and dispatch actions, without having to wrap your components 
 in [`connect()`](#connect).
+
+> [!TIP]
+> **We recommend using the React-Redux hooks API as the default approach in your React components.**
+>
+> The existing connect API still works and will continue to be supported, but the hooks API is simpler, 
+> requires less OverReact boilerplate, and doesn't involve suppressing validation for required props 
+> (see [connect](#connect) docs for more info).
 
 > See: <https://react-redux.js.org/api/hooks>
 


### PR DESCRIPTION
## Motivation
The null safety migration guide could use a little more detail to help guide consumers on whether to migrate `connect`-ed components as is, vs first migrating them to use hooks.

Also, our Redux docs don't communicate a preference between `connect` or hooks, unlike the official React Redux docs which [recommends hooks](https://react-redux.js.org/api/hooks):
> **We recommend using the React-Redux hooks API as the default approach in your React components.**
> 
> The existing connect API still works and will continue to be supported, but the hooks API is simpler and works better with TypeScript.

## Changes
- Add info in migration guide around preferring hooks, and caveats to migrating them
- Update Redux docs to prefer hooks, and list hooks ahead of `connect` in TOC

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
