### PR TITLE
FED-3255 Allow analyzer 6.x

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -131,9 +131,13 @@ jobs:
       matrix:
         sdk: [ 2.19.6, stable ]
         analyzer:
-          # We only have one version currently, but we'll leave this CI step in place
-          # for the next time we need to support multiple analyzer versions.
           - ^5.1.0
+          - ^6.0.0
+        exclude:
+          # Analyzer 6 only resolves in Dart 3
+          - sdk: 2.19.6
+            analyzer: ^6.0.0
+
     steps:
       - uses: actions/checkout@v4
       - id: setup-dart

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -131,7 +131,7 @@ jobs:
       matrix:
         sdk: [ 2.19.6, stable ]
         analyzer:
-          - ^5.1.0
+          - ^5.13.0 # This should match the lower bound
           - ^6.0.0
         exclude:
           # Analyzer 6 only resolves in Dart 3

--- a/lib/src/builder/codegen/typed_map_impl_generator.dart
+++ b/lib/src/builder/codegen/typed_map_impl_generator.dart
@@ -556,7 +556,7 @@ class _TypedMapImplGenerator extends TypedMapImplGenerator {
         for (var i = 0; i < mixins.length; i++) {
           final mixin = mixins[i];
           final typeArguments = mixin.typeArguments?.toSource() ?? '';
-          final names = TypedMapNames(mixin.name.name);
+          final names = TypedMapNames(mixin.nameWithPrefix);
           header.write('${names.consumerName}$typeArguments');
           header.write(',');
           // Add a space at the beginning of the line so that dartfmt indents it

--- a/lib/src/builder/parsing/ast_util.dart
+++ b/lib/src/builder/parsing/ast_util.dart
@@ -69,7 +69,17 @@ extension TypeAnnotationNameHelper on TypeAnnotation {
 /// field of [Identifier]s.
 extension TypeNameHelper on NamedType {
   /// The type name without any namespace prefixes.
-  String get nameWithoutPrefix => name.nameWithoutPrefix;
+  String get nameWithoutPrefix => name2.lexeme;
+
+  /// The type name including the namespace prefix.
+  String get nameWithPrefix {
+    final prefix = importPrefix?.name.lexeme;
+    final name = name2.lexeme;
+    return [
+      if (prefix != null) prefix,
+      name,
+    ].join('.');
+  }
 }
 
 /// Utilities related to simplifying access to node identifier fields.

--- a/lib/src/builder/parsing/declarations.dart
+++ b/lib/src/builder/parsing/declarations.dart
@@ -204,7 +204,7 @@ mixin _TypedMapMixinShorthandDeclaration {
         .toList();
 
     if (badConstraints != null && badConstraints.isNotEmpty) {
-      final badConstraintsString = badConstraints.map((c) => c.name.name).join(', ');
+      final badConstraintsString = badConstraints.map((c) => c.nameWithPrefix).join(', ');
 
       final suggestedImplName = mixin.name.name.endsWith('Mixin')
           ? mixin.name.name.replaceFirst(RegExp(r'Mixin$'), '')
@@ -229,7 +229,7 @@ extension on Union<BoilerplateProps, BoilerplatePropsMixin> {
   /// This is the safest way to retrieve that information because it takes
   /// into account the nature of the [Union] typing of `props`.
   List<String> get allPropsMixins => this.switchCase(
-        (a) => a.nodeHelper.mixins.map((name) => name.name.name).toList(),
+        (a) => a.nodeHelper.mixins.map((name) => name.nameWithPrefix).toList(),
         (b) => [b.name.name],
       );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  analyzer: ^5.13.0
+  analyzer: '>=5.13.0 <7.0.0'
   build: ^2.0.0
   dart_style: ^2.0.0
   js: ^0.6.1+1

--- a/test/vm_tests/builder/parsing/ast_util/classish_declaration_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util/classish_declaration_test.dart
@@ -65,7 +65,7 @@ main() {
 
             expect(parseAndGetSingleClassish('''
               abstract class Foo implements Bar, Baz {}
-            ''').interfaces.map((i) => i.name.name), ['Bar', 'Baz']);
+            ''').interfaces.map((i) => i.name2.name), ['Bar', 'Baz']);
           });
 
           test('withClause', () {
@@ -105,7 +105,7 @@ main() {
 
             expect(parseAndGetSingleClassish('''
               class Foo extends Bar {}
-            ''').superclass?.name.name, 'Bar');
+            ''').superclass?.name2.name, 'Bar');
           });
 
           test('mixins', () {
@@ -115,13 +115,13 @@ main() {
 
             expect(parseAndGetSingleClassish('''
               class Foo extends Object with Bar, Baz {}
-            ''').mixins.map((m) => m.name.name), ['Bar', 'Baz']);
+            ''').mixins.map((m) => m.name2.name), ['Bar', 'Baz']);
           });
 
           test('allSuperTypes', () {
             expect(parseAndGetSingleClassish('''
               class Foo extends Bar with Baz implements Qux {}
-            ''').allSuperTypes.map((m) => m.name.name), unorderedEquals(['Bar', 'Baz', 'Qux']));
+            ''').allSuperTypes.map((m) => m.name2.name), unorderedEquals(['Bar', 'Baz', 'Qux']));
           });
         });
       });
