### PR TITLE
dart_dependency_validator_config

### DIFF
--- a/tools/analyzer_plugin/dart_dependency_validator.yaml
+++ b/tools/analyzer_plugin/dart_dependency_validator.yaml
@@ -1,0 +1,5 @@
+ignore:
+  # Ignore the over_react pin
+  - over_react
+exclude:
+  - playground/**

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -34,18 +34,9 @@ dev_dependencies:
   test_reflective_loader: ^0.2.0
   uuid: '>3.0.0 <5.0.0'
   workiva_analysis_options: ^1.1.0
-
-dependency_validator:
-  ignore:
-    # Ignore the over_react pin
-    - over_react
-  exclude:
-    - playground/**
-
 workiva:
   core_checks:
     react_boilerplate: disabled
-
 # If you're developing on changes in over_react that the analyzer plugin needs to consume,
 # point to the local copy of over_react. This must be an absolute path.
 #


### PR DESCRIPTION
Updates the pubspec.yaml configuration of dependency_validator to use the updated dart_dependency_validator configuration

For any questions, please reach out to #support-frontend-dx

[_Created by Sourcegraph batch change `Workiva/dart_dependency_validator_config`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/dart_dependency_validator_config)