### PR TITLE
FED-3730 Exclude images when publishing, reducing tarball from 5.9MB to 1.3MB

### DIFF
--- a/doc/.pubignore
+++ b/doc/.pubignore
@@ -1,0 +1,7 @@
+# Prevent everything in this directory from being published to Pub, so that
+# we don't unnecessarily bloat the package with image files.
+#
+# Use a .pubignore per directory instead of one at the repo root,
+# so that we don't have to redeclare all of our .gitignore entries.
+# See: https://github.com/dart-lang/pub/issues/4545#issuecomment-2739756059
+*

--- a/snippets/.pubignore
+++ b/snippets/.pubignore
@@ -1,0 +1,7 @@
+# Prevent everything in this directory from being published to Pub, so that
+# we don't unnecessarily bloat the package with image files.
+#
+# Use a .pubignore per directory instead of one at the repo root,
+# so that we don't have to redeclare all of our .gitignore entries.
+# See: https://github.com/dart-lang/pub/issues/4545#issuecomment-2739756059
+*

--- a/tools/analyzer_plugin/doc/.pubignore
+++ b/tools/analyzer_plugin/doc/.pubignore
@@ -1,0 +1,7 @@
+# Prevent everything in this directory from being published to Pub, so that
+# we don't unnecessarily bloat the package with image files.
+#
+# Use a .pubignore per directory instead of one at the repo root,
+# so that we don't have to redeclare all of our .gitignore entries.
+# See: https://github.com/dart-lang/pub/issues/4545#issuecomment-2739756059
+*


### PR DESCRIPTION
## Motivation
The over_react package currently publishes all the repo's contents, including images in various non-production documentation-esque directories, a couple of which are pretty large.

I noticed the last couple times I published that there are warnings for this.

We should avoid unnecessarily large assets in our published package, and also fix warnings so that we have less noise when publishing.

## Changes
Stop publishing directories that contain images, none of which are needed when consuming the package:
- docs
- snippets
- tools/analyzer_plugin/docs

We could potentially extend this to other directories like examples/tests, but it'd be diminishing returns since those files are smaller and compress better. And it seems like the convention is to keep files published unless they're causing issues—see info [here](https://dart.dev/tools/pub/publishing#what-files-are-published) and in the linked StackOverflow post. So, I think we're good to call it here for now.

Size reductions of this branch:
* Tarball: 5.9MB -> **1.3MB**
* Extracted directory: 13.1MB ->  8.1MB

Example showing the image files that were published before:
```console
over_react@tags/5.4.4 % dart pub publish --dry-run 2>&1 | grep -E 'png|gif'
│   ├── AdvancedFluxArchitecture.png (45 KB)
│   ├── AdvancedReduxArchitecture.png (35 KB)
│   ├── FluxArchitecture.png (24 KB)
│   ├── InfluxArchitecture.png (33 KB)
│   ├── ReduxArchitecture.png (24 KB)
│   ├── StartingArchitecture.png (13 KB)
│   ├── component2-perf-initial-mount.png (62 KB)
│   ├── component2-perf-rerender.png (62 KB)
│   ├── component_store_relationships.png (27 KB)
│   ├── flux_store_decision_tree.png (58 KB)
│   │       ├── interop_ref.gif (45 KB)
│   │       └── interop_reference_error.png (31 KB)
│   ├── new-boilerplate-side-by-side.png (227 KB)
│   ├── vs_code.gif (2 MB)
│   └── webstorm_intelliJ.gif (1 MB)
│       │   ├── create-configuration-1.png (19 KB)
│       │   ├── create-configuration-2.png (76 KB)
│       │   ├── create-configuration-3.png (60 KB)
│       │   ├── edit-jetbrains-registry.png (36 KB)
│       │   ├── find-the-port.png (70 KB)
│       │   ├── open-analyzer-diagnostics.png (34 KB)
│       │   ├── open-jetbrains-registry.png (24 KB)
│       │   ├── run-configuration-1.png (10 KB)
│       │   ├── run-configuration-2.png (30 KB)
│       │   └── verify-connected.png (22 KB)

```
and that those files are no longer published (no output from `grep`):
```console
over_react@dont-publish-images % dart pub publish --dry-run 2>&1 | grep -E 'png|gif'
```


#### Release Notes
Exclude images when publishing, reducing Pub package tarball from 5.9MB to 1.3MB

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
        - If desired, repeat `pub publish --dry-run` commands shown above locally and verify that images are no longer included
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react/blob/master/CONTRIBUTING.md#manual-testing-criteria