@@ -148,7 +148,7 @@ main() {
 
             expect(parseAndGetSingleClassish('''
               abstract class Foo = Object with Something implements Bar, Baz;
-            ''').interfaces.map((i) => i.name.name), ['Bar', 'Baz']);
+            ''').interfaces.map((i) => i.name2.name), ['Bar', 'Baz']);
           });
 
           test('withClause', () {
@@ -180,19 +180,19 @@ main() {
           test('superclass', () {
             expect(parseAndGetSingleClassish('''
               class Foo = Bar with Baz;
-            ''').superclass?.name.name, 'Bar');
+            ''').superclass?.name2.name, 'Bar');
           });
 
           test('mixins', () {
             expect(parseAndGetSingleClassish('''
               class Foo = Object with Bar, Baz;
-            ''').mixins.map((m) => m.name.name), ['Bar', 'Baz']);
+            ''').mixins.map((m) => m.name2.name), ['Bar', 'Baz']);
           });
 
           test('allSuperTypes', () {
             expect(parseAndGetSingleClassish('''
               class Foo = Bar with Baz implements Qux;
-            ''').allSuperTypes.map((m) => m.name.name), unorderedEquals(['Bar', 'Baz', 'Qux']));
+            ''').allSuperTypes.map((m) => m.name2.name), unorderedEquals(['Bar', 'Baz', 'Qux']));
           });
         });
       });
@@ -232,7 +232,7 @@ main() {
 
             expect(parseAndGetSingleClassish('''
               mixin Foo on Bar implements Baz {}
-            ''').interfaces.map((i) => i.name.name), unorderedEquals(['Bar', 'Baz']));
+            ''').interfaces.map((i) => i.name2.name), unorderedEquals(['Bar', 'Baz']));
           });
 
           test('withClause', () {
@@ -268,7 +268,7 @@ main() {
           test('allSuperTypes', () {
             expect(parseAndGetSingleClassish('''
               mixin Foo on Bar implements Baz {}
-            ''').allSuperTypes.map((m) => m.name.name), unorderedEquals(['Bar', 'Baz']));
+            ''').allSuperTypes.map((m) => m.name2.name), unorderedEquals(['Bar', 'Baz']));
           });
         });
       });

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -166,13 +166,14 @@ main() {
 
     group('NameHelper', () {
       test('nameWithoutPrefix', () {
-        expect(NameHelper(parseAndGetFirstWithType('''
-          SomeName foo;
-        ''')).nameWithoutPrefix, 'SomeName');
+        final identifier = parseAndGetSingleWithType<ExpressionFunctionBody>('''
+          example() => identifier;
+        ''').expression as Identifier;
+        expect(NameHelper(identifier).nameWithoutPrefix, 'identifier');
 
         expect(NameHelper(parseAndGetFirstWithType<PrefixedIdentifier>('''
-          example() => foo.SomeName;
-        ''')).nameWithoutPrefix, 'SomeName');
+          example() => foo.identifier;
+        ''')).nameWithoutPrefix, 'identifier');
       });
     });
 

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -160,8 +160,8 @@ main() {
           SomeName foo;
         ''')).nameWithoutPrefix, 'SomeName');
 
-        expect(NameHelper(parseAndGetFirstWithType('''
-          foo.SomeName foo;
+        expect(NameHelper(parseAndGetFirstWithType<PrefixedIdentifier>('''
+          example() => foo.SomeName;
         ''')).nameWithoutPrefix, 'SomeName');
       });
     });

--- a/test/vm_tests/builder/parsing/ast_util_test.dart
+++ b/test/vm_tests/builder/parsing/ast_util_test.dart
@@ -152,6 +152,16 @@ main() {
           foo.SomeTypeName foo;
         ''')).nameWithoutPrefix, 'SomeTypeName');
       });
+
+      test('nameWithPrefix', () {
+        expect(TypeNameHelper(parseAndGetSingleWithType('''
+          SomeTypeName foo;
+        ''')).nameWithPrefix, 'SomeTypeName');
+
+        expect(TypeNameHelper(parseAndGetSingleWithType('''
+          foo.SomeTypeName foo;
+        ''')).nameWithPrefix, 'foo.SomeTypeName');
+      });
     });
 
     group('NameHelper', () {


### PR DESCRIPTION
Depends on https://github.com/Workiva/over_react/pull/958

## Motivation
over_react currently allows analyzer 5.x, but not analyzer 6.x, which prevents newer versions of other packages from being pulled in.

We were previously blocked on supporting analyzer 6.x since it can only be used in Dart 3, but now we support Dart 3!

## Changes
- Raise analyzer upper bound to allow 6.x
- Add 6.x to CI matrix that validates behavior under different analyzer majors
- Fix usages of deprecated `NamedType.name`, which was removed in analyzer 6.0.0
    - This getter included the name and any import prefix, and was deprecated in favor of the following getters:
        - `name2` (the name without the prefix)
        - `importPrefix` (just the prefix)

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
