### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/react_dom.dart
+++ b/lib/react_dom.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 Workiva Inc.
+// Copyright 2025 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,36 +25,4 @@
 ///     import 'package:over_react/over_react.dart';
 library over_react.react_dom;
 
-import 'dart:html';
-
-import 'package:over_react/over_react.dart';
-import 'package:react/react_dom.dart' as react_dom show render, unmountComponentAtNode;
-
-/// Renders the provided [element] into the DOM mounted in the provided [mountNode]
-/// and returns a reference to it based on its type:
-///
-/// 1. Returns an [Element] if [element] is a DOM component _(e.g. [Dom.div])_.
-/// 2. Returns a React `Component` if [element] is a composite component.
-///
-/// > __Throws__ if [element] or [mountNode] are `null`.
-///
-/// If the [element] was previously rendered into the [mountNode], this will perform an update on it and only
-/// mutate the DOM as necessary to reflect the latest React component.
-///
-/// Use [unmountComponentAtNode] to unmount the instance.
-///
-/// > Proxies [react_dom.render].
-dynamic render(ReactNode element, Element mountNode) {
-  return react_dom.render(element, mountNode);
-}
-
-/// Removes a React `Component` from the DOM that was mounted via [render]
-/// and cleans up its event handlers and state.
-///
-/// * Returns `false` if a `Component` was not mounted in the [mountNode].
-/// * Returns `true` if a `Component` was mounted in the [mountNode].
-///
-/// > Proxies [react_dom.unmountComponentAtNode].
-bool unmountComponentAtNode(Element mountNode) {
-  return react_dom.unmountComponentAtNode(mountNode) as bool;
-}
+export 'package:over_react/src/react_dom.dart' show render, unmountComponentAtNode;

--- a/lib/src/component/_deprecated/abstract_transition.dart
+++ b/lib/src/component/_deprecated/abstract_transition.dart
@@ -19,7 +19,11 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component/_deprecated/abstract_transition.dart';
+import 'package:over_react/src/component/_deprecated/abstract_transition_props.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
+import 'package:over_react/src/util/validation_util.dart';
 
 
 export '../abstract_transition.dart' show TransitionPhase;

--- a/lib/src/component/_deprecated/abstract_transition.dart
+++ b/lib/src/component/_deprecated/abstract_transition.dart
@@ -25,7 +25,6 @@ import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:over_react/src/util/validation_util.dart';
 
-
 export '../abstract_transition.dart' show TransitionPhase;
 
 part 'abstract_transition.over_react.g.dart';

--- a/lib/src/component/_deprecated/abstract_transition.dart
+++ b/lib/src/component/_deprecated/abstract_transition.dart
@@ -19,8 +19,8 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
-import 'package:over_react/component_base.dart' as component_base;
+
+
 
 export '../abstract_transition.dart' show TransitionPhase;
 

--- a/lib/src/component/_deprecated/abstract_transition_props.dart
+++ b/lib/src/component/_deprecated/abstract_transition_props.dart
@@ -16,7 +16,7 @@ library over_react.deprecated.abstract_transition_props;
 
 import 'dart:collection';
 
-import 'package:over_react/over_react.dart';
+
 
 part 'abstract_transition_props.over_react.g.dart';
 

--- a/lib/src/component/_deprecated/abstract_transition_props.dart
+++ b/lib/src/component/_deprecated/abstract_transition_props.dart
@@ -16,7 +16,8 @@ library over_react.deprecated.abstract_transition_props;
 
 import 'dart:collection';
 
-
+import 'package:over_react/src/component/callback_typedefs.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
 
 part 'abstract_transition_props.over_react.g.dart';
 

--- a/lib/src/component/_deprecated/error_boundary.dart
+++ b/lib/src/component/_deprecated/error_boundary.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:logging/logging.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component/_deprecated/error_boundary_mixins.dart';
 import 'package:over_react/src/component/_deprecated/error_boundary_recoverable.dart';
 
@@ -25,8 +25,8 @@ part 'error_boundary.over_react.g.dart';
 /// __Deprecated.__ Use the `ErrorBoundary` component exported from `package:over_react/components.dart` instead:
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/components.dart' as c;
+/// 
+/// 
 ///
 /// // Then use `c.ErrorBoundary` instead of `ErrorBoundary`:
 /// main() {

--- a/lib/src/component/_deprecated/error_boundary.dart
+++ b/lib/src/component/_deprecated/error_boundary.dart
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 import 'package:logging/logging.dart';
-
 import 'package:over_react/src/component/_deprecated/error_boundary_mixins.dart';
 import 'package:over_react/src/component/_deprecated/error_boundary_recoverable.dart';
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/error_boundary_api.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:react/react_client/react_interop.dart';
 
 part 'error_boundary.over_react.g.dart';
 
@@ -25,8 +29,8 @@ part 'error_boundary.over_react.g.dart';
 /// __Deprecated.__ Use the `ErrorBoundary` component exported from `package:over_react/components.dart` instead:
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/components.dart' as c;
 ///
 /// // Then use `c.ErrorBoundary` instead of `ErrorBoundary`:
 /// main() {

--- a/lib/src/component/_deprecated/error_boundary.dart
+++ b/lib/src/component/_deprecated/error_boundary.dart
@@ -19,6 +19,10 @@ import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/error_boundary_api.dart';
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy;
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart';
 
 part 'error_boundary.over_react.g.dart';

--- a/lib/src/component/_deprecated/error_boundary_mixins.dart
+++ b/lib/src/component/_deprecated/error_boundary_mixins.dart
@@ -17,7 +17,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 
 part 'error_boundary_mixins.over_react.g.dart';
 

--- a/lib/src/component/_deprecated/error_boundary_mixins.dart
+++ b/lib/src/component/_deprecated/error_boundary_mixins.dart
@@ -17,7 +17,14 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/error_boundary_api.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/react_util.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:react/react_client.dart' show  ReactNode;
+import 'package:react/react_client/react_interop.dart' show ReactErrorInfo;
 
 part 'error_boundary_mixins.over_react.g.dart';
 

--- a/lib/src/component/_deprecated/error_boundary_recoverable.dart
+++ b/lib/src/component/_deprecated/error_boundary_recoverable.dart
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import 'package:over_react/src/component/_deprecated/error_boundary_mixins.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'error_boundary_recoverable.over_react.g.dart';
 

