### PR TITLE
RM-343175 RM-343174 Release over_react 5.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OverReact Changelog
 
-## Unreleased
+## 5.4.6
 - [#986] Set up gha-dart-oss
 - [#985] Remove entrypoint imports
 - [#984] Rollout React 18 to tests and example apps

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.4.5
+version: 5.4.6
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.4.5
+  over_react: 5.4.6
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Rollout React 18 to tests and example apps](https://github.com/Workiva/over_react/pull/984)
	* [no_entrypoint_imports](https://github.com/Workiva/over_react/pull/985)
	* [FED-4063 Set up gha-dart-oss](https://github.com/Workiva/over_react/pull/986)
	* [Consume react-dart 7.3.1](https://github.com/Workiva/over_react/pull/987)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.4.5...Workiva:release_over_react_5.4.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.4.5...5.4.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=988)