### PR TITLE
FED-4063 Set up gha-dart-oss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Dart CI
+name: CI
 
 on:
   push:
@@ -19,22 +19,21 @@ permissions:
 jobs:
   # Run as a separate job outside the Dart SDK matrix below,
   # since we can only emit a single SBOM.
-  create-sbom-release-asset:
-    name: Create SBOM Release Asset
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 2.19.6 # This version doesn't matter so long as it resolves.
-      - run: dart pub get
-      - name: Publish SBOM to Release Assets
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./
-          format: cyclonedx-json
-
   build:
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.11
+
+  checks:
+    strategy:
+      matrix:
+        sdk: [ 2.19.6, stable ]
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.11
+    with:
+      sdk: ${{ matrix.sdk }}
+      format-check: ${{ matrix.sdk == '2.19.6' }}
+      additional-checks: |
+        no_entrypoint_imports
+
+  build2:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -61,15 +60,6 @@ jobs:
             ./tool/delete_dart_2_only_files.sh
             ./tool/update_tests_for_dart_3.sh
           fi
-
-      - name: Validate dependencies
-        run: dart run dependency_validator
-        if: always() && steps.install.outcome == 'success'
-
-      - name: Verify formatting
-        run: dart run dart_dev format --check
-        # Only run on one sdk version in case there are conflicts
-        if: always() && matrix.sdk == '2.19.6' && steps.install.outcome == 'success'
 
       # Analyze before generated files are created to verify that component boilerplate analysis is "clean" without the need for building
       - name: Analyze example source (pre-build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     name: Testing and Checks Completed
     needs: [ build, checks, test, validate_analyzer, analyzer_plugin ]
     if: ${{ !cancelled() && github.event_name == 'pull_request' || github.ref_type == 'tag' }}
-    runs-on: [ xs-al2023 ]
+    runs-on: ubuntu-latest
     steps:
       - run: |
           if [ "${{ needs.checks.result }}" == "failure" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,12 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.11
 
   checks:
-    strategy:
-      matrix:
-        sdk: [ 2.19.6, stable ]
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.11
     with:
-      sdk: ${{ matrix.sdk }}
-      format-check: ${{ matrix.sdk == '2.19.6' }}
       additional-checks: |
         no_entrypoint_imports
 
-  build2:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,16 @@ jobs:
         run: dart run dart_dev test
         if: always() && steps.install.outcome == 'success'
         timeout-minutes: 8
+
+  testing-and-checks-complete:
+    name: Testing and Checks Completed
+    needs: [ build, checks, test, validate_analyzer, analyzer_plugin ]
+    if: ${{ !cancelled() && github.event_name == 'pull_request' || github.ref_type == 'tag' }}
+    runs-on: [ xs-al2023 ]
+    steps:
+      - run: |
+          if [ "${{ needs.checks.result }}" == "failure" ]; then
+            echo "Some checks have failed. Please fix the issues and try again."
+            exit 1
+          fi
+          echo 'All Testing and checks have completed.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       additional-checks: |
         no_entrypoint_imports
 
-  test:
+  test_and_check_generated_files:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -222,7 +222,7 @@ jobs:
 
   testing-and-checks-complete:
     name: Testing and Checks Completed
-    needs: [ build, checks, test, validate_analyzer, analyzer_plugin ]
+    needs: [ build, checks, test_and_check_generated_files, validate_analyzer, analyzer_plugin ]
     if: ${{ !cancelled() && github.event_name == 'pull_request' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  publish:
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OverReact Changelog
 
-## 5.4.6
+## Unreleased
 - [#986] Set up gha-dart-oss
 - [#985] Remove entrypoint imports
 - [#984] Rollout React 18 to tests and example apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OverReact Changelog
 
+## 5.4.6
+- [#986] Set up gha-dart-oss
+- [#985] Remove entrypoint imports
+- [#984] Rollout React 18 to tests and example apps
+
 ## 5.4.5
 - Update analyzer dependency to `>=5.13.0 <8.0.0` (allow v8)
 - Update dart_style dependency to `>=2.0.0 <4.0.0` (allow v3)


### PR DESCRIPTION
We should set up gha-dart-oss so we can:
- take advantage of shared workflows
- use the publish workflow to auto-publish on merge 🎉 

## QA instructions
- [ ] CI passes
- [ ] All steps previously run in CI are still running even if some of them are in the shared jobs now
- [ ] When this merges, follow along to make sure the package actually publishes