### PR TITLE
FED-3476 Adjust builder for Dart 3

### DIFF
--- a/lib/src/builder/builder.dart
+++ b/lib/src/builder/builder.dart
@@ -250,7 +250,7 @@ class OverReactBuilder extends Builder {
     // analyzer version in this builder.
     result.errors.forEach(log.warning);
 
-    return null;
+    return result.unit;
   }
 
   static const _ignoreForFileCodes = {


### PR DESCRIPTION
# Summary
The over_react builder fails to generate code when there are analysis errors in the source file, regardless of their severity, due to the short-circuit [here](https://github.com/Workiva/over_react/blob/5c028ef0f13bfd3e835c3e35d7472c9e5d3eb77d/lib/src/builder/builder.dart#L246-L253).

Historically, this hasn't been an issue since we do a non-resolved AST parse, and most infos/warnings require resolved AST.

However, apparently the warning for bad doc comment directives comes through in unresolved AST.

This causes failures to emit several over_react.g.dart files due to doc comments like this:
```
  /// Optional props to forward to the `ClickAwayListener` component
  /// when {@link disableClickAwayListener } is `false`.
```
and also outputs this warning:
```
[WARNING] over_react:overReactBuilder on package:unify_ui/src/components/custom/popper_trigger/popper_trigger.dart:
lib/src/components/custom/popper_trigger/popper_trigger.dart(2016..2019): Doc directive 'link' is unknown.
```

This issue should not prevent over_react from generating code.

