### PR TITLE
Test consume react-dart dual support (force React 18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ and add an HTML element with a unique identifier where you’ll mount your OverR
           // OverReact component render() output will show up here.
         </div>
 
-        <script src="packages/react/react.js"></script>
-        <script src="packages/react/react_dom.js"></script>
+        <script src="packages/react/js/react.dev.js"></script>
 
         <!-- NOTE: "index" should correspond to the
              name of the `.dart` file that contains your `main()` entrypoint. -->

--- a/app/over_react_redux/todo_client/test/unit/_templates/react_components_test_template.html
+++ b/app/over_react_redux/todo_client/test/unit/_templates/react_components_test_template.html
@@ -1,8 +1,7 @@
 <!-- See: https://pub.dev/packages/test_html_builder -->
 <html>
     <head>
-        <script src="packages/react/react_with_addons.js"></script>
-        <script src="packages/react/react_dom.js"></script>
+        <script src="packages/react/js/react.dev.js"></script>
         <script src="packages/todo_client/src/test_fixtures/mock_js_objects.js"></script>
         <script src="https://unpkg.com/@material-ui/core/umd/material-ui.development.js" crossorigin="anonymous"></script>
 

--- a/app/over_react_redux/todo_client/test/unit/_templates/react_test_template.html
+++ b/app/over_react_redux/todo_client/test/unit/_templates/react_test_template.html
@@ -1,8 +1,7 @@
 <!-- See: https://pub.dev/packages/test_html_builder -->
 <html>
     <head>
-        <script src="packages/react/react_with_addons.js"></script>
-        <script src="packages/react/react_dom.js"></script>
+        <script src="packages/react/js/react.dev.js"></script>
 
         {{testScript}}
 

--- a/app/over_react_redux/todo_client/web/index.html
+++ b/app/over_react_redux/todo_client/web/index.html
@@ -13,8 +13,7 @@
 
   <div id="todo-container"></div>
 
-  <script src="packages/react/react.js"></script>
-  <script src="packages/react/react_dom.js"></script>
+  <script src="packages/react/js/react.dev.js"></script>
   <script src="https://unpkg.com/@material-ui/core/umd/material-ui.development.js" crossorigin="anonymous"></script>
 
   <!-- Serve compiled output. -->

--- a/example/boilerplate_versions/index.html
+++ b/example/boilerplate_versions/index.html
@@ -33,8 +33,7 @@
 <body>
 <div id="content"></div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="main.dart.js"></script>
 </body>

--- a/example/builder/index.html
+++ b/example/builder/index.html
@@ -33,8 +33,7 @@
 <body>
 <div id="content"></div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="main.dart.js"></script>
 </body>

--- a/example/context/index.html
+++ b/example/context/index.html
@@ -33,8 +33,7 @@
 <body>
 <div id="content"></div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="main.dart.js"></script>
 </body>

--- a/example/error_boundary/index.html
+++ b/example/error_boundary/index.html
@@ -33,8 +33,7 @@
 <body>
 <div id="content"></div>
 
-<script src="packages/react/react_prod.js"></script>
-<script src="packages/react/react_dom_prod.js"></script>
+<script src="packages/react/js/react.min.js"></script>
 
 <script type="application/javascript" defer src="main.dart.js"></script>
 </body>

--- a/example/hooks/index.html
+++ b/example/hooks/index.html
@@ -33,8 +33,7 @@
 <body>
 <div id="content"></div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="main.dart.js"></script>
 </body>

--- a/example/suspense/index.html
+++ b/example/suspense/index.html
@@ -29,8 +29,7 @@
   <body>
     <div id="content"></div>
 
-    <script src="packages/react/react_prod.js"></script>
-    <script src="packages/react/react_dom_prod.js"></script>
+    <script src="packages/react/js/react.min.js"></script>
     <script>
       const defaultMessageContext = React.createContext('default context value');
       window.TestJsComponent = React.forwardRef(function (props, ref) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,4 +53,8 @@ dependency_overrides:
     git:
       url: https://github.com/Workiva/react-dart.git
       ref: FED-3283-dual-support
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18-dual-version-spike
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,3 +46,11 @@ workiva:
   core_checks:
     version: 1
     react_boilerplate: disabled
+
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: FED-3283-dual-support
+

--- a/test/over_react_component_declaration_non_null_safe_test.html
+++ b/test/over_react_component_declaration_non_null_safe_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
     <title>OverReact Unit Tests - over_react component_declaration</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
     <link rel="x-dart-test"  href="over_react_component_declaration_non_null_safe_test.dart">

--- a/test/over_react_component_declaration_test.html
+++ b/test/over_react_component_declaration_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
     <title>OverReact Unit Tests - over_react component_declaration</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
     <link rel="x-dart-test"  href="over_react_component_declaration_test.dart">

--- a/test/over_react_component_test.html
+++ b/test/over_react_component_test.html
@@ -19,8 +19,7 @@ limitations under the License.
   <head>
     <title>OverReact Tests - over_react component</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script src="packages/react_testing_library/js/react-testing-library.js"></script>
     <script>
       const defaultMessageContext = React.createContext('default context value');

--- a/test/over_react_dom_test.html
+++ b/test/over_react_dom_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
     <title>OverReact Unit Tests - over_react.react.dom library</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <link rel="x-dart-test"  href="over_react_dom_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/over_react_prod_test.html
+++ b/test/over_react_prod_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
   <title>OverReact Unit Tests - react.dart prod</title>
   <!-- javascript -->
-  <script src="packages/react/react_prod.js"></script>
-  <script src="packages/react/react_dom_prod.js"></script>
+  <script src="packages/react/js/react.min.js"></script>
   <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
   <script>

--- a/test/over_react_redux_test.html
+++ b/test/over_react_redux_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
     <title>OverReact Tests - over_react_redux</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <link rel="x-dart-test"  href="over_react_redux_test.dart">
     <script src="packages/test/dart.js"></script>

--- a/test/over_react_util_test.html
+++ b/test/over_react_util_test.html
@@ -19,8 +19,7 @@ limitations under the License.
 <head>
     <title>OverReact Unit Tests - over_react util</title>
     <!-- javascript -->
-    <script src="packages/react/react_with_addons.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
     <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
     <script>

--- a/web/component1/index.html
+++ b/web/component1/index.html
@@ -82,8 +82,7 @@
         </div>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <!--un comment to serve in Dart 1-->
     <!--<script type="application/dart" src="index.dart"></script>-->

--- a/web/component2/index.html
+++ b/web/component2/index.html
@@ -132,8 +132,7 @@
         </div>
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <!--un comment to serve in Dart 1-->
     <!--<script type="application/dart" src="index.dart"></script>-->

--- a/web/flux_to_redux/advanced/examples/flux_implementation/index.html
+++ b/web/flux_to_redux/advanced/examples/flux_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/flux_to_redux/advanced/examples/influx_implementation/index.html
+++ b/web/flux_to_redux/advanced/examples/influx_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/flux_to_redux/advanced/examples/redux_implementation/index.html
+++ b/web/flux_to_redux/advanced/examples/redux_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/flux_to_redux/simple/examples/flux_implementation/index.html
+++ b/web/flux_to_redux/simple/examples/flux_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/flux_to_redux/simple/examples/influx_implementation/index.html
+++ b/web/flux_to_redux/simple/examples/influx_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/flux_to_redux/simple/examples/redux_implementation/index.html
+++ b/web/flux_to_redux/simple/examples/redux_implementation/index.html
@@ -31,8 +31,7 @@
     Loading...
 </div>
 
-<script src="packages/react/react.js"></script>
-<script src="packages/react/react_dom.js"></script>
+<script src="packages/react/js/react.dev.js"></script>
 
 <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/over_react_redux/examples/dev_tools/index.html
+++ b/web/over_react_redux/examples/dev_tools/index.html
@@ -31,8 +31,7 @@
         Loading...
     </div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/over_react_redux/examples/multiple_stores/index.html
+++ b/web/over_react_redux/examples/multiple_stores/index.html
@@ -29,8 +29,7 @@
 <body>
     <div id="content"></div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <script type="application/javascript" defer src="index.dart.js"></script>
 </body>

--- a/web/over_react_redux/examples/simple/index.html
+++ b/web/over_react_redux/examples/simple/index.html
@@ -29,8 +29,7 @@
 <body>
     <div id="content"></div>
 
-    <script src="packages/react/react.js"></script>
-    <script src="packages/react/react_dom.js"></script>
+    <script src="packages/react/js/react.dev.js"></script>
 
     <script type="application/javascript" defer src="index.dart.js"></script>
 </body>


### PR DESCRIPTION
Testing https://github.com/Workiva/react-dart/pull/414 in over_react, using React 18 JS assets