### PR TITLE
FED-3585 Fix fragment type check assert

### DIFF
--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -307,7 +307,16 @@ Object? getComponentTypeFromAlias(Object? typeAlias) {
 /// * [Function] factory (Dart components)
 /// * [ReactClass] component type (JS composite component classes, JS function component functions, Dart component JS classes)
 bool isPotentiallyValidComponentType(dynamic type) {
-  return type is Function || type is ReactClass || type is String;
+  return type is Function ||
+      // In DDC, `type is ReactClass` is true for JS symbols (such as for Fragment ReactElements),
+      // but in dart2js it is false.
+      // Since isPotentiallyValidComponentType is only used in aliasing code now, this isn't a big deal since
+      // people aren't likely aliasing Fragment, but we should make this behavior consistent.
+      // TODO handle that case in dart2js once our Dart SDK constraint is >=3.0.0, with the following code:
+      //    typeofEquals(type, 'symbol') ||
+      // TODO also add a test (see TODO in component_type_checking_test.dart)
+      type is ReactClass ||
+      type is String;
 }
 
 /// Returns an [Iterable] of all component types that are ancestors of [type].

--- a/lib/src/component_declaration/component_type_checking.dart
+++ b/lib/src/component_declaration/component_type_checking.dart
@@ -172,9 +172,6 @@ bool isTypeAlias(dynamic type) {
 /// Returns the [ComponentTypeMeta] associated with the component type [type] in [setComponentTypeMeta],
 /// or `const ComponentTypeMeta.none()` if there is no associated meta.
 ComponentTypeMeta getComponentTypeMeta(Object type) {
-  assert(isPotentiallyValidComponentType(type),
-      '`type` should be a valid component type (and not null or a type alias).');
-
   if (type is! String) {
     return getProperty(type, _componentTypeMetaKey) as ComponentTypeMeta? ??
         const ComponentTypeMeta.none();


### PR DESCRIPTION
## Motivation
`getProps(child, traverseWrappers: true)` incorrectly raises the following assertion error, only in dart2js (when using `--enable-asserts`):
```
Assertion failed: "`type` should be a valid component type (and not null or a type alias)."
/_internal/js_runtime/lib/js_helper.dart 1128:37                                                        Object.wrapException
/_internal/js_runtime/lib/js_helper.dart 2596:3                                                         Object.assertThrow
/packages/over_react/src/component_declaration/component_type_checking.dart 175:3                       Object.getComponentTypeMeta
/packages/over_react/src/util/react_wrappers.dart 143:28                                                Object.getProps
```

For Fragment ReactElements (`Fragment()(...)`), `.type` is apparently JS Symbol instance, and is a case not handled by [this check](https://github.com/Workiva/over_react/blob/93b7031633634354a2a08801241c398064b5debf/lib/src/component_declaration/component_type_checking.dart#L310) causing [this assertion](https://github.com/Workiva/over_react/blob/93b7031633634354a2a08801241c398064b5debf/lib/src/component_declaration/component_type_checking.dart#L175) to fail.

This case should not throw.

Also, we just shouldn't try to validate the `.type` that originates from `ReactElement`s; if we don't make any assumptions about what type it can be, this issue won't occur.

## Changes
- Remove unnecessary assert as a workaround for false positive with Fragment, add TODOs

    isPotentiallyValidComponentType is incorrect in dart2js (see TODO on that function) and it returns false for Fragment's Symbol type.
    
    There's not a great way to fix that behavior until Dart 3 (see TODO), so in the meantime, we'll just remove this assert.
    
    The assert really isn't necessary, since only guaranteed-to-be-valid component types from ReactElements and ReactComponentFactoryProxys get passed into it, as opposed to consumer arguments, so we should be able to safely remove it. Any cases it might have caught should also be covered by test coverage on type checking code.

- Add regression test

    Note: due to current behavioral differences of isPotentiallyValidComponentType between dart2js and DDC, these regression tests only fail in dart2js with `--enable-asserts`, which we don't want to run our tests with.

    As opposed to adding a whole new build configuration and updating our test setup just for that one case, which we'll be able to fix once we move to Dart 3, we'll just verify this manually as part of QAing this PR.

#### Release Notes
Fix false positive `assert` in dart2js (when using `--enable-asserts`)  when passing a `Fragment` into `getProps(..., traverseWrappers: true)`

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify locally that regression tests fail in dart2js with `--enable-asserts`, before the fix. 
          Normally you'd need to update build.yaml, but you can also use `--build-args`, which I've done here for convenience. Just run the following commands:
          ```console
          $ git checkout 698779f
          $ dart run dart_dev test --release \
              --build-args='--define=build_web_compilers|entrypoint=dart2js_args=["--enable-asserts","--no-minify"]' \
              -N 'type checking and related utilities' test/over_react_component_declaration_test.dart
          ```
          You should see failures that look like this: https://gist.github.com/greglittlefield-wf/afb337f5b9ccf15f93be5a3a2d956edc

        - Verify locally that regression tests (and other tests in suite) pass in dart2js with `--enable-asserts`, after the fix.
          Use the following commands:
          ```console
          $ git checkout fix-fragment-type-check-assert
          $ dart run dart_dev test --release \
              --build-args='--define=build_web_compilers|entrypoint=dart2js_args=["--enable-asserts","--no-minify"]' \
              --test-args='--exclude-tags=ddc,no-ddc' \
              test/over_react_component_declaration_test.dart
          ```
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
