### PR TITLE
RM-298715 RM-298714 Release over_react 5.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # OverReact Changelog
 
+## 5.4.3
+- [#966] Revert #964 (an attempt to fix `manageAndReturnTypedDisposable` typing)
+- [#969] Use a `dart_dependency_validator.yaml` config file
+- [#973] React 18 Prep
+  - Bumps the minimum Dart SDK from `2.17.0` to `2.19.0`
+- [#974] Fix fragment type check assert
+
 ## 5.4.2
 - [#964] Fix bad override of `manageAndReturnTypedDisposable` caused by w_common 3.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.4.2
+version: 5.4.3
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.2
+  over_react: 5.4.3
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Revert "FEDX-1997: adjust `manageAndReturnTypedDisposable`"](https://github.com/Workiva/over_react/pull/966)
	* [dart_dependency_validator_config](https://github.com/Workiva/over_react/pull/969)
	* [FED-3274 React 18 Prep](https://github.com/Workiva/over_react/pull/973)
	* [FED-3585 Fix fragment type check assert](https://github.com/Workiva/over_react/pull/974)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.4.2...Workiva:release_over_react_5.4.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.4.2...5.4.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=975)