### PR TITLE
RM-288897 RM-288896 Release over_react 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OverReact Changelog
 
+## 5.4.1
+- [#958] Officially support Dart 3, raise SDK constraint explicitly
+    - This did not involve any changes that would affect consumers; previous null-safe versions should also work in Dart 3.
+    - Note: there's a known bug in Dart >=3.3.0 <3.5.0 that breaks behavior in DDC of certain functions passed to components, 
+      such as refs and potentially JS callback props: https://github.com/dart-lang/sdk/issues/56897. 
+    
+      During development, we recommend either avoiding those Dart versions or compiling with dart2js.
+
+- [#960] Raise `analyzer` upper bound to allow 6.x
+- [#957] Docs: add more details around connect vs hooks
+
 ## 5.4.0
 - [#941] Add Dart wrapper for React [lazy](https://react.dev/reference/react/lazy)
 - [#952] Docs: fix diagram formatting in null safety migration guide

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.4.0
+version: 5.4.1
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.0
+  over_react: 5.4.1
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3236 Docs: add more details around connect vs hooks](https://github.com/Workiva/over_react/pull/957)
	* [FED-3254 Officially support Dart 3](https://github.com/Workiva/over_react/pull/958)
	* [FED-3255 Allow analyzer 6.x](https://github.com/Workiva/over_react/pull/960)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.4.0...Workiva:release_over_react_5.4.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.4.0...5.4.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=962)