### PR TITLE
Rollout React 18 to tests and example apps

### DIFF
--- a/app/over_react_redux/todo_client/pubspec.yaml
+++ b/app/over_react_redux/todo_client/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   color: ^3.0.0
   memoize: ^3.0.0
   meta: ^1.16.0
-  over_react: '>=4.8.4 <6.0.0'
+  over_react: ^5.4.5
   json_annotation: ^4.6.0
   redux: '>=3.0.0 <6.0.0'
   redux_dev_tools: '>=0.4.0 <0.8.0'
@@ -21,7 +21,7 @@ dev_dependencies:
   dart_dev: ^4.0.0
   glob: ^2.0.0
   json_serializable: ^6.0.0
-  over_react_test: '>=2.10.2 <4.0.0'
+  over_react_test: ^3.0.2
   pedantic: ^1.8.0
   test: ^1.15.7
   test_html_builder: ^3.0.0

--- a/app/over_react_redux/todo_client/test/unit/_templates/react_components_test_template.html
+++ b/app/over_react_redux/todo_client/test/unit/_templates/react_components_test_template.html
@@ -1,8 +1,7 @@
 <!-- See: https://pub.dev/packages/test_html_builder -->
 <html>
     <head>
-        <script src="packages/react/react_with_addons.js"></script>
-        <script src="packages/react/react_dom.js"></script>
+        <script src="packages/react/js/react.dev.js"></script>
         <script src="packages/todo_client/src/test_fixtures/mock_js_objects.js"></script>
         <script src="https://unpkg.com/@material-ui/core/umd/material-ui.development.js" crossorigin="anonymous"></script>
 

--- a/app/over_react_redux/todo_client/test/unit/_templates/react_test_template.html
+++ b/app/over_react_redux/todo_client/test/unit/_templates/react_test_template.html
@@ -1,8 +1,7 @@
 <!-- See: https://pub.dev/packages/test_html_builder -->
 <html>
     <head>
-        <script src="packages/react/react_with_addons.js"></script>
-        <script src="packages/react/react_dom.js"></script>
+        <script src="packages/react/js/react.dev.js"></script>
 
         {{testScript}}
 

--- a/app/over_react_redux/todo_client/web/index.html
+++ b/app/over_react_redux/todo_client/web/index.html
@@ -13,8 +13,7 @@
 
   <div id="todo-container"></div>
 
-  <script src="packages/react/react.js"></script>
-  <script src="packages/react/react_dom.js"></script>
+  <script src="packages/react/js/react.dev.js"></script>
   <script src="https://unpkg.com/@material-ui/core/umd/material-ui.development.js" crossorigin="anonymous"></script>
 
   <!-- Serve compiled output. -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,8 +36,8 @@ dev_dependencies:
   dependency_validator: ^3.0.0
   glob: ^2.0.1
   io: ^1.0.0
-  react_testing_library: ^3.0.1
-  over_react_test: ^3.0.0
+  react_testing_library: ^3.1.1
+  over_react_test: ^3.0.2
   test: ^1.20.0
   workiva_analysis_options: ^1.4.0
   yaml: ^3.1.0

--- a/tools/analyzer_plugin/playground/pubspec.yaml
+++ b/tools/analyzer_plugin/playground/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 environment:
   sdk: ">=2.13.0 <3.0.0"
 dependencies:
-  over_react: '>=3.5.3 <6.0.0'
+  over_react: ^5.4.5
 dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers: ^3.0.0

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.5
+  over_react: ^5.4.5
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION
This PR updates all references to React JS files from the React 17 to [React 18 versions](https://github.com/Workiva/react-dart?tab=readme-ov-file#react-18) which will cause most tests and example apps to run on React 18.

This is Step 2 in our [React 18 migration plan](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=405122049&spaceKey=FEF&title=React%2B18%2BUpgrade#tab-Step+2): `opt most of CI and example apps into React 18, finalize manual testing`.

**Note**: Prod will still be running on React 17 until we roll out React 18 in LaunchDarkly so there will be a period of time after this PR merges
that tests will run on React 18 while prod is still on React 17. This should not cause issues and we will try to keep this period of time as short as possible. Please reach out to `#support-ui-platform` with any questions!

We request that repo owners perform the QA instructions and review/merge these PRs as soon as CI passes. Thank you!

## QA Instructions

- [ ] Verify that updates in this PR affect only tests or example/dev apps, and not HTML files deployed to end-users
- [ ] Passing CI
- [ ] Passing CI on [React 18 Test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) in this repo
- [ ] Manually QA and smoke test your app on React 18 - either by using the `?ld.fews-enable-react-18-in-dart=true` LD flag or by serving the [React 18 test batch PR](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test) locally (see [full instructions on React 18 manual testing here](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade#React18Upgrade-test-in-react-18HowcanItestmyappinReact18?))
  - From our testing, we do not anticipate there being any issues, but would like owning teams to manually smoke test their apps on React 18, focusing on areas of code with more complex components or less test coverage in CI.

For more info, refer to the [React 18 Upgrade wiki page](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) or reach out to `#support-ui-platform` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_18_upgrade`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_upgrade)