### PR TITLE
TEST: Running tests on React 18

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -32,3 +32,15 @@ dev_dependencies:
 dependency_overrides:
   over_react:
     path: '../../../'
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,3 +46,17 @@ workiva:
   core_checks:
     version: 1
     react_boilerplate: disabled
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test_fixtures/test_packages/non_null_safe/pubspec.yaml
+++ b/test_fixtures/test_packages/non_null_safe/pubspec.yaml
@@ -14,3 +14,17 @@ dev_dependencies:
 
 workiva:
   disable_core_checks: true
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test_fixtures/test_packages/null_safe/pubspec.yaml
+++ b/test_fixtures/test_packages/null_safe/pubspec.yaml
@@ -11,3 +11,17 @@ dev_dependencies:
 
 workiva:
   disable_core_checks: true
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -14,6 +14,18 @@ dependency_overrides:
   over_react:
       path: ../../..
 
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18
 workiva:
   core_checks:
     react_boilerplate: disabled

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -45,3 +45,17 @@ workiva:
 # dependency_overrides:
 #   over_react:
 #     path: /Users/me/workspaces/over_react
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/tools/analyzer_plugin/test/test_fixtures/over_react_project/pubspec.yaml
+++ b/tools/analyzer_plugin/test/test_fixtures/over_react_project/pubspec.yaml
@@ -4,3 +4,17 @@ environment:
 dependencies:
   over_react:
     path: ../../../../..
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18


### PR DESCRIPTION
DO NOT MERGE. No action needed. This PR adds dependency overrides to https://github.com/Workiva/react-dart/pull/416
in order to test all consumers before rolling out React 18 in all repos.
For more info, see [our Wiki page with the rollout plan](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) and reach out to `#support-ui-platform` on Slack with any questions.

[_Created by Sourcegraph batch change `Workiva/react_18_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test)