### PR TITLE
RM-326642 RM-326641 Release over_react 5.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Update analyzer dependency to `>=5.13.0 <8.0.0` (allow v8)
 - Update dart_style dependency to `>=2.0.0 <4.0.0` (allow v3)
 - Pub package tarball: exclude documentation image files, optimizing download size from ~5.9MB to ~1.3MB
+- Consume react-dart 7.3.0 (React 18 compatible)
 
 ## 5.4.4
 - [#972] Generate parts even when there are analysis warnings/errors in the source file's unresolved AST 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.4.4
+version: 5.4.5
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.4
+  over_react: 5.4.5
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* [Consume react-dart 7.3.0](https://github.com/Workiva/over_react/pull/978)
* [FED-3730 Exclude images when publishing, reducing tarball from 5.9MB to 1.3MB](https://github.com/Workiva/over_react/pull/979)
* [FED-3977 Allow analyzer 7](https://github.com/Workiva/over_react/pull/982)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.4.4...Workiva:release_over_react_5.4.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.4.4...5.4.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=983)