### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   color: ^3.0.0
   memoize: ^3.0.0
-  meta: ^1.6.0
+  meta: ^1.16.0
   over_react: '>=4.8.4 <6.0.0'
   json_annotation: ^4.6.0
   redux: '>=3.0.0 <6.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   dart_style: ^2.0.0
   js: ^0.6.1+1
   logging: ^1.0.0
-  meta: ^1.6.0
+  meta: ^1.16.0
   package_config: ^2.1.0
   path: ^1.5.1
   react: ^7.2.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   analyzer: ^5.1.0
   analyzer_plugin: ^0.11.0
   collection: ^1.15.0-nullsafety.4
-  meta: ^1.6.0
+  meta: ^1.16.0
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)