--- a/lib/src/component/_deprecated/error_boundary_recoverable.dart
+++ b/lib/src/component/_deprecated/error_boundary_recoverable.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component/_deprecated/error_boundary_mixins.dart';
 
 part 'error_boundary_recoverable.over_react.g.dart';

--- a/lib/src/component/_deprecated/resize_sensor.dart
+++ b/lib/src/component/_deprecated/resize_sensor.dart
@@ -20,9 +20,18 @@ import 'dart:collection';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:over_react/src/util/string_util.dart';
+import 'package:react/react.dart' show SyntheticEvent;
+import 'package:over_react/src/component/callback_typedefs.dart';
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/ref_util.dart';
 import 'package:over_react/src/component/resize_sensor.dart' show ResizeSensorEvent, SafeAnimationFrameMixin;
 import 'package:over_react/src/component/resize_sensor_constants.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/validation_util.dart';
 
 export 'package:over_react/src/component/resize_sensor.dart' show ResizeSensorEvent;
 

--- a/lib/src/component/_deprecated/resize_sensor.dart
+++ b/lib/src/component/_deprecated/resize_sensor.dart
@@ -20,7 +20,7 @@ import 'dart:collection';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component/resize_sensor.dart' show ResizeSensorEvent, SafeAnimationFrameMixin;
 import 'package:over_react/src/component/resize_sensor_constants.dart';
 

--- a/lib/src/component/_deprecated/resize_sensor.dart
+++ b/lib/src/component/_deprecated/resize_sensor.dart
@@ -21,9 +21,10 @@ import 'dart:html';
 
 import 'package:meta/meta.dart';
 import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:over_react/src/util/string_util.dart';
-import 'package:react/react.dart' show SyntheticEvent;
+import 'package:react/react.dart' show ReactComponentFactoryProxy, SyntheticEvent;
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/ref_util.dart';
@@ -32,6 +33,7 @@ import 'package:over_react/src/component/resize_sensor_constants.dart';
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
 import 'package:over_react/src/util/validation_util.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 export 'package:over_react/src/component/resize_sensor.dart' show ResizeSensorEvent;
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -18,9 +18,11 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
-
-
+import 'package:over_react/src/component/abstract_transition_props.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/validation_util.dart';
 
 part 'abstract_transition.over_react.g.dart';
 

--- a/lib/src/component/abstract_transition.dart
+++ b/lib/src/component/abstract_transition.dart
@@ -18,9 +18,9 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart' hide TransitionPropsMixin;
-import 'package:over_react/components.dart' show TransitionPropsMixin;
-import 'package:over_react/component_base.dart' as component_base;
+
+
+
 
 part 'abstract_transition.over_react.g.dart';
 

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -14,8 +14,10 @@
 
 library over_react.abstract_transition_props;
 
-
-
+import 'package:over_react/src/component/callback_typedefs.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component/abstract_transition.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
 
 part 'abstract_transition_props.over_react.g.dart';
 

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -18,6 +18,8 @@ import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component/abstract_transition.dart';
 import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'abstract_transition_props.over_react.g.dart';
 

--- a/lib/src/component/abstract_transition_props.dart
+++ b/lib/src/component/abstract_transition_props.dart
@@ -14,8 +14,8 @@
 
 library over_react.abstract_transition_props;
 
-import 'package:over_react/over_react.dart' hide AbstractTransitionComponent, AbstractTransitionProps;
-import 'package:over_react/components.dart' show AbstractTransitionComponent, AbstractTransitionProps;
+
+
 
 part 'abstract_transition_props.over_react.g.dart';
 

--- a/lib/src/component/aria_mixin.dart
+++ b/lib/src/component/aria_mixin.dart
@@ -18,7 +18,7 @@ import 'dart:collection';
 
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_shown_name
-
+import 'package:over_react/over_react.dart' show PropDescriptor, PropsMeta;
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'aria_mixin.over_react.g.dart';

--- a/lib/src/component/aria_mixin.dart
+++ b/lib/src/component/aria_mixin.dart
@@ -18,8 +18,7 @@ import 'dart:collection';
 
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_shown_name
-import 'package:over_react/over_react.dart'
-    show PropDescriptor, PropsMeta;
+
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'aria_mixin.over_react.g.dart';

--- a/lib/src/component/aria_mixin.dart
+++ b/lib/src/component/aria_mixin.dart
@@ -16,10 +16,10 @@ library over_react.aria_mixin;
 
 import 'dart:collection';
 
+import 'package:over_react/src/component_declaration/annotations.dart';
 // Must import these consts because they are used in the transformed code.
 // ignore: unused_shown_name
-import 'package:over_react/over_react.dart' show PropDescriptor, PropsMeta;
-import 'package:over_react/src/component_declaration/annotations.dart';
+import 'package:over_react/src/component_declaration/component_base.dart' show PropDescriptor, PropsMeta;
 
 part 'aria_mixin.over_react.g.dart';
 

--- a/lib/src/component/callback_typedefs.dart
+++ b/lib/src/component/callback_typedefs.dart
@@ -17,7 +17,7 @@ library over_react.callback_typedefs;
 
 import 'dart:html';
 
-
+import 'package:over_react/src/component/_deprecated/resize_sensor.dart' show ResizeSensorEvent;
 import 'package:react/react.dart' as react;
 
 // Callbacks for React's DOM event system

--- a/lib/src/component/callback_typedefs.dart
+++ b/lib/src/component/callback_typedefs.dart
@@ -17,7 +17,7 @@ library over_react.callback_typedefs;
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart' show ResizeSensorEvent;
+
 import 'package:react/react.dart' as react;
 
 // Callbacks for React's DOM event system

--- a/lib/src/component/dummy_component2.dart
+++ b/lib/src/component/dummy_component2.dart
@@ -14,6 +14,10 @@
 
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'dummy_component2.over_react.g.dart';
 

--- a/lib/src/component/dummy_component2.dart
+++ b/lib/src/component/dummy_component2.dart
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
 
 part 'dummy_component2.over_react.g.dart';
 

--- a/lib/src/component/dummy_component2.dart
+++ b/lib/src/component/dummy_component2.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
+
 
 part 'dummy_component2.over_react.g.dart';
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -13,9 +13,14 @@
 // limitations under the License.
 
 import 'package:logging/logging.dart';
