### PR TITLE
RM-389600 RM-389599 Release over_react 5.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # OverReact Changelog
 
-## Unreleased
+## 5.7.0
 - Remove `dart:mirrors` usage in builder to fix AOT compilation used in newer build_runner versions
 - Remove `dart_style` and `pub_semver` dependencies, remove generated code formatter step
     - Generated code was already pretty well-formatted before it was passed to `dart_style`, and since consumers don't interact with generated code much, this should have very little impact.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react
-version: 5.6.2
+version: 5.7.0
 description: A library for building statically-typed React UI components using Dart.
 homepage: https://github.com/Workiva/over_react/
 environment:

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # Upon release, this should be pinned to the over_react version from ../../pubspec.yaml
   # so that it always resolves to the same version of over_react that the user has pulled in,
   # and thus has the same boilerplate parsing code that's running in the builder.
-  over_react: 5.6.2
+  over_react: 5.7.0
   path: ^1.5.1
   source_span: ^1.7.0
   yaml: ^3.0.0


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [FED-4777 Remove dart_style dep, fix builder AOT compilation](https://github.com/Workiva/over_react/pull/1009)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react/compare/5.6.2...Workiva:release_over_react_5.7.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react/compare/5.6.2...5.7.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6449952306233344/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6449952306233344/?repo_name=Workiva%2Fover_react&pull_number=1010)