### PR TITLE
Raise the uuid dependency min to v4.0.0

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   json_annotation: ^4.6.0
   redux: '>=3.0.0 <6.0.0'
   redux_dev_tools: '>=0.4.0 <0.8.0'
-  uuid: ^3.0.7
+  uuid: ^4.0.0
 
 dev_dependencies:
   build_runner: ^2.2.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
   markdown: ^4.0.0
   test: ^1.14.0
   test_reflective_loader: ^0.2.0
-  uuid: '>3.0.0 <5.0.0'
+  uuid: ^4.0.0
   workiva_analysis_options: ^1.1.0
 
 dependency_validator:


### PR DESCRIPTION
This PR raises the min version of uuid to 4.0.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/uuid_raise_min_v4_0_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/uuid_raise_min_v4_0_0)