-
+import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/error_boundary_api.dart';
 import 'package:over_react/src/component/error_boundary_recoverable.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:react/react_client.dart' show ReactNode;
+import 'package:react/react_client/react_interop.dart' show ReactErrorInfo;
 
 part 'error_boundary.over_react.g.dart';
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:logging/logging.dart';
-import 'package:over_react/over_react.dart' hide ErrorBoundary, ErrorBoundaryProps, ErrorBoundaryState;
+
 import 'package:over_react/src/component/error_boundary_api.dart';
 import 'package:over_react/src/component/error_boundary_recoverable.dart';
 

--- a/lib/src/component/error_boundary.dart
+++ b/lib/src/component/error_boundary.dart
@@ -19,7 +19,10 @@ import 'package:over_react/src/component/error_boundary_recoverable.dart';
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
 import 'package:over_react/src/util/cast_ui_factory.dart';
-import 'package:react/react_client.dart' show ReactNode;
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy, ReactNode;
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart' show ReactErrorInfo;
 
 part 'error_boundary.over_react.g.dart';

--- a/lib/src/component/error_boundary_api.dart
+++ b/lib/src/component/error_boundary_api.dart
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import 'package:meta/meta.dart';
-
-
+import 'package:over_react/src/component/error_boundary.dart' as v2;
+import 'package:over_react/src/component_declaration/component_base_2.dart';
 
 @visibleForTesting
 const String defaultErrorBoundaryLoggerName = 'over_react.ErrorBoundary';

--- a/lib/src/component/error_boundary_api.dart
+++ b/lib/src/component/error_boundary_api.dart
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
-import 'package:over_react/components.dart' as v2;
+
+
 
 @visibleForTesting
 const String defaultErrorBoundaryLoggerName = 'over_react.ErrorBoundary';

--- a/lib/src/component/error_boundary_recoverable.dart
+++ b/lib/src/component/error_boundary_recoverable.dart
@@ -16,9 +16,18 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/error_boundary.dart' as v2;
 import 'package:over_react/src/component/error_boundary_api.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy, ReactNode;
+import 'package:react/react_client/js_backed_map.dart';
+import 'package:react/react_client/react_interop.dart';
 
 part 'error_boundary_recoverable.over_react.g.dart';
 

--- a/lib/src/component/error_boundary_recoverable.dart
+++ b/lib/src/component/error_boundary_recoverable.dart
@@ -16,7 +16,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component/error_boundary.dart' as v2;
 import 'package:over_react/src/component/error_boundary_api.dart';
 

--- a/lib/src/component/hooks.dart
+++ b/lib/src/component/hooks.dart
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+import 'package:over_react/src/util/context.dart';
+import 'package:react/hooks.dart' show StateHook, ReducerHook;
 import 'package:react/hooks.dart' as react_hooks;
+import 'package:react/react_client/react_interop.dart' show Ref;
 
 /// Adds local state to a [uiFunction] component
 /// by returning a [StateHook] with [StateHook.value] initialized to [initialValue].

--- a/lib/src/component/hooks.dart
+++ b/lib/src/component/hooks.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
+
 import 'package:react/hooks.dart' as react_hooks;
 
 /// Adds local state to a [uiFunction] component

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -17,10 +17,11 @@
 /// Various prop related mixins to be used with `UiComponent` descendants.
 library over_react.prop_mixins;
 
-
+import 'package:over_react/src/component/aria_mixin.dart' show AriaPropsMapView, AriaPropsMixin;
+import 'package:over_react/src/component/dom_components.dart' show DomProps;
 // Must import these consts because they are used in the transformed code.
 // ignore: deprecated_member_use, unused_shown_name
-
+import 'package:over_react/src/component_declaration/component_base.dart' show PropDescriptor, ConsumedProps, PropsMeta;
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/annotations.dart';
 import 'package:react/react_client/js_backed_map.dart';

--- a/lib/src/component/prop_mixins.dart
+++ b/lib/src/component/prop_mixins.dart
@@ -17,10 +17,10 @@
 /// Various prop related mixins to be used with `UiComponent` descendants.
 library over_react.prop_mixins;
 
-import 'package:over_react/over_react.dart' show AriaPropsMapView, AriaPropsMixin, DomProps, PropsMeta;
+
 // Must import these consts because they are used in the transformed code.
 // ignore: deprecated_member_use, unused_shown_name
-import 'package:over_react/over_react.dart' show PropDescriptor, ConsumedProps, PropsMeta;
+
 import 'package:over_react/src/component/callback_typedefs.dart';
 import 'package:over_react/src/component_declaration/annotations.dart';
 import 'package:react/react_client/js_backed_map.dart';

--- a/lib/src/component/prop_typedefs.dart
+++ b/lib/src/component/prop_typedefs.dart
@@ -15,7 +15,7 @@
 // ignore_for_file: prefer_generic_function_type_aliases
 library over_react.prop_typedefs;
 
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 
 /// A custom rendering prop typedef that allows a custom rendering function to be provided

--- a/lib/src/component/prop_typedefs.dart
+++ b/lib/src/component/prop_typedefs.dart
@@ -15,8 +15,9 @@
 // ignore_for_file: prefer_generic_function_type_aliases
 library over_react.prop_typedefs;
 
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
+import 'package:react/react_client.dart' show ReactElement;
 
 /// A custom rendering prop typedef that allows a custom rendering function to be provided
 /// with the current [props] and [state] of the [component].

--- a/lib/src/component/pure_component_mixin.dart
+++ b/lib/src/component/pure_component_mixin.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
+
 
 /// A mixin to make a `Component2` instance behave
 /// like a [ReactJS `PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent).

--- a/lib/src/component/pure_component_mixin.dart
+++ b/lib/src/component/pure_component_mixin.dart
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/equality.dart';
 
 /// A mixin to make a `Component2` instance behave
 /// like a [ReactJS `PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent).

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -18,7 +18,7 @@ import 'package:over_react/src/component_declaration/builder_helpers.dart' as bh
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
-import 'package:over_react/component_base.dart';
+
 
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.
 ///

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:over_react/src/component_declaration/component_base.dart';
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:over_react/src/component_declaration/function_component.dart';
 import 'package:over_react/src/component_declaration/builder_helpers.dart' as bh;

