### PR TITLE
RM-323591 RM-323590 Release over_react 5.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OverReact Changelog
 
+## 5.4.4
+- [#972] Generate parts even when there are analysis warnings/errors in the source file's unresolved AST 
+    - For example, the new `doc_directive_unknown` warning on doc comments in Dart 3
+
 ## 5.4.3
 - [#966] Revert #964 (an attempt to fix `manageAndReturnTypedDisposable` typing)
 - [#969] Use a `dart_dependency_validator.yaml` config file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.4.3
+version: 5.4.4
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.3
+  over_react: 5.4.4
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3476 Adjust builder for Dart 3](https://github.com/Workiva/over_react/pull/972)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.4.3...Workiva:release_over_react_5.4.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.4.3...5.4.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=976)