--- a/lib/src/component/ref_util.dart
+++ b/lib/src/component/ref_util.dart
@@ -20,7 +20,6 @@ import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
 
-
 /// Creates a [Ref] object that can be attached to a [ReactElement] via the ref prop.
 ///
 /// __Example__:

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -19,8 +19,18 @@ library over_react.resize_sensor;
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component/callback_typedefs.dart';
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/ref_util.dart';
 import 'package:over_react/src/component/resize_sensor_constants.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:over_react/src/util/string_util.dart';
+import 'package:over_react/src/util/validation_util.dart';
+import 'package:react/react.dart' show SyntheticEvent;
 
 part 'resize_sensor.over_react.g.dart';
 

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -27,10 +27,12 @@ import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
 import 'package:over_react/src/util/cast_ui_factory.dart';
 import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:over_react/src/util/string_util.dart';
 import 'package:over_react/src/util/validation_util.dart';
-import 'package:react/react.dart' show SyntheticEvent;
+import 'package:react/react.dart' show ReactComponentFactoryProxy, SyntheticEvent;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'resize_sensor.over_react.g.dart';
 

--- a/lib/src/component/resize_sensor.dart
+++ b/lib/src/component/resize_sensor.dart
@@ -19,7 +19,7 @@ library over_react.resize_sensor;
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart' hide ResizeSensor, ResizeSensorComponent, ResizeSensorProps;
+
 import 'package:over_react/src/component/resize_sensor_constants.dart';
 
 part 'resize_sensor.over_react.g.dart';

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/js_component.dart';
+
 import 'package:over_react/src/component_declaration/function_component.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client/js_backed_map.dart';

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 import 'package:over_react/src/component_declaration/function_component.dart';
 import 'package:over_react/src/util/js_component.dart';
 import 'package:react/react.dart' as react;

--- a/lib/src/component/strictmode_component.dart
+++ b/lib/src/component/strictmode_component.dart
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-
 import 'package:over_react/src/component_declaration/function_component.dart';
+import 'package:over_react/src/util/js_component.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client/js_backed_map.dart';
 

--- a/lib/src/component/suspense_component.dart
+++ b/lib/src/component/suspense_component.dart
@@ -16,9 +16,10 @@
 library over_react.component.suspense_component;
 
 import 'package:js/js.dart';
-
 import 'package:react/react.dart' as react;
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/util/js_component.dart';
+import 'package:react/react_client.dart' show ReactNode;
 
 part 'suspense_component.over_react.g.dart';
 

--- a/lib/src/component/suspense_component.dart
+++ b/lib/src/component/suspense_component.dart
@@ -16,10 +16,13 @@
 library over_react.component.suspense_component;
 
 import 'package:js/js.dart';
+import 'package:over_react/src/component_declaration/function_component.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
 import 'package:react/react.dart' as react;
 import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/util/js_component.dart';
 import 'package:react/react_client.dart' show ReactNode;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'suspense_component.over_react.g.dart';
 

--- a/lib/src/component/suspense_component.dart
+++ b/lib/src/component/suspense_component.dart
@@ -16,7 +16,7 @@
 library over_react.component.suspense_component;
 
 import 'package:js/js.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:react/react.dart' as react;
 import 'package:over_react/src/util/js_component.dart';
 

--- a/lib/src/component/test_fixtures/redraw_counter_component_mixin.dart
+++ b/lib/src/component/test_fixtures/redraw_counter_component_mixin.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
 
 mixin RedrawCounterMixin<T extends UiProps> on UiComponent2<T> {
   int _desiredRedrawCount = 1;

--- a/lib/src/component/test_fixtures/redraw_counter_component_mixin.dart
+++ b/lib/src/component/test_fixtures/redraw_counter_component_mixin.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 
 mixin RedrawCounterMixin<T extends UiProps> on UiComponent2<T> {
   int _desiredRedrawCount = 1;

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -107,7 +107,7 @@ part 'with_transition.over_react.g.dart';
 /// the CSS transition using `uiForwardRef`:
 ///
 /// ```dart
-///
+/// import 'package:over_react/over_react.dart';
 ///
 /// mixin CustomChildProps on UiProps {}
 ///

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -18,8 +18,19 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
-
+import 'package:over_react/src/component/_deprecated/abstract_transition.dart';
+import 'package:over_react/src/component/abstract_transition.dart' as v2;
+import 'package:over_react/src/component/abstract_transition_props.dart' as v2;
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/ref_util.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:over_react/src/util/class_names.dart';
+import 'package:over_react/src/util/prop_errors.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:over_react/src/util/validation_util.dart';
+import 'package:react/react_client.dart' show ReactElement, chainRefs;
 
 part 'with_transition.over_react.g.dart';
 
@@ -33,8 +44,8 @@ part 'with_transition.over_react.g.dart';
 /// `onDidShow`, `onDidHide` to know when the CSS transition has completed.
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/components.dart' show WithTransition;
 ///
 /// mixin WithTransitionExampleProps on UiProps {
 ///   bool? initiallyShown;
@@ -93,7 +104,7 @@ part 'with_transition.over_react.g.dart';
 /// the CSS transition using `uiForwardRef`:
 ///
 /// ```dart
-/// 
+///
 ///
 /// mixin CustomChildProps on UiProps {}
 ///

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -18,8 +18,8 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
-import 'package:over_react/components.dart' as v2;
+
+
 
 part 'with_transition.over_react.g.dart';
 
@@ -33,8 +33,8 @@ part 'with_transition.over_react.g.dart';
 /// `onDidShow`, `onDidHide` to know when the CSS transition has completed.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/components.dart' show WithTransition;
+/// 
+/// 
 ///
 /// mixin WithTransitionExampleProps on UiProps {
 ///   bool? initiallyShown;
@@ -93,7 +93,7 @@ part 'with_transition.over_react.g.dart';
 /// the CSS transition using `uiForwardRef`:
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
+/// 
 ///
 /// mixin CustomChildProps on UiProps {}
 ///

--- a/lib/src/component/with_transition.dart
+++ b/lib/src/component/with_transition.dart
@@ -27,10 +27,13 @@ import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
 import 'package:over_react/src/util/cast_ui_factory.dart';
 import 'package:over_react/src/util/class_names.dart';
+import 'package:over_react/src/util/map_util.dart';
 import 'package:over_react/src/util/prop_errors.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
 import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:over_react/src/util/validation_util.dart';
-import 'package:react/react_client.dart' show ReactElement, chainRefs;
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy, ReactElement, chainRefs;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'with_transition.over_react.g.dart';
 

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/component_base.dart' as component_base;
+
 import 'package:over_react/src/util/component_debug_name.dart';
 import 'package:w_flux/w_flux.dart';
 

--- a/lib/src/component_declaration/flux_component.dart
+++ b/lib/src/component_declaration/flux_component.dart
@@ -20,7 +20,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
 import 'package:over_react/src/util/component_debug_name.dart';
 import 'package:w_flux/w_flux.dart';
 

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -17,8 +17,11 @@ library over_react.component_declaration.function_component;
 
 import 'package:js/js_util.dart';
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
 import 'package:react/react.dart' as react;
+import 'package:react/react_client.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 import 'component_type_checking.dart';
 

--- a/lib/src/component_declaration/function_component.dart
+++ b/lib/src/component_declaration/function_component.dart
@@ -17,7 +17,7 @@ library over_react.component_declaration.function_component;
 
 import 'package:js/js_util.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:react/react.dart' as react;
 
 import 'component_type_checking.dart';

--- a/lib/src/over_react_redux/hooks/use_dispatch.dart
+++ b/lib/src/over_react_redux/hooks/use_dispatch.dart
@@ -42,8 +42,8 @@ import 'package:redux/redux.dart';
 /// > It also assumes that you have two actions wired up to your reducer - `IncrementAction` and `DecrementAction`.
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/over_react_redux.dart';
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}

--- a/lib/src/over_react_redux/hooks/use_dispatch.dart
+++ b/lib/src/over_react_redux/hooks/use_dispatch.dart
@@ -42,8 +42,8 @@ import 'package:redux/redux.dart';
 /// > It also assumes that you have two actions wired up to your reducer - `IncrementAction` and `DecrementAction`.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/over_react_redux.dart';
+/// 
+/// 
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}

--- a/lib/src/over_react_redux/hooks/use_selector.dart
+++ b/lib/src/over_react_redux/hooks/use_selector.dart
@@ -53,8 +53,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 ///   that is wired up to a Redux `Store` instance with a `CounterState` instance containing a field called `count`.
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/over_react_redux.dart';
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}
@@ -80,8 +80,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 /// of these can get a little messy:
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/over_react_redux.dart';
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}
@@ -101,8 +101,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 /// Instead of needing to declare those generic parameters each time on `useSelector`, shadow it like so:
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/over_react_redux.dart';
 /// import 'counter_state.dart';
 ///
 /// /// All the types for state fields within `CounterState` will be inferred!
@@ -163,8 +163,8 @@ external Object? /*[1]*/ _jsUseSelector(_JsSelectorFn selector, [_JsReduxStateEq
 /// ### Custom Context Example
 ///
 /// ```dart
-/// 
-/// 
+/// import 'package:over_react/over_react.dart';
+/// import 'package:over_react/over_react_redux.dart';
 /// import 'package:redux/redux.dart';
 ///
 /// // ------------------------------------

--- a/lib/src/over_react_redux/hooks/use_selector.dart
+++ b/lib/src/over_react_redux/hooks/use_selector.dart
@@ -53,8 +53,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 ///   that is wired up to a Redux `Store` instance with a `CounterState` instance containing a field called `count`.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/over_react_redux.dart';
+/// 
+/// 
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}
@@ -80,8 +80,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 /// of these can get a little messy:
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/over_react_redux.dart';
+/// 
+/// 
 /// import 'counter_state.dart';
 ///
 /// mixin CounterProps on UiProps {}
@@ -101,8 +101,8 @@ import 'package:react/react_client/react_interop.dart' show ReactContext;
 /// Instead of needing to declare those generic parameters each time on `useSelector`, shadow it like so:
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/over_react_redux.dart';
+/// 
+/// 
 /// import 'counter_state.dart';
 ///
 /// /// All the types for state fields within `CounterState` will be inferred!
@@ -163,8 +163,8 @@ external Object? /*[1]*/ _jsUseSelector(_JsSelectorFn selector, [_JsReduxStateEq
 /// ### Custom Context Example
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
-/// import 'package:over_react/over_react_redux.dart';
+/// 
+/// 
 /// import 'package:redux/redux.dart';
 ///
 /// // ------------------------------------

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -393,7 +393,7 @@ mixin InfluxStoreMixin<S> on flux.Store {
 ///
 /// __Example:__
 /// ```dart
-///
+/// import 'package:over_react/react_dom.dart' as react_dom;
 ///
 /// Store store1 = Store<CounterState>(counterStateReducer, initialState: CounterState(count: 0));
 /// Store store2 = Store<BigCounterState>(bigCounterStateReducer, initialState: BigCounterState(bigCount: 100));

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -16,8 +16,8 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
-import 'package:over_react/over_react_redux.dart';
+
+
 import 'package:redux/redux.dart' as redux;
 import 'package:w_flux/w_flux.dart' as flux;
 
@@ -391,7 +391,7 @@ mixin InfluxStoreMixin<S> on flux.Store {
 ///
 /// __Example:__
 /// ```dart
-/// import 'package:over_react/react_dom.dart' as react_dom;
+/// 
 ///
 /// Store store1 = Store<CounterState>(counterStateReducer, initialState: CounterState(count: 0));
 /// Store store2 = Store<BigCounterState>(bigCounterStateReducer, initialState: BigCounterState(bigCount: 100));

--- a/lib/src/over_react_redux/over_react_flux.dart
+++ b/lib/src/over_react_redux/over_react_flux.dart
@@ -16,8 +16,10 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/over_react_redux/over_react_redux.dart';
+import 'package:over_react/src/util/context.dart';
+import 'package:over_react/src/util/equality.dart';
 import 'package:redux/redux.dart' as redux;
 import 'package:w_flux/w_flux.dart' as flux;
 
@@ -391,7 +393,7 @@ mixin InfluxStoreMixin<S> on flux.Store {
 ///
 /// __Example:__
 /// ```dart
-/// 
+///
 ///
 /// Store store1 = Store<CounterState>(counterStateReducer, initialState: CounterState(count: 0));
 /// Store store2 = Store<BigCounterState>(bigCounterStateReducer, initialState: BigCounterState(bigCount: 100));

--- a/lib/src/over_react_redux/redux_multi_provider.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.dart
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
-import 'package:over_react/over_react_flux.dart';
+
+
 import 'package:redux/redux.dart';
 
 part 'redux_multi_provider.over_react.g.dart';

--- a/lib/src/over_react_redux/redux_multi_provider.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.dart
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/over_react_redux/over_react_redux.dart';
+import 'package:over_react/src/util/context.dart';
+import 'package:over_react/src/util/prop_errors.dart';
+import 'package:react/react_client.dart' show ReactNode;
 import 'package:redux/redux.dart';
 
 part 'redux_multi_provider.over_react.g.dart';

--- a/lib/src/over_react_redux/redux_multi_provider.dart
+++ b/lib/src/over_react_redux/redux_multi_provider.dart
@@ -16,8 +16,11 @@ import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/component_base_2.dart';
 import 'package:over_react/src/over_react_redux/over_react_redux.dart';
 import 'package:over_react/src/util/context.dart';
+import 'package:over_react/src/util/map_util.dart';
 import 'package:over_react/src/util/prop_errors.dart';
-import 'package:react/react_client.dart' show ReactNode;
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy, ReactNode;
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:redux/redux.dart';
 
 part 'redux_multi_provider.over_react.g.dart';

--- a/lib/src/react_dom.dart
+++ b/lib/src/react_dom.dart
@@ -1,0 +1,47 @@
+// Copyright 2025 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import 'dart:html';
+
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:react/react_client.dart' show ReactNode;
+import 'package:react/react_dom.dart' as react_dom show render, unmountComponentAtNode;
+
+/// Renders the provided [element] into the DOM mounted in the provided [mountNode]
+/// and returns a reference to it based on its type:
+///
+/// 1. Returns an [Element] if [element] is a DOM component _(e.g. [Dom.div])_.
+/// 2. Returns a React `Component` if [element] is a composite component.
+///
+/// > __Throws__ if [element] or [mountNode] are `null`.
+///
+/// If the [element] was previously rendered into the [mountNode], this will perform an update on it and only
+/// mutate the DOM as necessary to reflect the latest React component.
+///
+/// Use [unmountComponentAtNode] to unmount the instance.
+///
+/// > Proxies [react_dom.render].
+dynamic render(ReactNode element, Element mountNode) {
+  return react_dom.render(element, mountNode);
+}
+
+/// Removes a React `Component` from the DOM that was mounted via [render]
+/// and cleans up its event handlers and state.
+///
+/// * Returns `false` if a `Component` was not mounted in the [mountNode].
+/// * Returns `true` if a `Component` was mounted in the [mountNode].
+///
+/// > Proxies [react_dom.unmountComponentAtNode].
+bool unmountComponentAtNode(Element mountNode) {
+  return react_dom.unmountComponentAtNode(mountNode) as bool;
+}

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -19,11 +19,11 @@ library over_react.class_names;
 import 'dart:collection';
 
 import 'package:over_react/src/component_declaration/builder_helpers.dart' show
-// Must import these consts because they are used in the transformed code.
-// ignore: unused_shown_name
-PropDescriptor, ConsumedProps,
-// ignore: unused_shown_name
-PropsMeta, UiComponent, UiProps;
+    // Must import these consts because they are used in the transformed code.
+    // ignore: unused_shown_name
+    PropDescriptor, ConsumedProps,
+    // ignore: unused_shown_name
+    PropsMeta, UiComponent, UiProps;
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'class_names.over_react.g.dart';

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -18,12 +18,7 @@ library over_react.class_names;
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'dart:collection';
 
-import 'package:over_react/over_react.dart' show
-    // Must import these consts because they are used in the transformed code.
-    // ignore: unused_shown_name
-    PropDescriptor, ConsumedProps,
-    // ignore: unused_shown_name
-    PropsMeta, UiComponent, UiProps;
+
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'class_names.over_react.g.dart';

--- a/lib/src/util/class_names.dart
+++ b/lib/src/util/class_names.dart
@@ -18,7 +18,12 @@ library over_react.class_names;
 // ignore_for_file: deprecated_member_use_from_same_package
 import 'dart:collection';
 
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart' show
+// Must import these consts because they are used in the transformed code.
+// ignore: unused_shown_name
+PropDescriptor, ConsumedProps,
+// ignore: unused_shown_name
+PropsMeta, UiComponent, UiProps;
 import 'package:over_react/src/component_declaration/annotations.dart';
 
 part 'class_names.over_react.g.dart';

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -4,7 +4,7 @@ library over_react.src.component_debug_name;
 
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
-import 'package:over_react/component_base.dart';
+
 
 /// __For use in debugging contexts only; not suitable for other use.__
 /// If there's another use-case for getting a component name from its mounted

--- a/lib/src/util/component_debug_name.dart
+++ b/lib/src/util/component_debug_name.dart
@@ -4,7 +4,7 @@ library over_react.src.component_debug_name;
 
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
-
+import 'package:over_react/src/component_declaration/component_base.dart';
 
 /// __For use in debugging contexts only; not suitable for other use.__
 /// If there's another use-case for getting a component name from its mounted

--- a/lib/src/util/handler_chain_util.dart
+++ b/lib/src/util/handler_chain_util.dart
@@ -14,7 +14,7 @@
 
 library over_react.handler_chain_util;
 
-
+import 'package:over_react/src/component/_deprecated/resize_sensor.dart' show ResizeSensorEvent;
 import 'package:react/react.dart' show
     SyntheticEvent,
     SyntheticAnimationEvent,

--- a/lib/src/util/handler_chain_util.dart
+++ b/lib/src/util/handler_chain_util.dart
@@ -14,7 +14,7 @@
 
 library over_react.handler_chain_util;
 
-import 'package:over_react/over_react.dart' show ResizeSensorEvent;
+
 import 'package:react/react.dart' show
     SyntheticEvent,
     SyntheticAnimationEvent,

--- a/lib/src/util/js_component.dart
+++ b/lib/src/util/js_component.dart
@@ -1,5 +1,7 @@
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/function_component.dart';
 import 'package:react/react_client/component_factory.dart';
+import 'package:react/react_client/js_backed_map.dart';
 
 /// Creates a Dart component factory that wraps a ReactJS [factoryProxy].
 ///

--- a/lib/src/util/js_component.dart
+++ b/lib/src/util/js_component.dart
@@ -1,4 +1,4 @@
-import 'package:over_react/over_react.dart';
+
 import 'package:react/react_client/component_factory.dart';
 
 /// Creates a Dart component factory that wraps a ReactJS [factoryProxy].

--- a/lib/src/util/key_constants.dart
+++ b/lib/src/util/key_constants.dart
@@ -14,7 +14,7 @@
 
 library over_react.key_constants;
 
-import 'package:over_react/over_react.dart';
+
 
 /// Key values that are returned from [SyntheticKeyboardEvent.key].
 ///

--- a/lib/src/util/key_constants.dart
+++ b/lib/src/util/key_constants.dart
@@ -14,7 +14,7 @@
 
 library over_react.key_constants;
 
-
+import 'package:react/react.dart' show SyntheticKeyboardEvent;
 
 /// Key values that are returned from [SyntheticKeyboardEvent.key].
 ///

--- a/lib/src/util/lazy.dart
+++ b/lib/src/util/lazy.dart
@@ -34,7 +34,7 @@ import '../component_declaration/function_component.dart';
 ///
 /// Example:
 /// ```dart
-///
+/// import 'package:over_react/over_react.dart';
 ///
 /// part 'main.over_react.g.dart';
 ///

--- a/lib/src/util/lazy.dart
+++ b/lib/src/util/lazy.dart
@@ -14,7 +14,7 @@
 
 library over_react.lazy;
 
-import 'package:over_react/over_react.dart';
+
 import 'package:react/react.dart' as react;
 
 import '../component_declaration/function_component.dart';
@@ -33,7 +33,7 @@ import '../component_declaration/function_component.dart';
 ///
 /// Example:
 /// ```dart
-/// import 'package:over_react/over_react.dart';
+/// 
 ///
 /// part 'main.over_react.g.dart';
 ///

--- a/lib/src/util/lazy.dart
+++ b/lib/src/util/lazy.dart
@@ -14,8 +14,9 @@
 
 library over_react.lazy;
 
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:react/react.dart' as react;
+import 'package:react/react_client/js_backed_map.dart';
 
 import '../component_declaration/function_component.dart';
 
@@ -33,7 +34,7 @@ import '../component_declaration/function_component.dart';
 ///
 /// Example:
 /// ```dart
-/// 
+///
 ///
 /// part 'main.over_react.g.dart';
 ///

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -18,7 +18,7 @@ import 'package:over_react/src/component_declaration/component_type_checking.dar
 import 'package:over_react/src/util/equality.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
-import 'package:over_react/component_base.dart';
+
 
 /// A [higher order component](https://reactjs.org/docs/higher-order-components.html) for function components
 /// that behaves similar to the way [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent)
@@ -31,7 +31,7 @@ import 'package:over_react/component_base.dart';
 /// > __NOTE:__ This should only be used to wrap function components.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
+/// 
 ///
 /// UiFactory<UiProps> MemoExample = memo(uiFunction(
 ///   (props) {
@@ -49,7 +49,7 @@ import 'package:over_react/component_base.dart';
 /// function to the [areEqual] argument as shown in the example below.
 ///
 /// ```dart
-/// import 'package:over_react/over_react.dart';
+/// 
 ///
 /// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo(uiFunction(
 ///   (props) {

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -18,7 +18,7 @@ import 'package:over_react/src/component_declaration/component_type_checking.dar
 import 'package:over_react/src/util/equality.dart';
 import 'package:react/react_client/react_interop.dart' as react_interop;
 import 'package:react/react_client.dart';
-
+import 'package:over_react/src/component_declaration/component_base.dart';
 
 /// A [higher order component](https://reactjs.org/docs/higher-order-components.html) for function components
 /// that behaves similar to the way [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent)
@@ -31,7 +31,7 @@ import 'package:react/react_client.dart';
 /// > __NOTE:__ This should only be used to wrap function components.
 ///
 /// ```dart
-/// 
+///
 ///
 /// UiFactory<UiProps> MemoExample = memo(uiFunction(
 ///   (props) {
@@ -49,7 +49,7 @@ import 'package:react/react_client.dart';
 /// function to the [areEqual] argument as shown in the example below.
 ///
 /// ```dart
-/// 
+///
 ///
 /// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo(uiFunction(
 ///   (props) {

--- a/lib/src/util/memo.dart
+++ b/lib/src/util/memo.dart
@@ -31,7 +31,7 @@ import 'package:over_react/src/component_declaration/component_base.dart';
 /// > __NOTE:__ This should only be used to wrap function components.
 ///
 /// ```dart
-///
+/// import 'package:over_react/over_react.dart';
 ///
 /// UiFactory<UiProps> MemoExample = memo(uiFunction(
 ///   (props) {
@@ -49,7 +49,7 @@ import 'package:over_react/src/component_declaration/component_base.dart';
 /// function to the [areEqual] argument as shown in the example below.
 ///
 /// ```dart
-///
+/// import 'package:over_react/over_react.dart';
 ///
 /// UiFactory<MemoWithComparisonProps> MemoWithComparison = memo(uiFunction(
 ///   (props) {

--- a/lib/src/util/prop_conversion.dart
+++ b/lib/src/util/prop_conversion.dart
@@ -3,7 +3,7 @@
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart' show Context, Ref;
+
 import 'package:over_react/src/util/weak_map.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/component_factory.dart';

--- a/lib/src/util/prop_conversion.dart
+++ b/lib/src/util/prop_conversion.dart
@@ -3,11 +3,11 @@
 import 'package:js/js.dart';
 import 'package:js/js_util.dart';
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/util/context.dart';
 import 'package:over_react/src/util/weak_map.dart';
 import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/component_factory.dart';
-import 'package:react/react_client/react_interop.dart' show JsRef, ReactContext;
+import 'package:react/react_client/react_interop.dart' show JsRef, ReactContext, Ref;
 
 // Export JsMap since props that utilize jsifyMapProp/unjsifyMapProp
 // via custom getters/setters will need JsMap to avoid implicit cast errors.

--- a/lib/src/util/prop_errors.dart
+++ b/lib/src/util/prop_errors.dart
@@ -14,7 +14,7 @@
 
 library over_react.prop_errors;
 
-import 'package:over_react/over_react.dart';
+
 
 /// Errors thrown due to a value within [UiComponent2.props] being set incorrectly.
 class PropError extends Error {

--- a/lib/src/util/prop_errors.dart
+++ b/lib/src/util/prop_errors.dart
@@ -14,7 +14,7 @@
 
 library over_react.prop_errors;
 
-
+import 'package:over_react/src/component_declaration/component_base_2.dart';
 
 /// Errors thrown due to a value within [UiComponent2.props] being set incorrectly.
 class PropError extends Error {

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component_declaration/util.dart';
 
 const _getPropKey = getPropKey;

--- a/lib/src/util/react_util.dart
+++ b/lib/src/util/react_util.dart
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 import 'package:meta/meta.dart';
-
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
 import 'package:over_react/src/component_declaration/util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:react/react_client.dart'
+    show
+    ReactElement,
+    ReactComponentFactoryProxy,
+    ReactNode;
 
 const _getPropKey = getPropKey;
 

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -20,7 +20,7 @@ import 'dart:html';
 import 'dart:js_util';
 
 import 'package:js/js.dart';
-import 'package:over_react/over_react.dart';
+
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';

--- a/lib/src/util/react_wrappers.dart
+++ b/lib/src/util/react_wrappers.dart
@@ -20,10 +20,11 @@ import 'dart:html';
 import 'dart:js_util';
 
 import 'package:js/js.dart';
-
 import 'package:over_react/src/component_declaration/component_type_checking.dart';
+import 'package:over_react/src/util/string_util.dart';
 import 'package:react/react.dart' as react;
 import 'package:react/react_client.dart';
+import 'package:react/react_client/js_backed_map.dart';
 import 'package:react/react_client/js_interop_helpers.dart' show jsifyAndAllowInterop;
 import 'package:react/react_client/react_interop.dart' hide createRef;
 import 'package:react/react_dom.dart' as react_dom;

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -20,10 +20,10 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-import 'package:over_react/over_react.dart';
-import 'package:over_react/components.dart' as v2;
+
+
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
-import 'package:over_react/react_dom.dart' as react_dom;
+
 import 'package:platform_detect/platform_detect.dart';
 
 // The computed font size of the HTML node isn't reliable in Chrome when the page is refreshed while zoomed.

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -23,10 +23,9 @@ import 'package:meta/meta.dart';
 import 'package:over_react/src/component/dom_components.dart';
 import 'package:over_react/src/component/resize_sensor.dart' as v2;
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
+import 'package:over_react/src/react_dom.dart' as react_dom;
 import 'package:over_react/src/util/css_value_util.dart';
 import 'package:platform_detect/platform_detect.dart';
-
-import '../../react_dom.dart' as react_dom;
 
 // The computed font size of the HTML node isn't reliable in Chrome when the page is refreshed while zoomed.
 // Instead, measure a container to determine how big 1rem is.

--- a/lib/src/util/rem_util.dart
+++ b/lib/src/util/rem_util.dart
@@ -20,11 +20,13 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:meta/meta.dart';
-
-
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component/resize_sensor.dart' as v2;
 import 'package:over_react/src/component_declaration/component_base.dart' as component_base;
-
+import 'package:over_react/src/util/css_value_util.dart';
 import 'package:platform_detect/platform_detect.dart';
+
+import '../../react_dom.dart' as react_dom;
 
 // The computed font size of the HTML node isn't reliable in Chrome when the page is refreshed while zoomed.
 // Instead, measure a container to determine how big 1rem is.

--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -15,10 +15,13 @@
 import 'dart:async';
 import 'dart:html';
 
-
-
+import 'package:over_react/src/component/ref_util.dart';
+import 'package:react/react_client.dart'
+    show
+    ReactElement;
 import 'package:w_common/disposable.dart';
 
+import '../../../react_dom.dart' as react_dom;
 import './safe_render_manager_helper.dart';
 
 /// A class that manages the top-level rendering of a [ReactElement] into a given node,

--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -15,8 +15,8 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
-import 'package:over_react/react_dom.dart' as react_dom;
+
+
 import 'package:w_common/disposable.dart';
 
 import './safe_render_manager_helper.dart';

--- a/lib/src/util/safe_render_manager/safe_render_manager.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager.dart
@@ -16,12 +16,12 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:over_react/src/component/ref_util.dart';
+import 'package:over_react/src/react_dom.dart' as react_dom;
 import 'package:react/react_client.dart'
     show
     ReactElement;
 import 'package:w_common/disposable.dart';
 
-import '../../../react_dom.dart' as react_dom;
 import './safe_render_manager_helper.dart';
 
 /// A class that manages the top-level rendering of a [ReactElement] into a given node,

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+import 'package:over_react/src/component/dom_components.dart';
+import 'package:over_react/src/component_declaration/builder_helpers.dart';
+import 'package:over_react/src/component_declaration/component_base_2.dart';
+import 'package:over_react/src/util/cast_ui_factory.dart';
+import 'package:over_react/src/util/map_util.dart';
+import 'package:over_react/src/util/prop_key_util.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
+import 'package:react/react_client.dart' show ReactComponentFactoryProxy, ReactElement, chainRefs;
+import 'package:react/react_client/js_backed_map.dart';
 
 part 'safe_render_manager_helper.over_react.g.dart';
 

--- a/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
+++ b/lib/src/util/safe_render_manager/safe_render_manager_helper.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:over_react/over_react.dart';
+
 
 part 'safe_render_manager_helper.over_react.g.dart';
 

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -17,7 +17,7 @@ library over_react.validation_util;
 
 import 'dart:html';
 
-import 'package:over_react/over_react.dart';
+
 import 'package:react/react.dart' as react;
 
 // ignore: prefer_generic_function_type_aliases

--- a/lib/src/util/validation_util.dart
+++ b/lib/src/util/validation_util.dart
@@ -17,7 +17,8 @@ library over_react.validation_util;
 
 import 'dart:html';
 
-
+import 'package:over_react/src/util/pretty_print.dart';
+import 'package:over_react/src/util/react_wrappers.dart';
 import 'package:react/react.dart' as react;
 
 // ignore: prefer_generic_function_type_aliases


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)